### PR TITLE
Outgoing payment errors

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentFailure.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentFailure.kt
@@ -4,42 +4,30 @@ import fr.acinq.eclair.channel.ChannelException
 import fr.acinq.eclair.utils.Either
 import fr.acinq.eclair.wire.*
 
-data class OutgoingPaymentFailure(val reason: Reason, val message: String, val problems: List<Either<ChannelException, FailureMessage>>) {
-    /**
-     * Simple error types designed for general users.
-     * Anything non-simple goes into the OTHER_ERROR category, and we rely on the problems list for details.
-     */
-    enum class Reason {
-        INVALID_PARAMETER, // e.g. (paymentAmount < 0), (recycled paymentId)
-        NO_AVAILABLE_CHANNELS, // Zero channels in Normal mode (excluding failed channels)
-        INSUFFICIENT_BALANCE_BASE, // Not enough capacity in channel(s) to support payment
-        INSUFFICIENT_BALANCE_FEES, // Not enough capacity, after fees are taken into account
-        NO_ROUTE_TO_RECIPIENT, // Trampoline was unable to find an acceptable route
-        OTHER_ERROR, // Some other error occurred
-    }
+/**
+ * Simple error types designed for general users.
+ * Anything non-simple goes into the UnknownError category, and we rely on the inner failures list for details.
+ */
+sealed class FailureReason {
+    abstract val message: String
 
-    companion object {
-        fun make(reason: Reason, problems: List<Either<ChannelException, FailureMessage>>): OutgoingPaymentFailure {
-            val message = when (reason) {
-                Reason.INVALID_PARAMETER -> "Invalid parameter"
-                Reason.NO_AVAILABLE_CHANNELS -> "No channels available to send payment. Check internet connection or ensure you have an available balance."
-                Reason.INSUFFICIENT_BALANCE_BASE -> "Not enough funds in wallet to afford payment"
-                Reason.INSUFFICIENT_BALANCE_FEES -> "Not enough funds in wallet, after fees are taken into account."
-                Reason.NO_ROUTE_TO_RECIPIENT -> "Unable to route payment to recipient"
-                Reason.OTHER_ERROR -> "Unknown error occurred"
-            }
-            return OutgoingPaymentFailure(reason, message, problems)
-        }
-    }
+    fun toPaymentFailure(): OutgoingPaymentFailure = OutgoingPaymentFailure(this, listOf())
 
-    object InvalidParameter {
-        fun paymentAmount() = OutgoingPaymentFailure(Reason.INVALID_PARAMETER, "Invalid parameter: payment amount must be positive", listOf())
-        fun paymentId() = OutgoingPaymentFailure(Reason.INVALID_PARAMETER, "Invalid parameter: paymentId must be unique", listOf())
-    }
+    // @formatter:off
+    object InvalidPaymentAmount : FailureReason() { override val message: String = "Invalid parameter: payment amount must be positive." }
+    object InvalidPaymentId : FailureReason() { override val message: String = "Invalid parameter: payment ID must be unique." }
+    object NoAvailableChannels : FailureReason() { override val message: String = "No channels available to send payment. Check internet connection or ensure you have an available balance." }
+    object InsufficientBalanceBase : FailureReason() { override val message: String = "Not enough funds in wallet to afford payment." }
+    object InsufficientBalanceFees : FailureReason() { override val message: String = "Not enough funds in wallet, after fees are taken into account." }
+    object NoRouteToRecipient : FailureReason() { override val message: String = "Unable to route payment to recipient." }
+    object UnknownError : FailureReason() { override val message: String = "An unknown error occurred." }
+    // @formatter:on
+}
+
+data class OutgoingPaymentFailure(val reason: FailureReason, val failures: List<Either<ChannelException, FailureMessage>>) {
 
     /** A simple summary of the problem, designed for general users. */
-    @Suppress("unused")
-    fun basicSummary(): String {
+    fun message(): String {
         // We strive to provide a message that would lead a general user toward solving their own problem.
         // And we must not assume any knowledge of the lightning protocol.
         //
@@ -49,17 +37,17 @@ data class OutgoingPaymentFailure(val reason: Reason, val message: String, val p
         // - the remaining channel contains an insufficient balance to make the payment
         //
         // So the UI should say:
-        // - basic = Not enough funds in wallet ...
+        // - message = Not enough funds in wallet ...
         // - details = HtlcValueTooHighInFlight ...
         //
         // The general user will see "not enough funds in wallet", and some gobbledygook.
-        // It may be a bit confusing, but it leads them toward the solution
-        // => add funds, retry payment, success!
+        // It may be a bit confusing, but it leads them toward the solution: add funds, retry payment, success!
 
-        fun isRouteError(problem: Either<ChannelException, FailureMessage>) = when (problem) {
+        fun isRouteError(failure: Either<ChannelException, FailureMessage>) = when (failure) {
             is Either.Left -> false
-            is Either.Right -> when (problem.value) {
+            is Either.Right -> when (failure.value) {
                 is UnknownNextPeer -> true
+                is ChannelDisabled -> true
                 is TemporaryChannelFailure -> true
                 is PermanentChannelFailure -> true
                 is TemporaryNodeFailure -> true
@@ -68,27 +56,24 @@ data class OutgoingPaymentFailure(val reason: Reason, val message: String, val p
             }
         }
 
-        if (reason == Reason.OTHER_ERROR) {
-            if (problems.any { isRouteError(it) }) {
-                return "Unable to route payment to recipient"
-            }
-            if (problems.any { (it is Either.Right) && (it.value is IncorrectOrUnknownPaymentDetails) }) {
-                return "Payment rejected by the recipient. " +
-                        "This usually occurs when the invoice has already been paid or when it contains an expiration date, " +
-                        "and you attempted to send a payment after the expiration."
-            }
+        if (failures.any { isRouteError(it) }) {
+            return FailureReason.NoRouteToRecipient.message
+        }
+        if (failures.any { (it is Either.Right) && (it.value is IncorrectOrUnknownPaymentDetails) }) {
+            return "Payment rejected by the recipient. " +
+                    "This usually occurs when the invoice has already been paid or when it contains an expiration date, " +
+                    "and you attempted to send a payment after the expiration."
         }
 
-        return message
+        return reason.message
     }
 
     /**
-     * A detailed summary of the ChannelExceptions and/or FailureMessages that occurred.
+     * A detailed summary of the all internal errors.
      * This is targeted at users with technical knowledge of the lightning protocol.
      */
-    @Suppress("unused")
-    fun detailedSummary(): String = problems.foldIndexed("", { index, msg, problem ->
-        msg + "$index: ${problem.fold({ ex -> ex.message }, { f -> f.message })}\n"
+    fun details(): String = failures.foldIndexed("", { index, msg, problem ->
+        msg + "${index + 1}: ${problem.fold({ ex -> ex.message }, { f -> f.message })}\n"
     })
 
 }

--- a/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandler.kt
@@ -17,53 +17,34 @@ import fr.acinq.eclair.wire.*
 
 class OutgoingPaymentHandler(val nodeParams: NodeParams) {
 
-    // Only those result types that can possibly be returned from `OutgoingPaymentHandler.sendPayment()`
     sealed class SendPaymentResult {
+        /** A payment attempt has been made: we provide information about the fees we're paying, which may increase as we re-try our payment. */
+        data class Progress(val payment: SendPayment, val trampolineFees: MilliSatoshi, val actions: List<PeerEvent>) : SendPaymentResult()
 
-        // The `Progress` result is emitted throughout the payment attempt.
-        // It includes information about the fees we're paying, which may increase as we re-try our payment.
-        data class Progress(
-            val payment: SendPayment,
-            val trampolineFees: MilliSatoshi,
-            val actions: List<PeerEvent>
-        ) : SendPaymentResult()
-
-        data class Failure(
-            val payment: SendPayment,
-            val failure: OutgoingPaymentFailure
-        ) : SendPaymentResult()
+        /** The payment could not be sent. */
+        data class Failure(val payment: SendPayment, val failure: OutgoingPaymentFailure) : SendPaymentResult()
     }
 
-    // Only those result types that can possibly be returned from `OutgoingPaymentHandler.processXFailure()`
     sealed class ProcessFailureResult {
+        /** The payment has been retried: we provide information about the updated fees we're paying. */
+        data class Progress(val payment: SendPayment, val trampolineFees: MilliSatoshi, val actions: List<PeerEvent>) : ProcessFailureResult()
 
-        data class Progress(
-            val payment: SendPayment,
-            val trampolineFees: MilliSatoshi,
-            val actions: List<PeerEvent>
-        ) : ProcessFailureResult()
+        /** The payment could not be sent. */
+        data class Failure(val payment: SendPayment, val failure: OutgoingPaymentFailure) : ProcessFailureResult()
 
-        data class Failure(
-            val payment: SendPayment,
-            val failure: OutgoingPaymentFailure
-        ) : ProcessFailureResult()
-
+        /** The payment is unknown. */
         object UnknownPaymentFailure : ProcessFailureResult()
     }
 
     // Only those result types that can possibly be returned from `OutgoingPaymentHandler.processFulfill()`
     sealed class ProcessFulfillResult {
+        /** The payment was successfully made. */
+        data class Success(val payment: SendPayment, val trampolineFees: MilliSatoshi) : ProcessFulfillResult()
 
-        data class Success(
-            val payment: SendPayment,
-            val trampolineFees: MilliSatoshi
-        ) : ProcessFulfillResult()
+        /** The payment could not be sent. */
+        data class Failure(val payment: SendPayment, val failure: OutgoingPaymentFailure) : ProcessFulfillResult()
 
-        data class Failure(
-            val payment: SendPayment,
-            val failure: OutgoingPaymentFailure
-        ) : ProcessFulfillResult()
-
+        /** The payment is unknown. */
         object UnknownPaymentFailure : ProcessFulfillResult()
     }
 
@@ -72,16 +53,10 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams) {
      * If that fails, we increase the fee(s) and retry (up to a point).
      * This class encapsulates the increase that occurs at a particular retry.
      */
-    data class TrampolineParams(
-        val feeBaseSat: Satoshi,
-        val feePercent: Float,
-        val cltvExpiryDelta: CltvExpiryDelta
-    ) {
-        constructor(feeBaseSat: Long, feePercent: Float, cltvExpiryDelta: Int) :
-                this(Satoshi(feeBaseSat), feePercent, CltvExpiryDelta(cltvExpiryDelta))
+    data class TrampolineParams(val feeBaseSat: Satoshi, val feePercent: Float, val cltvExpiryDelta: CltvExpiryDelta) {
+        constructor(feeBaseSat: Long, feePercent: Float, cltvExpiryDelta: Int) : this(Satoshi(feeBaseSat), feePercent, CltvExpiryDelta(cltvExpiryDelta))
 
         companion object {
-
             // Todo: Fetch this from the server first, and have it passed into us somehow...
             val attempts = listOf(
                 TrampolineParams(0, 0.0f, 576),
@@ -136,8 +111,7 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams) {
         val failedChannelProblems: MutableList<Either<ChannelException, FailureMessage>>
 
         val trampolinePaymentSecret = Eclair.randomBytes32() // must be different from invoice.paymentSecret
-        val fees: MilliSatoshi
-            get() = trampolineParams.feeBaseSat.toMilliSatoshi() + (paymentAmount * trampolineParams.feePercent)
+        val fees: MilliSatoshi get() = trampolineParams.feeBaseSat.toMilliSatoshi() + (paymentAmount * trampolineParams.feePercent)
 
         private constructor(
             sendPayment: SendPayment,
@@ -182,49 +156,26 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams) {
 
     fun pendingPaymentAttempt(paymentId: UUID): PaymentAttempt? = pending[paymentId]
 
-    fun sendPayment(
-        sendPayment: SendPayment,
-        channels: Map<ByteVector32, ChannelState>,
-        currentBlockHeight: Int
-    ): SendPaymentResult {
-
+    fun sendPayment(sendPayment: SendPayment, channels: Map<ByteVector32, ChannelState>, currentBlockHeight: Int): SendPaymentResult {
         if (sendPayment.paymentAmount <= 0.msat) {
             logger.warning { "paymentAmount(${sendPayment.paymentAmount}) must be positive" }
-            return SendPaymentResult.Failure(
-                payment = sendPayment,
-                failure = OutgoingPaymentFailure.InvalidParameter.paymentAmount()
-            )
+            return SendPaymentResult.Failure(sendPayment, FailureReason.InvalidPaymentAmount.toPaymentFailure())
         }
         if (pending.containsKey(sendPayment.paymentId)) {
             logger.error { "contract violation: caller is recycling uuid's" }
-            return SendPaymentResult.Failure(
-                payment = sendPayment,
-                failure = OutgoingPaymentFailure.InvalidParameter.paymentId()
-            )
+            return SendPaymentResult.Failure(sendPayment, FailureReason.InvalidPaymentId.toPaymentFailure())
         }
 
         val paymentAttempt = PaymentAttempt(sendPayment)
         return when (val either = setupPaymentAttempt(paymentAttempt, channels, currentBlockHeight)) {
             is Either.Left -> SendPaymentResult.Failure(sendPayment, either.value)
-            is Either.Right -> SendPaymentResult.Progress(
-                payment = paymentAttempt.sendPayment,
-                trampolineFees = paymentAttempt.fees,
-                actions = either.value
-            )
+            is Either.Right -> SendPaymentResult.Progress(paymentAttempt.sendPayment, paymentAttempt.fees, either.value)
         }
     }
 
-    fun processLocalFailure(
-        event: WrappedChannelError,
-        channels: Map<ByteVector32, ChannelState>,
-        currentBlockHeight: Int
-    ): ProcessFailureResult? {
-
+    fun processLocalFailure(event: WrappedChannelError, channels: Map<ByteVector32, ChannelState>, currentBlockHeight: Int): ProcessFailureResult? {
         // We are looking for errors from the channel in response to our CMD_ADD_HTLC request
-        val cmdAddHtlc = (event.trigger as? ExecuteCommand)?.command as? CMD_ADD_HTLC
-        if (cmdAddHtlc == null) {
-            return null
-        }
+        val cmdAddHtlc = (event.trigger as? ExecuteCommand)?.command as? CMD_ADD_HTLC ?: return null
 
         val paymentAttempt = pending[cmdAddHtlc.paymentId]
         if (paymentAttempt == null) {
@@ -248,20 +199,11 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams) {
 
         return when (val either = setupPaymentAttempt(paymentAttempt, channels, currentBlockHeight)) {
             is Either.Left -> ProcessFailureResult.Failure(paymentAttempt.sendPayment, either.value)
-            is Either.Right -> ProcessFailureResult.Progress(
-                payment = paymentAttempt.sendPayment,
-                trampolineFees = paymentAttempt.fees,
-                actions = either.value
-            )
+            is Either.Right -> ProcessFailureResult.Progress(paymentAttempt.sendPayment, paymentAttempt.fees, either.value)
         }
     }
 
-    fun processRemoteFailure(
-        event: ProcessRemoteFailure,
-        channels: Map<ByteVector32, ChannelState>,
-        currentBlockHeight: Int
-    ): ProcessFailureResult {
-
+    fun processRemoteFailure(event: ProcessRemoteFailure, channels: Map<ByteVector32, ChannelState>, currentBlockHeight: Int): ProcessFailureResult {
         val paymentAttempt = pending[event.paymentId]
         if (paymentAttempt == null) {
             logger.error { "paymentId doesn't match any known payment attempt" }
@@ -292,41 +234,22 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams) {
         pending.remove(paymentAttempt.paymentId)
 
         if (!shouldRetry) {
-            return ProcessFailureResult.Failure(
-                payment = paymentAttempt.sendPayment,
-                failure = OutgoingPaymentFailure.make(
-                    reason = OutgoingPaymentFailure.Reason.OTHER_ERROR,
-                    problems = paymentAttempt.allProblems()
-                )
-            )
+            return ProcessFailureResult.Failure(paymentAttempt.sendPayment, OutgoingPaymentFailure(FailureReason.UnknownError, paymentAttempt.allProblems()))
         }
 
         // increment failedAttempts, and jump to next TrampolineParams (if possible)
         val nextPaymentAttempt = paymentAttempt.nextPaymentAttempt()
         if (nextPaymentAttempt == null) {
-            return ProcessFailureResult.Failure(
-                payment = paymentAttempt.sendPayment,
-                failure = OutgoingPaymentFailure.make(
-                    reason = OutgoingPaymentFailure.Reason.NO_ROUTE_TO_RECIPIENT,
-                    problems = paymentAttempt.allProblems()
-                )
-            )
+            return ProcessFailureResult.Failure(paymentAttempt.sendPayment, OutgoingPaymentFailure(FailureReason.NoRouteToRecipient, paymentAttempt.allProblems()))
         }
 
         return when (val either = setupPaymentAttempt(nextPaymentAttempt, channels, currentBlockHeight)) {
             is Either.Left -> ProcessFailureResult.Failure(nextPaymentAttempt.sendPayment, either.value)
-            is Either.Right -> ProcessFailureResult.Progress(
-                payment = nextPaymentAttempt.sendPayment,
-                trampolineFees = nextPaymentAttempt.fees,
-                actions = either.value
-            )
+            is Either.Right -> ProcessFailureResult.Progress(nextPaymentAttempt.sendPayment, nextPaymentAttempt.fees, either.value)
         }
     }
 
-    fun processFulfill(
-        event: ProcessFulfill
-    ): ProcessFulfillResult {
-
+    fun processFulfill(event: ProcessFulfill): ProcessFulfillResult {
         val paymentAttempt = pending[event.paymentId]
         if (paymentAttempt == null) {
             logger.error { "paymentId doesn't match any known payment attempt" }
@@ -334,64 +257,33 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams) {
         }
 
         pending.remove(paymentAttempt.paymentId)
-        return ProcessFulfillResult.Success(
-            payment = paymentAttempt.sendPayment,
-            trampolineFees = paymentAttempt.fees
-        )
+        return ProcessFulfillResult.Success(paymentAttempt.sendPayment, paymentAttempt.fees)
     }
 
-    private fun setupPaymentAttempt(
-        paymentAttempt: PaymentAttempt,
-        channels: Map<ByteVector32, ChannelState>,
-        currentBlockHeight: Int
-    ): Either<OutgoingPaymentFailure, List<PeerEvent>> {
-
+    private fun setupPaymentAttempt(paymentAttempt: PaymentAttempt, channels: Map<ByteVector32, ChannelState>, currentBlockHeight: Int): Either<OutgoingPaymentFailure, List<PeerEvent>> {
         // Channels have a balance & capacity, but they also have other limits.
         // And these other limits affect a channel's ability to send a payment.
-        data class ChannelState(
-            val availableForSend: MilliSatoshi,
-            val htlcMinimumMsat: MilliSatoshi
-        )
+        data class ChannelState(val availableForSend: MilliSatoshi, val htlcMinimumMsat: MilliSatoshi)
 
         val sortedChannels = channels.values.filterIsInstance<Normal>().filterNot {
             // exclude any channels that have previously failed
             paymentAttempt.failedChannelIds.contains(it.channelId)
         }.map {
-            Pair(
-                it, ChannelState(
-                    availableForSend = it.commitments.availableBalanceForSend(),
-                    htlcMinimumMsat = it.commitments.remoteParams.htlcMinimum
-                )
-            )
+            Pair(it, ChannelState(it.commitments.availableBalanceForSend(), it.commitments.remoteParams.htlcMinimum))
         }.sortedBy {
             it.second.availableForSend
         }.reversed()
 
         if (sortedChannels.isEmpty()) {
-            return Either.Left(
-                OutgoingPaymentFailure.make(
-                    reason = OutgoingPaymentFailure.Reason.NO_AVAILABLE_CHANNELS,
-                    problems = paymentAttempt.allProblems()
-                )
-            )
+            return Either.Left(OutgoingPaymentFailure(FailureReason.NoAvailableChannels, paymentAttempt.allProblems()))
         }
 
         val totalAvailableForSend = sortedChannels.map { it.second.availableForSend }.sum()
         if (paymentAttempt.paymentAmount > totalAvailableForSend) {
-            return Either.Left(
-                OutgoingPaymentFailure.make(
-                    reason = OutgoingPaymentFailure.Reason.INSUFFICIENT_BALANCE_BASE,
-                    problems = paymentAttempt.allProblems()
-                )
-            )
+            return Either.Left(OutgoingPaymentFailure(FailureReason.InsufficientBalanceBase, paymentAttempt.allProblems()))
         }
         if (paymentAttempt.paymentAmount + paymentAttempt.fees > totalAvailableForSend) {
-            return Either.Left(
-                OutgoingPaymentFailure.make(
-                    reason = OutgoingPaymentFailure.Reason.INSUFFICIENT_BALANCE_FEES,
-                    problems = paymentAttempt.allProblems()
-                )
-            )
+            return Either.Left(OutgoingPaymentFailure(FailureReason.InsufficientBalanceFees, paymentAttempt.allProblems()))
         }
 
         // Phase 1: No mpp.
@@ -404,18 +296,9 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams) {
         }
         if (filteredChannels.isEmpty()) {
             val closest = sortedChannels.maxByOrNull { it.second.htlcMinimumMsat }!!
-            val channelException = HtlcValueTooSmall(
-                channelId = closest.first.channelId,
-                minimum = closest.second.htlcMinimumMsat,
-                actual = amountToSend
-            )
+            val channelException = HtlcValueTooSmall(closest.first.channelId, closest.second.htlcMinimumMsat, amountToSend)
             paymentAttempt.problems.add(Either.Left(channelException))
-            return Either.Left(
-                OutgoingPaymentFailure.make(
-                    reason = OutgoingPaymentFailure.Reason.OTHER_ERROR,
-                    problems = paymentAttempt.allProblems()
-                )
-            )
+            return Either.Left(OutgoingPaymentFailure(FailureReason.UnknownError, paymentAttempt.allProblems()))
         }
 
         val selectedChannel = filteredChannels.first()
@@ -435,24 +318,14 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams) {
      * - Creating the CMD_ADD_HTLC
      * - Creating the WrappedChannelEvent
      */
-    private fun createHtlc(
-        channel: Normal,
-        paymentAttempt: PaymentAttempt,
-        currentBlockHeight: Int
-    ): WrappedChannelEvent {
-
-        val finalExpiryDelta = paymentAttempt.invoice.minFinalExpiryDelta
-            ?: Channel.MIN_CLTV_EXPIRY_DELTA // default value if unspecified, as per Bolt 11
+    private fun createHtlc(channel: Normal, paymentAttempt: PaymentAttempt, currentBlockHeight: Int): WrappedChannelEvent {
+        val finalExpiryDelta = paymentAttempt.invoice.minFinalExpiryDelta ?: Channel.MIN_CLTV_EXPIRY_DELTA // default value if unspecified, as per Bolt 11
         val finalExpiry = finalExpiryDelta.toCltvExpiry(currentBlockHeight.toLong())
 
         val features = paymentAttempt.invoice.features?.let { Features(it) } ?: Features(setOf())
         val recipientSupportsTrampoline = features.hasFeature(Feature.TrampolinePayment)
 
-        val finalPayload = FinalPayload.createSinglePartPayload(
-            amount = paymentAttempt.paymentAmount,
-            expiry = finalExpiry,
-            paymentSecret = paymentAttempt.invoice.paymentSecret
-        )
+        val finalPayload = FinalPayload.createSinglePartPayload(paymentAttempt.paymentAmount, finalExpiry, paymentAttempt.invoice.paymentSecret)
         val nodeHops = listOf(
             NodeHop(
                 nodeId = channel.staticParams.nodeParams.nodeId, // us
@@ -470,28 +343,13 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams) {
 
         val (trampolineAmount, trampolineExpiry, trampolineOnion) = if (recipientSupportsTrampoline) {
             // Full trampoline! Full privacy!
-            OutgoingPacket.buildPacket(
-                paymentHash = paymentAttempt.invoice.paymentHash,
-                hops = nodeHops,
-                finalPayload = finalPayload,
-                payloadLength = OnionRoutingPacket.TrampolinePacketLength
-            )
+            OutgoingPacket.buildPacket(paymentAttempt.invoice.paymentHash, nodeHops, finalPayload, OnionRoutingPacket.TrampolinePacketLength)
         } else {
             // Legacy workaround
-            OutgoingPacket.buildTrampolineToLegacyPacket(
-                invoice = paymentAttempt.invoice,
-                hops = nodeHops,
-                finalPayload = finalPayload
-            )
+            OutgoingPacket.buildTrampolineToLegacyPacket(paymentAttempt.invoice, nodeHops, finalPayload)
         }
 
-        val trampolinePayload = FinalPayload.createTrampolinePayload(
-            amount = trampolineAmount,
-            totalAmount = trampolineAmount,
-            expiry = trampolineExpiry,
-            paymentSecret = paymentAttempt.trampolinePaymentSecret,
-            trampolinePacket = trampolineOnion.packet
-        )
+        val trampolinePayload = FinalPayload.createTrampolinePayload(trampolineAmount, trampolineAmount, trampolineExpiry, paymentAttempt.trampolinePaymentSecret, trampolineOnion.packet)
 
         val channelHops: List<ChannelHop> = listOf(
             ChannelHop(
@@ -500,22 +358,10 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams) {
                 lastUpdate = channel.channelUpdate
             )
         )
-        val (cmdAddHtlc, secrets) = OutgoingPacket.buildCommand(
-            paymentId = paymentAttempt.paymentId,
-            paymentHash = paymentAttempt.invoice.paymentHash,
-            hops = channelHops,
-            finalPayload = trampolinePayload
-        )
-
-        val part = TrampolinePaymentPart(
-            channelId = channel.channelId,
-            amount = trampolineAmount,
-            trampolineFees = paymentAttempt.fees,
-            cltvExpiryDelta = paymentAttempt.trampolineParams.cltvExpiryDelta,
-            secrets = secrets
-        )
+        val (cmdAddHtlc, secrets) = OutgoingPacket.buildCommand(paymentAttempt.paymentId, paymentAttempt.invoice.paymentHash, channelHops, trampolinePayload)
+        val part = TrampolinePaymentPart(channel.channelId, trampolineAmount, paymentAttempt.fees, paymentAttempt.trampolineParams.cltvExpiryDelta, secrets)
         paymentAttempt.parts.add(part)
 
-        return WrappedChannelEvent(channelId = channel.channelId, channelEvent = ExecuteCommand(cmdAddHtlc))
+        return WrappedChannelEvent(channel.channelId, ExecuteCommand(cmdAddHtlc))
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/eclair/payment/OutgoingPaymentFailureTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/payment/OutgoingPaymentFailureTestsCommon.kt
@@ -1,0 +1,50 @@
+package fr.acinq.eclair.payment
+
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.eclair.channel.TooManyAcceptedHtlcs
+import fr.acinq.eclair.tests.utils.EclairTestSuite
+import fr.acinq.eclair.utils.Either
+import fr.acinq.eclair.wire.PaymentTimeout
+import fr.acinq.eclair.wire.TemporaryNodeFailure
+import fr.acinq.eclair.wire.UnknownNextPeer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OutgoingPaymentFailureTestsCommon : EclairTestSuite() {
+
+    @Test
+    fun `identify common route failures`() {
+        val failure = OutgoingPaymentFailure(
+            FailureReason.InsufficientBalanceBase,
+            listOf(
+                Either.Right(TemporaryNodeFailure),
+                Either.Right(UnknownNextPeer),
+                Either.Left(TooManyAcceptedHtlcs(ByteVector32.Zeroes, 42))
+            )
+        )
+        assertEquals(failure.message(), "Unable to route payment to recipient.")
+    }
+
+    @Test
+    fun `defaults to simple message`() {
+        val failure = OutgoingPaymentFailure(FailureReason.InsufficientBalanceBase, listOf(Either.Right(PaymentTimeout)))
+        assertEquals(failure.message(), "Not enough funds in wallet to afford payment.")
+    }
+
+    @Test
+    fun `prints technical details`() {
+        val failure = OutgoingPaymentFailure(
+            FailureReason.InsufficientBalanceBase,
+            listOf(
+                Either.Right(TemporaryNodeFailure),
+                Either.Right(UnknownNextPeer),
+                Either.Left(TooManyAcceptedHtlcs(ByteVector32.Zeroes, 42))
+            )
+        )
+        val expected = "1: general temporary failure of the processing node\n" +
+                "2: processing node does not know the next peer in the route\n" +
+                "3: too many accepted htlcs: maximum=42\n"
+        assertEquals(failure.details(), expected)
+    }
+
+}


### PR DESCRIPTION
Move OutgoingPaymentFailure to its own file.

Fix payment failure model: we cannot rely on the top-level reason to be the most accurate message for the user. In most cases earlier failures are better indicators of the message we want to display.
    
Reformatted files as well to match the rest of the project.