### PR TITLE
Precompute channel keys

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
@@ -573,9 +573,8 @@ data class WaitForInit(override val staticParams: StaticParams, override val cur
                 Pair(nextState, listOf())
             }
             event is ChannelEvent.InitFunder -> {
-                val fundingPubKey = keyManager.fundingPublicKey(event.localParams.fundingKeyPath).publicKey
-                val channelKeyPath = keyManager.channelKeyPath(event.localParams, event.channelVersion)
-                val paymentBasepoint = keyManager.paymentPoint(channelKeyPath)
+                val fundingPubKey = event.localParams.channelKeys.fundingPubKey
+                val paymentBasepoint = event.localParams.channelKeys.paymentBasepoint
                 val open = OpenChannel(
                     staticParams.nodeParams.chainHash,
                     temporaryChannelId = event.temporaryChannelId,
@@ -589,11 +588,11 @@ data class WaitForInit(override val staticParams: StaticParams, override val cur
                     toSelfDelay = event.localParams.toSelfDelay,
                     maxAcceptedHtlcs = event.localParams.maxAcceptedHtlcs,
                     fundingPubkey = fundingPubKey,
-                    revocationBasepoint = keyManager.revocationPoint(channelKeyPath).publicKey,
-                    paymentBasepoint = paymentBasepoint.publicKey,
-                    delayedPaymentBasepoint = keyManager.delayedPaymentPoint(channelKeyPath).publicKey,
-                    htlcBasepoint = keyManager.htlcPoint(channelKeyPath).publicKey,
-                    firstPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 0),
+                    revocationBasepoint = event.localParams.channelKeys.revocationBasepoint,
+                    paymentBasepoint = paymentBasepoint,
+                    delayedPaymentBasepoint = event.localParams.channelKeys.delayedPaymentBasepoint,
+                    htlcBasepoint = event.localParams.channelKeys.htlcBasepoint,
+                    firstPerCommitmentPoint = keyManager.commitmentPoint(event.localParams.channelKeys.shaSeed, 0),
                     channelFlags = event.channelFlags,
                     // In order to allow TLV extensions and keep backwards-compatibility, we include an empty upfront_shutdown_script.
                     // See https://github.com/lightningnetwork/lightning-rfc/pull/714.
@@ -730,8 +729,7 @@ data class Offline(val state: ChannelStateWithCommitments) : ChannelState() {
                     }
                     else -> {
                         val yourLastPerCommitmentSecret = state.commitments.remotePerCommitmentSecrets.lastIndex?.let { state.commitments.remotePerCommitmentSecrets.getHash(it) } ?: ByteVector32.Zeroes
-                        val channelKeyPath = keyManager.channelKeyPath(state.commitments.localParams, state.commitments.channelVersion)
-                        val myCurrentPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, state.commitments.localCommit.index)
+                        val myCurrentPerCommitmentPoint = keyManager.commitmentPoint(state.commitments.localParams.channelKeys.shaSeed, state.commitments.localCommit.index)
 
                         val channelReestablish = ChannelReestablish(
                             channelId = state.channelId,
@@ -861,8 +859,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                         }
 
                         val yourLastPerCommitmentSecret = nextState.commitments.remotePerCommitmentSecrets.lastIndex?.let { nextState.commitments.remotePerCommitmentSecrets.getHash(it) } ?: ByteVector32.Zeroes
-                        val channelKeyPath = keyManager.channelKeyPath(state.commitments.localParams, nextState.commitments.channelVersion)
-                        val myCurrentPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, nextState.commitments.localCommit.index)
+                        val myCurrentPerCommitmentPoint = keyManager.commitmentPoint(state.commitments.localParams.channelKeys.shaSeed, nextState.commitments.localCommit.index)
 
                         val channelReestablish = ChannelReestablish(
                             channelId = nextState.channelId,
@@ -897,19 +894,17 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                     }
                     state is WaitForFundingLocked -> {
                         logger.debug { "c:${state.channelId} re-sending fundingLocked" }
-                        val channelKeyPath = keyManager.channelKeyPath(state.commitments.localParams, state.commitments.channelVersion)
-                        val nextPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 1)
+                        val nextPerCommitmentPoint = keyManager.commitmentPoint(state.commitments.localParams.channelKeys.shaSeed, 1)
                         val fundingLocked = FundingLocked(state.commitments.channelId, nextPerCommitmentPoint)
                         val actions = listOf(ChannelAction.Message.Send(fundingLocked))
                         Pair(state, actions)
                     }
                     state is Normal -> {
-                        val channelKeyPath = keyManager.channelKeyPath(state.commitments.localParams, state.commitments.channelVersion)
                         when {
                             !Helpers.checkLocalCommit(state.commitments, event.message.nextRemoteRevocationNumber) -> {
                                 // if next_remote_revocation_number is greater than our local commitment index, it means that either we are using an outdated commitment, or they are lying
                                 // but first we need to make sure that the last per_commitment_secret that they claim to have received from us is correct for that next_remote_revocation_number minus 1
-                                if (keyManager.commitmentSecret(channelKeyPath, event.message.nextRemoteRevocationNumber - 1) == event.message.yourLastCommitmentSecret) {
+                                if (keyManager.commitmentSecret(state.commitments.localParams.channelKeys.shaSeed, event.message.nextRemoteRevocationNumber - 1) == event.message.yourLastCommitmentSecret) {
                                     logger.warning { "c:${state.channelId} counterparty proved that we have an outdated (revoked) local commitment!!! ourCommitmentNumber=${state.commitments.localCommit.index} theirCommitmentNumber=${event.message.nextRemoteRevocationNumber}" }
                                     // their data checks out, we indeed seem to be using an old revoked commitment, and must absolutely *NOT* publish it, because that would be a cheating attempt and they
                                     // would punish us by taking all the funds in the channel
@@ -954,7 +949,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                                 if (event.message.nextLocalCommitmentNumber == 1L && state.commitments.localCommit.index == 0L) {
                                     // If next_local_commitment_number is 1 in both the channel_reestablish it sent and received, then the node MUST retransmit funding_locked, otherwise it MUST NOT
                                     logger.debug { "c:${state.channelId} re-sending fundingLocked" }
-                                    val nextPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 1)
+                                    val nextPerCommitmentPoint = keyManager.commitmentPoint(state.commitments.localParams.channelKeys.shaSeed, 1)
                                     val fundingLocked = FundingLocked(state.commitments.channelId, nextPerCommitmentPoint)
                                     actions.add(ChannelAction.Message.Send(fundingLocked))
                                 }
@@ -1166,10 +1161,9 @@ data class WaitForOpenChannel(
                         }
                         val channelOrigin = event.message.tlvStream.records.filterIsInstance<ChannelTlv.ChannelOriginTlv>().firstOrNull()?.channelOrigin
 
-                        val fundingPubkey = keyManager.fundingPublicKey(localParams.fundingKeyPath).publicKey
-                        val channelKeyPath = keyManager.channelKeyPath(localParams, channelVersion)
+                        val fundingPubkey = localParams.channelKeys.fundingPubKey
                         val minimumDepth = Helpers.minDepthForFunding(staticParams.nodeParams, event.message.fundingSatoshis)
-                        val paymentBasepoint = keyManager.paymentPoint(channelKeyPath)
+                        val paymentBasepoint = localParams.channelKeys.paymentBasepoint
                         val accept = AcceptChannel(
                             temporaryChannelId = event.message.temporaryChannelId,
                             dustLimitSatoshis = localParams.dustLimit,
@@ -1180,11 +1174,11 @@ data class WaitForOpenChannel(
                             toSelfDelay = localParams.toSelfDelay,
                             maxAcceptedHtlcs = localParams.maxAcceptedHtlcs,
                             fundingPubkey = fundingPubkey,
-                            revocationBasepoint = keyManager.revocationPoint(channelKeyPath).publicKey,
-                            paymentBasepoint = paymentBasepoint.publicKey,
-                            delayedPaymentBasepoint = keyManager.delayedPaymentPoint(channelKeyPath).publicKey,
-                            htlcBasepoint = keyManager.htlcPoint(channelKeyPath).publicKey,
-                            firstPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 0),
+                            revocationBasepoint = localParams.channelKeys.revocationBasepoint,
+                            paymentBasepoint = paymentBasepoint,
+                            delayedPaymentBasepoint = localParams.channelKeys.delayedPaymentBasepoint,
+                            htlcBasepoint = localParams.channelKeys.htlcBasepoint,
+                            firstPerCommitmentPoint = keyManager.commitmentPoint(keyManager.channelKeyPath(localParams, channelVersion), 0),
                             // In order to allow TLV extensions and keep backwards-compatibility, we include an empty upfront_shutdown_script.
                             // See https://github.com/lightningnetwork/lightning-rfc/pull/714.
                             tlvStream = TlvStream(listOf(ChannelTlv.UpfrontShutdownScript(ByteVector.empty)))
@@ -1267,7 +1261,6 @@ data class WaitForFundingCreated(
                         // they fund the channel with their funding tx, so the money is theirs (but we are paid pushMsat)
                         val firstCommitTxRes = Helpers.Funding.makeFirstCommitTxs(
                             keyManager,
-                            channelVersion,
                             temporaryChannelId,
                             localParams,
                             remoteParams,
@@ -1286,11 +1279,11 @@ data class WaitForFundingCreated(
                             is Either.Right -> {
                                 val firstCommitTx = firstCommitTxRes.value
                                 // check remote signature validity
-                                val fundingPubKey = keyManager.fundingPublicKey(localParams.fundingKeyPath)
-                                val localSigOfLocalTx = keyManager.sign(firstCommitTx.localCommitTx, fundingPubKey)
+                                val fundingPubKey = localParams.channelKeys.fundingPubKey
+                                val localSigOfLocalTx = keyManager.sign(firstCommitTx.localCommitTx, localParams.channelKeys.fundingPrivateKey)
                                 val signedLocalCommitTx = Transactions.addSigs(
                                     firstCommitTx.localCommitTx,
-                                    fundingPubKey.publicKey,
+                                    fundingPubKey,
                                     remoteParams.fundingPubKey,
                                     localSigOfLocalTx,
                                     event.message.signature
@@ -1301,7 +1294,7 @@ data class WaitForFundingCreated(
                                         handleLocalError(event, result.error)
                                     }
                                     is Try.Success -> {
-                                        val localSigOfRemoteTx = keyManager.sign(firstCommitTx.remoteCommitTx, fundingPubKey)
+                                        val localSigOfRemoteTx = keyManager.sign(firstCommitTx.remoteCommitTx, localParams.channelKeys.fundingPrivateKey)
                                         val channelId = Lightning.toLongId(event.message.fundingTxid, event.message.fundingOutputIndex)
                                         // watch the funding tx transaction
                                         val commitInput = firstCommitTx.localCommitTx.input
@@ -1407,8 +1400,8 @@ data class WaitForAcceptChannel(
                     htlcBasepoint = event.message.htlcBasepoint,
                     features = Features(initFunder.remoteInit.features)
                 )
-                val localFundingPubkey = keyManager.fundingPublicKey(initFunder.localParams.fundingKeyPath)
-                val fundingPubkeyScript = ByteVector(Script.write(Script.pay2wsh(Scripts.multiSig2of2(localFundingPubkey.publicKey, remoteParams.fundingPubKey))))
+                val localFundingPubkey = initFunder.localParams.channelKeys.fundingPubKey
+                val fundingPubkeyScript = ByteVector(Script.write(Script.pay2wsh(Scripts.multiSig2of2(localFundingPubkey, remoteParams.fundingPubKey))))
                 val makeFundingTx = ChannelAction.Blockchain.MakeFundingTx(fundingPubkeyScript, initFunder.fundingAmount, initFunder.fundingTxFeerate)
                 val nextState = WaitForFundingInternal(
                     staticParams,
@@ -1465,7 +1458,6 @@ data class WaitForFundingInternal(
                 // let's create the first commitment tx that spends the yet uncommitted funding tx
                 val firstCommitTxRes = Helpers.Funding.makeFirstCommitTxs(
                     keyManager,
-                    channelVersion,
                     temporaryChannelId,
                     localParams,
                     remoteParams,
@@ -1484,7 +1476,7 @@ data class WaitForFundingInternal(
                     is Either.Right -> {
                         val firstCommitTx = firstCommitTxRes.value
                         require(event.fundingTx.txOut[event.fundingTxOutputIndex].publicKeyScript == firstCommitTx.localCommitTx.input.txOut.publicKeyScript) { "pubkey script mismatch!" }
-                        val localSigOfRemoteTx = keyManager.sign(firstCommitTx.remoteCommitTx, keyManager.fundingPublicKey(localParams.fundingKeyPath))
+                        val localSigOfRemoteTx = keyManager.sign(firstCommitTx.remoteCommitTx, localParams.channelKeys.fundingPrivateKey)
                         // signature of their initial commitment tx that pays remote pushMsat
                         val fundingCreated = FundingCreated(
                             temporaryChannelId = temporaryChannelId,
@@ -1555,9 +1547,9 @@ data class WaitForFundingSigned(
         return when {
             event is ChannelEvent.MessageReceived && event.message is FundingSigned -> {
                 // we make sure that their sig checks out and that our first commit tx is spendable
-                val fundingPubKey = keyManager.fundingPublicKey(localParams.fundingKeyPath)
-                val localSigOfLocalTx = keyManager.sign(localCommitTx, fundingPubKey)
-                val signedLocalCommitTx = Transactions.addSigs(localCommitTx, fundingPubKey.publicKey, remoteParams.fundingPubKey, localSigOfLocalTx, event.message.signature)
+                val fundingPubKey = localParams.channelKeys.fundingPubKey
+                val localSigOfLocalTx = keyManager.sign(localCommitTx, localParams.channelKeys.fundingPrivateKey)
+                val signedLocalCommitTx = Transactions.addSigs(localCommitTx, fundingPubKey, remoteParams.fundingPubKey, localSigOfLocalTx, event.message.signature)
                 when (Transactions.checkSpendable(signedLocalCommitTx)) {
                     is Try.Failure -> handleLocalError(event, InvalidCommitmentSignature(channelId, signedLocalCommitTx.tx))
                     is Try.Success -> {
@@ -1656,8 +1648,7 @@ data class WaitForFundingConfirmed(
                             return handleLocalError(event, InvalidCommitmentSignature(channelId, event.watch.tx))
                         }
                         val watchLost = WatchLost(this.channelId, commitments.commitInput.outPoint.txid, staticParams.nodeParams.minDepthBlocks.toLong(), BITCOIN_FUNDING_LOST)
-                        val channelKeyPath = keyManager.channelKeyPath(commitments.localParams, commitments.channelVersion)
-                        val nextPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 1)
+                        val nextPerCommitmentPoint = keyManager.commitmentPoint(commitments.localParams.channelKeys.shaSeed, 1)
                         val fundingLocked = FundingLocked(commitments.channelId, nextPerCommitmentPoint)
                         // this is the temporary channel id that we will use in our channel_update message, the goal is to be able to use our channel
                         // as soon as it reaches NORMAL state, and before it is announced on the network
@@ -3048,9 +3039,8 @@ object Channel {
                 channelReestablish.nextRemoteRevocationNumber + 1 -> {
                     // our last revocation got lost, let's resend it
                     log.debug { "re-sending last revocation" }
-                    val channelKeyPath = keyManager.channelKeyPath(d.commitments.localParams, d.commitments.channelVersion)
-                    val localPerCommitmentSecret = keyManager.commitmentSecret(channelKeyPath, d.commitments.localCommit.index - 1)
-                    val localNextPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, d.commitments.localCommit.index + 1)
+                    val localPerCommitmentSecret = keyManager.commitmentSecret(d.commitments.localParams.channelKeys.shaSeed, d.commitments.localCommit.index - 1)
+                    val localNextPerCommitmentPoint = keyManager.commitmentPoint(d.commitments.localParams.channelKeys.shaSeed, d.commitments.localCommit.index + 1)
                     val revocation = RevokeAndAck(commitments1.channelId, localPerCommitmentSecret, localNextPerCommitmentPoint)
                     sendQueue.add(ChannelAction.Message.Send(revocation))
                 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelTypes.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelTypes.kt
@@ -392,10 +392,26 @@ data class RevokedCommitPublished(
     }
 }
 
+data class ChannelKeys(
+    val fundingKeyPath: KeyPath,
+    val fundingPrivateKey: PrivateKey,
+    val paymentKey: PrivateKey,
+    val delayedPaymentKey: PrivateKey,
+    val htlcKey: PrivateKey,
+    val revocationKey: PrivateKey,
+    val shaSeed: ByteVector32
+) {
+    val fundingPubKey: PublicKey = fundingPrivateKey.publicKey()
+    val htlcBasepoint: PublicKey = htlcKey.publicKey()
+    val paymentBasepoint: PublicKey = paymentKey.publicKey()
+    val delayedPaymentBasepoint: PublicKey = delayedPaymentKey.publicKey()
+    val revocationBasepoint: PublicKey = revocationKey.publicKey()
+}
+
 @OptIn(ExperimentalUnsignedTypes::class)
 data class LocalParams constructor(
     val nodeId: PublicKey,
-    val fundingKeyPath: KeyPath,
+    val channelKeys: ChannelKeys,
     val dustLimit: Satoshi,
     val maxHtlcValueInFlightMsat: Long, // this is not MilliSatoshi because it can exceed the total amount of MilliSatoshi
     val channelReserve: Satoshi,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -459,7 +459,7 @@ data class Commitments(
 
         // remote commitment will include all local changes + remote acked changes
         val spec = CommitmentSpec.reduce(remoteCommit.spec, remoteChanges.acked, localChanges.proposed)
-        val (remoteCommitTx, htlcTxs) = makeRemoteTxs( remoteCommit.index + 1, localParams, remoteParams, commitInput, remoteNextPerCommitmentPoint, spec)
+        val (remoteCommitTx, htlcTxs) = makeRemoteTxs(remoteCommit.index + 1, localParams, remoteParams, commitInput, remoteNextPerCommitmentPoint, spec)
         val sig = keyManager.sign(remoteCommitTx, localParams.channelKeys.fundingPrivateKey)
 
         val sortedHtlcTxs: List<HtlcTx> = htlcTxs.sortedBy { it.input.outPoint.index }
@@ -504,7 +504,7 @@ data class Commitments(
 
         val spec = CommitmentSpec.reduce(localCommit.spec, localChanges.acked, remoteChanges.proposed)
         val localPerCommitmentPoint = keyManager.commitmentPoint(localParams.channelKeys.shaSeed, localCommit.index + 1)
-        val (localCommitTx, htlcTxs) = makeLocalTxs( localCommit.index + 1, localParams, remoteParams, commitInput, localPerCommitmentPoint, spec)
+        val (localCommitTx, htlcTxs) = makeLocalTxs(localCommit.index + 1, localParams, remoteParams, commitInput, localPerCommitmentPoint, spec)
         val sig = Transactions.sign(localCommitTx, localParams.channelKeys.fundingPrivateKey)
 
         log.info {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -341,8 +341,8 @@ object Helpers {
             val fundingPubKey = localParams.channelKeys.fundingPubKey
             val commitmentInput = makeFundingInputInfo(fundingTxHash, fundingTxOutputIndex, fundingAmount, fundingPubKey, remoteParams.fundingPubKey)
             val localPerCommitmentPoint = keyManager.commitmentPoint(localParams.channelKeys.shaSeed, 0)
-            val localCommitTx = Commitments.makeLocalTxs( 0, localParams, remoteParams, commitmentInput, localPerCommitmentPoint, localSpec).first
-            val remoteCommitTx = Commitments.makeRemoteTxs( 0, localParams, remoteParams, commitmentInput, remoteFirstPerCommitmentPoint, remoteSpec).first
+            val localCommitTx = Commitments.makeLocalTxs(0, localParams, remoteParams, commitmentInput, localPerCommitmentPoint, localSpec).first
+            val remoteCommitTx = Commitments.makeRemoteTxs(0, localParams, remoteParams, commitmentInput, remoteFirstPerCommitmentPoint, remoteSpec).first
 
             return Either.Right(FirstCommitTx(localSpec, localCommitTx, remoteSpec, remoteCommitTx))
         }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
@@ -54,14 +54,18 @@ interface KeyManager {
      */
     fun newFundingKeyPath(isFunder: Boolean): KeyPath
 
-    fun channelKeys(fundingKeyPath: KeyPath) : ChannelKeys
+    /**
+     * generate channel-specific keys and secrets
+     * @params funding public key BIP32 path
+     * @return channel keys and secrets
+     */
+    fun channelKeys(fundingKeyPath: KeyPath): ChannelKeys
 
     /**
      *
      * @param tx        input transaction
-     * @param publicKey extended public key
-     * @return a signature generated with the private key that matches the input
-     *         extended public key
+     * @param privateKey private key
+     * @return a signature generated with the input private key
      */
     fun sign(tx: TransactionWithInputInfo, privateKey: PrivateKey): ByteVector64
 
@@ -69,10 +73,9 @@ interface KeyManager {
      * This method is used to spend funds send to htlc keys/delayed keys
      *
      * @param tx          input transaction
-     * @param publicKey   extended public key
+     * @param privateKey  private key
      * @param remotePoint remote point
-     * @return a signature generated with a private key generated from the input keys's matching
-     *         private key and the remote point.
+     * @return a signature generated with a private key generated from the input private key and the remote point.
      */
     fun sign(tx: TransactionWithInputInfo, privateKey: PrivateKey, remotePoint: PublicKey, sigHash: Int): ByteVector64
 
@@ -80,10 +83,9 @@ interface KeyManager {
      * Ths method is used to spend revoked transactions, with the corresponding revocation key
      *
      * @param tx           input transaction
-     * @param publicKey    extended public key
+     * @param privateKey   private key
      * @param remoteSecret remote secret
-     * @return a signature generated with a private key generated from the input keys's matching
-     *         private key and the remote secret.
+     * @return a signature generated with a private key generated from the input private key and the remote secret.
      */
     fun sign(tx: TransactionWithInputInfo, privateKey: PrivateKey, remoteSecret: PrivateKey): ByteVector64
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -526,7 +526,7 @@ class Peer(
                         val (_, closingPubkeyScript) = nodeParams.keyManager.closingPubkeyScript(fundingPubkey.publicKey)
                         val localParams = LocalParams(
                             nodeParams.nodeId,
-                            fundingKeyPath,
+                            nodeParams.keyManager.channelKeys(fundingKeyPath),
                             nodeParams.dustLimit,
                             nodeParams.maxHtlcValueInFlightMsat,
                             Satoshi(600),

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/PeerChannels.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/PeerChannels.kt
@@ -17,7 +17,7 @@ object PeerChannels {
     fun makeChannelParams(nodeParams: NodeParams, defaultFinalScriptPubkey: ByteVector, isFunder: Boolean, fundingAmount: Satoshi, fundingKeyPath: KeyPath): LocalParams {
         return LocalParams(
             nodeParams.nodeId,
-            fundingKeyPath,
+            nodeParams.keyManager.channelKeys(fundingKeyPath),
             dustLimit = nodeParams.dustLimit,
             maxHtlcValueInFlightMsat = nodeParams.maxHtlcValueInFlightMsat,
             channelReserve = (fundingAmount * nodeParams.reserveToFundingRatio).max(nodeParams.dustLimit), // BOLT #2: make sure that our reserve is above our dust limit

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v1/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v1/ChannelState.kt
@@ -169,7 +169,7 @@ data class LocalParams constructor(
 ) {
     constructor(from: fr.acinq.lightning.channel.LocalParams) : this(
         from.nodeId,
-        from.fundingKeyPath,
+        from.channelKeys.fundingKeyPath,
         from.dustLimit,
         from.maxHtlcValueInFlightMsat,
         from.channelReserve,
@@ -181,7 +181,7 @@ data class LocalParams constructor(
         from.features
     )
 
-    fun export() = fr.acinq.lightning.channel.LocalParams(nodeId, fundingKeyPath, dustLimit, maxHtlcValueInFlightMsat, channelReserve, htlcMinimum, toSelfDelay, maxAcceptedHtlcs, isFunder, defaultFinalScriptPubKey, features)
+    fun export(nodeParams: NodeParams) = fr.acinq.lightning.channel.LocalParams(nodeId, nodeParams.keyManager.channelKeys(fundingKeyPath), dustLimit, maxHtlcValueInFlightMsat, channelReserve, htlcMinimum, toSelfDelay, maxAcceptedHtlcs, isFunder, defaultFinalScriptPubKey, features)
 }
 
 @OptIn(ExperimentalUnsignedTypes::class)
@@ -290,9 +290,9 @@ data class Commitments(
         from.remoteChannelData
     )
 
-    fun export() = fr.acinq.lightning.channel.Commitments(
+    fun export(nodeParams: NodeParams) = fr.acinq.lightning.channel.Commitments(
         channelVersion.export(),
-        localParams.export(),
+        localParams.export(nodeParams),
         remoteParams.export(),
         channelFlags,
         localCommit.export(),
@@ -445,7 +445,7 @@ data class WaitForRemotePublishFutureCommitment(
     )
 
     override fun export(nodeParams: NodeParams) =
-        fr.acinq.lightning.channel.WaitForRemotePublishFutureCommitment(staticParams.export(nodeParams), currentTip, currentOnChainFeerates.export(), commitments.export(), remoteChannelReestablish)
+        fr.acinq.lightning.channel.WaitForRemotePublishFutureCommitment(staticParams.export(nodeParams), currentTip, currentOnChainFeerates.export(), commitments.export(nodeParams), remoteChannelReestablish)
 }
 
 @Serializable
@@ -615,7 +615,7 @@ data class WaitForFundingConfirmed(
         staticParams.export(nodeParams),
         currentTip,
         currentOnChainFeerates.export(),
-        commitments.export(),
+        commitments.export(nodeParams),
         fundingTx,
         waitingSinceBlock,
         deferred,
@@ -645,7 +645,7 @@ data class WaitForFundingLocked(
         staticParams.export(nodeParams),
         currentTip,
         currentOnChainFeerates.export(),
-        commitments.export(),
+        commitments.export(nodeParams),
         shortChannelId,
         lastSent
     )
@@ -683,7 +683,7 @@ data class Normal(
         staticParams.export(nodeParams),
         currentTip,
         currentOnChainFeerates.export(),
-        commitments.export(),
+        commitments.export(nodeParams),
         shortChannelId,
         buried,
         channelAnnouncement,
@@ -716,7 +716,7 @@ data class ShuttingDown(
         staticParams.export(nodeParams),
         currentTip,
         currentOnChainFeerates.export(),
-        commitments.export(),
+        commitments.export(nodeParams),
         localShutdown,
         remoteShutdown
     )
@@ -753,7 +753,7 @@ data class Negotiating(
         staticParams.export(nodeParams),
         currentTip,
         currentOnChainFeerates.export(),
-        commitments.export(),
+        commitments.export(nodeParams),
         localShutdown,
         remoteShutdown,
         closingTxProposed.map { x -> x.map { it.export() } },
@@ -797,7 +797,7 @@ data class Closing(
         staticParams.export(nodeParams),
         currentTip,
         currentOnChainFeerates.export(),
-        commitments.export(),
+        commitments.export(nodeParams),
         fundingTx,
         waitingSinceBlock,
         mutualCloseProposed,
@@ -840,6 +840,6 @@ data class ErrorInformationLeak(
         staticParams.export(nodeParams),
         currentTip,
         currentOnChainFeerates.export(),
-        commitments.export()
+        commitments.export(nodeParams)
     )
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v1/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v1/ChannelState.kt
@@ -152,6 +152,11 @@ data class RevokedCommitPublished(
     fun export() = fr.acinq.lightning.channel.RevokedCommitPublished(commitTx, remotePerCommitmentSecret, claimMainOutputTx, mainPenaltyTx, htlcPenaltyTxs, claimHtlcDelayedPenaltyTxs, irrevocablySpent)
 }
 
+/**
+ * README: by design, we do not include channel private keys and secret here, so they won't be included in our backups (local files, encrypted peer backup, ...), so even
+ * if these backups were compromised channel private keys would not be leaked unless the main seed was also compromised.
+ * This means that they will be recomputed once when we convert serialized data to their "live" counterparts.
+ */
 @OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class LocalParams constructor(

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
@@ -472,8 +472,9 @@ class CommitmentsTestsCommon : LightningTestSuite() {
     @OptIn(ExperimentalUnsignedTypes::class)
     companion object {
         fun makeCommitments(toLocal: MilliSatoshi, toRemote: MilliSatoshi, feeRatePerKw: FeeratePerKw = FeeratePerKw(0.sat), dustLimit: Satoshi = 0.sat, isFunder: Boolean = true, announceChannel: Boolean = true): Commitments {
+            val channelKeys = ChannelKeys(KeyPath("42"), randomKey(), randomKey(), randomKey(), randomKey() , randomKey(), randomBytes32())
             val localParams = LocalParams(
-                randomKey().publicKey(), KeyPath("42"), dustLimit, Long.MAX_VALUE, 0.sat, 1.msat, CltvExpiryDelta(144), 50, isFunder, ByteVector.empty, Features.empty
+                randomKey().publicKey(), channelKeys, dustLimit, Long.MAX_VALUE, 0.sat, 1.msat, CltvExpiryDelta(144), 50, isFunder, ByteVector.empty, Features.empty
             )
             val remoteParams = RemoteParams(
                 randomKey().publicKey(), dustLimit, Long.MAX_VALUE, 0.sat, 1.msat, CltvExpiryDelta(144), 50,
@@ -505,8 +506,9 @@ class CommitmentsTestsCommon : LightningTestSuite() {
         }
 
         fun makeCommitments(toLocal: MilliSatoshi, toRemote: MilliSatoshi, localNodeId: PublicKey, remoteNodeId: PublicKey, announceChannel: Boolean): Commitments {
+            val channelKeys = ChannelKeys(KeyPath("42"), randomKey(), randomKey(), randomKey(), randomKey() , randomKey(), randomBytes32())
             val localParams = LocalParams(
-                localNodeId, KeyPath("42L"), 0.sat, Long.MAX_VALUE, 0.sat, 1.msat, CltvExpiryDelta(144), 50, isFunder = true, ByteVector.empty, Features.empty
+                localNodeId, channelKeys, 0.sat, Long.MAX_VALUE, 0.sat, 1.msat, CltvExpiryDelta(144), 50, isFunder = true, ByteVector.empty, Features.empty
             )
             val remoteParams = RemoteParams(
                 remoteNodeId, 0.sat, Long.MAX_VALUE, 0.sat, 1.msat, CltvExpiryDelta(144), 50, randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey(), Features.empty

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
@@ -2,6 +2,7 @@ package fr.acinq.lightning.crypto
 
 import fr.acinq.bitcoin.*
 import fr.acinq.bitcoin.crypto.Pack
+import fr.acinq.lightning.channel.ChannelKeys
 import fr.acinq.lightning.channel.ChannelVersion
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
@@ -37,6 +38,29 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     }
 
     @Test
+    fun `generate channel keys`() {
+        val seed = ByteVector("aeb3e9b5642cd4523e9e09164047f60adb413633549c3c6189192921311894d501")
+        val keyManager = LocalKeyManager(seed, Block.TestnetGenesisBlock.hash)
+        val fundingKeyPath = makefundingKeyPath(ByteVector("06535806c1aa73971ec4877a5e2e684fa636136c073810f190b63eefc58ca488"), isFunder = false)
+        val channelKeys = keyManager.channelKeys(fundingKeyPath)
+
+        // README !
+        // test data generated with v1.0-beta11, but they should never change
+        // if this test fails it means that we cannot restore channels created with older phoenix of lightning-kmp without
+        // some kind of migration process
+        val expected = ChannelKeys(
+            fundingKeyPath = fundingKeyPath,
+            fundingPrivateKey = PrivateKey.fromHex("cd85f39fad742e5c742eeab16f5f1acaa9d9c48977767c7daa4708a47b7222ec"),
+            paymentKey = PrivateKey.fromHex("ad635d9d4919e5657a9f306963a5976b533e9d70c8defa454f1bd958fae316c8"),
+            delayedPaymentKey = PrivateKey.fromHex("0f3c23df3feec614117de23d0b3f014174271826a16e59a17d9ebb655cc55e3f"),
+            htlcKey = PrivateKey.fromHex("664ca828a0510950f24859b62203af192ccc1188f20eb87de33c76e7e04ab0d4"),
+            revocationKey = PrivateKey.fromHex("ee211f583f3b1b1fb10dca7c82708d985fde641e83e28080f669eb496de85113"),
+            shaSeed = ByteVector32.fromValidHex("6255a59ea8155d41e62cddef2c8c63a077f75e23fd3eec1fd4881f6851412518")
+        )
+        assertEquals(expected, channelKeys, "channel key generation is broken !!!")
+    }
+
+    @Test
     fun `generate different node ids from the same seed on different chains`() {
         val seed = ByteVector("17b086b228025fa8f4416324b6ba2ec36e68570ae2fc3d392520969f2a9d0c1501")
         val keyManager1 = LocalKeyManager(seed, Block.TestnetGenesisBlock.hash)
@@ -69,7 +93,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         val fundingKeyPath = makefundingKeyPath(ByteVector("be4fa97c62b9f88437a3be577b31eb48f2165c7bc252194a15ff92d995778cfb"), isFunder = true)
         val fundingPub = keyManager.fundingPublicKey(fundingKeyPath)
 
-        val localParams = TestConstants.Alice.channelParams.copy(fundingKeyPath = fundingKeyPath)
+        val localParams = TestConstants.Alice.channelParams.copy(channelKeys = keyManager.channelKeys(fundingKeyPath))
         val channelKeyPath = keyManager.channelKeyPath(localParams, ChannelVersion.STANDARD)
 
         assertEquals(fundingPub.publicKey, PrivateKey.fromHex("730c0f99408dbfbff00146acf84183ce539fabeeb22c143212f459d71374f715").publicKey())
@@ -87,7 +111,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         val fundingKeyPath = makefundingKeyPath(ByteVector("06535806c1aa73971ec4877a5e2e684fa636136c073810f190b63eefc58ca488"), isFunder = false)
         val fundingPub = keyManager.fundingPublicKey(fundingKeyPath)
 
-        val localParams = TestConstants.Alice.channelParams.copy(fundingKeyPath = fundingKeyPath)
+        val localParams = TestConstants.Alice.channelParams.copy(channelKeys = keyManager.channelKeys(fundingKeyPath))
         val channelKeyPath = keyManager.channelKeyPath(localParams, ChannelVersion.STANDARD)
 
         assertEquals(fundingPub.publicKey, PrivateKey.fromHex("cd85f39fad742e5c742eeab16f5f1acaa9d9c48977767c7daa4708a47b7222ec").publicKey())
@@ -105,7 +129,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         val fundingKeyPath = makefundingKeyPath(ByteVector("ec1c41cd6be2b6e4ef46c1107f6c51fbb2066d7e1f7720bde4715af233ae1322"), isFunder = true)
         val fundingPub = keyManager.fundingPublicKey(fundingKeyPath)
 
-        val localParams = TestConstants.Alice.channelParams.copy(fundingKeyPath = fundingKeyPath)
+        val localParams = TestConstants.Alice.channelParams.copy(channelKeys = keyManager.channelKeys(fundingKeyPath))
         val channelKeyPath = keyManager.channelKeyPath(localParams, ChannelVersion.STANDARD)
 
         assertEquals(fundingPub.publicKey, PrivateKey.fromHex("b3b3f1af2ef961ee7aa62451a93a1fd57ea126c81008e5d95ced822cca30da6e").publicKey())
@@ -123,7 +147,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         val fundingKeyPath = makefundingKeyPath(ByteVector("2b4f045be5303d53f9d3a84a1e70c12251168dc29f300cf9cece0ec85cd8182b"), isFunder = false)
         val fundingPub = keyManager.fundingPublicKey(fundingKeyPath)
 
-        val localParams = TestConstants.Alice.channelParams.copy(fundingKeyPath = fundingKeyPath)
+        val localParams = TestConstants.Alice.channelParams.copy(channelKeys = keyManager.channelKeys(fundingKeyPath))
         val channelKeyPath = keyManager.channelKeyPath(localParams, ChannelVersion.STANDARD)
 
         assertEquals(fundingPub.publicKey, PrivateKey.fromHex("033880995016c275e725da625e4a78ea8c3215ab8ea54145fa3124bbb2e4a3d4").publicKey())

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
@@ -46,7 +46,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
 
         // README !
         // test data generated with v1.0-beta11, but they should never change
-        // if this test fails it means that we cannot restore channels created with older phoenix of lightning-kmp without
+        // if this test fails it means that we cannot restore channels created with older versions of lightning-kmp without
         // some kind of migration process
         val expected = ChannelKeys(
             fundingKeyPath = fundingKeyPath,

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -104,7 +104,7 @@ class PeerTest : LightningTestSuite() {
         alice.forward(open3)
         alice2bob.expect<AcceptChannel>()
 
-        assertEquals(3, alice.channels.values.filterIsInstance<WaitForFundingCreated>().map { it.localParams.fundingKeyPath }.toSet().size)
+        assertEquals(3, alice.channels.values.filterIsInstance<WaitForFundingCreated>().map { it.localParams.channelKeys.fundingKeyPath }.toSet().size)
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/lightning/transactions/AnchorOutputsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/transactions/AnchorOutputsTestsCommon.kt
@@ -88,7 +88,7 @@ class AnchorOutputsTestsCommon {
     private fun runHighLevelTest(testCase: TestCase) {
         val localParams = LocalParams(
             TestConstants.Alice.nodeParams.nodeId,
-            ChannelKeys( KeyPath.empty, local_funding_privkey, local_payment_basepoint_secret, local_delayed_payment_basepoint_secret, local_payment_basepoint_secret, local_payment_basepoint_secret, randomBytes32()),
+            ChannelKeys(KeyPath.empty, local_funding_privkey, local_payment_basepoint_secret, local_delayed_payment_basepoint_secret, local_payment_basepoint_secret, local_payment_basepoint_secret, randomBytes32()),
             546.sat, 1000000000L, 0.sat, 0.msat, CltvExpiryDelta(144), 1000, true,
             Script.write(Script.pay2wpkh(randomKey().publicKey())).toByteVector(),
             TestConstants.Alice.nodeParams.features,
@@ -136,7 +136,7 @@ class AnchorOutputsTestsCommon {
         */
 
         val (commitTx, htlcTxs) = Commitments.makeLocalTxs(
-             42, localParams, remoteParams,
+            42, localParams, remoteParams,
             Transactions.InputInfo(OutPoint(funding_tx, 0), funding_tx.txOut[0], Scripts.multiSig2of2(local_funding_pubkey, remote_funding_pubkey)),
             local_per_commitment_point,
             spec

--- a/src/commonTest/kotlin/fr/acinq/lightning/transactions/AnchorOutputsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/transactions/AnchorOutputsTestsCommon.kt
@@ -3,12 +3,10 @@ package fr.acinq.lightning.transactions
 import fr.acinq.bitcoin.*
 import fr.acinq.lightning.CltvExpiry
 import fr.acinq.lightning.CltvExpiryDelta
+import fr.acinq.lightning.Lightning.randomBytes32
 import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
-import fr.acinq.lightning.channel.ChannelVersion
-import fr.acinq.lightning.channel.Commitments
-import fr.acinq.lightning.channel.LocalParams
-import fr.acinq.lightning.channel.RemoteParams
+import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.crypto.Generators
 import fr.acinq.lightning.crypto.KeyManager
 import fr.acinq.lightning.tests.TestConstants
@@ -90,7 +88,8 @@ class AnchorOutputsTestsCommon {
     private fun runHighLevelTest(testCase: TestCase) {
         val localParams = LocalParams(
             TestConstants.Alice.nodeParams.nodeId,
-            KeyPath.empty, 546.sat, 1000000000L, 0.sat, 0.msat, CltvExpiryDelta(144), 1000, true,
+            ChannelKeys( KeyPath.empty, local_funding_privkey, local_payment_basepoint_secret, local_delayed_payment_basepoint_secret, local_payment_basepoint_secret, local_payment_basepoint_secret, randomBytes32()),
+            546.sat, 1000000000L, 0.sat, 0.msat, CltvExpiryDelta(144), 1000, true,
             Script.write(Script.pay2wpkh(randomKey().publicKey())).toByteVector(),
             TestConstants.Alice.nodeParams.features,
         )
@@ -135,53 +134,9 @@ class AnchorOutputsTestsCommon {
         # From local_delayed_payment_basepoint_secret, local_per_commitment_point and local_delayed_payment_basepoint
         INTERNAL: local_delayed_privkey: adf3464ce9c2f230fd2582fda4c6965e4993ca5524e8c9580e3df0cf226981ad01
         */
-        class MyKeyManager : KeyManager {
-            override val nodeKey: DeterministicWallet.ExtendedPrivateKey get() = DeterministicWallet.ExtendedPrivateKey(TestConstants.Alice.nodeParams.nodePrivateKey.value, ByteVector32.Zeroes, 0, KeyPath.empty, 0)
-            override val nodeId: PublicKey get() = nodeKey.publicKey
 
-            fun PrivateKey.toExtendedPrivateKey() = DeterministicWallet.ExtendedPrivateKey(this.value, ByteVector32.Zeroes, 0, KeyPath.empty, 0)
-
-            fun PublicKey.toExtendedPublicKey() = DeterministicWallet.ExtendedPublicKey(this.value, ByteVector32.Zeroes, 0, KeyPath.empty, 0)
-
-            override fun closingPubkeyScript(fundingPubKey: PublicKey): Pair<PublicKey, ByteArray> {
-                TODO("Not yet implemented")
-            }
-
-            override fun fundingPublicKey(keyPath: KeyPath): DeterministicWallet.ExtendedPublicKey = local_funding_pubkey.toExtendedPublicKey()
-
-            override fun revocationPoint(channelKeyPath: KeyPath): DeterministicWallet.ExtendedPublicKey = local_revocation_pubkey.toExtendedPublicKey()
-
-            override fun paymentPoint(channelKeyPath: KeyPath): DeterministicWallet.ExtendedPublicKey = local_payment_basepoint_secret.publicKey().toExtendedPublicKey()
-
-            override fun delayedPaymentPoint(channelKeyPath: KeyPath): DeterministicWallet.ExtendedPublicKey = local_delayed_payment_basepoint.toExtendedPublicKey()
-
-            override fun htlcPoint(channelKeyPath: KeyPath): DeterministicWallet.ExtendedPublicKey = PrivateKey.fromHex("1111111111111111111111111111111111111111111111111111111111111111").publicKey().toExtendedPublicKey()
-
-            override fun commitmentSecret(channelKeyPath: KeyPath, index: Long): PrivateKey = local_per_commitment_secret
-
-            override fun commitmentPoint(channelKeyPath: KeyPath, index: Long): PublicKey = local_per_commitment_point
-
-            override fun newFundingKeyPath(isFunder: Boolean): KeyPath {
-                TODO("Not yet implemented")
-            }
-
-            override fun sign(tx: Transactions.TransactionWithInputInfo, publicKey: DeterministicWallet.ExtendedPublicKey): ByteVector64 {
-                val privateKey = local_funding_privkey
-                return Transactions.sign(tx, privateKey)
-            }
-
-            override fun sign(tx: Transactions.TransactionWithInputInfo, publicKey: DeterministicWallet.ExtendedPublicKey, remotePoint: PublicKey, sigHash: Int): ByteVector64 {
-                TODO("Not yet implemented")
-            }
-
-            override fun sign(tx: Transactions.TransactionWithInputInfo, publicKey: DeterministicWallet.ExtendedPublicKey, remoteSecret: PrivateKey): ByteVector64 {
-                TODO("Not yet implemented")
-            }
-        }
-
-        val keyManager = MyKeyManager()
         val (commitTx, htlcTxs) = Commitments.makeLocalTxs(
-            keyManager, channelVersion, 42, localParams, remoteParams,
+             42, localParams, remoteParams,
             Transactions.InputInfo(OutPoint(funding_tx, 0), funding_tx.txOut[0], Scripts.multiSig2of2(local_funding_pubkey, remote_funding_pubkey)),
             local_per_commitment_point,
             spec


### PR DESCRIPTION
Key manager will compute all channel keys and will pass generated private keys back to the channel where they will be kept and used. We use the same scheme as before and this is not a breaking change, we just return private keys as well as public keys now.
This is much more efficient than re-computing them from the channel path every time as we do now.
Another option would be to cache private keys in the key manager (as we do on eclair) but it's not as useful for mobile apps as we are not likely to delegate signing to an external module.