### PR TITLE
Use current timestamp in invoice preimage

### DIFF
--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/PaymentRequestTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/PaymentRequestTestsCommon.kt
@@ -1,9 +1,11 @@
 package fr.acinq.lightning.payment
 
 import fr.acinq.bitcoin.*
+import fr.acinq.bitcoin.io.ByteArrayInput
 import fr.acinq.lightning.*
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.utils.*
+import fr.acinq.lightning.wire.LightningCodecs
 import fr.acinq.secp256k1.Hex
 import kotlin.test.*
 
@@ -315,6 +317,18 @@ class PaymentRequestTestsCommon : LightningTestSuite() {
         )
         val check = pr.sign(priv).write()
         assertEquals(ref, check)
+    }
+
+    @Test
+    fun `insert current timestamp in payment preimage generation`() {
+        val now = currentTimestampMillis()
+        val pr1 = PaymentRequest.generatePreimage()
+        val preimageTimestamp = LightningCodecs.tu64(ByteArrayInput(pr1.takeRight(6).toByteArray()))
+        assertTrue(now <= preimageTimestamp)
+        assertTrue(preimageTimestamp <= now + 5000)
+
+        val pr2 = PaymentRequest.generatePreimage()
+        assertNotEquals(pr1, pr2)
     }
 
     @Test


### PR DESCRIPTION
In case our random number generator completely fails, we may end up generating the same payment preimage for unrelated payments.

To mitigate that, we use the current time at the end of the preimage.
This still leaves at least 192 bits of randomness which is more than enough.

NB: wallets who want to leverage this (e.g. Phoenix) will need to call this new function instead of `randomBytes32()` when generating an invoice.