### PR TITLE
LigthningMessage encoding is not nullable

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -210,7 +210,7 @@ class Peer(
                 }
             }
             logger.info { "sending init $ourInit" }
-            send(LightningMessage.encode(ourInit) ?: error("cannot serialize $ourInit"))
+            send(LightningMessage.encode(ourInit))
 
             suspend fun doPing() {
                 val ping = Hex.decode("0012000a0004deadbeef")
@@ -265,10 +265,8 @@ class Peer(
 
     private suspend fun sendToPeer(msg: LightningMessage) {
         val encoded = LightningMessage.encode(msg)
-        encoded?.let { bin ->
-            logger.info { "sending $msg encoded as ${Hex.encode(bin)}" }
-            output.send(bin)
-        }
+        logger.info { "sending $msg encoded as ${Hex.encode(encoded)}" }
+        output.send(encoded)
     }
 
     private suspend fun processActions(channelId: ByteVector32, actions: List<ChannelAction>) {
@@ -418,7 +416,7 @@ class Peer(
                     }
                     msg is Ping -> {
                         val pong = Pong(ByteVector(ByteArray(msg.pongLength)))
-                        output.send(LightningMessage.encode(pong)!!)
+                        output.send(LightningMessage.encode(pong))
                     }
                     msg is Pong -> {
                         logger.debug { "received pong" }

--- a/src/commonMain/kotlin/fr/acinq/eclair/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/wire/LightningMessages.kt
@@ -69,14 +69,11 @@ interface LightningMessage {
                     @Suppress("UNCHECKED_CAST")
                     (LightningSerializer.writeBytes((input.serializer() as LightningSerializer<LightningSerializable<*>>).write(input), out))
                 }
-                else -> {
-                    logger.warning { "cannot encode $input" }
-                    Unit
-                }
+                else -> logger.warning { "cannot encode $input" }
             }
         }
 
-        fun encode(input: LightningMessage): ByteArray? {
+        fun encode(input: LightningMessage): ByteArray {
             val out = ByteArrayOutput()
             encode(input, out)
             return out.toByteArray()
@@ -158,7 +155,7 @@ data class Init(@Serializable(with = ByteVectorKSerializer::class) val features:
             writeBytes(message.features, out)
             val serializers = HashMap<Long, LightningSerializer<InitTlv>>()
             @Suppress("UNCHECKED_CAST")
-            serializers.put(InitTlv.Networks.tag.toLong(), InitTlv.Networks.Companion as LightningSerializer<InitTlv>)
+            serializers.put(InitTlv.Networks.tag, InitTlv.Networks.Companion as LightningSerializer<InitTlv>)
             val serializer = TlvStreamSerializer<InitTlv>(false, serializers)
             serializer.write(message.tlvs, out)
         }
@@ -305,7 +302,7 @@ data class OpenChannel(
             writeU64(message.fundingSatoshis.toLong(), out)
             writeU64(message.pushMsat.toLong(), out)
             writeU64(message.dustLimitSatoshis.toLong(), out)
-            writeU64(message.maxHtlcValueInFlightMsat.toLong(), out)
+            writeU64(message.maxHtlcValueInFlightMsat, out)
             writeU64(message.channelReserveSatoshis.toLong(), out)
             writeU64(message.htlcMinimumMsat.toLong(), out)
             writeU32(message.feeratePerKw.toLong().toInt(), out)
@@ -381,7 +378,7 @@ data class AcceptChannel(
 
             writeBytes(message.temporaryChannelId, out)
             writeU64(message.dustLimitSatoshis.toLong(), out)
-            writeU64(message.maxHtlcValueInFlightMsat.toLong(), out)
+            writeU64(message.maxHtlcValueInFlightMsat, out)
             writeU64(message.channelReserveSatoshis.toLong(), out)
             writeU64(message.htlcMinimumMsat.toLong(), out)
             writeU32(message.minimumDepth.toInt(), out)

--- a/src/commonTest/kotlin/fr/acinq/eclair/wire/LightningSerializerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/wire/LightningSerializerTestsCommon.kt
@@ -4,7 +4,6 @@ import fr.acinq.bitcoin.*
 import fr.acinq.bitcoin.io.ByteArrayInput
 import fr.acinq.bitcoin.io.ByteArrayOutput
 import fr.acinq.eclair.CltvExpiryDelta
-import fr.acinq.eclair.Eclair
 import fr.acinq.eclair.Eclair.randomBytes
 import fr.acinq.eclair.Eclair.randomBytes32
 import fr.acinq.eclair.Eclair.randomBytes64
@@ -345,7 +344,7 @@ class LightningSerializerTestsCommon : EclairTestSuite() {
                 ByteVector.empty
             )
             assertEquals(expected, decoded)
-            val reencoded = LightningMessage.encode(decoded)!!
+            val reencoded = LightningMessage.encode(decoded)
             assertArrayEquals(bin, reencoded)
         }
     }
@@ -362,7 +361,7 @@ class LightningSerializerTestsCommon : EclairTestSuite() {
                 ByteVector("0101010101010101")
             )
             assertEquals(expected, decoded)
-            val reencoded = LightningMessage.encode(decoded)!!
+            val reencoded = LightningMessage.encode(decoded)
             assertArrayEquals(bin, reencoded)
         }
     }
@@ -380,7 +379,7 @@ class LightningSerializerTestsCommon : EclairTestSuite() {
                 ByteArray(1300) { 1.toByte() }.toByteVector()
             )
             assertEquals(expected, decoded)
-            val reencoded = LightningMessage.encode(decoded)!!
+            val reencoded = LightningMessage.encode(decoded)
             assertArrayEquals(bin, reencoded)
         }
     }
