### PR TITLE
Add explicit failure for UnknownNextPeer

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentFailure.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentFailure.kt
@@ -18,6 +18,7 @@ sealed class FinalFailure {
     object NoAvailableChannels : FinalFailure() { override fun toString(): String = "no channels available to send payment" }
     object InsufficientBalance : FinalFailure() { override fun toString(): String = "not enough funds in wallet to afford payment" }
     object NoRouteToRecipient : FinalFailure() { override fun toString(): String = "unable to route payment to recipient" }
+    object RecipientUnreachable : FinalFailure() { override fun toString(): String = "the recipient was offline or did not have enough liquidity to receive the payment" }
     object RetryExhausted: FinalFailure() { override fun toString(): String = "payment attempts exhausted without success" }
     object WalletRestarted: FinalFailure() { override fun toString(): String = "wallet restarted while a payment was ongoing" }
     object UnknownError : FinalFailure() { override fun toString(): String = "an unknown error occurred" }

--- a/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandler.kt
@@ -136,6 +136,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
             is PaymentAttempt.PaymentInProgress -> {
                 val finalError = when {
                     walletParams.trampolineFees.size <= payment.attemptNumber + 1 -> FinalFailure.RetryExhausted
+                    failure == UnknownNextPeer -> FinalFailure.RecipientUnreachable
                     failure != TrampolineExpiryTooSoon && failure != TrampolineFeeInsufficient -> FinalFailure.UnknownError // non-retriable error
                     else -> null
                 }


### PR DESCRIPTION
When an `UnknownNextPeer` error is returned, we know it means the final recipient is either offline or doesn't have enough inbound liquidity.