### PR TITLE
Updated Socket facade so that it is now possible to start TLS *after* the socket has opened.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,10 +26,10 @@ allprojects {
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
 kotlin {
-    val ktorVersion: String by extra { "1.4.1" }
+    val ktorVersion: String by extra { "1.5.0" }
     fun ktor(module: String) = "io.ktor:ktor-$module:$ktorVersion"
     val secp256k1Version = "0.4.1"
-    val serializationVersion = "1.0.0"
+    val serializationVersion = "1.0.1"
     val coroutineVersion = "1.4.2-native-mt"
 
     val commonMain by sourceSets.getting {

--- a/src/commonMain/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumClient.kt
@@ -227,10 +227,8 @@ class ElectrumClient(
         else logger.warning { "electrum client is already running" }
     }
 
-    fun disconnect() {
-        launch {
-            connectionJob?.cancelAndJoin()
-        }
+    suspend fun disconnect() {
+        connectionJob?.cancelAndJoin()
     }
 
     private var connectionJob: Job? = null

--- a/src/commonMain/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumClient.kt
@@ -8,6 +8,7 @@ import fr.acinq.eclair.blockchain.electrum.ElectrumClient.Companion.logger
 import fr.acinq.eclair.blockchain.electrum.ElectrumClient.Companion.version
 import fr.acinq.eclair.io.TcpSocket
 import fr.acinq.eclair.io.linesFlow
+import fr.acinq.eclair.io.send
 import fr.acinq.eclair.utils.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BroadcastChannel

--- a/src/commonMain/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumClient.kt
@@ -291,8 +291,7 @@ class ElectrumClient(
 
         launch { ping() }
         launch { respond() }
-
-        listen() // This suspends until the coroutines is cancelled or the socket is closed
+        launch { listen() }.join() // This suspends until the coroutines is cancelled or the socket is closed
     }
 
     fun sendElectrumRequest(request: ElectrumRequest): Unit = sendMessage(SendElectrumRequest(request))

--- a/src/commonMain/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumDataTypes.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/blockchain/electrum/ElectrumDataTypes.kt
@@ -213,6 +213,7 @@ internal fun parseJsonResponse(request: ElectrumRequest, rpcResponse: JsonRPCRes
             error = rpcResponse.error
         )
     }
+    else if (rpcResponse.id != null && rpcResponse.id < 0 ) PingResponse
     else when (request) {
         is ServerVersion -> {
             val resultArray = rpcResponse.result.jsonArray

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -199,7 +199,7 @@ class Peer(
 
     fun disconnect() {
         launch {
-            connectionJob?.cancel()
+            connectionJob?.cancelAndJoin()
         }
     }
 
@@ -220,8 +220,8 @@ class Peer(
             if (_connectionState.value == Connection.CLOSED) return
             logger.warning { "closing TCP socket." }
             socket.close()
-            _connectionState.value = Connection.CLOSED
             if(isActive) cancel()
+            _connectionState.value = Connection.CLOSED
         }
 
         val priv = nodeParams.nodePrivateKey

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -197,10 +197,8 @@ class Peer(
         else logger.warning { "Peer is already connecting / connected" }
     }
 
-    fun disconnect() {
-        launch {
-            connectionJob?.cancelAndJoin()
-        }
+    suspend fun disconnect() {
+        connectionJob?.cancelAndJoin()
     }
 
 

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -60,7 +60,7 @@ class Peer(
     val walletParams: WalletParams,
     val watcher: ElectrumWatcher,
     val db: Databases,
-    socketBuilder: TcpSocket.Builder,
+    socketBuilder: TcpSocket.Builder?,
     scope: CoroutineScope
 ) : CoroutineScope by scope {
     companion object {
@@ -68,7 +68,7 @@ class Peer(
         private val prologue = "lightning".encodeToByteArray()
     }
 
-    public var socketBuilder = socketBuilder
+    public var socketBuilder: TcpSocket.Builder? = socketBuilder
         set(value) {
             logger.debug { "n:$remoteNodeId swap socket builder=$value" }
             field = value
@@ -209,8 +209,8 @@ class Peer(
         logger.info { "n:$remoteNodeId connecting to ${walletParams.trampolineNode.host}" }
         _connectionState.value = Connection.ESTABLISHING
         val socket = try {
-            socketBuilder.connect(walletParams.trampolineNode.host, walletParams.trampolineNode.port)
-        } catch (ex: TcpSocket.IOException) {
+            socketBuilder?.connect(walletParams.trampolineNode.host, walletParams.trampolineNode.port) ?: error("socket builder is null.")
+        } catch (ex: Throwable) {
             logger.warning { "n:$remoteNodeId TCP connect: ${ex.message}" }
             _connectionState.value = Connection.CLOSED
             return@launch

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -200,7 +200,6 @@ class Peer(
     fun disconnect() {
         launch {
             connectionJob?.cancel()
-            connectionJob = null
         }
     }
 
@@ -218,14 +217,11 @@ class Peer(
         }
 
         fun closeSocket() {
-            if (_connectionState.value == Connection.CLOSED) {
-                logger.warning { "TCP socket is already closed." }
-                return
-            }
-            logger.warning { "n:$remoteNodeId closing TCP socket" }
+            if (_connectionState.value == Connection.CLOSED) return
+            logger.warning { "closing TCP socket." }
             socket.close()
             _connectionState.value = Connection.CLOSED
-            cancel()
+            if(isActive) cancel()
         }
 
         val priv = nodeParams.nodePrivateKey

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/TcpSocket.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/TcpSocket.kt
@@ -16,10 +16,12 @@ interface TcpSocket {
         class Unknown(message: String?, cause: Throwable? = null) : IOException(message ?: "Unknown", cause)
     }
 
-    suspend fun send(bytes: ByteArray?, flush: Boolean = true)
+    suspend fun send(bytes: ByteArray?, offset: Int, length: Int, flush: Boolean = true)
 
-    suspend fun receiveFully(buffer: ByteArray)
-    suspend fun receiveAvailable(buffer: ByteArray): Int
+    suspend fun receiveFully(buffer: ByteArray, offset: Int, length: Int)
+    suspend fun receiveAvailable(buffer: ByteArray, offset: Int, maxLength: Int): Int
+
+    suspend fun startTls(tls: TLS = TLS.SAFE): TcpSocket
 
     fun close()
 
@@ -35,6 +37,10 @@ interface TcpSocket {
         }
     }
 }
+
+suspend fun TcpSocket.send(bytes: ByteArray, flush: Boolean = true) = send(bytes, 0, bytes.size, flush)
+suspend fun TcpSocket.receiveFully(buffer: ByteArray) = receiveFully(buffer, 0, buffer.size)
+suspend fun TcpSocket.receiveAvailable(buffer: ByteArray) = receiveAvailable(buffer, 0, buffer.size)
 
 internal expect object PlatformSocketBuilder : TcpSocket.Builder
 

--- a/src/iosMain/kotlin/fr/acinq/eclair/io/dispatchData.kt
+++ b/src/iosMain/kotlin/fr/acinq/eclair/io/dispatchData.kt
@@ -1,0 +1,28 @@
+package fr.acinq.eclair.io
+
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.darwin.*
+import platform.posix.memcpy
+
+
+@OptIn(ExperimentalUnsignedTypes::class)
+internal fun dispatch_data_t.copyTo(buffer: ByteArray, offset: Int) {
+    buffer.usePinned { pinned ->
+        dispatch_data_apply(this) { _, dataOffset, src, size ->
+            memcpy(pinned.addressOf(offset + dataOffset.toInt()), src, size)
+            true
+        }
+    }
+}
+
+@OptIn(ExperimentalUnsignedTypes::class)
+internal inline fun <R> ByteArray.useDataView(offset: Int, length: Int, block: (dispatch_data_t) -> R): R {
+    usePinned { pinned ->
+        val data = pinned.let { dispatch_data_create(pinned.addressOf(offset), length.toULong(), dispatch_get_main_queue(), ({})) }
+        return block(data)
+    }
+}
+
+@OptIn(ExperimentalUnsignedTypes::class)
+internal fun dispatch_data_t.size(): Int = dispatch_data_get_size(this).toInt()

--- a/src/iosMain/kotlin/fr/acinq/eclair/io/networkFramework.kt
+++ b/src/iosMain/kotlin/fr/acinq/eclair/io/networkFramework.kt
@@ -1,0 +1,167 @@
+package fr.acinq.eclair.io
+
+import fr.acinq.eclair.io.ios_network_framework.nw_k_connection_receive
+import fr.acinq.eclair.io.ios_network_framework.nw_k_parameters_create_secure_tcp
+import fr.acinq.eclair.io.ios_network_framework.nw_k_parameters_create_secure_tcp_custom
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.Network.*
+import platform.Security.sec_protocol_options_set_peer_authentication_required
+import platform.Security.sec_protocol_options_set_verify_block
+import platform.darwin.dispatch_data_t
+import platform.darwin.dispatch_get_main_queue
+import platform.posix.ECONNREFUSED
+import platform.posix.ECONNRESET
+import platform.posix.ECANCELED
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+
+private fun nw_error_t.toIOException(): TcpSocket.IOException =
+    when (nw_error_get_error_domain(this)) {
+        nw_error_domain_posix -> when (nw_error_get_error_code(this)) {
+            ECONNREFUSED -> TcpSocket.IOException.ConnectionRefused()
+            ECONNRESET, ECANCELED -> TcpSocket.IOException.ConnectionClosed()
+            else -> TcpSocket.IOException.Unknown("Posix error ${nw_error_get_error_code(this)}: ${this?.debugDescription} ")
+        }
+        nw_error_domain_dns -> TcpSocket.IOException.Unknown("DNS: ${this?.debugDescription}")
+        nw_error_domain_tls -> TcpSocket.IOException.Unknown("TLS: ${this?.debugDescription}")
+        else -> TcpSocket.IOException.Unknown("Unknown: ${this?.debugDescription}")
+    }
+
+
+@OptIn(ExperimentalUnsignedTypes::class)
+internal suspend fun nw_connection_t.receiveData(min: Int, max: Int): dispatch_data_t {
+    return suspendCoroutine { continuation ->
+        nw_k_connection_receive(this, min.toUInt(), max.toUInt()) { data, isComplete, error ->
+            when {
+                error != null -> continuation.resumeWithException(error.toIOException())
+                data != null -> continuation.resume(data)
+                isComplete -> continuation.resumeWithException(TcpSocket.IOException.ConnectionClosed())
+                else -> continuation.resumeWithException(Exception("Connection has no error, no data and is not complete"))
+            }
+        }
+    }
+}
+
+internal suspend fun nw_connection_t.sendData(data: dispatch_data_t, flush: Boolean) {
+    suspendCancellableCoroutine<Unit> { continuation ->
+        nw_connection_send(this, data, null, flush) { error ->
+            if (error != null) continuation.resumeWithException(error.toIOException())
+            else continuation.resume(Unit)
+        }
+    }
+}
+
+@OptIn(ExperimentalUnsignedTypes::class)
+private suspend fun nw_connection_t.start() {
+    suspendCancellableCoroutine<Unit> { continuation ->
+        nw_connection_set_queue(this, dispatch_get_main_queue())
+
+        nw_connection_set_state_changed_handler(this) { state, error ->
+            when {
+                error != null -> {
+                    nw_connection_set_state_changed_handler(this, null)
+                    continuation.resumeWithException(error.toIOException())
+                }
+                state == nw_connection_state_ready -> {
+                    nw_connection_set_state_changed_handler(this, null)
+                    continuation.resume(Unit)
+                }
+            }
+        }
+        nw_connection_start(this)
+    }
+}
+
+internal fun nw_connection_t.cancel() {
+    nw_connection_cancel(this)
+}
+
+internal class NwTls(val safe: Boolean, val auth: Boolean)
+
+internal suspend fun openClientConnection(host: String, port: Int, tls: NwTls?): nw_connection_t {
+    val endpoint = nw_endpoint_create_host(host, port.toString())
+
+    val parameters =
+        when {
+            tls == null -> nw_k_parameters_create_secure_tcp(false)
+            tls.safe && tls.auth -> nw_k_parameters_create_secure_tcp(true)
+            else -> nw_k_parameters_create_secure_tcp_custom {
+                val secOptions = nw_tls_copy_sec_protocol_options(it)
+                if (!tls.safe) sec_protocol_options_set_verify_block(secOptions, { _, _, handler -> handler!!(true) }, dispatch_get_main_queue())
+                if (!tls.auth) sec_protocol_options_set_peer_authentication_required(secOptions, false)
+            }
+        }
+
+    val connection = nw_connection_create(endpoint, parameters)
+    connection.start()
+
+    return connection
+}
+
+internal class NwListener(private val listener: nw_listener_t, val connections: ReceiveChannel<nw_connection_t>) {
+
+    @OptIn(ExperimentalUnsignedTypes::class)
+    val port: Int = nw_listener_get_port(listener).toInt()
+
+    fun close() {
+        nw_listener_cancel(listener)
+    }
+}
+
+@OptIn(ExperimentalUnsignedTypes::class, ExperimentalCoroutinesApi::class)
+internal suspend fun openListener(scope: CoroutineScope, host: String, port: String): NwListener {
+    val params = nw_k_parameters_create_secure_tcp(false)
+    val endpoint = nw_endpoint_create_host(host, port)
+    nw_parameters_set_local_endpoint(params, endpoint)
+    val listener = nw_listener_create(params)
+    nw_listener_set_queue(listener, dispatch_get_main_queue())
+
+    val connections = Channel<nw_connection_t>()
+    nw_listener_set_new_connection_handler(listener) { connection ->
+        nw_connection_set_queue(connection, dispatch_get_main_queue())
+        scope.launch {
+            connection.start()
+            connections.send(connection)
+        }
+    }
+
+    suspendCoroutine<Unit> { continuation ->
+        var continued = false
+        nw_listener_set_state_changed_handler(listener) { state, error ->
+            if (state == nw_listener_state_cancelled) connections.close()
+
+            if (!continued) {
+                when {
+                    error != null -> {
+                        continued = true
+                        continuation.resumeWithException(error.toIOException())
+                    }
+                    state == nw_listener_state_ready -> {
+                        continued = true
+                        continuation.resume(Unit)
+                    }
+                }
+            }
+        }
+        nw_listener_start(listener)
+    }
+
+    return NwListener(listener, connections)
+}
+
+@OptIn(ExperimentalUnsignedTypes::class)
+suspend fun transferLoop(from: nw_connection_t, to: nw_connection_t) {
+    try {
+        while (true) {
+            val data = from.receiveData(1, 8 * 1024)
+            to.sendData(data, true)
+        }
+    } catch (_: TcpSocket.IOException.ConnectionClosed) {}
+}

--- a/src/jvmMain/kotlin/fr/acinq/eclair/io/JvmTcpSocket.kt
+++ b/src/jvmMain/kotlin/fr/acinq/eclair/io/JvmTcpSocket.kt
@@ -14,15 +14,16 @@ import java.net.SocketException
 import java.security.cert.X509Certificate
 import javax.net.ssl.X509TrustManager
 
-class JvmTcpSocket(val socket: Socket) : TcpSocket {
-    private val readChannel = socket.openReadChannel()
-    private val writeChannel = socket.openWriteChannel()
+class JvmTcpSocket(socket: Socket) : TcpSocket {
+    private val connection = socket.connection()
 
-    override suspend fun send(bytes: ByteArray?, flush: Boolean) =
+    private val logger by eclairLogger()
+
+    override suspend fun send(bytes: ByteArray?, offset: Int, length: Int, flush: Boolean) =
         withContext(Dispatchers.IO) {
             try {
-                if (bytes != null) writeChannel.writeFully(bytes, 0, bytes.size)
-                if (flush) writeChannel.flush()
+                if (bytes != null) connection.output.writeFully(bytes, offset, length)
+                if (flush) connection.output.flush()
             } catch (ex: java.io.IOException) {
                 throw TcpSocket.IOException.ConnectionClosed(ex)
             } catch (ex: Throwable) {
@@ -47,17 +48,31 @@ class JvmTcpSocket(val socket: Socket) : TcpSocket {
             tryReceive { read() }
         }
 
-    override suspend fun receiveFully(buffer: ByteArray): Unit = receive { readChannel.readFully(buffer) }
+    override suspend fun receiveFully(buffer: ByteArray, offset: Int, length: Int): Unit = receive { connection.input.readFully(buffer, offset, length) }
 
-    override suspend fun receiveAvailable(buffer: ByteArray): Int {
-        return tryReceive { readChannel.readAvailable(buffer) }
+    override suspend fun receiveAvailable(buffer: ByteArray, offset: Int, maxLength: Int): Int {
+        return tryReceive { connection.input.readAvailable(buffer, 0, maxLength) }
             .takeUnless { it == -1 } ?: throw TcpSocket.IOException.ConnectionClosed()
     }
 
-    override fun close() {
-        socket.close()
-    }
+    override suspend fun startTls(tls: TcpSocket.TLS): TcpSocket =
+        JvmTcpSocket(when (tls) {
+            TcpSocket.TLS.SAFE -> connection.tls(Dispatchers.IO)
+            TcpSocket.TLS.UNSAFE_CERTIFICATES -> connection.tls(Dispatchers.IO) {
+                logger.warning { "Using unsafe TLS!" }
+                trustManager = UnsafeX509TrustManager
+            }
+        })
 
+    override fun close() {
+        connection.socket.close()
+    }
+}
+
+private object UnsafeX509TrustManager : X509TrustManager {
+    override fun checkClientTrusted(p0: Array<out X509Certificate>?, p1: String?) {}
+    override fun checkServerTrusted(p0: Array<out X509Certificate>?, p1: String?) {}
+    override fun getAcceptedIssuers(): Array<X509Certificate>? = null
 }
 
 @OptIn(KtorExperimentalAPI::class)
@@ -75,11 +90,7 @@ internal actual object PlatformSocketBuilder : TcpSocket.Builder {
                         TcpSocket.TLS.SAFE -> socket.tls(Dispatchers.IO)
                         TcpSocket.TLS.UNSAFE_CERTIFICATES -> socket.tls(Dispatchers.IO) {
                             logger.warning { "Using unsafe TLS!" }
-                            trustManager = object : X509TrustManager {
-                                override fun checkClientTrusted(p0: Array<out X509Certificate>?, p1: String?) {}
-                                override fun checkServerTrusted(p0: Array<out X509Certificate>?, p1: String?) {}
-                                override fun getAcceptedIssuers(): Array<X509Certificate>? = null
-                            }
+                            trustManager = UnsafeX509TrustManager
                         }
                     }
                 })


### PR DESCRIPTION
This allows to have TLS over Tor (because the socks5 handshake happens **before** the TLS handshake).

Also (Romain):
- ElectrumClient
    - Simplify the ElectrumClient state machine (less states, less rounds).
    - Prevent multiple connection attempt on the ElectrumClient (edge case)
- Improve ElectrumClient / Peer connectivity
    - nullable `TcpSocket.Builder`, avoiding the use of a default one (e.g. Phoenix startup with Tor activated  doesn't want to run on a classic one "transparently")
    - `disconnect` functions close the socket that will end the connection job.
- Small fixes


tested with `eclair-kmp-tests` / `simulator` / `device`
    