### PR TITLE
Fix: enable breakpoints when debugging files with lazy delegates

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/utils/breakpointWorkaround.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/utils/breakpointWorkaround.kt
@@ -1,0 +1,10 @@
+package fr.acinq.eclair.utils
+
+import kotlin.reflect.KProperty
+
+/*
+    Workaround for "MPP: Can't stop on breakpoint anywhere in file if it contains lazy"
+    https://youtrack.jetbrains.com/issue/KT-41471
+    To be removed when fixed...
+ */
+operator fun <T> Lazy<T>.getValue(thisRef: Any?, property: KProperty<*>) = value

--- a/src/commonMain/kotlin/fr/acinq/eclair/utils/logger.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/utils/logger.kt
@@ -23,9 +23,3 @@ fun eclairLogger(of: KClass<*>) = lazy {
 inline fun <reified T> T.eclairLogger() = eclairLogger(T::class)
 
 inline fun <reified T> eclairLogger() = eclairLogger(T::class)
-
-/*
-    Workaround for "MPP: Can't stop on breakpoint anywhere in file if it contains lazy"
-    https://youtrack.jetbrains.com/issue/KT-41471
- */
-operator fun <T> Lazy<T>.getValue(thisRef: Any?, property: KProperty<*>) = value


### PR DESCRIPTION
Before:

<img width="533" alt="Screenshot 2020-12-07 at 15 23 22" src="https://user-images.githubusercontent.com/10594945/101362466-6d9f2080-38a0-11eb-8e34-d5bf0cb402b7.png">

After:

<img width="533" alt="Screenshot 2020-12-07 at 15 24 37" src="https://user-images.githubusercontent.com/10594945/101362483-73950180-38a0-11eb-846f-6703aba61513.png">
