### PR TITLE
Use coroutine v1.4.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
     fun ktor(module: String) = "io.ktor:ktor-$module:$ktorVersion"
     val secp256k1Version = "0.4.1"
     val serializationVersion = "1.0.0"
-    val coroutineVersion = "1.4.2"
+    val coroutineVersion = "1.4.2-native-mt"
 
     val commonMain by sourceSets.getting {
         dependencies {


### PR DESCRIPTION
### Changes from 1.3.9:
- [Some breaking changes](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.4.0-M1) that do not seem to affect us
- quite a few bug fixes which don't harm

I think it's better to upgrade sooner than later. Tests run fine.

### About the `-native-mt` suffix

According to the [official documentation](https://kotlinlang.org/docs/reference/whatsnew14.html#specifying-dependencies-only-once), suffixes are not supported anymore:

> Don’t use kotlinx library artifact names with suffixes specifying the platform, such as -common, -native, or similar, as they are NOT supported anymore.

So if I understand correctly we should directly use version `1.4.2` and not `1.4.2-native-mt`.

---
Edit: Turns out using `1.4.2` causes issues on MacOS/iOS (`kotlin.IllegalStateException: There is no event loop. Use runBlocking { ... } to start one.`) which is fixed by using the native suffix.