### PR TITLE
Return "unknown" channel when we cannot decrypt peer backup data

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -482,7 +482,8 @@ class Peer(
                                     _channels = _channels + (msg.channelId to state3)
                                 }
                                 is Try.Failure -> {
-                                    logger.error(decrypted.error) { "failed to restore channelId=${msg.channelId}" }
+                                    logger.error(decrypted.error) { "failed to restore channelId=${msg.channelId} from peer backup" }
+                                    sendToPeer(Error(msg.channelId, "unknown channel"))
                                 }
                             }
                         }


### PR DESCRIPTION
Here we don't have a local backup and we cannot decrypt what our peer sent us, returning "unknown channel" is the best we can do (if we do nothing we'd get stuck in `Syncing` state).