@@ -394,7 +393,7 @@ class LightningSerializerTestsCommon : EclairTestSuite() {
             PrivateKey.fromHex("34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55"),
             PublicKey.fromHex("02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867")
         )
-        val encoded = LightningMessage.encode(channelReestablish)!!
+        val encoded = LightningMessage.encode(channelReestablish)
         val expected =
             "0088c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c000000000003b49a000000000000002a34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b5502bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867"
         assertEquals(expected, Hex.encode(encoded))
@@ -403,8 +402,8 @@ class LightningSerializerTestsCommon : EclairTestSuite() {
     @Test
     fun `encode - decode channel_update`() {
         val channelUpdate = ChannelUpdate(
-            Eclair.randomBytes64(),
-            Eclair.randomBytes32(),
+            randomBytes64(),
+            randomBytes32(),
             ShortChannelId(561),
             1105,
             0,
@@ -415,7 +414,7 @@ class LightningSerializerTestsCommon : EclairTestSuite() {
             10,
             null
         )
-        val encoded = LightningMessage.encode(channelUpdate)!!
+        val encoded = LightningMessage.encode(channelUpdate)
         val decoded = LightningMessage.decode(encoded)
         assertEquals(channelUpdate, decoded)
     }
@@ -440,15 +439,15 @@ class LightningSerializerTestsCommon : EclairTestSuite() {
             980000000.msat
         )
         assertEquals(expected, decoded)
-        val reEncoded = LightningMessage.encode(decoded)!!.toByteVector()
+        val reEncoded = LightningMessage.encode(decoded).toByteVector()
         assertEquals(encoded, reEncoded)
     }
 
     @Test
     fun `encode - decode channel_update with unknown trailing bytes`() {
         val channelUpdate = ChannelUpdate(
-            Eclair.randomBytes64(),
-            Eclair.randomBytes32(),
+            randomBytes64(),
+            randomBytes32(),
             ShortChannelId(561),
             1105,
             0,
@@ -460,7 +459,7 @@ class LightningSerializerTestsCommon : EclairTestSuite() {
             null,
             ByteVector("010203")
         )
-        val encoded = LightningMessage.encode(channelUpdate)!!
+        val encoded = LightningMessage.encode(channelUpdate)
         val decoded = LightningMessage.decode(encoded)
         assertEquals(channelUpdate, decoded)
     }
@@ -521,7 +520,7 @@ class LightningSerializerTestsCommon : EclairTestSuite() {
         refs.forEach {
             val decoded = LightningMessage.decode(it.key.first + it.key.second)
             assertEquals(it.value, decoded)
-            val encoded = LightningMessage.encode(it.value)!!
+            val encoded = LightningMessage.encode(it.value)
             assertArrayEquals(it.key.first, encoded)
         }
     }


### PR DESCRIPTION
The signature was invalid, there was no case where this could be null.