### PR TITLE
ElectrumClient / Peer : allow connect function to provide a specific TcpSocket.Builder

### DIFF
--- a/eclair-kmp-test-fixtures/src/commonMain/kotlin/fr/acinq/eclair/tests/io/peer/builders.kt
+++ b/eclair-kmp-test-fixtures/src/commonMain/kotlin/fr/acinq/eclair/tests/io/peer/builders.kt
@@ -169,9 +169,9 @@ public fun buildPeer(
     walletParams: WalletParams,
     databases: InMemoryDatabases = InMemoryDatabases()
 ): Peer {
-    val electrum = ElectrumClient(TcpSocket.Builder(), scope)
+    val electrum = ElectrumClient(scope)
     val watcher = ElectrumWatcher(electrum, scope)
-    val peer = Peer(TcpSocket.Builder(), nodeParams, walletParams, watcher, databases, scope)
+    val peer = Peer(nodeParams, walletParams, watcher, databases, scope)
     peer.currentTipFlow.value = 0 to Block.RegtestGenesisBlock.header
     peer.onChainFeeratesFlow.value = OnChainFeerates(
         mutualCloseFeerate = FeeratePerKw(FeeratePerByte(20.sat)),

--- a/src/commonTest/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumClientIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumClientIntegrationTest.kt
@@ -46,7 +46,7 @@ class ElectrumClientIntegrationTest : EclairTestSuite() {
 
     private suspend fun CoroutineScope.connectToMainnetServer(): ElectrumClient {
         val client =
-            ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES)) }
+            ElectrumClient(this).apply { connect(ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES)) }
 
         client.connectionState.first { it == Connection.CLOSED }
         client.connectionState.first { it == Connection.ESTABLISHING }

--- a/src/commonTest/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumClientStateTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumClientStateTest.kt
@@ -7,7 +7,6 @@ import fr.acinq.eclair.utils.Connection
 import fr.acinq.eclair.utils.ServerAddress
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertTrue
 
 class ElectrumClientStateTest : EclairTestSuite() {
@@ -27,7 +26,10 @@ class ElectrumClientStateTest : EclairTestSuite() {
             assertTrue { actions.isEmpty() }
         }
 
-        WaitingForConnection.process(Start(ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES))).let { (newState, actions) ->
+        WaitingForConnection.process(Start(
+            ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES),
+            TcpSocket.Builder()
+        )).let { (newState, actions) ->
             assertEquals(WaitingForConnection, newState)
             assertTrue { actions.isEmpty() }
         }
@@ -54,7 +56,10 @@ class ElectrumClientStateTest : EclairTestSuite() {
 
     @Test
     fun `ClientClosed state`() {
-        ClientClosed.process(Start(ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES))).let { (newState, actions) ->
+        ClientClosed.process(Start(
+            ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES),
+            TcpSocket.Builder()
+        )).let { (newState, actions) ->
             assertEquals(WaitingForConnection, newState)
             assertEquals(2, actions.size)
             assertTrue(actions[0] is BroadcastStatus)

--- a/src/commonTest/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
@@ -47,7 +47,7 @@ class ElectrumWatcherIntegrationTest : EclairTestSuite() {
 
     @Test
     fun `watch for confirmed transactions`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(this).apply { connect(ServerAddress("localhost", 51001, null)) }
         val watcher = ElectrumWatcher(client, this)
 
         val (address, _) = bitcoincli.getNewAddress()
@@ -74,7 +74,7 @@ class ElectrumWatcherIntegrationTest : EclairTestSuite() {
 
     @Test
     fun `watch for confirmed transactions created while being offline`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(this).apply { connect(ServerAddress("localhost", 51001, null)) }
         val watcher = ElectrumWatcher(client, this)
 
         val (address, _) = bitcoincli.getNewAddress()
@@ -102,7 +102,7 @@ class ElectrumWatcherIntegrationTest : EclairTestSuite() {
 
     @Test
     fun `watch for spent transactions`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(this).apply { connect(ServerAddress("localhost", 51001, null)) }
         val watcher = ElectrumWatcher(client, this)
 
         val (address, privateKey) = bitcoincli.getNewAddress()
@@ -159,7 +159,7 @@ class ElectrumWatcherIntegrationTest : EclairTestSuite() {
 
     @Test
     fun `watch for spent transactions before client is connected`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this)
+        val client = ElectrumClient(this)
         val watcher = ElectrumWatcher(client, this)
 
         val (address, privateKey) = bitcoincli.getNewAddress()
@@ -218,7 +218,7 @@ class ElectrumWatcherIntegrationTest : EclairTestSuite() {
 
     @Test
     fun `watch for spent transactions while being offline`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(this).apply { connect(ServerAddress("localhost", 51001, null)) }
         val watcher = ElectrumWatcher(client, this)
 
         val (address, privateKey) = bitcoincli.getNewAddress()
@@ -277,7 +277,7 @@ class ElectrumWatcherIntegrationTest : EclairTestSuite() {
 
     @Test
     fun `watch for mempool transactions (txs in mempool before we set the watch)`() = runSuspendTest(timeout = 50.seconds) {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(this).apply { connect(ServerAddress("localhost", 51001, null)) }
         val watcher = ElectrumWatcher(client, this)
 
         val (address, privateKey) = bitcoincli.getNewAddress()
@@ -322,7 +322,7 @@ class ElectrumWatcherIntegrationTest : EclairTestSuite() {
 
     @Test
     fun `watch for mempool transactions (txs not yet in the mempool when we set the watch)`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(this).apply { connect(ServerAddress("localhost", 51001, null)) }
         val watcher = ElectrumWatcher(client, this)
 
         val (address, privateKey) = bitcoincli.getNewAddress()
@@ -355,7 +355,7 @@ class ElectrumWatcherIntegrationTest : EclairTestSuite() {
 
     @Test
     fun `publish transactions with relative and absolute delays`() = runSuspendTest(timeout = 2.minutes) {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(this).apply { connect(ServerAddress("localhost", 51001, null)) }
         val watcher = ElectrumWatcher(client, this)
         val watcherNotifications = watcher.openWatchNotificationsSubscription()
 
@@ -479,7 +479,7 @@ class ElectrumWatcherIntegrationTest : EclairTestSuite() {
     @Test
     fun `get transaction`() = runSuspendTest(timeout = 50.seconds) {
         // Run on a production server
-        val electrumClient = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES)) }
+        val electrumClient = ElectrumClient(this).apply { connect(ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES)) }
         val electrumWatcher = ElectrumWatcher(electrumClient, this)
 
         delay(1_000) // Wait for the electrum client to be ready

--- a/src/jvmTest/kotlin/fr/acinq/eclair/Node.kt
+++ b/src/jvmTest/kotlin/fr/acinq/eclair/Node.kt
@@ -208,9 +208,9 @@ object Node {
         }
 
         runBlocking {
-            val electrum = ElectrumClient(TcpSocket.Builder(), this).apply { connect(electrumServerAddress) }
+            val electrum = ElectrumClient(this).apply { connect(electrumServerAddress) }
             val watcher = ElectrumWatcher(electrum, this)
-            val peer = Peer(TcpSocket.Builder(), nodeParams, walletParams, watcher, db, this)
+            val peer = Peer(nodeParams, walletParams, watcher, db, this)
 
             launch { connectLoop(peer) }
 


### PR DESCRIPTION
This will allow to provide specific implementation of `TcpSocket.Builder`, in the case of Phoenix-KMM this will allow us to swap the connection from regular TCP to Tor routage without recreating (almost) everything (ElectrumClient + Peer).