### PR TITLE
Add build option to display test results in the console

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           java-version: 11
       - name: Check with integration
         if: matrix.os == 'ubuntu-latest'
-        run: ./gradlew check -PintegrationTests=include
+        run: ./gradlew check -PintegrationTests=include -PverboseTests=ON
       - name: Check without integration
         if: matrix.os != 'ubuntu-latest'
-        run: ./gradlew check
+        run: ./gradlew check -PverboseTests=ON

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -147,11 +147,12 @@ afterEvaluate {
 
 afterEvaluate {
     tasks.withType<AbstractTestTask>() {
+        val verboseTests = project.findProperty("verboseTests") == "ON"
         testLogging {
             events("skipped", "failed")
             showExceptions = true
             showStackTraces = true
-            showStandardStreams = false
+            showStandardStreams = verboseTests
         }
     }
 }


### PR DESCRIPTION
Gradle builds will not log test outputs unless gradle is launched with -PverboseTests=ON.
This option is explicitly set on github CI to help debugging failing tests.