### PR TITLE
Don't pay already paid invoices

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
@@ -13,6 +13,7 @@ sealed class FinalFailure {
     fun toPaymentFailure(): OutgoingPaymentFailure = OutgoingPaymentFailure(this, listOf<OutgoingPayment.Part.Status.Failed>())
 
     // @formatter:off
+    object AlreadyPaid : FinalFailure() { override fun toString(): String = "this invoice has already been paid" }
     object InvalidPaymentAmount : FinalFailure() { override fun toString(): String = "payment amount must be positive" }
     object InvalidPaymentId : FinalFailure() { override fun toString(): String = "payment ID must be unique" }
     object NoAvailableChannels : FinalFailure() { override fun toString(): String = "no channels available to send payment" }


### PR DESCRIPTION
If we already have the preimage for a given invoice, we should not attempt to pay it again. We will introduce static invoices in the future to allow paying multiple times the same recipient, but it shouldn't be done with standard invoices.

Fixes #238