### PR TITLE
Adding support for legacy trampoline

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandler.kt
@@ -392,7 +392,11 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams) {
             )
         } else {
             // Legacy workaround
-            throw RuntimeException("Not implemented")
+            OutgoingPacket.buildTrampolineToLegacyPacket(
+                invoice = paymentAttempt.invoice,
+                hops = nodeHops,
+                finalPayload = finalPayload
+            )
         }
 
         val trampolinePayload = FinalPayload.createTrampolinePayload(


### PR DESCRIPTION
Implements the last remaining Todo item for single-part payments.