### PR TITLE
Don't display test logs in the console

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -148,9 +148,10 @@ afterEvaluate {
 afterEvaluate {
     tasks.withType<AbstractTestTask>() {
         testLogging {
-            events("passed", "skipped", "failed", "standard_out", "standard_error")
+            events("skipped", "failed")
             showExceptions = true
             showStackTraces = true
+            showStandardStreams = false
         }
     }
 }


### PR DESCRIPTION
Ideally, I would have preferred to display the logs *only* for failed tests, but it is not supported.

NB: Logs are still displayed when run from intellij.