### PR TITLE
Remove legacy tlv for channel version

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/wire/ChannelTlv.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/wire/ChannelTlv.kt
@@ -33,27 +33,6 @@ sealed class ChannelTlv : Tlv {
         }
     }
 
-    // this type should not be needed: unfortunately Phoenix previously used a value that was not a valid tlv in message extensions,
-    // so it's needed for backwards-compatibility until we can deprecate the old value.
-    @Serializable
-    data class ChannelVersionTlvLegacy(val channelVersion: ChannelVersion) : ChannelTlv() {
-        override val tag: Long get() = ChannelVersionTlvLegacy.tag
-
-        override fun write(out: Output) {
-            LightningCodecs.writeBytes(channelVersion.bits.bytes, out)
-        }
-
-        companion object : TlvValueReader<ChannelVersionTlvLegacy> {
-            const val tag: Long = 0x47000000
-
-            override fun read(input: Input): ChannelVersionTlvLegacy {
-                val len = 4 // len is missing, value is always 4 bytes
-                val buffer = LightningCodecs.bytes(input, len)
-                return ChannelVersionTlvLegacy(ChannelVersion(BitField.from(buffer)))
-            }
-        }
-    }
-
     @Serializable
     data class ChannelVersionTlv(val channelVersion: ChannelVersion) : ChannelTlv() {
         override val tag: Long get() = ChannelVersionTlv.tag

--- a/src/commonMain/kotlin/fr/acinq/eclair/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/wire/LightningMessages.kt
@@ -273,7 +273,7 @@ data class OpenChannel(
     val channelFlags: Byte,
     val tlvStream: TlvStream<ChannelTlv> = TlvStream.empty()
 ) : ChannelMessage, HasTemporaryChannelId, HasChainHash {
-    val channelVersion: ChannelVersion? get() = tlvStream.get<ChannelTlv.ChannelVersionTlv>()?.channelVersion ?: tlvStream.get<ChannelTlv.ChannelVersionTlvLegacy>()?.channelVersion
+    val channelVersion: ChannelVersion? get() = tlvStream.get<ChannelTlv.ChannelVersionTlv>()?.channelVersion
 
     override val type: Long get() = OpenChannel.type
 
@@ -311,8 +311,7 @@ data class OpenChannel(
             @Suppress("UNCHECKED_CAST")
             val readers = mapOf(
                 ChannelTlv.UpfrontShutdownScript.tag to ChannelTlv.UpfrontShutdownScript.Companion as TlvValueReader<ChannelTlv>,
-                ChannelTlv.ChannelVersionTlv.tag to ChannelTlv.ChannelVersionTlv.Companion as TlvValueReader<ChannelTlv>,
-                ChannelTlv.ChannelVersionTlvLegacy.tag to ChannelTlv.ChannelVersionTlvLegacy.Companion as TlvValueReader<ChannelTlv>
+                ChannelTlv.ChannelVersionTlv.tag to ChannelTlv.ChannelVersionTlv.Companion as TlvValueReader<ChannelTlv>
             )
             return OpenChannel(
                 ByteVector32(LightningCodecs.bytes(input, 32)),

--- a/src/commonMain/kotlin/fr/acinq/eclair/wire/TlvCodecs.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/wire/TlvCodecs.kt
@@ -81,7 +81,7 @@ class TlvStreamSerializer<T : Tlv>(private val lengthPrefixed: Boolean, private 
             previousTag = tag
 
             val reader = readers[tag]
-            val length = if (tag == ChannelTlv.ChannelVersionTlvLegacy.tag) 4 else LightningCodecs.bigSize(input)
+            val length = LightningCodecs.bigSize(input)
             val data = LightningCodecs.bytes(input, length)
             reader?.let {
                 records.add(reader.read(data))

--- a/src/commonTest/kotlin/fr/acinq/eclair/wire/OpenTlvTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/wire/OpenTlvTestsCommon.kt
@@ -10,15 +10,12 @@ class OpenTlvTestsCommon : EclairTestSuite() {
     @Test
     fun `channel version TLV`() {
         val testCases = listOf(
-            Triple(ChannelVersion.STANDARD, Hex.decode("fe47000000 00000007"), Hex.decode("fe47000000 00000001")),
             Triple(ChannelVersion.STANDARD, Hex.decode("fe47000001 04 00000007"), Hex.decode("fe47000000 00000001")),
-            Triple(ChannelVersion.STANDARD or ChannelVersion.ZERO_RESERVE, Hex.decode("fe47000000 0000000f"), Hex.decode("fe47000000 0000000f")),
             Triple(ChannelVersion.STANDARD or ChannelVersion.ZERO_RESERVE, Hex.decode("fe47000001 04 0000000f"), Hex.decode("fe47000000 0000000f"))
         )
 
         @Suppress("UNCHECKED_CAST")
         val readers = mapOf(
-            ChannelTlv.ChannelVersionTlvLegacy.tag to ChannelTlv.ChannelVersionTlvLegacy.Companion as TlvValueReader<ChannelTlv>,
             ChannelTlv.ChannelVersionTlv.tag to ChannelTlv.ChannelVersionTlv.Companion as TlvValueReader<ChannelTlv>
         )
         val tlvStreamSerializer = TlvStreamSerializer(false, readers)
@@ -27,7 +24,6 @@ class OpenTlvTestsCommon : EclairTestSuite() {
             val decoded = tlvStreamSerializer.read(it.second)
             val version = decoded.records.mapNotNull { record ->
                 when (record) {
-                    is ChannelTlv.ChannelVersionTlvLegacy -> record.channelVersion
                     is ChannelTlv.ChannelVersionTlv -> record.channelVersion
                     else -> null
                 }


### PR DESCRIPTION
We had to handle a legacy format for backward compatibility, but it's
gone now. Our node only sends the new format.