### PR TITLE
Channel: do check for timed-out HTLCs until explicitly told to do so

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/serialization/v1/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/serialization/v1/ChannelState.kt
@@ -446,7 +446,7 @@ data class WaitForRemotePublishFutureCommitment(
     )
 
     override fun export(nodeParams: NodeParams) =
-        fr.acinq.eclair.channel.WaitForRemotePublishFutureCommitment(staticParams.export(nodeParams), currentTip, currentOnChainFeerates.export(), commitments.export(), remoteChannelReestablish)
+        fr.acinq.eclair.channel.WaitForRemotePublishFutureCommitment(staticParams.export(nodeParams), currentTip, currentOnChainFeerates.export(), false, commitments.export(), remoteChannelReestablish)
 }
 
 @Serializable
@@ -684,6 +684,7 @@ data class Normal(
         staticParams.export(nodeParams),
         currentTip,
         currentOnChainFeerates.export(),
+        false,
         commitments.export(),
         shortChannelId,
         buried,
@@ -717,6 +718,7 @@ data class ShuttingDown(
         staticParams.export(nodeParams),
         currentTip,
         currentOnChainFeerates.export(),
+        false,
         commitments.export(),
         localShutdown,
         remoteShutdown
@@ -754,6 +756,7 @@ data class Negotiating(
         staticParams.export(nodeParams),
         currentTip,
         currentOnChainFeerates.export(),
+        false,
         commitments.export(),
         localShutdown,
         remoteShutdown,

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/OfflineTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/OfflineTestsCommon.kt
@@ -455,13 +455,13 @@ class OfflineTestsCommon : EclairTestSuite() {
         assertTrue(alice2 is Offline)
 
         // alice restarted after the htlc timed out
-        val alice3 = alice2.copy(state = (alice2.state as Normal).copy(currentTip = alice2.currentTip.copy(first = htlc.cltvExpiry.toLong().toInt())))
-        val (alice4, actions) = alice3.processEx(ChannelEvent.CheckHtlcTimeout)
-        assertTrue(alice4 is Closing)
-        assertNotNull(alice4.localCommitPublished)
+        val alice4 = alice2.copy(state = (alice2.state as Normal).copy(currentTip = alice2.currentTip.copy(first = htlc.cltvExpiry.toLong().toInt())))
+        val (alice5, actions) = alice4.processEx(ChannelEvent.CheckHtlcTimeout)
+        assertTrue(alice5 is Closing)
+        assertNotNull(alice5.localCommitPublished)
         actions.hasOutgoingMessage<Error>()
         actions.has<ChannelAction.Storage.StoreState>()
-        val lcp = alice4.localCommitPublished!!
+        val lcp = alice5.localCommitPublished!!
         actions.hasTx(lcp.commitTx)
         assertEquals(1, lcp.htlcTimeoutTxs.size)
         assertEquals(1, lcp.claimHtlcDelayedTxs.size)
@@ -481,12 +481,13 @@ class OfflineTestsCommon : EclairTestSuite() {
         assertTrue(bob3 is Offline)
 
         // bob restarts when the fulfilled htlc is close to timing out: alice hasn't signed, so bob closes the channel
-        val (bob4, actions4) = bob3.processEx(ChannelEvent.NewBlock(htlc.cltvExpiry.toLong().toInt(), bob3.state.currentTip.second))
-        assertTrue(bob4 is Closing)
-        assertNotNull(bob4.localCommitPublished)
+        val (bob4, _) = bob3.processEx(ChannelEvent.CheckHtlcTimeout)
+        val (bob5, actions4) = bob4.processEx(ChannelEvent.NewBlock(htlc.cltvExpiry.toLong().toInt(), bob3.state.currentTip.second))
+        assertTrue(bob5 is Closing)
+        assertNotNull(bob5.localCommitPublished)
         actions4.has<ChannelAction.Storage.StoreState>()
 
-        val lcp = bob4.localCommitPublished!!
+        val lcp = bob5.localCommitPublished!!
         assertNotNull(lcp.claimMainDelayedOutputTx)
         assertEquals(1, lcp.htlcSuccessTxs.size)
         Transaction.correctlySpends(lcp.htlcSuccessTxs.first(), lcp.commitTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)

--- a/src/commonTest/kotlin/fr/acinq/eclair/serialization/StateSerializationTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/serialization/StateSerializationTestsCommon.kt
@@ -15,11 +15,11 @@ class StateSerializationTestsCommon : EclairTestSuite() {
         val (alice, bob) = TestsHelper.reachNormal()
         val bytes = Serialization.serialize(alice)
         val check = Serialization.deserialize(bytes, alice.staticParams.nodeParams)
-        assertEquals(alice, check)
+        assertEquals(alice.copy(doCheckForTimedOutHtlcs = false), check)
 
         val bytes1 = Serialization.serialize(bob)
         val check1 = Serialization.deserialize(bytes1, bob.staticParams.nodeParams)
-        assertEquals(bob, check1)
+        assertEquals(bob.copy(doCheckForTimedOutHtlcs = false), check1)
     }
 
     @Test
@@ -28,10 +28,10 @@ class StateSerializationTestsCommon : EclairTestSuite() {
         val priv = randomKey()
         val bytes = Serialization.encrypt(priv, alice)
         val check = Serialization.decrypt(priv, bytes, alice.staticParams.nodeParams)
-        assertEquals(alice, check)
+        assertEquals(alice.copy(doCheckForTimedOutHtlcs = false), check)
 
         val bytes1 = Serialization.encrypt(priv, bob)
         val check1 = Serialization.decrypt(priv, bytes1, bob.staticParams.nodeParams)
-        assertEquals(bob, check1)
+        assertEquals(bob.copy(doCheckForTimedOutHtlcs = false), check1)
     }
 }

--- a/src/jvmTest/kotlin/fr/acinq/eclair/db/sqlite/SqliteChannelsDbTestsJvm.kt
+++ b/src/jvmTest/kotlin/fr/acinq/eclair/db/sqlite/SqliteChannelsDbTestsJvm.kt
@@ -22,7 +22,7 @@ class SqliteChannelsDbTestsJvm : EclairTestSuite() {
             db.addOrUpdateChannel(alice)
             val (bob, _) = TestsHelper.reachNormal(ChannelVersion.STANDARD, 2, 2000000.sat)
             db.addOrUpdateChannel(bob)
-            assertEquals(db.listLocalChannels(), listOf(alice, bob))
+            assertEquals(db.listLocalChannels(), listOf(alice.copy(doCheckForTimedOutHtlcs = false), bob.copy(doCheckForTimedOutHtlcs = false)))
         }
     }
 }


### PR DESCRIPTION
This PR fixes an issue when channels are restored from their encrypted peer backup but get closed by Phoenix because we don't give our peer enough time to re-send messages that we've missed: we need to wait a bit before we check for timed-out HTLCs 

So when we receive a new block, we won't perform this check unless we've already received an explicit ChannelEvent.CheckHtlcTimeout message from our local Peer.
