### PR TITLE
Phoenix-kmm issue #123: Missing transactions when closing channels

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -15,6 +15,7 @@ import fr.acinq.eclair.channel.Helpers.Closing.overriddenOutgoingHtlcs
 import fr.acinq.eclair.channel.Helpers.Closing.timedOutHtlcs
 import fr.acinq.eclair.crypto.KeyManager
 import fr.acinq.eclair.crypto.ShaChain
+import fr.acinq.eclair.db.OutgoingPayment
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.serialization.Serialization
 import fr.acinq.eclair.transactions.CommitmentSpec
@@ -704,10 +705,10 @@ data class Offline(val state: ChannelStateWithCommitments) : ChannelState() {
                                 currentTip,
                                 currentOnChainFeerates,
                                 state.commitments,
-                                null,
-                                currentBlockHeight.toLong(),
-                                state.closingTxProposed.flatten().map { it.unsignedTx },
-                                listOf(watch.tx)
+                                fundingTx = null,
+                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                mutualCloseProposed = state.closingTxProposed.flatten().map { it.unsignedTx },
+                                mutualClosePublished = listOf(watch.tx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -965,10 +966,10 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                                 currentTip,
                                 currentOnChainFeerates,
                                 state.commitments,
-                                null,
-                                currentBlockHeight.toLong(),
-                                state.closingTxProposed.flatten().map { it.unsignedTx },
-                                listOf(watch.tx)
+                                fundingTx = null,
+                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                mutualCloseProposed = state.closingTxProposed.flatten().map { it.unsignedTx },
+                                mutualClosePublished = listOf(watch.tx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -2266,10 +2267,10 @@ data class Negotiating(
                                 currentTip,
                                 currentOnChainFeerates,
                                 commitments,
-                                null,
-                                currentBlockHeight.toLong(),
-                                this.closingTxProposed.flatten().map { it.unsignedTx },
-                                listOf(signedClosingTx)
+                                fundingTx = null,
+                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                mutualCloseProposed = this.closingTxProposed.flatten().map { it.unsignedTx },
+                                mutualClosePublished = listOf(signedClosingTx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -2287,10 +2288,10 @@ data class Negotiating(
                                 currentTip,
                                 currentOnChainFeerates,
                                 commitments,
-                                null,
-                                currentBlockHeight.toLong(),
-                                this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(signedClosingTx),
-                                listOf(signedClosingTx)
+                                fundingTx =null,
+                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                mutualCloseProposed = this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(signedClosingTx),
+                                mutualClosePublished = listOf(signedClosingTx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -2333,10 +2334,10 @@ data class Negotiating(
                             currentTip,
                             currentOnChainFeerates,
                             commitments,
-                            null,
-                            currentBlockHeight.toLong(),
-                            this.closingTxProposed.flatten().map { it.unsignedTx },
-                            listOf(watch.tx)
+                            fundingTx = null,
+                            waitingSinceBlock = currentBlockHeight.toLong(),
+                            mutualCloseProposed = this.closingTxProposed.flatten().map { it.unsignedTx },
+                            mutualClosePublished = listOf(watch.tx)
                         )
                         val actions = listOf(
                             ChannelAction.Storage.StoreState(nextState),
@@ -2373,10 +2374,10 @@ data class Negotiating(
                     currentTip,
                     currentOnChainFeerates,
                     commitments,
-                    null,
-                    currentBlockHeight.toLong(),
-                    this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(bestUnpublishedClosingTx),
-                    listOf(bestUnpublishedClosingTx)
+                    fundingTx = null,
+                    waitingSinceBlock = currentBlockHeight.toLong(),
+                    mutualCloseProposed = this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(bestUnpublishedClosingTx),
+                    mutualClosePublished = listOf(bestUnpublishedClosingTx)
                 )
                 val actions = listOf(
                     ChannelAction.Storage.StoreState(nextState),

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/InMemoryPaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/InMemoryPaymentsDb.kt
@@ -51,22 +51,16 @@ class InMemoryPaymentsDb : PaymentsDb {
         return outgoing[id]?.let { payment ->
             val parts = outgoingParts.values.filter { it.first == payment.id }.map { it.second }
             return when (payment.status) {
-                is OutgoingPayment.Status.Succeeded -> payment.copy(parts = parts.filter { it.status is OutgoingPayment.Part.Status.Succeeded })
+                is OutgoingPayment.Status.Completed.Succeeded -> payment.copy(parts = parts.filter { it.status is OutgoingPayment.Part.Status.Succeeded })
                 else -> payment.copy(parts = parts)
             }
         }
     }
 
-    override suspend fun updateOutgoingPayment(id: UUID, failure: FinalFailure, completedAt: Long) {
+    override suspend fun updateOutgoingPayment(id: UUID, completed: OutgoingPayment.Status.Completed) {
         require(outgoing.contains(id)) { "outgoing payment with id=$id doesn't exist" }
         val payment = outgoing[id]!!
-        outgoing[id] = payment.copy(status = OutgoingPayment.Status.Failed(failure, completedAt))
-    }
-
-    override suspend fun updateOutgoingPayment(id: UUID, preimage: ByteVector32, completedAt: Long) {
-        require(outgoing.contains(id)) { "outgoing payment with id=$id doesn't exist" }
-        val payment = outgoing[id]!!
-        outgoing[id] = payment.copy(status = OutgoingPayment.Status.Succeeded(preimage, completedAt))
+        outgoing[id] = payment.copy(status = completed)
     }
 
     override suspend fun addOutgoingParts(parentId: UUID, parts: List<OutgoingPayment.Part>) {
@@ -104,7 +98,7 @@ class InMemoryPaymentsDb : PaymentsDb {
     override suspend fun listOutgoingPayments(count: Int, skip: Int, filters: Set<PaymentTypeFilter>): List<OutgoingPayment> =
         outgoing.values
             .asSequence()
-            .filter { it.details.matchesFilters(filters) && (it.status is OutgoingPayment.Status.Failed || it.status is OutgoingPayment.Status.Succeeded) }
+            .filter { it.details.matchesFilters(filters) && (it.status is OutgoingPayment.Status.Completed) }
             .sortedByDescending { WalletPayment.completedAt(it) }
             .drop(skip)
             .take(count)

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -40,11 +40,8 @@ interface OutgoingPaymentsDb {
     /** Get information about an outgoing payment (settled or not). */
     suspend fun getOutgoingPayment(id: UUID): OutgoingPayment?
 
-    /** Mark an outgoing payment as failed. */
-    suspend fun updateOutgoingPayment(id: UUID, failure: FinalFailure, completedAt: Long = currentTimestampMillis())
-
-    /** Mark an outgoing payment as succeeded. This should delete all intermediate failed payment parts and only keep the successful ones. */
-    suspend fun updateOutgoingPayment(id: UUID, preimage: ByteVector32, completedAt: Long = currentTimestampMillis())
+    /** Mark an outgoing payment as completed (failed, succeeded, mined). */
+    suspend fun updateOutgoingPayment(id: UUID, completed: OutgoingPayment.Status.Completed)
 
     /** Add new partial payments to a pending outgoing payment. */
     suspend fun addOutgoingParts(parentId: UUID, parts: List<OutgoingPayment.Part>)
@@ -65,7 +62,7 @@ interface OutgoingPaymentsDb {
     suspend fun listOutgoingPayments(count: Int, skip: Int, filters: Set<PaymentTypeFilter> = setOf()): List<OutgoingPayment>
 }
 
-enum class PaymentTypeFilter { Normal, KeySend, SwapIn, SwapOut }
+enum class PaymentTypeFilter { Normal, KeySend, SwapIn, SwapOut, ChannelClosing }
 
 /** A payment made to or from the wallet. */
 sealed class WalletPayment {
@@ -74,8 +71,7 @@ sealed class WalletPayment {
         fun completedAt(payment: WalletPayment): Long = when (payment) {
             is IncomingPayment -> payment.received?.receivedAt ?: 0
             is OutgoingPayment -> when (val status = payment.status) {
-                is OutgoingPayment.Status.Succeeded -> status.completedAt
-                is OutgoingPayment.Status.Failed -> status.completedAt
+                is OutgoingPayment.Status.Completed -> status.completedAt
                 else -> 0
             }
         }
@@ -159,7 +155,7 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
 
     val paymentHash: ByteVector32 = details.paymentHash
     val fees: MilliSatoshi = when (status) {
-        is Status.Failed -> 0.msat
+        is Status.Completed.Failed -> 0.msat
         else -> parts.filter { it.status is Part.Status.Succeeded || it.status == Part.Status.Pending }.map { it.amount }.sum() - recipientAmount
     }
 
@@ -179,17 +175,24 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
         /** Swaps out send a lightning payment to a swap server, which will send an on-chain transaction to a given address. */
         data class SwapOut(val address: String, override val paymentHash: ByteVector32) : Details()
 
+        data class ChannelClosing(val closingAddress: String, val fundingKeyPath: String?, override val paymentHash: ByteVector32) : Details()
+
         fun matchesFilters(filters: Set<PaymentTypeFilter>): Boolean = when (this) {
             is Normal -> filters.isEmpty() || filters.contains(PaymentTypeFilter.Normal)
             is KeySend -> filters.isEmpty() || filters.contains(PaymentTypeFilter.KeySend)
             is SwapOut -> filters.isEmpty() || filters.contains(PaymentTypeFilter.SwapOut)
+            is ChannelClosing -> filters.isEmpty() || filters.contains(PaymentTypeFilter.ChannelClosing)
         }
     }
 
     sealed class Status {
         object Pending : Status()
-        data class Succeeded(val preimage: ByteVector32, val completedAt: Long = currentTimestampMillis()) : Status()
-        data class Failed(val reason: FinalFailure, val completedAt: Long = currentTimestampMillis()) : Status()
+        sealed class Completed : Status() {
+            abstract val completedAt: Long
+            data class Succeeded(val preimage: ByteVector32, override val completedAt: Long = currentTimestampMillis()) : Completed()
+            data class Failed(val reason: FinalFailure, override val completedAt: Long = currentTimestampMillis()) : Completed()
+            data class Mined(val txids: List<ByteVector32>, override val completedAt: Long = currentTimestampMillis()) : Completed()
+        }
     }
 
     /**

--- a/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandler.kt
@@ -59,10 +59,11 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
         return when (val result = RouteCalculation.findRoutes(request.paymentId, trampolineAmount, channels)) {
             is Either.Left -> {
                 logger.warning { "h:${request.paymentHash} p:${request.paymentId} payment failed: ${result.value}" }
-                val failure = result.value.toPaymentFailure()
                 db.addOutgoingPayment(OutgoingPayment(request.paymentId, request.amount, request.recipient, request.details))
-                db.updateOutgoingPayment(request.paymentId, failure.reason)
-                Failure(request, failure)
+                val finalFailure = result.value
+                val failed = OutgoingPayment.Status.Completed.Failed(finalFailure)
+                db.updateOutgoingPayment(request.paymentId, failed)
+                Failure(request, finalFailure.toPaymentFailure())
             }
             is Either.Right -> {
                 // We generate a random secret for this payment to avoid leaking the invoice secret to the trampoline node.
@@ -158,7 +159,8 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                                 logger.warning { "h:${payment.request.paymentHash} p:${payment.request.paymentId} payment failed: ${routes.value}" }
                                 val aborted = PaymentAttempt.PaymentAborted(payment.request, routes.value, mapOf(), payment.failures + Either.Right(failure))
                                 val result = Failure(payment.request, OutgoingPaymentFailure(aborted.reason, aborted.failures))
-                                db.updateOutgoingPayment(payment.request.paymentId, result.failure.reason)
+                                val completed = OutgoingPayment.Status.Completed.Failed(result.failure.reason)
+                                db.updateOutgoingPayment(payment.request.paymentId, completed)
                                 Pair(aborted, result)
                             }
                             is Either.Right -> {
@@ -203,7 +205,8 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                 val hasMorePendingParts = payment.parts.any { it.status == OutgoingPayment.Part.Status.Pending && it.id != partId }
                 return if (!hasMorePendingParts) {
                     logger.warning { "h:${payment.paymentHash} p:${payment.id} payment failed: ${FinalFailure.WalletRestarted}" }
-                    db.updateOutgoingPayment(payment.id, FinalFailure.WalletRestarted)
+                    val completed = OutgoingPayment.Status.Completed.Failed(FinalFailure.WalletRestarted)
+                    db.updateOutgoingPayment(payment.id, completed)
                     Failure(
                         SendPayment(payment.id, payment.recipientAmount, payment.recipient, payment.details as OutgoingPayment.Details.Normal),
                         OutgoingPaymentFailure(FinalFailure.WalletRestarted, payment.parts.map { it.status }.filterIsInstance<OutgoingPayment.Part.Status.Failed>() + OutgoingPaymentFailure.convertFailure(failure))
@@ -238,9 +241,10 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
 
         return if (updated.isComplete()) {
             logger.info { "h:${payment.request.paymentHash} p:${payment.request.paymentId} payment successfully sent (fees=${updated.fees})" }
-            db.updateOutgoingPayment(payment.request.paymentId, preimage)
+            val completed = OutgoingPayment.Status.Completed.Succeeded(preimage)
+            db.updateOutgoingPayment(payment.request.paymentId, completed)
             val r = payment.request
-            Success(r, OutgoingPayment(r.paymentId, r.amount, r.recipient, r.details, updated.parts, OutgoingPayment.Status.Succeeded(preimage)), preimage)
+            Success(r, OutgoingPayment(r.paymentId, r.amount, r.recipient, r.details, updated.parts, OutgoingPayment.Status.Completed.Succeeded(preimage)), preimage)
         } else {
             PreimageReceived(payment.request, preimage)
         }
@@ -260,7 +264,8 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                 val hasMorePendingParts = payment.parts.any { it.status == OutgoingPayment.Part.Status.Pending && it.id != partId }
                 return if (!hasMorePendingParts) {
                     logger.info { "h:${payment.paymentHash} p:${payment.id} payment successfully sent (wallet restart)" }
-                    db.updateOutgoingPayment(payment.id, preimage)
+                    val completed = OutgoingPayment.Status.Completed.Succeeded(preimage)
+                    db.updateOutgoingPayment(payment.id, completed)
                     val succeeded = db.getOutgoingPayment(payment.id)!! //  NB: we reload the payment to ensure all parts status are updated
                     Success(request, succeeded, preimage)
                 } else {
@@ -377,7 +382,8 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                 val updated = copy(pending = pending - childId, failures = failures + failure)
                 val result = if (updated.isComplete()) {
                     logger.warning { "h:${request.paymentHash} p:${request.paymentId} payment failed: ${updated.reason}" }
-                    db.updateOutgoingPayment(request.paymentId, updated.reason)
+                    val completed = OutgoingPayment.Status.Completed.Failed(updated.reason)
+                    db.updateOutgoingPayment(request.paymentId, completed)
                     Failure(request, OutgoingPaymentFailure(updated.reason, updated.failures))
                 } else {
                     null
@@ -411,8 +417,9 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                 val updated = copy(pending = pending - childId)
                 val result = if (updated.isComplete()) {
                     logger.info { "h:${request.paymentHash} p:${request.paymentId} payment successfully sent (fees=${updated.fees})" }
-                    db.updateOutgoingPayment(request.paymentId, preimage)
-                    Success(request, OutgoingPayment(request.paymentId, request.amount, request.recipient, request.details, parts, OutgoingPayment.Status.Succeeded(preimage)), preimage)
+                    val completed = OutgoingPayment.Status.Completed.Succeeded(preimage)
+                    db.updateOutgoingPayment(request.paymentId, completed)
+                    Success(request, OutgoingPayment(request.paymentId, request.amount, request.recipient, request.details, parts, OutgoingPayment.Status.Completed.Succeeded(preimage)), preimage)
                 } else {
                     null
                 }

--- a/src/commonMain/kotlin/fr/acinq/eclair/utils/UUID.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/utils/UUID.kt
@@ -90,6 +90,11 @@ class UUID(val mostSignificantBits: Long, val leastSignificantBits: Long) : Comp
 
         fun randomUUID(): UUID {
             val data = ByteArray(16).also { Random.secure().nextBytes(it) }
+            return fromBytes(data)
+        }
+
+        fun fromBytes(data: ByteArray): UUID {
+            require(data.size == 16) { "data must be exactly 16 bytes" }
             data[6] = (data[6].toInt() and 0x0F).toByte()
             data[6] = (data[6].toInt() or 0x40).toByte()
             data[8] = (data[8].toInt() and 0x3F).toByte()


### PR DESCRIPTION
Phoenix-kmm [issue #123](https://github.com/ACINQ/phoenix-kmm/issues/123):

> When the user chooses to close (or force-close) a channel, there should be a corresponding transaction. From the user's perspective, any operation that alters the ledger should have a corresponding transaction.

This PR is an attempt to satisfy the requirement.

In terms of code changes, the general idea is quite simple: Whenever the Channel transitions to the Closing state, and the channel has a positive balance, we should inject a transaction into the ledger.

Now there are 19 different places where we transition to Closing within the `Channel.kt` file. So it seemed cleaner to encapsulate this logic within `Peer.kt`, where we can simply observe changes to a channel. So we have this setup:



```kotlin
launch {
  var oldChannels = channelsFlow.value
  channelsFlow.collect { newChannels ->
    // ... check for transition to Closing...
    oldChannels = newChannels
  }
  
  suspend fun handleChannelTransitionToClosing(
    channelId: ByteVector32,
    oldChannel: ChannelState,
    newChannel: Closing
  ): Unit {
    // ... inject transaction if needed ...
  }
}
```



(There are other ways to observe the Channel transitions. I think it's possible to use a custom setter for the `_channels` or `_channelsFlow`.)

In terms of the database entry, we now have a new `OutgoingPayment.Details` type:

```kotlin
data class ChannelClosing( ... )
```

From the UI perspective, the user would like to see where the funds are being sent to. That is, the bitcoin address that is to receive the funds.

Also, this represents a bitcoin transaction. And just because we broadcast a transaction to the network doesn't mean it will get mined. So we should monitor the network, and inform the user as to when it's safely mined. Luckily the code already does this. And that event triggers a transition from `Closing` to `Closed`. So again, we just need to monitor the channels state:

```kotlin
launch {
  var oldChannels = channelsFlow.value
  channelsFlow.collect { newChannels ->
    // ... check for transition to Closing...
    oldChannels = newChannels
  }
  
  suspend fun handleChannelTransitionToClosing(...) {
    // ...
  }
  suspend fun handleChannelTransitionToClosed(...) {
    // ...
  }
}
```

In terms of the database entry, we have a new status type: `Mined`:

```kotlin
sealed class Status {
  object Pending : Status()
  sealed class Completed : Status() {
    abstract val completedAt: Long
    data class Succeeded(val preimage: ByteVector32, override val completedAt: Long = currentTimestampMillis()) : Completed()
    data class Failed(val reason: FinalFailure, override val completedAt: Long = currentTimestampMillis()) : Completed()
    data class Mined(val txids: List<ByteVector32>, override val completedAt: Long = currentTimestampMillis()) : Completed()
  }
}
```

There is a corresponding branch for phoenix-kmm that handles all the necessary changes on that side of the codebase.

