### PR TITLE
Decrypt incoming onions

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/crypto/sphinx/Sphinx.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/crypto/sphinx/Sphinx.kt
@@ -156,7 +156,7 @@ object Sphinx {
      *         failure messages upstream.
      *         or a BadOnion error containing the hash of the invalid onion.
      */
-    fun peel(privateKey: PrivateKey, associatedData: ByteVector, packet: OnionRoutingPacket, packetLength: Int): Either<BadOnion, DecryptedPacket> = when (packet.version) {
+    fun peel(privateKey: PrivateKey, associatedData: ByteVector, packet: OnionRoutingPacket, packetLength: Int): Either<FailureMessage, DecryptedPacket> = when (packet.version) {
         0 -> {
             when (val result = runTrying { PublicKey(packet.publicKey) }) {
                 is Try.Success -> {

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -480,7 +480,7 @@ class Peer(
                         val expiry = expiryDelta.toCltvExpiry(channel.currentBlockHeight.toLong())
                         val isDirectPayment = event.paymentRequest.nodeId == remoteNodeId
                         val finalPayload = when(isDirectPayment) {
-                            true -> Onion.createSinglePartPayload(event.paymentRequest.amount!!, expiry)
+                            true -> FinalPayload.createSinglePartPayload(event.paymentRequest.amount!!, expiry)
                             false -> TODO("implement trampoline payment")
                         }
                         // one hop: this a direct payment to our peer

--- a/src/commonMain/kotlin/fr/acinq/eclair/payment/IncomingPacket.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/payment/IncomingPacket.kt
@@ -1,0 +1,86 @@
+package fr.acinq.eclair.payment
+
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.eclair.crypto.sphinx.Sphinx
+import fr.acinq.eclair.utils.Either
+import fr.acinq.eclair.wire.*
+
+object IncomingPacket {
+
+    /**
+     * Decrypt the onion packet of a received htlc. We expect to be the final recipient, and we validate that the HTLC
+     * fields match the onion fields (this prevents intermediate nodes from sending an invalid amount or expiry).
+     *
+     * @param add incoming htlc.
+     * @param privateKey this node's private key.
+     * @return either:
+     *  - a decrypted and valid onion final payload
+     *  - or a Bolt4 failure message that can be returned to the sender if the HTLC is invalid
+     */
+    fun decrypt(add: UpdateAddHtlc, privateKey: PrivateKey): Either<FailureMessage, FinalPayload> {
+        return when (val decrypted = decryptOnion(add.paymentHash, add.onionRoutingPacket, OnionRoutingPacket.PaymentPacketLength, privateKey)) {
+            is Either.Left -> Either.Left(decrypted.value)
+            is Either.Right -> when (val outer = decrypted.value) {
+                is FinalLegacyPayload -> validate(add, outer)
+                is FinalTlvPayload -> run {
+                    val trampolineOnion = outer.records.get<OnionTlv.TrampolineOnion>()
+                    if (trampolineOnion == null) {
+                        validate(add, outer)
+                    } else {
+                        when (val inner = decryptOnion(add.paymentHash, trampolineOnion.packet, OnionRoutingPacket.TrampolinePacketLength, privateKey)) {
+                            is Either.Left -> Either.Left(inner.value)
+                            is Either.Right -> validate(add, outer, inner.value)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @OptIn(ExperimentalUnsignedTypes::class)
+    private fun decryptOnion(paymentHash: ByteVector32, packet: OnionRoutingPacket, packetLength: Int, privateKey: PrivateKey): Either<FailureMessage, FinalPayload> {
+        return when (val decrypted = Sphinx.peel(privateKey, paymentHash, packet, packetLength)) {
+            is Either.Left -> Either.Left(decrypted.value)
+            is Either.Right -> run {
+                if (!decrypted.value.isLastPacket) {
+                    Either.Left(UnknownNextPeer)
+                } else {
+                    try {
+                        Either.Right(FinalPayload.read(decrypted.value.payload.toByteArray()))
+                    } catch (_: Throwable) {
+                        Either.Left(InvalidOnionPayload(0U, 0))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun validate(add: UpdateAddHtlc, payload: FinalPayload): Either<FailureMessage, FinalPayload> {
+        return when {
+            add.amountMsat != payload.amount -> Either.Left(FinalIncorrectHtlcAmount(add.amountMsat))
+            add.cltvExpiry != payload.expiry -> Either.Left(FinalIncorrectCltvExpiry(add.cltvExpiry))
+            else -> Either.Right(payload)
+        }
+    }
+
+    @OptIn(ExperimentalUnsignedTypes::class)
+    private fun validate(add: UpdateAddHtlc, outerPayload: FinalPayload, innerPayload: FinalPayload): Either<FailureMessage, FinalPayload> {
+        return when {
+            add.amountMsat != outerPayload.amount -> Either.Left(FinalIncorrectHtlcAmount(add.amountMsat))
+            add.cltvExpiry != outerPayload.expiry -> Either.Left(FinalIncorrectCltvExpiry(add.cltvExpiry))
+            // previous trampoline didn't forward the right expiry
+            outerPayload.expiry != innerPayload.expiry -> Either.Left(FinalIncorrectCltvExpiry(add.cltvExpiry))
+            // previous trampoline didn't forward the right amount
+            outerPayload.totalAmount != innerPayload.amount -> Either.Left(FinalIncorrectHtlcAmount(outerPayload.totalAmount))
+            // trampoline recipients always provide a payment secret in the invoice
+            innerPayload.paymentSecret == null -> Either.Left(InvalidOnionPayload(8U, 0))
+            else -> {
+                // We merge contents from the outer and inner payloads.
+                // We must use the inner payload's total amount and payment secret because the payment may be split between multiple trampoline payments (#reckless).
+                Either.Right(FinalPayload.createMultiPartPayload(outerPayload.amount, innerPayload.totalAmount, outerPayload.expiry, innerPayload.paymentSecret!!))
+            }
+        }
+    }
+
+}

--- a/src/commonMain/kotlin/fr/acinq/eclair/router/Router.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/router/Router.kt
@@ -6,21 +6,21 @@ import fr.acinq.eclair.Eclair
 import fr.acinq.eclair.MilliSatoshi
 import fr.acinq.eclair.wire.ChannelUpdate
 
-interface Hop {
-    /** @return the id of the start node. */
-    val nodeId: PublicKey
+sealed class Hop {
+    /** The id of the start node. */
+    abstract val nodeId: PublicKey
 
-    /** @return the id of the end node. */
-    val nextNodeId: PublicKey
+    /** The id of the end node. */
+    abstract val nextNodeId: PublicKey
 
     /**
      * @param amount amount to be forwarded.
      * @return total fee required by the current hop.
      */
-    fun fee(amount: MilliSatoshi): MilliSatoshi
+    abstract fun fee(amount: MilliSatoshi): MilliSatoshi
 
-    /** @return cltv delta required by the current hop. */
-    val cltvExpiryDelta: CltvExpiryDelta
+    /** Cltv delta required by the current hop. */
+    abstract val cltvExpiryDelta: CltvExpiryDelta
 }
 
 /**
@@ -30,9 +30,8 @@ interface Hop {
  * @param nextNodeId id of the end node.
  * @param lastUpdate last update of the channel used for the hop.
  */
-data class ChannelHop(override val nodeId: PublicKey, override val nextNodeId: PublicKey, val lastUpdate: ChannelUpdate) : Hop {
+data class ChannelHop(override val nodeId: PublicKey, override val nextNodeId: PublicKey, val lastUpdate: ChannelUpdate) : Hop() {
     override val cltvExpiryDelta: CltvExpiryDelta = lastUpdate.cltvExpiryDelta
-
     override fun fee(amount: MilliSatoshi): MilliSatoshi = Eclair.nodeFee(lastUpdate.feeBaseMsat, lastUpdate.feeProportionalMillionths, amount)
 }
 
@@ -46,7 +45,6 @@ data class ChannelHop(override val nodeId: PublicKey, override val nextNodeId: P
  * @param cltvExpiryDelta cltv expiry delta.
  * @param fee             total fee for that hop.
  */
-data class NodeHop(override val nodeId: PublicKey, override val nextNodeId: PublicKey, override val cltvExpiryDelta: CltvExpiryDelta, val fee: MilliSatoshi) : Hop {
+data class NodeHop(override val nodeId: PublicKey, override val nextNodeId: PublicKey, override val cltvExpiryDelta: CltvExpiryDelta, val fee: MilliSatoshi) : Hop() {
     override fun fee(amount: MilliSatoshi): MilliSatoshi = fee
 }
-

--- a/src/commonTest/kotlin/fr/acinq/eclair/payment/PaymentPacketTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/payment/PaymentPacketTestsCommon.kt
@@ -1,0 +1,149 @@
+package fr.acinq.eclair.payment
+
+import fr.acinq.bitcoin.Block
+import fr.acinq.bitcoin.Crypto
+import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.bitcoin.io.ByteArrayInput
+import fr.acinq.eclair.CltvExpiry
+import fr.acinq.eclair.CltvExpiryDelta
+import fr.acinq.eclair.Eclair.nodeFee
+import fr.acinq.eclair.Eclair.randomBytes32
+import fr.acinq.eclair.Eclair.randomBytes64
+import fr.acinq.eclair.Eclair.randomKey
+import fr.acinq.eclair.ShortChannelId
+import fr.acinq.eclair.channel.Channel
+import fr.acinq.eclair.crypto.sphinx.Sphinx
+import fr.acinq.eclair.router.ChannelHop
+import fr.acinq.eclair.router.NodeHop
+import fr.acinq.eclair.utils.msat
+import fr.acinq.eclair.utils.toByteVector32
+import fr.acinq.eclair.wire.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class PaymentPacketTestsCommon {
+
+    private val privA = randomKey()
+    private val a = privA.publicKey()
+    private val privB = randomKey()
+    private val b = privB.publicKey()
+    private val privC = randomKey()
+    private val c = privC.publicKey()
+    private val privD = randomKey()
+    private val d = privD.publicKey()
+    private val privE = randomKey()
+    private val e = privE.publicKey()
+    private val defaultChannelUpdate = ChannelUpdate(randomBytes64(), Block.RegtestGenesisBlock.hash, ShortChannelId(0), 0, 1, 0, CltvExpiryDelta(0), 42000.msat, 0.msat, 0, 500000000.msat)
+    private val channelUpdateAB = defaultChannelUpdate.copy(shortChannelId = ShortChannelId(1), cltvExpiryDelta = CltvExpiryDelta(4), feeBaseMsat = 642000.msat, feeProportionalMillionths = 7)
+    private val channelUpdateBC = defaultChannelUpdate.copy(shortChannelId = ShortChannelId(2), cltvExpiryDelta = CltvExpiryDelta(5), feeBaseMsat = 153000.msat, feeProportionalMillionths = 4)
+    private val channelUpdateCD = defaultChannelUpdate.copy(shortChannelId = ShortChannelId(3), cltvExpiryDelta = CltvExpiryDelta(10), feeBaseMsat = 60000.msat, feeProportionalMillionths = 1)
+    private val channelUpdateDE = defaultChannelUpdate.copy(shortChannelId = ShortChannelId(4), cltvExpiryDelta = CltvExpiryDelta(7), feeBaseMsat = 766000.msat, feeProportionalMillionths = 10)
+
+    // simple route a -> b -> c -> d -> e
+    private val hops = listOf(
+        ChannelHop(a, b, channelUpdateAB),
+        ChannelHop(b, c, channelUpdateBC),
+        ChannelHop(c, d, channelUpdateCD),
+        ChannelHop(d, e, channelUpdateDE)
+    )
+
+    private val finalAmount = 42000000.msat
+    private val currentBlockCount = 400000L
+    private val finalExpiry = CltvExpiry(currentBlockCount) + Channel.MIN_CLTV_EXPIRY_DELTA
+    private val paymentPreimage = randomBytes32()
+    private val paymentHash = Crypto.sha256(paymentPreimage).toByteVector32()
+    private val paymentSecret = randomBytes32()
+
+    private val expiryDE = finalExpiry
+    private val amountDE = finalAmount
+    private val feeD = nodeFee(channelUpdateDE.feeBaseMsat, channelUpdateDE.feeProportionalMillionths, amountDE)
+
+    private val expiryCD = expiryDE + channelUpdateDE.cltvExpiryDelta
+    private val amountCD = amountDE + feeD
+    private val feeC = nodeFee(channelUpdateCD.feeBaseMsat, channelUpdateCD.feeProportionalMillionths, amountCD)
+
+    private val expiryBC = expiryCD + channelUpdateCD.cltvExpiryDelta
+    private val amountBC = amountCD + feeC
+    private val feeB = nodeFee(channelUpdateBC.feeBaseMsat, channelUpdateBC.feeProportionalMillionths, amountBC)
+
+    private val expiryAB = expiryBC + channelUpdateBC.cltvExpiryDelta
+    private val amountAB = amountBC + feeB
+
+    // simple trampoline route to e:
+    //             .--.   .--.
+    //            /    \ /    \
+    // a -> b -> c      d      e
+
+    private val trampolineHops = listOf(
+        NodeHop(a, c, channelUpdateAB.cltvExpiryDelta + channelUpdateBC.cltvExpiryDelta, feeB),
+        NodeHop(c, d, channelUpdateCD.cltvExpiryDelta, feeC),
+        NodeHop(d, e, channelUpdateDE.cltvExpiryDelta, feeD)
+    )
+
+    private val trampolineChannelHops = listOf(
+        ChannelHop(a, b, channelUpdateAB),
+        ChannelHop(b, c, channelUpdateBC)
+    )
+
+    private fun testBuildOnion(legacy: Boolean) {
+        val finalPayload = if (legacy) {
+            FinalLegacyPayload(finalAmount, finalExpiry)
+        } else {
+            FinalTlvPayload(TlvStream(listOf(OnionTlv.AmountToForward(finalAmount), OnionTlv.OutgoingCltv(finalExpiry))))
+        }
+        val (firstAmount, firstExpiry, onion) = OutgoingPacket.buildPacket(paymentHash, hops, finalPayload, OnionRoutingPacket.PaymentPacketLength)
+        assertEquals(amountAB, firstAmount)
+        assertEquals(expiryAB, firstExpiry)
+        assertEquals(OnionRoutingPacket.PaymentPacketLength, onion.packet.payload.size())
+
+        // let's peel the onion
+        testPeelOnion(onion.packet)
+    }
+
+    private fun testPeelOnion(packet_b: OnionRoutingPacket) {
+        val addB = UpdateAddHtlc(randomBytes32(), 0, amountAB, paymentHash, expiryAB, packet_b)
+        val (payloadB, packetC) = decryptChannelRelay(addB, privB)
+        assertEquals(OnionRoutingPacket.PaymentPacketLength, packetC.payload.size())
+        assertEquals(amountBC, payloadB.amountToForward)
+        assertEquals(expiryBC, payloadB.outgoingCltv)
+        assertEquals(channelUpdateBC.shortChannelId, payloadB.outgoingChannelId)
+
+        val addC = UpdateAddHtlc(randomBytes32(), 1, amountBC, paymentHash, expiryBC, packetC)
+        val (payloadC, packetD) = decryptChannelRelay(addC, privC)
+        assertEquals(OnionRoutingPacket.PaymentPacketLength, packetD.payload.size())
+        assertEquals(amountCD, payloadC.amountToForward)
+        assertEquals(expiryCD, payloadC.outgoingCltv)
+        assertEquals(channelUpdateCD.shortChannelId, payloadC.outgoingChannelId)
+
+        val addD = UpdateAddHtlc(randomBytes32(), 2, amountCD, paymentHash, expiryCD, packetD)
+        val (payloadD, packetE) = decryptChannelRelay(addD, privD)
+        assertEquals(OnionRoutingPacket.PaymentPacketLength, packetE.payload.size())
+        assertEquals(amountDE, payloadD.amountToForward)
+        assertEquals(expiryDE, payloadD.outgoingCltv)
+        assertEquals(channelUpdateDE.shortChannelId, payloadD.outgoingChannelId)
+
+        val addE = UpdateAddHtlc(randomBytes32(), 2, amountDE, paymentHash, expiryDE, packetE)
+        val payloadE = IncomingPacket.decrypt(addE, privE).right!!
+        assertEquals(finalAmount, payloadE.amount)
+        assertEquals(finalAmount, payloadE.totalAmount)
+        assertEquals(finalExpiry, payloadE.expiry)
+        assertNull(payloadE.paymentSecret)
+    }
+
+    // Wallets don't need to decrypt onions for intermediate nodes, but it's useful to test that encryption works correctly.
+    private fun decryptChannelRelay(add: UpdateAddHtlc, privateKey: PrivateKey): Pair<RelayLegacyPayload, OnionRoutingPacket> {
+        val decrypted = Sphinx.peel(privateKey, paymentHash, add.onionRoutingPacket, OnionRoutingPacket.PaymentPacketLength).right!!
+        assertFalse(decrypted.isLastPacket)
+        val decoded = RelayLegacyPayload.read(ByteArrayInput(decrypted.payload.toByteArray()))
+        return Pair(decoded, decrypted.nextPacket)
+    }
+
+    @Test
+    fun `build onion with final legacy payload`() {
+        testBuildOnion(legacy = true)
+    }
+
+}
+


### PR DESCRIPTION
Decrypt the onion in incoming HTLCs, assuming that we're always the final recipient (wallets don't relay payments).

Add early support for decrypting trampoline onions.

NB: TlvStream serialization is a bit lacking, so we're still missing pieces before we can send/receive all kinds of payments.