### PR TITLE
Syncing: detect and react when the funding tx is spent

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -702,7 +702,7 @@ data class Offline(val state: ChannelStateWithCommitments) : ChannelStateWithCom
                                 currentOnChainFeerates,
                                 state.commitments,
                                 null,
-                                currentTimestampMillis(),
+                                currentBlockHeight.toLong(),
                                 state.closingTxProposed.flatten().map { it.unsignedTx },
                                 listOf(watch.tx)
                             )
@@ -968,7 +968,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                                 currentOnChainFeerates,
                                 state.commitments,
                                 null,
-                                currentTimestampMillis(),
+                                currentBlockHeight.toLong(),
                                 state.closingTxProposed.flatten().map { it.unsignedTx },
                                 listOf(watch.tx)
                             )
@@ -2269,7 +2269,7 @@ data class Negotiating(
                                 currentOnChainFeerates,
                                 commitments,
                                 null,
-                                currentTimestampMillis(),
+                                currentBlockHeight.toLong(),
                                 this.closingTxProposed.flatten().map { it.unsignedTx },
                                 listOf(signedClosingTx)
                             )
@@ -2290,7 +2290,7 @@ data class Negotiating(
                                 currentOnChainFeerates,
                                 commitments,
                                 null,
-                                currentTimestampMillis(),
+                                currentBlockHeight.toLong(),
                                 this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(signedClosingTx),
                                 listOf(signedClosingTx)
                             )
@@ -2336,7 +2336,7 @@ data class Negotiating(
                             currentOnChainFeerates,
                             commitments,
                             null,
-                            currentTimestampMillis(),
+                            currentBlockHeight.toLong(),
                             this.closingTxProposed.flatten().map { it.unsignedTx },
                             listOf(watch.tx)
                         )
@@ -2376,7 +2376,7 @@ data class Negotiating(
                     currentOnChainFeerates,
                     commitments,
                     null,
-                    currentTimestampMillis(),
+                    currentBlockHeight.toLong(),
                     this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(bestUnpublishedClosingTx),
                     listOf(bestUnpublishedClosingTx)
                 )

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/SyncingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/SyncingTestsCommon.kt
@@ -28,7 +28,7 @@ class SyncingTestsCommon : EclairTestSuite() {
         val aliceCommitTx = alice.commitments.localCommit.publishableTxs.commitTx.tx
         val (bob1, actions) = bob.processEx(ChannelEvent.WatchReceived(WatchEventSpent(bob.channelId, BITCOIN_FUNDING_SPENT, aliceCommitTx)))
         assertTrue(bob1 is Closing)
-        // we published our a tx to claim our main output
+        // we published a tx to claim our main output
         val claimTx = actions.filterIsInstance<ChannelAction.Blockchain.PublishTx>().map { it.tx }.first()
         Transaction.correctlySpends(claimTx, alice.commitments.localCommit.publishableTxs.commitTx.tx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
         val watches = actions.findWatches<WatchConfirmed>()


### PR DESCRIPTION
We should also react to watch events in Syncing state, even though it's supposed to be a transient state.