### PR TITLE
Channel: improve type hierarchy

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/serialization/v1/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/serialization/v1/ChannelState.kt
@@ -338,6 +338,8 @@ sealed class ChannelState {
             is fr.acinq.eclair.channel.WaitForRemotePublishFutureCommitment -> WaitForRemotePublishFutureCommitment(from)
             is fr.acinq.eclair.channel.WaitForFundingCreated -> WaitForFundingCreated(from)
             is fr.acinq.eclair.channel.WaitForFundingSigned -> WaitForFundingSigned(from)
+            is fr.acinq.eclair.channel.Offline -> Offline(from)
+            is fr.acinq.eclair.channel.Syncing -> Syncing(from)
             is fr.acinq.eclair.channel.ChannelStateWithCommitments -> ChannelStateWithCommitments.import(from)
         }
     }
@@ -354,8 +356,6 @@ sealed class ChannelStateWithCommitments : ChannelState() {
             is fr.acinq.eclair.channel.WaitForRemotePublishFutureCommitment -> WaitForRemotePublishFutureCommitment(from)
             is fr.acinq.eclair.channel.WaitForFundingConfirmed -> WaitForFundingConfirmed(from)
             is fr.acinq.eclair.channel.WaitForFundingLocked -> WaitForFundingLocked(from)
-            is fr.acinq.eclair.channel.Offline -> Offline(from)
-            is fr.acinq.eclair.channel.Syncing -> Syncing(from)
             is fr.acinq.eclair.channel.Normal -> Normal(from)
             is fr.acinq.eclair.channel.ShuttingDown -> ShuttingDown(from)
             is fr.acinq.eclair.channel.Negotiating -> Negotiating(from)
@@ -385,29 +385,21 @@ data class WaitForInit(
 }
 
 @Serializable
-data class Offline(val state: ChannelStateWithCommitments) : ChannelStateWithCommitments() {
+data class Offline(val state: ChannelStateWithCommitments) : ChannelState() {
     override val staticParams: StaticParams get() = state.staticParams
     override val currentTip: Pair<Int, BlockHeader> get() = state.currentTip
     override val currentOnChainFeerates: OnChainFeerates get() = state.currentOnChainFeerates
-    override val commitments: Commitments get() = state.commitments
 
-    constructor(from: fr.acinq.eclair.channel.Offline) : this(import(from.state))
-
-    override fun export(nodeParams: NodeParams): fr.acinq.eclair.channel.ChannelStateWithCommitments =
-        fr.acinq.eclair.channel.Offline(state.export(nodeParams))
+    constructor(from: fr.acinq.eclair.channel.Offline) : this(ChannelStateWithCommitments.import(from.state))
 }
 
 @Serializable
-data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReestablishMessage: Boolean) : ChannelStateWithCommitments() {
+data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReestablishMessage: Boolean) : ChannelState() {
     override val staticParams: StaticParams get() = state.staticParams
     override val currentTip: Pair<Int, BlockHeader> get() = state.currentTip
     override val currentOnChainFeerates: OnChainFeerates get() = state.currentOnChainFeerates
-    override val commitments: Commitments get() = state.commitments
 
-    constructor(from: fr.acinq.eclair.channel.Syncing) : this(import(from.state), from.waitForTheirReestablishMessage)
-
-    override fun export(nodeParams: NodeParams): fr.acinq.eclair.channel.ChannelStateWithCommitments =
-        fr.acinq.eclair.channel.Syncing(state.export(nodeParams), waitForTheirReestablishMessage)
+    constructor(from: fr.acinq.eclair.channel.Syncing) : this(ChannelStateWithCommitments.import(from.state), from.waitForTheirReestablishMessage)
 }
 
 @Serializable

--- a/src/commonTest/kotlin/fr/acinq/eclair/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/io/peer/PeerTest.kt
@@ -134,20 +134,20 @@ class PeerTest : EclairTestSuite() {
         val syncChannels = peer.channelsFlow
             .first { it.values.size == 1 && it.values.all { channelState -> channelState is Syncing } }
             .map { it.value as Syncing }
-        assertEquals(alice2.channelId, syncChannels.first().channelId)
+        assertEquals(alice2.channelId, syncChannels.first().state.channelId)
 
         val syncState = syncChannels.first()
         val yourLastPerCommitmentSecret = ByteVector32.Zeroes
-        val channelKeyPath = peer.nodeParams.keyManager.channelKeyPath(syncState.commitments.localParams, syncState.commitments.channelVersion)
-        val myCurrentPerCommitmentPoint = peer.nodeParams.keyManager.commitmentPoint(channelKeyPath, syncState.commitments.localCommit.index)
+        val channelKeyPath = peer.nodeParams.keyManager.channelKeyPath(syncState.state.commitments.localParams, syncState.state.commitments.channelVersion)
+        val myCurrentPerCommitmentPoint = peer.nodeParams.keyManager.commitmentPoint(channelKeyPath, syncState.state.commitments.localCommit.index)
 
         val channelReestablish = ChannelReestablish(
-            channelId = syncState.channelId,
-            nextLocalCommitmentNumber = syncState.commitments.localCommit.index + 1,
-            nextRemoteRevocationNumber = syncState.commitments.remoteCommit.index,
+            channelId = syncState.state.channelId,
+            nextLocalCommitmentNumber = syncState.state.commitments.localCommit.index + 1,
+            nextRemoteRevocationNumber = syncState.state.commitments.remoteCommit.index,
             yourLastCommitmentSecret = PrivateKey(yourLastPerCommitmentSecret),
             myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint,
-            syncState.commitments.remoteChannelData
+            syncState.state.commitments.remoteChannelData
         )
 
         val reestablishMsg = LightningMessage.encode(channelReestablish)


### PR DESCRIPTION
Offline and Syncing are special states that wrap ChannelStateWithCommitments states, but they should not be treated as ChannelStateWithCommitments:
- they will not be persisted (only the wrapped inner state will)
- it leads to hard to spot bugs where "this" is used instead of "this.state"

Fixes issue #186