### PR TITLE
Don't check for timed out HTLCs when we receive a new block

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -1938,7 +1938,7 @@ data class Normal(
             is ChannelEvent.CheckHtlcTimeout -> checkHtlcTimeout()
             is ChannelEvent.NewBlock -> {
                 logger.info { "c:$channelId new tip ${event.height} ${event.Header.hash}" }
-                this.copy(currentTip = Pair(event.height, event.Header)).checkHtlcTimeout()
+                Pair(this.copy(currentTip = Pair(event.height, event.Header)), listOf())
             }
             is ChannelEvent.SetOnChainFeerates -> {
                 logger.info { "c:$channelId using on-chain fee rates ${event.feerates}" }
@@ -2164,7 +2164,7 @@ data class ShuttingDown(
                 else -> unhandled(event)
             }
             is ChannelEvent.CheckHtlcTimeout -> checkHtlcTimeout()
-            is ChannelEvent.NewBlock -> this.copy(currentTip = Pair(event.height, event.Header)).checkHtlcTimeout()
+            is ChannelEvent.NewBlock -> Pair(this.copy(currentTip = Pair(event.height, event.Header)), listOf())
             is ChannelEvent.SetOnChainFeerates -> Pair(this.copy(currentOnChainFeerates = event.feerates), listOf())
             is ChannelEvent.Disconnected -> Pair(Offline(this), listOf())
             else -> unhandled(event)
@@ -2319,7 +2319,7 @@ data class Negotiating(
                 else -> unhandled(event)
             }
             event is ChannelEvent.CheckHtlcTimeout -> checkHtlcTimeout()
-            event is ChannelEvent.NewBlock -> this.copy(currentTip = Pair(event.height, event.Header)).checkHtlcTimeout()
+            event is ChannelEvent.NewBlock -> Pair(this.copy(currentTip = Pair(event.height, event.Header)), listOf())
             event is ChannelEvent.SetOnChainFeerates -> Pair(this.copy(currentOnChainFeerates = event.feerates), listOf())
             event is ChannelEvent.Disconnected -> Pair(Offline(this), listOf())
             event is ChannelEvent.ExecuteCommand && event.command is CMD_ADD_HTLC -> handleCommandError(event.command, ChannelUnavailable(channelId))
@@ -2623,7 +2623,7 @@ data class Closing(
                 else -> Pair(this, emptyList())
             }
             is ChannelEvent.CheckHtlcTimeout -> checkHtlcTimeout()
-            is ChannelEvent.NewBlock -> this.copy(currentTip = Pair(event.height, event.Header)).checkHtlcTimeout()
+            is ChannelEvent.NewBlock -> Pair(this.copy(currentTip = Pair(event.height, event.Header)), listOf())
             is ChannelEvent.SetOnChainFeerates -> Pair(this.copy(currentOnChainFeerates = event.feerates), listOf())
             is ChannelEvent.Disconnected -> Pair(Offline(this), listOf())
             else -> unhandled(event)

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/NormalTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/NormalTestsCommon.kt
@@ -1813,7 +1813,10 @@ class NormalTestsCommon : EclairTestSuite() {
         actions3.hasOutgoingMessage<CommitSig>()
 
         // fulfilled htlc is close to timing out and alice still hasn't signed, so bob closes the channel
-        val (bob4, actions4) = bob3.processEx(ChannelEvent.NewBlock(htlc.cltvExpiry.toLong().toInt() - 3, bob3.currentTip.second))
+        val (bob4, actions4) = run {
+            val (tmp, _) = bob3.processEx(ChannelEvent.NewBlock(htlc.cltvExpiry.toLong().toInt() - 3, bob3.currentTip.second))
+            tmp.processEx(ChannelEvent.CheckHtlcTimeout)
+        }
         checkFulfillTimeout(bob4, actions4)
     }
 
@@ -1849,7 +1852,10 @@ class NormalTestsCommon : EclairTestSuite() {
         val (bob4, _) = bob3.processEx(ChannelEvent.MessageReceived(ack))
 
         // fulfilled htlc is close to timing out and alice has revoked her previous commitment but not signed the new one, so bob closes the channel
-        val (bob5, actions5) = bob4.processEx(ChannelEvent.NewBlock(htlc.cltvExpiry.toLong().toInt() - 3, bob3.currentTip.second))
+        val (bob5, actions5) = run {
+            val (tmp, _) = bob4.processEx(ChannelEvent.NewBlock(htlc.cltvExpiry.toLong().toInt() - 3, bob3.currentTip.second))
+            tmp.processEx(ChannelEvent.CheckHtlcTimeout)
+        }
         checkFulfillTimeout(bob5, actions5)
     }
 

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/OfflineTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/OfflineTestsCommon.kt
@@ -481,7 +481,10 @@ class OfflineTestsCommon : EclairTestSuite() {
         assertTrue(bob3 is Offline)
 
         // bob restarts when the fulfilled htlc is close to timing out: alice hasn't signed, so bob closes the channel
-        val (bob4, actions4) = bob3.processEx(ChannelEvent.NewBlock(htlc.cltvExpiry.toLong().toInt(), bob3.state.currentTip.second))
+        val (bob4, actions4) = run {
+            val (tmp, _) = bob3.processEx(ChannelEvent.NewBlock(htlc.cltvExpiry.toLong().toInt(), bob3.state.currentTip.second))
+            tmp.processEx(ChannelEvent.CheckHtlcTimeout)
+        }
         assertTrue(bob4 is Closing)
         assertNotNull(bob4.localCommitPublished)
         actions4.has<ChannelAction.Storage.StoreState>()

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ShutdownTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ShutdownTestsCommon.kt
@@ -354,7 +354,10 @@ class ShutdownTestsCommon : EclairTestSuite() {
         val (alice, _) = init()
         val commitTx = alice.commitments.localCommit.publishableTxs.commitTx.tx
         val htlcExpiry = alice.commitments.localCommit.spec.htlcs.map { it.add.cltvExpiry }.first()
-        val (alice1, actions1) = alice.processEx(ChannelEvent.NewBlock(htlcExpiry.toLong().toInt(), alice.currentTip.second))
+        val (alice1, actions1) = run {
+            val (tmp, _) = alice.processEx(ChannelEvent.NewBlock(htlcExpiry.toLong().toInt(), alice.currentTip.second))
+            tmp.processEx(ChannelEvent.CheckHtlcTimeout)
+        }
         assertTrue(alice1 is Closing)
         assertNotNull(alice1.localCommitPublished)
         actions1.hasTx(commitTx)


### PR DESCRIPTION
We only check for them when we receive an explicit CheckHtlcTimeout message (i.e about 15 seconds after we got (re)connected). This is much simpler than #188 and should not be a problem on iOS or Android but if we ever use eclair-kmp in a different context (to provide a "wallet" API in a server setup for example) we'll have to revisit this.  