### PR TITLE
Remove fee estimator from NodeParams

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/NodeParams.kt
@@ -15,7 +15,6 @@ data class NodeParams(
     val alias: String,
     val features: Features,
     @Serializable(with = SatoshiKSerializer::class) val dustLimit: Satoshi,
-    val onChainFeeConf: OnChainFeeConf,
     val maxHtlcValueInFlightMsat: Long,
     val maxAcceptedHtlcs: Int,
     val expiryDeltaBlocks: CltvExpiryDelta,

--- a/src/commonMain/kotlin/fr/acinq/eclair/blockchain/fee/ConstantFeeEstimator.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/blockchain/fee/ConstantFeeEstimator.kt
@@ -1,25 +1,8 @@
 package fr.acinq.eclair.blockchain.fee
 
 import fr.acinq.eclair.Eclair.feerateKw2KB
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.polymorphic
-import kotlinx.serialization.modules.subclass
 
-
-@Serializable
 data class ConstantFeeEstimator(var currentFeerates: Long = 750) : FeeEstimator {
-
-
     override fun getFeeratePerKb(target: Int): Long = feerateKw2KB(currentFeerates)
-
     override fun getFeeratePerKw(target: Int): Long = currentFeerates
-
-    companion object {
-        val testSerializersModule = SerializersModule {
-            polymorphic(FeeEstimator::class) {
-                subclass(serializer())
-            }
-        }
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -152,7 +152,6 @@ interface HasCommitments {
             include(Tlv.serializersModule)
             include(KeyManager.serializersModule)
             include(UpdateMessage.serializersModule)
-            include(ConstantFeeEstimator.testSerializersModule)
         }
 
         private val cbor = Cbor {

--- a/src/commonTest/kotlin/fr/acinq/eclair/TestConstants.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/TestConstants.kt
@@ -4,13 +4,9 @@ import fr.acinq.bitcoin.Block
 import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Script
-import fr.acinq.eclair.blockchain.fee.ConstantFeeEstimator
-import fr.acinq.eclair.blockchain.fee.FeeTargets
-import fr.acinq.eclair.blockchain.fee.OnChainFeeConf
 import fr.acinq.eclair.channel.LocalParams
 import fr.acinq.eclair.crypto.LocalKeyManager
 import fr.acinq.eclair.io.PeerChannels
-import fr.acinq.eclair.payment.PaymentHandler
 import fr.acinq.eclair.utils.msat
 import fr.acinq.eclair.utils.sat
 import fr.acinq.eclair.wire.OnionRoutingPacket
@@ -39,13 +35,6 @@ object TestConstants {
                 )
             ),
             dustLimit = 1100.sat,
-            onChainFeeConf = OnChainFeeConf(
-                feeTargets = FeeTargets(6, 2, 2, 6),
-                feeEstimator = ConstantFeeEstimator(10000),
-                maxFeerateMismatch = 1.5,
-                closeOnOfflineMismatch = true,
-                updateFeeMinDiffRatio = 0.1
-            ),
             maxHtlcValueInFlightMsat = 150000000L,
             maxAcceptedHtlcs = 100,
             expiryDeltaBlocks = CltvExpiryDelta(144),
@@ -102,13 +91,6 @@ object TestConstants {
                 )
             ),
             dustLimit = 1100.sat,
-            onChainFeeConf = OnChainFeeConf(
-                feeTargets = FeeTargets(6, 2, 2, 6),
-                feeEstimator = ConstantFeeEstimator(10000),
-                maxFeerateMismatch = 1.5,
-                closeOnOfflineMismatch = true,
-                updateFeeMinDiffRatio = 0.1
-            ),
             maxHtlcValueInFlightMsat = Long.MAX_VALUE,
             maxAcceptedHtlcs = 100,
             expiryDeltaBlocks = CltvExpiryDelta(144),

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/ChannelStateSerializationTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/ChannelStateSerializationTestsCommon.kt
@@ -1,6 +1,5 @@
 package fr.acinq.eclair.channel
 
-import fr.acinq.eclair.blockchain.fee.ConstantFeeEstimator
 import fr.acinq.eclair.io.eclairSerializersModule
 import fr.acinq.eclair.tests.utils.EclairTestSuite
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -16,7 +15,6 @@ import kotlin.test.assertEquals
 class ChannelStateSerializationTestsCommon : EclairTestSuite() {
     val serializationModules = SerializersModule {
         include(eclairSerializersModule)
-        include(ConstantFeeEstimator.testSerializersModule)
     }
 
     val cbor = Cbor {

--- a/src/jvmTest/kotlin/fr/acinq/eclair/Node.kt
+++ b/src/jvmTest/kotlin/fr/acinq/eclair/Node.kt
@@ -45,13 +45,6 @@ object Node {
             )
         ),
         dustLimit = 100.sat,
-        onChainFeeConf = OnChainFeeConf(
-            feeTargets = FeeTargets(6, 2, 2, 6),
-            feeEstimator = ConstantFeeEstimator(10000),
-            maxFeerateMismatch = 1.5,
-            closeOnOfflineMismatch = true,
-            updateFeeMinDiffRatio = 0.1
-        ),
         maxHtlcValueInFlightMsat = 150000000L,
         maxAcceptedHtlcs = 100,
         expiryDeltaBlocks = CltvExpiryDelta(144),
@@ -85,7 +78,6 @@ object Node {
 
     private val serializationModules = SerializersModule {
         include(eclairSerializersModule)
-        include(ConstantFeeEstimator.testSerializersModule)
     }
 
     private val json = Json {


### PR DESCRIPTION
NodeParams is supposed to be a simple container for static configuration parameters, having a fee estimator there was a code smell and it created serialization headaches.
When we add support for LN's update_fee, we will just create new events/actions for the channel FSM, and we could for example have a coroutine that calls our fee estimator and update channel states with the appropriate event.