### PR TITLE
Add support for simple trusted swap-in

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/wire/LightningMessages.kt
@@ -71,6 +71,9 @@ interface LightningMessage {
                 PayToOpenRequest.type -> PayToOpenRequest.read(stream)
                 FCMToken.type -> FCMToken.read(stream)
                 UnsetFCMToken.type -> UnsetFCMToken
+                SwapInResponse.type -> SwapInResponse.read(stream)
+                SwapInPending.type -> SwapInPending.read(stream)
+                SwapInConfirmed.type -> SwapInConfirmed.read(stream)
                 else -> {
                     logger.warning { "cannot decode ${Hex.encode(input)}" }
                     null
@@ -1080,4 +1083,91 @@ object UnsetFCMToken : LightningMessage {
     override val type: Long get() = 35019
 
     override fun write(out: Output) {}
+}
+@OptIn(ExperimentalUnsignedTypes::class)
+data class SwapInRequest(
+    override val chainHash: ByteVector32
+) : LightningMessage, HasChainHash {
+    override val type: Long get() = SwapInRequest.type
+
+    override fun write(out: Output) {
+        LightningCodecs.writeBytes(chainHash, out)
+    }
+
+    companion object : LightningMessageReader<SwapInRequest> {
+        const val type: Long = 35007
+
+        override fun read(input: Input): SwapInRequest {
+            TODO("Not implemented (not needed)")
+        }
+    }
+}
+
+@OptIn(ExperimentalUnsignedTypes::class)
+data class SwapInResponse(
+    override val chainHash: ByteVector32,
+    val bitcoinAddress: String
+) : LightningMessage, HasChainHash {
+    override val type: Long get() = SwapInResponse.type
+
+    override fun write(out: Output) {
+        TODO("Not implemented (not needed)")
+    }
+
+    companion object : LightningMessageReader<SwapInResponse> {
+        const val type: Long = 35009
+
+        override fun read(input: Input): SwapInResponse {
+            return SwapInResponse(
+                chainHash = ByteVector32(LightningCodecs.bytes(input, 32)),
+                bitcoinAddress = LightningCodecs.bytes(input, LightningCodecs.u16(input)).decodeToString()
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalUnsignedTypes::class)
+data class SwapInPending(
+    val bitcoinAddress: String,
+    val amount: Satoshi
+) : LightningMessage {
+    override val type: Long get() = SwapInPending.type
+
+    override fun write(out: Output) {
+        TODO("Not implemented (not needed)")
+    }
+
+    companion object : LightningMessageReader<SwapInPending> {
+        const val type: Long = 35005
+
+        override fun read(input: Input): SwapInPending {
+            return SwapInPending(
+                bitcoinAddress = LightningCodecs.bytes(input, LightningCodecs.u16(input)).decodeToString(),
+                amount = Satoshi(LightningCodecs.u64(input))
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalUnsignedTypes::class)
+data class SwapInConfirmed(
+    val bitcoinAddress: String,
+    val amount: MilliSatoshi
+) : LightningMessage {
+    override val type: Long get() = SwapInConfirmed.type
+
+    override fun write(out: Output) {
+        TODO("Not implemented (not needed)")
+    }
+
+    companion object : LightningMessageReader<SwapInConfirmed> {
+        const val type: Long = 35015
+
+        override fun read(input: Input): SwapInConfirmed {
+            return SwapInConfirmed(
+                bitcoinAddress = LightningCodecs.bytes(input, LightningCodecs.u16(input)).decodeToString(),
+                amount = MilliSatoshi(LightningCodecs.u64(input))
+            )
+        }
+    }
 }

--- a/src/commonTest/kotlin/fr/acinq/eclair/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/wire/LightningCodecsTestsCommon.kt
@@ -8,6 +8,7 @@ import fr.acinq.eclair.Eclair.randomBytes
 import fr.acinq.eclair.Eclair.randomBytes32
 import fr.acinq.eclair.Eclair.randomBytes64
 import fr.acinq.eclair.Eclair.randomKey
+import fr.acinq.eclair.MilliSatoshi
 import fr.acinq.eclair.ShortChannelId
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.crypto.assertArrayEquals
@@ -523,5 +524,29 @@ class LightningCodecsTestsCommon : EclairTestSuite() {
             val encoded = LightningMessage.encode(it.value)
             assertArrayEquals(it.key.first, encoded)
         }
+    }
+
+    @Test
+    fun `encode - decode swap-in messages`() {
+        assertArrayEquals(
+            a = Hex.decode("88bf000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"),
+            b = LightningMessage.encode(SwapInRequest(Block.LivenetGenesisBlock.blockId))
+        )
+
+        assertEquals(
+            expected = SwapInResponse(Block.LivenetGenesisBlock.blockId, "bc1qms2el02t3fv8ecln0j74auassqwcg3ejekmypv"),
+            actual = LightningMessage.decode(Hex.decode("88c1000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f002a626331716d7332656c3032743366763865636c6e306a373461756173737177636733656a656b6d797076"))
+        )
+
+        assertEquals(
+            expected = SwapInPending("bc1qms2el02t3fv8ecln0j74auassqwcg3ejekmypv", Satoshi(123456)),
+            actual = LightningMessage.decode(Hex.decode("88bd002a626331716d7332656c3032743366763865636c6e306a373461756173737177636733656a656b6d797076000000000001e240"))
+        )
+
+        assertEquals(
+            expected = SwapInConfirmed("39gzznpTuzhtjdN5R2LZu8GgWLR9NovLdi", MilliSatoshi(42_000_000)),
+            actual = LightningMessage.decode(Hex.decode("88c700223339677a7a6e7054757a68746a644e3552324c5a75384767574c52394e6f764c6469000000000280de80"))
+        )
+
     }
 }


### PR DESCRIPTION
The workflow is as follow:

```
  Phoenix                    ACINQ
     |                         |
     |-----swap_in_request---->|
     |<----swap_in_response----|
     |                         |
     | (wait for on-chain tx)  |
     |                         |
     |<----swap_in_pending---->|
     |                         |
     | (wait for confirmation) |
     |                         |
     |<---swap_in_confirmed----|
     |<-----open_channel-------|
     |                         |
```

Phoenix starts by sending a `SwapInRequest` message, in order to get a
bitcoin address. ACINQ will always return the same address, until a
confirmed transaction has been made to that address at which point it
will be rotated. Address reuse is discouraged but supported for UX
purposes.

As soon as ACINQ detects an incoming unconfirmed transaction, it
will emit a `SwapInPending` message. This message will be sent after
every reconnection, with possibly an updated amount, if the user sends
multiple transactions to the same address.

Once the transaction is confirmed, ACINQ will emit a single
`SwapInConfirmed` message and will start attempting to create a channel
which pushes a certain amount to the user. The `SwapInConfirmed` message
is only sent once, its purpose is to be a notification. The channel
open will be attempted until it succeeds. Note that since #209, the
`OpenChannel` message contains a tlv that indicates the origin of the
channel. In the case of a swap-in, the origin will be the bitcoin
address.

Gotchas:
- `SwapInPending.amount` is in _satoshis_. It indicates the amount paid
  to the bitcoin adress by the user;
- `SwapInConfirmed.amount` is in _millisatoshis_. It indicates the
  amount that will actually be pushed to the user in the newly created
  channel (importantly, fees will be deducted).