### PR TITLE
Make logging inheritable with deffered invocation

### DIFF
--- a/common/src/commonMain/kotlin/fr/acinq/eklair/Logger.kt
+++ b/common/src/commonMain/kotlin/fr/acinq/eklair/Logger.kt
@@ -1,12 +1,15 @@
 package fr.acinq.eklair
 
-sealed class LogLevel {
-    object DEBUG : LogLevel()
-    object INFO : LogLevel()
-    object WARN : LogLevel()
-    object ERROR : LogLevel()
+
+abstract class Logging {
+    val logger by lazy {
+        Logger(this::class.simpleName ?: "noname")
+    }
 }
 
-expect fun log(level: LogLevel, tag: String, message: String)
-
-expect fun log(level: LogLevel, tag: String, message: String, error: Throwable)
+expect class Logger(tag: String) {
+    fun debug(message: () -> String)
+    fun info(message: () -> String)
+    fun warn(message: () -> String)
+    fun error(message: () -> String, t: Throwable? = null)
+}

--- a/common/src/iosMain/kotlin/fr/acinq/eklair/Logger.kt
+++ b/common/src/iosMain/kotlin/fr/acinq/eklair/Logger.kt
@@ -3,25 +3,33 @@ package fr.acinq.eklair
 import platform.Foundation.NSDate
 import platform.Foundation.NSDateFormatter
 
-private fun getCurrentTime() = dateFormatter.stringFromDate(NSDate())
+actual class Logger actual constructor(private val tag: String) {
+    private val dateFormatter = NSDateFormatter().apply {
+        dateFormat = "yyyy-MM-dd HH:mm:ss.SSSSSSZ" // ~ 2020-04-09 07:15:12.255002+0200
+    }
 
-private val dateFormatter = NSDateFormatter().apply {
-    dateFormat = "yyyy-MM-dd HH:mm:ss.SSSSSSZ" // ~ 2020-04-09 07:15:12.255002+0200
-}
+    actual fun debug(message: () -> String) {
+        log("DEBUG", message.invoke())
+    }
 
-private fun log(level: String, message: String) {
-    println("${getCurrentTime()} [${level}]: ${message}")
-}
+    actual fun info(message: () -> String) {
+        log("INFO", message.invoke())
+    }
 
-actual fun log(level: LogLevel, tag: String, message: String, error: Throwable) {
-    log(level, tag, message)
-}
+    actual fun warn(message: () -> String) {
+        log("WARN", message.invoke())
+    }
 
-actual fun log(level: LogLevel, tag: String, message: String) {
-    when (level) {
-        is LogLevel.DEBUG -> log("DEBUG", message)
-        is LogLevel.INFO -> log("INFO", message)
-        is LogLevel.WARN -> log("WARN", message)
-        is LogLevel.ERROR -> log("ERROR", message)
+    actual fun error(message: () -> String, t: Throwable?) {
+        if (t == null) {
+            log("ERROR", message.invoke())
+        } else {
+            log("ERROR", "$message: ${t.message}")
+        }
+    }
+
+    private fun log(level: String, message: String) {
+        val now = dateFormatter.stringFromDate(NSDate())
+        println("$now [$level] $tag: $message")
     }
 }

--- a/common/src/jvmMain/kotlin/fr/acinq/eklair/Boot.kt
+++ b/common/src/jvmMain/kotlin/fr/acinq/eklair/Boot.kt
@@ -9,16 +9,16 @@ import kotlinx.coroutines.runBlocking
 import java.net.InetSocketAddress
 
 @ExperimentalStdlibApi
-actual object SocketBuilder {
+actual object SocketBuilder: Logging() {
 
     @KtorExperimentalAPI
     actual suspend fun buildSocketHandler(host: String, port: Int): SocketHandler {
-        log(LogLevel.INFO, "SocketBuilder", "building ktor socket")
+        logger.info { "building ktor socket handler" }
         val socketBuilder = aSocket(ActorSelectorManager(Dispatchers.IO)).tcp()
         val address = InetSocketAddress(host, port)
-        log(LogLevel.INFO, "SocketBuilder", "connecting to $address")
+        logger.info { "connecting to $address" }
         val connect = socketBuilder.connect(address)
-        log(LogLevel.INFO, "SocketBuilder", "connected to $address!")
+        logger.info { "connected to $address!" }
         return KtorSocketWrapperHandler(connect)
     }
 

--- a/common/src/jvmMain/kotlin/fr/acinq/eklair/Logger.kt
+++ b/common/src/jvmMain/kotlin/fr/acinq/eklair/Logger.kt
@@ -2,22 +2,26 @@ package fr.acinq.eklair
 
 import org.slf4j.LoggerFactory
 
-actual fun log(level: LogLevel, tag: String, message: String, error: Throwable) {
-    val logger = LoggerFactory.getLogger(tag)
-    when (level) {
-        is LogLevel.DEBUG -> logger.debug("$message: ", error)
-        is LogLevel.INFO -> logger.info("$message: ", error)
-        is LogLevel.WARN -> logger.warn("$message: ", error)
-        is LogLevel.ERROR -> logger.error("$message: ", error)
-    }
-}
+actual class Logger actual constructor(tag: String) {
+    private val logger: org.slf4j.Logger = LoggerFactory.getLogger(tag)
 
-actual fun log(level: LogLevel, tag: String, message: String) {
-    val logger = LoggerFactory.getLogger(tag)
-    when (level) {
-        is LogLevel.DEBUG -> logger.debug(message)
-        is LogLevel.INFO -> logger.info(message)
-        is LogLevel.WARN -> logger.warn(message)
-        is LogLevel.ERROR -> logger.error(message)
+    actual fun debug(message: () -> String) {
+        if (logger.isDebugEnabled) logger.debug(message.invoke())
+    }
+
+    actual fun info(message: () -> String) {
+        if (logger.isInfoEnabled) logger.info(message.invoke())
+    }
+
+    actual fun warn(message: () -> String) {
+        if (logger.isWarnEnabled) logger.warn(message.invoke())
+    }
+
+    actual fun error(message: () -> String, t: Throwable?) {
+        if (t == null) {
+            logger.error(message.invoke())
+        } else {
+            logger.error(message.invoke(), t)
+        }
     }
 }

--- a/common/src/linuxMain/kotlin/fr/acinq/eklair/Logger.kt
+++ b/common/src/linuxMain/kotlin/fr/acinq/eklair/Logger.kt
@@ -1,11 +1,28 @@
 package fr.acinq.eklair
 
-import android.util.Log
+actual class Logger actual constructor(val tag: String) {
 
-actual fun log(level: LogLevel, tag: String, message: String, error: Throwable) {
-    println("[$level] - $tag - $message: ${error.message}")
-}
+    actual fun debug(message: () -> String) {
+        log("DEBUG", message.invoke())
+    }
 
-actual fun log(level: LogLevel, tag: String, message: String) {
-    println("[$level] - $tag - $message")
+    actual fun info(message: () -> String) {
+        log("INFO", message.invoke())
+    }
+
+    actual fun warn(message: () -> String) {
+        log("WARN", message.invoke())
+    }
+
+    actual fun error(message: () -> String, t: Throwable?) {
+        if (t == null) {
+            log("ERROR", message.invoke())
+        } else {
+            log("ERROR", "${message.invoke()}: ${t.message}")
+        }
+    }
+
+    private fun log(level: String, message: String) {
+        println("[$level] $tag: $message")
+    }
 }

--- a/common/src/linuxMain/kotlin/fr/acinq/eklair/Main.kt
+++ b/common/src/linuxMain/kotlin/fr/acinq/eklair/Main.kt
@@ -10,7 +10,7 @@ object BootOld {
 }
 
 actual object SocketBuilder {
-    actual suspend fun buildSocketHandler(): SocketHandler = LinuxSocketHandler()
+    actual suspend fun buildSocketHandler(host: String, port: Int): SocketHandler = LinuxSocketHandler()
     actual fun runBlockingCoroutine(closure: suspend (CoroutineScope) -> Unit) {
         runBlocking { closure(this) }
     }

--- a/iOS/Playground/Sources/NodeManager.swift
+++ b/iOS/Playground/Sources/NodeManager.swift
@@ -28,13 +28,13 @@ public class NodeManager {
 
     func hash(message: String) -> String {
         let hash = CommonKt.hash(value: message)
-        LoggerKt.log(level: .INFO(), tag: "NodeManager", message: "Hash '\(message)' > \(hash)")
+        // LoggerKt.log(level: .INFO(), tag: "NodeManager", message: "Hash '\(message)' > \(hash)")
 
         return hash
     }
 
     func connect(_ completion: @escaping (() -> Void)) {
-        LoggerKt.log(level: .INFO(), tag: "NodeManager", message: "Connect()")
+        // LoggerKt.log(level: .INFO(), tag: "NodeManager", message: "Connect()")
 
         self.host = self.user.id
 


### PR DESCRIPTION
This PR removes the previous static log methods, and adds a new `Logging` class that can be inherited. This allow classes in the `common` module to easily output pretty logs, with a log level and a name tag (should be the class name). 

It's also less verbose to use.

Usage is as follow:

```kotlin
class Foo(val foo: String) : Logging {

  fun doSomething() {
    logger.info { "hello $foo" }
  }
}
```

The log content is invoked only if necessary in the `jvm` implementation by using the SLF4J `isXXXenabled` methods. For iOS the message is always invoked but surely that can be improved!



