### PR TITLE
Fixing subtle timing bug that could cause invalid-mac errors on the server

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -548,9 +548,9 @@ class Peer(
                         val state = _channels[msg.temporaryChannelId] ?: error("channel ${msg.temporaryChannelId} not found")
                         val event1 = ChannelEvent.MessageReceived(msg)
                         val (state1, actions) = state.process(event1)
+                        processActions(msg.temporaryChannelId, actions)
                         _channels = _channels + (msg.temporaryChannelId to state1)
                         logger.info { "n:$remoteNodeId c:${msg.temporaryChannelId} new state: ${state1::class}" }
-                        processActions(msg.temporaryChannelId, actions)
                         actions.filterIsInstance<ChannelAction.ChannelId.IdSwitch>().forEach {
                             logger.info { "n:$remoteNodeId id switch from ${it.oldChannelId} to ${it.newChannelId}" }
                             _channels = _channels - it.oldChannelId + (it.newChannelId to state1)
@@ -565,17 +565,17 @@ class Peer(
                         val state = _channels[msg.channelId] ?: error("channel ${msg.channelId} not found")
                         val event1 = ChannelEvent.MessageReceived(msg)
                         val (state1, actions) = state.process(event1)
+                        processActions(msg.channelId, actions)
                         _channels = _channels + (msg.channelId to state1)
                         logger.info { "n:$remoteNodeId c:${msg.channelId} new state: ${state1::class}" }
-                        processActions(msg.channelId, actions)
                     }
                     msg is ChannelUpdate -> {
                         logger.info { "n:$remoteNodeId received ${msg::class} for channel ${msg.shortChannelId}" }
                         _channels.values.filterIsInstance<Normal>().find { it.shortChannelId == msg.shortChannelId }?.let { state ->
                             val event1 = ChannelEvent.MessageReceived(msg)
                             val (state1, actions) = state.process(event1)
-                            _channels = _channels + (state.channelId to state1)
                             processActions(state.channelId, actions)
+                            _channels = _channels + (state.channelId to state1)
                         }
                     }
                     msg is PayToOpenRequest -> {


### PR DESCRIPTION
I think there's a subtle timing bug that could result in errors such as "invalid mac" on the server side. Here's the previous setup:

```kotlin
// Peer.kt
suspend fun send(message: ByteArray) {
  try {
    session.send(message) { data, flush -> socket.send(data, flush) }
  } catch (ex: TcpSocket.IOException) {
    closeSocket()
  }
}

suspend fun doPing() {
  val ping = Hex.decode("0012000a0004deadbeef")
  while (isActive) {
    delay(30.seconds)
    send(ping) // <=!= calling send
  }
}

suspend fun respond() {
  for (msg in output) send(msg) // <=!= calling send
}

launch { doPing() }
launch { respond() }
```

*(I trimmed code not related to this discussion)*

I could be wrong, but I think this could lead to the following being run in parallel:

- doPing() => send() => session.send()
- respond() => send() => session.send()

When we consider the code for session.send(), a problem appears:

```kotlin
// LightningSession.kt
suspend fun send(data: ByteArray, write: suspend (ByteArray, flush: Boolean) -> Unit) {
  // the conversion here is not lossy if data.size() fits on 2 bytes, which it should
  val plainlen = Pack.writeInt16BE(data.size.toShort())
  val (tmp, cipherlen) = encryptor.encryptWithAd(ByteArray(0), plainlen)
  encryptor = tmp
  write(cipherlen, false) // suspending call
  val (tmp1, cipherbytes) = encryptor.encryptWithAd(ByteArray(0), data)
  encryptor = tmp1
  write(cipherbytes, true) // suspending call
}
```

I believe this means, if the timing happens just right:

1. doPing() => send() => session.send() => send length
2. respond() => send() => session.send() => send length
3. doPing() => send() => session.send() => send data
4. respond() => send() => session.send() => send data

Which I'm guessing would result in an invalid mac error on the server.

And the simple fix being:
```kotlin
suspend fun doPing() {
  val ping = Hex.decode("0012000a0004deadbeef")
  while (isActive) {
    delay(30.seconds)
    output.send(ping) // <= fixed
  }
}
```