### PR TITLE
Fix tests

### DIFF
--- a/src/commonTest/kotlin/fr/acinq/eclair/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/wire/LightningCodecsTestsCommon.kt
@@ -471,7 +471,7 @@ class LightningCodecsTestsCommon : EclairTestSuite() {
     fun `encode - decode channel_announcement`() {
         val testCases = listOf(
             ChannelAnnouncement(randomBytes64(), randomBytes64(), randomBytes64(), randomBytes64(), Features(Hex.decode("09004200")), randomBytes32(), ShortChannelId(42), randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey()),
-            ChannelAnnouncement(randomBytes64(), randomBytes64(), randomBytes64(), randomBytes64(), Features(emptySet()), randomBytes32(), ShortChannelId(42), randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey(), ByteVector("01020304")),
+            ChannelAnnouncement(randomBytes64(), randomBytes64(), randomBytes64(), randomBytes64(), Features(mapOf()), randomBytes32(), ShortChannelId(42), randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey(), ByteVector("01020304")),
         )
 
         testCases.forEach {


### PR DESCRIPTION
Merging PR #224 broke the test suite, because it added a test case that conflicted with PR #225 but was not detected as a merge conflict because it was completely new code.