### PR TITLE
Add missing Normal/Shutdown/Negotiating tests

### DIFF
--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/NegotiatingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/NegotiatingTestsCommon.kt
@@ -9,6 +9,7 @@ import fr.acinq.eclair.MilliSatoshi
 import fr.acinq.eclair.blockchain.*
 import fr.acinq.eclair.channel.*
 import fr.acinq.eclair.channel.TestsHelper.mutualClose
+import fr.acinq.eclair.tests.TestConstants
 import fr.acinq.eclair.tests.utils.EclairTestSuite
 import fr.acinq.eclair.utils.msat
 import fr.acinq.eclair.utils.sat
@@ -124,7 +125,6 @@ class NegotiatingTestsCommon : EclairTestSuite() {
         actions.hasOutgoingMessage<Error>()
         actions.hasWatch<WatchConfirmed>()
         actions.findTxs().contains(bob.commitments.localCommit.publishableTxs.commitTx.tx)
-        println(actions)
     }
 
     @Test
@@ -146,7 +146,7 @@ class NegotiatingTestsCommon : EclairTestSuite() {
 
     companion object {
         fun init(tweakFees: Boolean = false, pushMsat: MilliSatoshi = TestConstants.pushMsat): Triple<Negotiating, Negotiating, ClosingSigned> {
-            val (alice, bob) = pushMsat?.let { TestsHelper.reachNormal(pushMsat = it) } ?: TestsHelper.reachNormal()
+            val (alice, bob) = TestsHelper.reachNormal(pushMsat = pushMsat)
             return mutualClose(alice, bob, tweakFees)
         }
 

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/NormalTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/NormalTestsCommon.kt
@@ -1387,7 +1387,7 @@ class NormalTestsCommon : EclairTestSuite() {
         val (_, actions4) = bob1.process(ChannelEvent.MessageReceived(commitSig))
         val revack = actions4.findOutgoingMessage<RevokeAndAck>()
 
-        // as soon as alice as received the revocation, she will send her shutdown message
+        // as soon as alice has received the revocation, she will send her shutdown message
         val (alice3, actions5) = alice2.process(ChannelEvent.MessageReceived(revack))
         assertTrue(alice3 is ShuttingDown)
         actions5.hasOutgoingMessage<Shutdown>()

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ShutdownTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ShutdownTestsCommon.kt
@@ -301,13 +301,11 @@ class ShutdownTestsCommon : EclairTestSuite() {
 
         val txs = actions.filterIsInstance<ChannelAction.Blockchain.PublishTx>().map { it.tx }
         assertEquals(6, txs.size)
-        // alice can only claim 3 out of 4 htlcs, she can't do anything regarding the htlc sent by bob for which she does not have the htlc
-        // so we expect 8 transactions:
+        // alice has sent 2 htlcs so we expect 6 transactions:
         // - alice's current commit tx
         // - 1 tx to claim the main delayed output
         // - 2 txes for each htlc
         // - 2 txes for each delayed output of the claimed htlc
-
         assertEquals(aliceCommitTx.tx, txs[0])
         assertEquals(aliceCommitTx.tx.txOut.size, 6) // 2 anchor outputs + 2 main output + 2 pending htlcs
         // the main delayed output spends the commitment transaction


### PR DESCRIPTION
This PR Implements some of the items in #147:
- Normal state shutdown / CMD_CLOSE tests
- Shutdown/Negotiating/Closing tests