### PR TITLE
Fixing floating-point math with MilliSatoshi's

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/MilliSatoshi.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/MilliSatoshi.kt
@@ -2,6 +2,8 @@ package fr.acinq.eclair
 
 import fr.acinq.bitcoin.Satoshi
 import kotlinx.serialization.Serializable
+import kotlin.math.ceil
+import kotlin.math.ulp
 
 /**
  * One MilliSatoshi is a thousand of a Satoshi, the smallest unit usable in bitcoin
@@ -14,11 +16,21 @@ data class MilliSatoshi(val msat: Long) : Comparable<MilliSatoshi> {
     // @formatter:off
     operator fun plus(other: MilliSatoshi) = MilliSatoshi(msat + other.msat)
     operator fun minus(other: MilliSatoshi) = MilliSatoshi(msat - other.msat)
-    operator fun times(m: Long) = MilliSatoshi(msat * m)
-    operator fun times(m: Double) = MilliSatoshi((msat * m).toLong())
-    operator fun times(m: Float) = MilliSatoshi((msat * m).toLong())
     operator fun div(d: Long) = MilliSatoshi(msat / d)
     operator fun unaryMinus() = MilliSatoshi(-msat)
+    operator fun times(m: Long) = MilliSatoshi(msat * m)
+    operator fun times(m: Double): MilliSatoshi {
+        // Credit:
+        // https://levelup.gitconnected.com/double-equality-in-kotlin-f99392cba0e4
+        val rawResult: Double = msat * m
+        val upResult: Double = ceil(rawResult)
+
+        val delta = rawResult.ulp * 4 // steps
+
+        val shouldRoundUp = (upResult - rawResult) < delta
+        val fixedResult: Double = if (shouldRoundUp) upResult else rawResult
+        return MilliSatoshi(fixedResult.toLong())
+    }
 
     override fun compareTo(other: MilliSatoshi): Int = msat.compareTo(other.msat)
     // Since BtcAmount is a sealed trait that MilliSatoshi cannot extend, we need to redefine comparison operators.

--- a/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandler.kt
@@ -81,22 +81,22 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams) {
      */
     data class TrampolineParams(
         val feeBaseSat: Satoshi,
-        val feePercent: Float,
+        val feePercent: Double,
         val cltvExpiryDelta: CltvExpiryDelta
     ) {
-        constructor(feeBaseSat: Long, feePercent: Float, cltvExpiryDelta: Int) :
+        constructor(feeBaseSat: Long, feePercent: Double, cltvExpiryDelta: Int) :
                 this(Satoshi(feeBaseSat), feePercent, CltvExpiryDelta(cltvExpiryDelta))
 
         companion object {
 
             // Todo: Fetch this from the server first, and have it passed into us somehow...
             val attempts = listOf(
-                TrampolineParams(0, 0.0f, 576),
-                TrampolineParams(1, 0.0001f, 576),
-                TrampolineParams(3, 0.0001f, 576),
-                TrampolineParams(5, 0.0005f, 576),
-                TrampolineParams(5, 0.001f, 576),
-                TrampolineParams(5, 0.0012f, 576)
+                TrampolineParams(0, 0.0, 576),
+                TrampolineParams(1, 0.0001, 576),
+                TrampolineParams(3, 0.0001, 576),
+                TrampolineParams(5, 0.0005, 576),
+                TrampolineParams(5, 0.001, 576),
+                TrampolineParams(5, 0.0012, 576)
             )
 
             fun get(failedAttempts: Int): TrampolineParams? {

--- a/src/commonTest/kotlin/fr/acinq/eclair/MilliSatoshiTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/MilliSatoshiTestsCommon.kt
@@ -30,6 +30,8 @@ class MilliSatoshiTestsCommon : EclairTestSuite() {
         assertEquals(561.msat, MilliSatoshi(561) * 1)
         assertEquals(1122.msat, MilliSatoshi(561) * 2)
         assertEquals(1402.msat, MilliSatoshi(561) * 2.5)
+        assertEquals(113_796.msat, 1_137_960_000L.msat * 0.0001)
+        assertEquals(120.msat, 100_000.msat * 0.0012)
 
         // divide
         assertEquals(MilliSatoshi(561), MilliSatoshi(561) / 1)


### PR DESCRIPTION
We've run into multiple problems with floating-point math & MilliSatoshi's. The first problem we encountered was:

```
100_000L * 0.0012 = 119.99999999999999 // wrong
```

It was [noted](https://github.com/ACINQ/eclair-kmp/pull/68/commits/cf9d1c424ef039a7c3557a5454c42a24ebed2ea5) at the time that using a **float** instead of a double worked:

```
100_000L * 0.0012f = 120.00001 // right (after truncation)
```

Both answers are off by a little bit. But since we're truncating the result to a `Long` for MilliSatoshi's:

- it's ok to be over
- it's NOT ok to be under

Except now we've run into the opposite problem:

```
1_137_960_000L * 0.0001 = 113796.0 // right
1_137_960_000L * 0.0001f = 113795.99 // wrong with float
```

I did a wee bit of research on this, and discovered this article:

https://levelup.gitconnected.com/double-equality-in-kotlin-f99392cba0e4

> the `ulp` ([**unit of least precision**](https://en.wikipedia.org/wiki/Unit_in_the_last_place)) is the gap between a given number and its adjacent larger number. Kotlin (via Java) has a method to [return the ulp of a number](https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#ulp-double-): `Math.ulp(double)`.

Which seemed to me to be a practicle solution to our problem.

My thought process on this is:

- since we're performing truncation, the only time we have problems is when the calculated value is just under a whole value
- in other words, the calculated value is `X.99999999999999`
- if the calculated value is a few ulp's away from the next highest integer, that is a very strong indicator that we're dealing with a floating-point "error"


Note:
``` kotlin
// This was added very recently:
operator fun times(m: Float) = MilliSatoshi((msat * m).toLong())
// This commit reverts that change, so that all multiplication is done using Double.
// This is as it was originally.
```
