### PR TITLE
Add FailureMessage serialization

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Commitments.kt
@@ -357,7 +357,7 @@ data class Commitments(
 
     fun sendFailMalformed(cmd: CMD_FAIL_MALFORMED_HTLC): Try<Pair<Commitments, UpdateFailMalformedHtlc>> {
         // BADONION bit must be set in failure_code
-        if ((cmd.failureCode and FailureMessageCodecs.BADONION) == 0) return Try.Failure(InvalidFailureCode(channelId))
+        if ((cmd.failureCode and FailureMessage.BADONION) == 0) return Try.Failure(InvalidFailureCode(channelId))
         val htlc = getIncomingHtlcCrossSigned(cmd.id) ?: return Try.Failure(UnknownHtlcId(channelId, cmd.id))
         return when {
             alreadyProposed(localChanges.proposed, htlc.id) -> {
@@ -379,7 +379,7 @@ data class Commitments(
 
     fun receiveFailMalformed(fail: UpdateFailMalformedHtlc): Try<Triple<Commitments, Origin, UpdateAddHtlc>> {
         // A receiving node MUST fail the channel if the BADONION bit in failure_code is not set for update_fail_malformed_htlc.
-        if ((fail.failureCode and FailureMessageCodecs.BADONION) == 0) return Try.Failure(InvalidFailureCode(channelId))
+        if ((fail.failureCode and FailureMessage.BADONION) == 0) return Try.Failure(InvalidFailureCode(channelId))
         val htlc = getOutgoingHtlcCrossSigned(fail.id) ?: return Try.Failure(UnknownHtlcId(channelId, fail.id))
         return runTrying { Triple(addRemoteProposal(fail), originChannels[fail.id]!!, htlc) }
     }

--- a/src/commonMain/kotlin/fr/acinq/eclair/wire/FailureMessage.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/wire/FailureMessage.kt
@@ -1,61 +1,257 @@
 package fr.acinq.eclair.wire
 
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.io.ByteArrayInput
+import fr.acinq.bitcoin.io.ByteArrayOutput
+import fr.acinq.bitcoin.io.Output
 import fr.acinq.eclair.CltvExpiry
 import fr.acinq.eclair.MilliSatoshi
+import fr.acinq.eclair.utils.toByteVector32
+import fr.acinq.secp256k1.Hex
+import org.kodein.log.Logger
+import org.kodein.log.LoggerFactory
 
-
-interface FailureMessage {
-    val message: String
-}
-interface BadOnion : FailureMessage { val onionHash: ByteVector32 }
-interface Perm : FailureMessage
-interface Node : FailureMessage
-interface Update : FailureMessage { val update: ChannelUpdate }
-
-sealed class AbstractFailureMessage : FailureMessage {
-    val code: Int by lazy { 0 } // TODO: This cannot go into prod!
-}
-
-object InvalidRealm : Perm { override val message get() = "realm was not understood by the processing node" }
-object TemporaryNodeFailure : Node { override val message get() = "general temporary failure of the processing node" }
-object PermanentNodeFailure : Perm, Node { override val message get() = "general permanent failure of the processing node" }
-object RequiredNodeFeatureMissing : Perm, Node { override val message get() = "processing node requires features that are missing from this onion" }
-data class InvalidOnionVersion(override val onionHash: ByteVector32) : BadOnion, Perm { override val message get() = "onion version was not understood by the processing node" }
-data class InvalidOnionHmac(override val onionHash: ByteVector32) : BadOnion, Perm { override val message get() = "onion HMAC was incorrect when it reached the processing node" }
-data class InvalidOnionKey(override val onionHash: ByteVector32) : BadOnion, Perm { override val message get() = "ephemeral key was unparsable by the processing node" }
-data class TemporaryChannelFailure(override val update: ChannelUpdate) : Update { override val message get() = "channel ${update.shortChannelId} is currently unavailable" }
-object PermanentChannelFailure : Perm { override val message get() = "channel is permanently unavailable" }
-object RequiredChannelFeatureMissing : Perm { override val message get() = "channel requires features not present in the onion" }
-object UnknownNextPeer : Perm { override val message get() = "processing node does not know the next peer in the route" }
-data class AmountBelowMinimum(val amount: MilliSatoshi, override val update: ChannelUpdate) : Update { override val message get() = "payment amount was below the minimum required by the channel" }
-data class FeeInsufficient(val amount: MilliSatoshi, override val update: ChannelUpdate) : Update { override val message get() = "payment fee was below the minimum required by the channel" }
-object TrampolineFeeInsufficient : Node { override val message get() = "payment fee was below the minimum required by the trampoline node" }
-data class ChannelDisabled(val messageFlags: Byte, val channelFlags: Byte, override val update: ChannelUpdate) : Update { override val message get() = "channel is currently disabled" }
-data class IncorrectCltvExpiry(val expiry: CltvExpiry, override val update: ChannelUpdate) : Update { override val message get() = "payment expiry doesn't match the value in the onion" }
-data class IncorrectOrUnknownPaymentDetails(val amount: MilliSatoshi, val height: Long) : Perm { override val message get() = "incorrect payment details or unknown payment hash" }
-data class ExpiryTooSoon(override val update: ChannelUpdate) : Update { override val message get() = "payment expiry is too close to the current block height for safe handling by the relaying node" }
-object TrampolineExpiryTooSoon : Node { override val message get() = "payment expiry is too close to the current block height for safe handling by the relaying node" }
-data class FinalIncorrectCltvExpiry(val expiry: CltvExpiry) : FailureMessage { override val message get() = "payment expiry doesn't match the value in the onion" }
-data class FinalIncorrectHtlcAmount(val amount: MilliSatoshi) : FailureMessage { override val message get() = "payment amount is incorrect in the final htlc" }
-object ExpiryTooFar : FailureMessage { override val message get() = "payment expiry is too far in the future" }
 @OptIn(ExperimentalUnsignedTypes::class)
-data class InvalidOnionPayload(val tag: ULong, val offset: Int) : Perm { override val message get() = "onion per-hop payload is invalid" }
-object PaymentTimeout : FailureMessage { override val message get() = "the complete payment amount was not received within a reasonable time" }
+sealed class FailureMessage {
+    abstract val message: String
+    abstract val code: Int
 
-/**
- * We allow remote nodes to send us unknown failure codes (e.g. deprecated failure codes).
- * By reading the PERM and NODE bits we can still extract useful information for payment retry even without knowing how
- * to decode the failure payload (but we can't extract a channel update or onion hash).
- */
-sealed class UnknownFailureMessage : AbstractFailureMessage() {
-    override val message get() = "unknown failure message"
-    override fun toString()= message
-    override fun equals(other: Any?): Boolean {
-        return (other as? UnknownFailureMessage)?.code == code
+    companion object {
+        const val BADONION = 0x8000
+        const val PERM = 0x4000
+        const val NODE = 0x2000
+        const val UPDATE = 0x1000
+
+        val logger = LoggerFactory.default.newLogger(Logger.Tag(FailureMessage::class))
+
+        private fun readChannelUpdate(stream: ByteArrayInput): ChannelUpdate {
+            val len = LightningSerializer.u16(stream)
+            val tag = LightningSerializer.u16(stream)
+            require(tag == ChannelUpdate.tag.toInt()) { "channel update should be prefixed with its lightning message type" }
+            return ChannelUpdate.read(LightningSerializer.bytes(stream, len - 2))
+        }
+
+        fun decode(input: ByteArray): FailureMessage? {
+            val stream = ByteArrayInput(input)
+            return when (val code = LightningSerializer.u16(stream)) {
+                InvalidRealm.code -> InvalidRealm
+                TemporaryNodeFailure.code -> TemporaryNodeFailure
+                PermanentNodeFailure.code -> PermanentNodeFailure
+                RequiredNodeFeatureMissing.code -> RequiredNodeFeatureMissing
+                InvalidOnionVersion.code -> InvalidOnionVersion(LightningSerializer.bytes(stream, 32).toByteVector32())
+                InvalidOnionHmac.code -> InvalidOnionHmac(LightningSerializer.bytes(stream, 32).toByteVector32())
+                InvalidOnionKey.code -> InvalidOnionKey(LightningSerializer.bytes(stream, 32).toByteVector32())
+                TemporaryChannelFailure.code -> TemporaryChannelFailure(readChannelUpdate(stream))
+                PermanentChannelFailure.code -> PermanentChannelFailure
+                RequiredChannelFeatureMissing.code -> RequiredChannelFeatureMissing
+                UnknownNextPeer.code -> UnknownNextPeer
+                AmountBelowMinimum.code -> AmountBelowMinimum(MilliSatoshi(LightningSerializer.u64(stream)), readChannelUpdate(stream))
+                FeeInsufficient.code -> FeeInsufficient(MilliSatoshi(LightningSerializer.u64(stream)), readChannelUpdate(stream))
+                TrampolineFeeInsufficient.code -> TrampolineFeeInsufficient
+                IncorrectCltvExpiry.code -> IncorrectCltvExpiry(CltvExpiry(LightningSerializer.u32(stream).toLong()), readChannelUpdate(stream))
+                ExpiryTooSoon.code -> ExpiryTooSoon(readChannelUpdate(stream))
+                TrampolineExpiryTooSoon.code -> TrampolineExpiryTooSoon
+                IncorrectOrUnknownPaymentDetails.code -> IncorrectOrUnknownPaymentDetails(MilliSatoshi(LightningSerializer.u64(stream)), LightningSerializer.u32(stream).toLong())
+                FinalIncorrectCltvExpiry.code -> FinalIncorrectCltvExpiry(CltvExpiry(LightningSerializer.u32(stream).toLong()))
+                FinalIncorrectHtlcAmount.code -> FinalIncorrectHtlcAmount(MilliSatoshi(LightningSerializer.u64(stream)))
+                ChannelDisabled.code -> ChannelDisabled(LightningSerializer.byte(stream).toByte(), LightningSerializer.byte(stream).toByte(), readChannelUpdate(stream))
+                ExpiryTooFar.code -> ExpiryTooFar
+                InvalidOnionPayload.code -> InvalidOnionPayload(LightningSerializer.bigSize(stream).toULong(), LightningSerializer.u16(stream))
+                PaymentTimeout.code -> PaymentTimeout
+                else -> {
+                    LightningMessage.logger.warning { "cannot decode ${Hex.encode(input)}" }
+                    UnknownFailureMessage(code)
+                }
+            }
+        }
+
+        private fun writeChannelUpdate(channelUpdate: ChannelUpdate, out: Output) {
+            val bin = ChannelUpdate.write(channelUpdate)
+            LightningSerializer.writeU16(bin.size + 2, out)
+            LightningSerializer.writeU16(ChannelUpdate.tag.toInt(), out)
+            LightningSerializer.writeBytes(bin, out)
+        }
+
+        fun encode(input: FailureMessage, out: Output) {
+            LightningSerializer.writeU16(input.code, out)
+            when (input) {
+                InvalidRealm -> return
+                TemporaryNodeFailure -> return
+                PermanentNodeFailure -> return
+                RequiredNodeFeatureMissing -> return
+                is InvalidOnionVersion -> LightningSerializer.writeBytes(input.onionHash, out)
+                is InvalidOnionHmac -> LightningSerializer.writeBytes(input.onionHash, out)
+                is InvalidOnionKey -> LightningSerializer.writeBytes(input.onionHash, out)
+                is TemporaryChannelFailure -> writeChannelUpdate(input.update, out)
+                PermanentChannelFailure -> return
+                RequiredChannelFeatureMissing -> return
+                UnknownNextPeer -> return
+                is AmountBelowMinimum -> {
+                    LightningSerializer.writeU64(input.amount.toLong(), out)
+                    writeChannelUpdate(input.update, out)
+                }
+                is FeeInsufficient -> {
+                    LightningSerializer.writeU64(input.amount.toLong(), out)
+                    writeChannelUpdate(input.update, out)
+                }
+                TrampolineFeeInsufficient -> return
+                is IncorrectCltvExpiry -> {
+                    LightningSerializer.writeU32(input.expiry.toLong().toInt(), out)
+                    writeChannelUpdate(input.update, out)
+                }
+                is ExpiryTooSoon -> writeChannelUpdate(input.update, out)
+                TrampolineExpiryTooSoon -> return
+                is IncorrectOrUnknownPaymentDetails -> {
+                    LightningSerializer.writeU64(input.amount.toLong(), out)
+                    LightningSerializer.writeU32(input.height.toInt(), out)
+                }
+                is FinalIncorrectCltvExpiry -> LightningSerializer.writeU32(input.expiry.toLong().toInt(), out)
+                is FinalIncorrectHtlcAmount -> LightningSerializer.writeU64(input.amount.toLong(), out)
+                is ChannelDisabled -> {
+                    LightningSerializer.writeByte(input.messageFlags.toInt(), out)
+                    LightningSerializer.writeByte(input.channelFlags.toInt(), out)
+                    writeChannelUpdate(input.update, out)
+                }
+                ExpiryTooFar -> return
+                is InvalidOnionPayload -> {
+                    LightningSerializer.writeBigSize(input.tag.toLong(), out)
+                    LightningSerializer.writeU16(input.offset, out)
+                }
+                PaymentTimeout -> return
+                is UnknownFailureMessage -> return
+            }
+        }
+
+        fun encode(input: FailureMessage): ByteArray {
+            val out = ByteArrayOutput()
+            encode(input, out)
+            return out.toByteArray()
+        }
     }
 }
 
-object FailureMessageCodecs {
-    val BADONION = 0x8000
+// @formatter:off
+interface BadOnion { val onionHash: ByteVector32 }
+interface Perm
+interface Node
+interface Update { val update: ChannelUpdate }
+
+object InvalidRealm : FailureMessage(), Perm {
+    override val code get() = PERM or 1
+    override val message get() = "realm was not understood by the processing node"
 }
+object TemporaryNodeFailure : FailureMessage(), Node {
+    override val code get() = NODE or 2
+    override val message get() = "general temporary failure of the processing node"
+}
+object PermanentNodeFailure : FailureMessage(), Perm, Node {
+    override val code get() = PERM or NODE or 2
+    override val message get() = "general permanent failure of the processing node"
+}
+object RequiredNodeFeatureMissing : FailureMessage(), Perm, Node {
+    override val code get() = PERM or NODE or 3
+    override val message get() = "processing node requires features that are missing from this onion"
+}
+data class InvalidOnionVersion(override val onionHash: ByteVector32) : FailureMessage(), BadOnion, Perm {
+    override val code get() = InvalidOnionVersion.code
+    override val message get() = "onion version was not understood by the processing node"
+    companion object { const val code = BADONION or PERM or 4 }
+}
+data class InvalidOnionHmac(override val onionHash: ByteVector32) : FailureMessage(), BadOnion, Perm {
+    override val code get() = InvalidOnionHmac.code
+    override val message get() = "onion HMAC was incorrect when it reached the processing node"
+    companion object { const val code = BADONION or PERM or 5 }
+}
+data class InvalidOnionKey(override val onionHash: ByteVector32) : FailureMessage(), BadOnion, Perm {
+    override val code get() = InvalidOnionKey.code
+    override val message get() = "ephemeral key was unparsable by the processing node"
+    companion object { const val code = BADONION or PERM or 6 }
+}
+data class TemporaryChannelFailure(override val update: ChannelUpdate) : FailureMessage(), Update {
+    override val code get() = TemporaryChannelFailure.code
+    override val message get() = "channel ${update.shortChannelId} is currently unavailable"
+    companion object { const val code = UPDATE or 7 }
+}
+object PermanentChannelFailure : FailureMessage(), Perm {
+    override val code get() = PERM or 8
+    override val message get() = "channel is permanently unavailable"
+}
+object RequiredChannelFeatureMissing : FailureMessage(), Perm {
+    override val code get() = PERM or 9
+    override val message get() = "channel requires features not present in the onion"
+}
+object UnknownNextPeer : FailureMessage(), Perm {
+    override val code get() = PERM or 10
+    override val message get() = "processing node does not know the next peer in the route"
+}
+data class AmountBelowMinimum(val amount: MilliSatoshi, override val update: ChannelUpdate) : FailureMessage(), Update {
+    override val code get() = AmountBelowMinimum.code
+    override val message get() = "payment amount was below the minimum required by the channel"
+    companion object { const val code = UPDATE or 11 }
+}
+data class FeeInsufficient(val amount: MilliSatoshi, override val update: ChannelUpdate) : FailureMessage(), Update {
+    override val code get() = FeeInsufficient.code
+    override val message get() = "payment fee was below the minimum required by the channel"
+    companion object { const val code = UPDATE or 12 }
+}
+object TrampolineFeeInsufficient : FailureMessage(), Node {
+    override val code get() = NODE or 51
+    override val message get() = "payment fee was below the minimum required by the trampoline node"
+}
+data class IncorrectCltvExpiry(val expiry: CltvExpiry, override val update: ChannelUpdate) : FailureMessage(), Update {
+    override val code get() = IncorrectCltvExpiry.code
+    override val message get() = "payment expiry doesn't match the value in the onion"
+    companion object { const val code = UPDATE or 13 }
+}
+data class ExpiryTooSoon(override val update: ChannelUpdate) : FailureMessage(), Update {
+    override val code get() = ExpiryTooSoon.code
+    override val message get() = "payment expiry is too close to the current block height for safe handling by the relaying node"
+    companion object { const val code = UPDATE or 14 }
+}
+object TrampolineExpiryTooSoon : FailureMessage(), Node {
+    override val code get() = NODE or 52
+    override val message get() = "payment expiry is too close to the current block height for safe handling by the relaying node"
+}
+data class IncorrectOrUnknownPaymentDetails(val amount: MilliSatoshi, val height: Long) : FailureMessage(), Perm {
+    override val code get() = IncorrectOrUnknownPaymentDetails.code
+    override val message get() = "incorrect payment details or unknown payment hash"
+    companion object { const val code = PERM or 15 }
+}
+data class FinalIncorrectCltvExpiry(val expiry: CltvExpiry) : FailureMessage() {
+    override val code get() = FinalIncorrectCltvExpiry.code
+    override val message get() = "payment expiry doesn't match the value in the onion"
+    companion object { const val code = 18 }
+}
+data class FinalIncorrectHtlcAmount(val amount: MilliSatoshi) : FailureMessage() {
+    override val code get() = FinalIncorrectHtlcAmount.code
+    override val message get() = "payment amount is incorrect in the final htlc"
+    companion object { const val code = 19 }
+}
+data class ChannelDisabled(val messageFlags: Byte, val channelFlags: Byte, override val update: ChannelUpdate) : FailureMessage(), Update {
+    override val code get() = ChannelDisabled.code
+    override val message get() = "channel is currently disabled"
+    companion object { const val code = UPDATE or 20 }
+}
+object ExpiryTooFar : FailureMessage() {
+    override val code get() = 21
+    override val message get() = "payment expiry is too far in the future"
+}
+@OptIn(ExperimentalUnsignedTypes::class)
+data class InvalidOnionPayload(val tag: ULong, val offset: Int) : FailureMessage(), Perm {
+    override val code get() = InvalidOnionPayload.code
+    override val message get() = "onion per-hop payload is invalid"
+    companion object { const val code = PERM or 22 }
+}
+object PaymentTimeout : FailureMessage() {
+    override val code get() = 23
+    override val message get() = "the complete payment amount was not received within a reasonable time"
+}
+/**
+ * We allow remote nodes to send us unknown failure codes (e.g. deprecated failure codes).
+ * By reading the PERM and NODE bits of the failure code we can still extract useful information for payment retry even
+ * without knowing how to decode the failure payload (but we can't extract a channel update or onion hash).
+ */
+data class UnknownFailureMessage(override val code: Int) : FailureMessage() {
+    override val message get() = "unknown failure message"
+}
+// @formatter:on

--- a/src/commonTest/kotlin/fr/acinq/eclair/wire/FailureMessageTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/wire/FailureMessageTestsCommon.kt
@@ -1,0 +1,105 @@
+package fr.acinq.eclair.wire
+
+import fr.acinq.bitcoin.Block
+import fr.acinq.bitcoin.ByteVector64
+import fr.acinq.eclair.CltvExpiry
+import fr.acinq.eclair.CltvExpiryDelta
+import fr.acinq.eclair.Eclair
+import fr.acinq.eclair.ShortChannelId
+import fr.acinq.eclair.utils.msat
+import fr.acinq.secp256k1.Hex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FailureMessageTestsCommon {
+    private val channelUpdate = ChannelUpdate(
+        signature = Eclair.randomBytes64(),
+        chainHash = Block.RegtestGenesisBlock.hash,
+        shortChannelId = ShortChannelId(12345),
+        timestamp = 1234567,
+        cltvExpiryDelta = CltvExpiryDelta(100),
+        messageFlags = 0,
+        channelFlags = 1,
+        htlcMinimumMsat = 1000.msat,
+        feeBaseMsat = 12.msat,
+        feeProportionalMillionths = 76,
+        htlcMaximumMsat = null
+    )
+
+    @ExperimentalUnsignedTypes
+    @Test
+    fun `encode - decode all failure messages`() {
+        val msgs = listOf(
+            InvalidRealm,
+            TemporaryNodeFailure,
+            PermanentNodeFailure,
+            RequiredNodeFeatureMissing,
+            InvalidOnionVersion(Eclair.randomBytes32()),
+            InvalidOnionHmac(Eclair.randomBytes32()),
+            InvalidOnionKey(Eclair.randomBytes32()),
+            TemporaryChannelFailure(channelUpdate),
+            PermanentChannelFailure,
+            RequiredChannelFeatureMissing,
+            UnknownNextPeer,
+            AmountBelowMinimum(123456.msat, channelUpdate),
+            FeeInsufficient(546463.msat, channelUpdate),
+            IncorrectCltvExpiry(CltvExpiry(1211), channelUpdate),
+            ExpiryTooSoon(channelUpdate),
+            IncorrectOrUnknownPaymentDetails(123456.msat, 1105),
+            FinalIncorrectCltvExpiry(CltvExpiry(1234)),
+            FinalIncorrectHtlcAmount(123456.msat),
+            ChannelDisabled(0, 1, channelUpdate),
+            ExpiryTooFar,
+            InvalidOnionPayload(561.toULong(), 1105),
+            PaymentTimeout,
+            TrampolineFeeInsufficient,
+            TrampolineExpiryTooSoon
+        )
+
+        msgs.forEach {
+            val encoded = FailureMessage.encode(it)
+            val decoded = FailureMessage.decode(encoded)
+            assertEquals(it, decoded)
+        }
+    }
+
+    @Test
+    fun `decode unknown failure messages`() {
+        val testCases = listOf(
+            // Deprecated incorrect_payment_amount.
+            Pair("4010", 0x4010),
+            // Deprecated final_expiry_too_soon.
+            Pair("4011", 0x4011),
+            // Unknown failure messages.
+            Pair("00ff 42", 0xff),
+            Pair("20ff 42", 0x20ff),
+            Pair("60ff 42", 0x60ff)
+        )
+
+        testCases.forEach {
+            val decoded = FailureMessage.decode(Hex.decode(it.first))
+            assertEquals(UnknownFailureMessage(it.second), decoded)
+        }
+    }
+
+    @Test
+    fun `encode - decode channel update`() {
+        val bin = "100700820102cc3e80149073ed487c76e48e9622bf980f78267b8a34a3f61921f2d8fce6063b08e74f34a073a13f2097337e4915bb4c001f3b5c4d81e9524ed575e1f45782196fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d619000000000008260500041300005b91b52f0003000e00000000000003e80000000100000001"
+        val expected = TemporaryChannelFailure(
+            ChannelUpdate(
+                ByteVector64("cc3e80149073ed487c76e48e9622bf980f78267b8a34a3f61921f2d8fce6063b08e74f34a073a13f2097337e4915bb4c001f3b5c4d81e9524ed575e1f4578219"),
+                Block.LivenetGenesisBlock.hash,
+                ShortChannelId(0x826050004130000L),
+                1536275759,
+                0,
+                3,
+                CltvExpiryDelta(14),
+                1000.msat,
+                1.msat,
+                1,
+                null
+            )
+        )
+        assertEquals(expected, FailureMessage.decode(Hex.decode(bin)))
+    }
+}


### PR DESCRIPTION
It's still a bit unclear how we will use the PERM/NODE bits in the (future)
outgoing payment state machine, maybe the interfaces won't be useful and
we'll just need static `isPerm`/`isNode` functions, but we'll decide when
we actually implement payment retry logic.