### PR TITLE
Add secondary pseudo-random number generator

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
@@ -3,7 +3,7 @@ package fr.acinq.lightning.crypto
 import fr.acinq.bitcoin.*
 import fr.acinq.bitcoin.DeterministicWallet.derivePrivateKey
 import fr.acinq.bitcoin.DeterministicWallet.hardened
-import fr.acinq.lightning.Lightning.secureRandom
+import fr.acinq.lightning.Lightning.randomLong
 import fr.acinq.lightning.transactions.Transactions
 
 data class LocalKeyManager(val seed: ByteVector, val chainHash: ByteVector32) : KeyManager {
@@ -56,7 +56,7 @@ data class LocalKeyManager(val seed: ByteVector, val chainHash: ByteVector32) : 
 
     override fun newFundingKeyPath(isFunder: Boolean): KeyPath {
         val last = hardened(if (isFunder) 1 else 0)
-        fun next() = secureRandom.nextInt().toLong() and 0xFFFFFFFF
+        fun next() = randomLong() and 0xFFFFFFFF
         return KeyPath(listOf(next(), next(), next(), next(), next(), next(), next(), next(), last))
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/WeakRandom.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/WeakRandom.kt
@@ -1,0 +1,56 @@
+package fr.acinq.lightning.crypto
+
+import fr.acinq.bitcoin.Crypto.sha1
+import fr.acinq.bitcoin.Crypto.sha256
+import fr.acinq.bitcoin.crypto.Pack
+import fr.acinq.lightning.utils.currentTimestampMillis
+import fr.acinq.lightning.utils.runtimeEntropy
+import fr.acinq.lightning.utils.toByteVector
+import fr.acinq.lightning.utils.xor
+import kotlin.native.concurrent.ThreadLocal
+
+/**
+ * A weak pseudo-random number generator that regularly samples a few entropy sources to build a hash chain.
+ * This should never be used alone but can be xor-ed with the OS random number generator in case it completely breaks.
+ */
+@ThreadLocal
+object WeakRandom {
+
+    private var seed = ByteArray(32)
+    private var opsSinceLastSample: Int = 0
+
+    private fun sampleEntropy() {
+        opsSinceLastSample = 0
+        val commonEntropy = Pack.writeInt64BE(currentTimestampMillis()) + Pack.writeInt32BE(ByteArray(0).hashCode())
+        val runtimeEntropy = runtimeEntropy()
+        seed = seed.xor(sha256(commonEntropy + runtimeEntropy))
+    }
+
+    /** We sample new entropy approximately every 8 operations and at most every 16 operations. */
+    private fun shouldSample(): Boolean {
+        opsSinceLastSample += 1
+        val condition1 = -16 <= seed.last() && seed.last() <= 16
+        val condition2 = opsSinceLastSample >= 16
+        return condition1 || condition2
+    }
+
+    fun nextBytes(array: ByteArray): ByteArray {
+        if (shouldSample()) {
+            sampleEntropy()
+        }
+
+        // Generate pseudo-random stream from the internal state.
+        val stream = ChaCha20(sha256(sha1(seed.toByteVector())), ByteArray(12), 0)
+        stream.encrypt(array, array, array.size)
+        // Update the internal state.
+        seed = sha256(seed)
+
+        return array
+    }
+
+    fun nextLong(): Long {
+        val bytes = ByteArray(8)
+        nextBytes(bytes)
+        return Pack.int64BE(bytes)
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/noise/Noise.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/noise/Noise.kt
@@ -1,6 +1,6 @@
 package fr.acinq.lightning.crypto.noise
 
-import kotlin.random.Random
+import fr.acinq.lightning.Lightning.randomBytes
 
 interface DHFunctions {
     fun name(): String
@@ -296,7 +296,7 @@ interface ByteStream {
 }
 
 object RandomBytes : ByteStream {
-    override fun nextBytes(length: Int) = Random.nextBytes(length)
+    override fun nextBytes(length: Int) = randomBytes(length)
 }
 
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/eclair.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/eclair.kt
@@ -4,7 +4,9 @@ import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.ByteVector64
 import fr.acinq.bitcoin.KeyPath
 import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.lightning.crypto.WeakRandom
 import fr.acinq.lightning.utils.secure
+import fr.acinq.lightning.utils.xor
 import kotlin.experimental.xor
 import kotlin.random.Random
 
@@ -15,7 +17,9 @@ object Lightning {
     fun randomBytes(length: Int): ByteArray {
         val buffer = ByteArray(length)
         secureRandom.nextBytes(buffer)
-        return buffer
+        val weakBuffer = ByteArray(length)
+        WeakRandom.nextBytes(weakBuffer)
+        return buffer.xor(weakBuffer)
     }
 
     fun randomBytes32(): ByteVector32 = ByteVector32(randomBytes(32))
@@ -29,7 +33,7 @@ object Lightning {
     }
 
     fun randomLong(): Long {
-        return secureRandom.nextLong()
+        return secureRandom.nextLong().xor(WeakRandom.nextLong())
     }
 
     fun toLongId(fundingTxHash: ByteVector32, fundingOutputIndex: Int): ByteVector32 {

--- a/src/commonMain/kotlin/fr/acinq/lightning/eclair.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/eclair.kt
@@ -10,7 +10,7 @@ import kotlin.random.Random
 
 object Lightning {
 
-    val secureRandom = Random.secure()
+    private val secureRandom = Random.secure()
 
     fun randomBytes(length: Int): ByteArray {
         val buffer = ByteArray(length)
@@ -24,8 +24,12 @@ object Lightning {
 
     fun randomKeyPath(length: Int): KeyPath {
         val path = mutableListOf<Long>()
-        repeat(length) { path.add(secureRandom.nextLong()) }
+        repeat(length) { path.add(randomLong()) }
         return KeyPath(path)
+    }
+
+    fun randomLong(): Long {
+        return secureRandom.nextLong()
     }
 
     fun toLongId(fundingTxHash: ByteVector32, fundingOutputIndex: Int): ByteVector32 {

--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/SecureRandom.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/SecureRandom.kt
@@ -4,3 +4,9 @@ import kotlin.random.Random
 
 // https://github.com/Kotlin/KEEP/issues/184
 expect fun Random.Default.secure(): Random
+
+/**
+ * This function should return some entropy based on application-specific runtime data.
+ * It doesn't need to be very strong entropy as it's only used as a backup, but it should be as good as possible.
+ */
+expect fun runtimeEntropy(): ByteArray

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/ShaChainTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/ShaChainTestsCommon.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 
-class SchaChainTestsCommon : LightningTestSuite() {
+class ShaChainTestsCommon : LightningTestSuite() {
     private val expected = listOf(
         Hex.decode("f85a0f7f237ed2139855703db4264de380ec731f64a3d832c22a5f2ef615f1d5"),
         Hex.decode("a07acb1203f8d7a761eb43e109e46fd877031a6fd2a8e6840f064a49ba826aec"),

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/WeakRandomTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/WeakRandomTestsCommon.kt
@@ -1,0 +1,75 @@
+package fr.acinq.lightning.crypto
+
+import fr.acinq.bitcoin.crypto.Pack
+import fr.acinq.lightning.tests.utils.LightningTestSuite
+import fr.acinq.lightning.utils.BitField
+import kotlin.math.log2
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertTrue
+
+class WeakRandomTestsCommon : LightningTestSuite() {
+
+    @Test
+    fun `random long generation`() {
+        val randomNumbers = (1..1000).map { WeakRandom.nextLong() }
+        assertEquals(1000, randomNumbers.toSet().size)
+        val entropy = randomNumbers.sumOf { entropyScore(it) } / 1000
+        assertTrue(entropy >= 0.98)
+    }
+
+    @Test
+    fun `random bytes generation (small length)`() {
+        val b1 = ByteArray(32)
+        WeakRandom.nextBytes(b1)
+        val b2 = ByteArray(32)
+        WeakRandom.nextBytes(b2)
+        val b3 = ByteArray(32)
+        WeakRandom.nextBytes(b3)
+        assertNotSame(b1, b2)
+        assertNotSame(b1, b3)
+        assertNotSame(b2, b3)
+    }
+
+    @Test
+    fun `random bytes generation (same length)`() {
+        var randomBytes = ByteArray(0)
+        for (i in 1..1000) {
+            val buffer = ByteArray(64)
+            WeakRandom.nextBytes(buffer)
+            randomBytes += buffer
+        }
+        val entropy = entropyScore(randomBytes)
+        assertTrue(entropy >= 0.99)
+    }
+
+    @Test
+    fun `random bytes generation (variable length)`() {
+        var randomBytes = ByteArray(0)
+        for (i in 10..500) {
+            val buffer = ByteArray(i)
+            WeakRandom.nextBytes(buffer)
+            randomBytes += buffer
+        }
+        val entropy = entropyScore(randomBytes)
+        assertTrue(entropy >= 0.99)
+    }
+
+    companion object {
+        // See https://en.wikipedia.org/wiki/Binary_entropy_function
+        private fun entropyScore(bits: BitField): Double {
+            val p = bits.asLeftSequence().fold(0) { acc, bit -> if (bit) acc + 1 else acc }.toDouble() / bits.bitCount
+            return (-p) * log2(p) - (1 - p) * log2(1 - p)
+        }
+
+        fun entropyScore(l: Long): Double {
+            return entropyScore(BitField.from(Pack.writeInt64BE(l)))
+        }
+
+        fun entropyScore(bytes: ByteArray): Double {
+            return entropyScore(BitField.from(bytes))
+        }
+    }
+
+}

--- a/src/jvmMain/kotlin/fr/acinq/lightning/utils/SecureRandomJvm.kt
+++ b/src/jvmMain/kotlin/fr/acinq/lightning/utils/SecureRandomJvm.kt
@@ -28,3 +28,13 @@ class SecureRandomJvm : Random() {
 }
 
 actual fun Random.Default.secure(): Random = SecureRandomJvm()
+
+actual fun runtimeEntropy(): ByteArray {
+    val freeMemory = Runtime.getRuntime().freeMemory()
+    val b = ByteArray(4)
+    b.set(0, freeMemory.toByte())
+    b.set(1, (freeMemory shr 8).toByte())
+    b.set(2, (freeMemory shr 16).toByte())
+    b.set(3, (freeMemory shr 24).toByte())
+    return ByteArray(0)
+}

--- a/src/nativeMain/kotlin/fr/acinq/lightning/utils/SecureRandomPosix.kt
+++ b/src/nativeMain/kotlin/fr/acinq/lightning/utils/SecureRandomPosix.kt
@@ -47,3 +47,7 @@ object SecureRandomPosix : Random() {
 }
 
 actual fun Random.Default.secure(): Random = SecureRandomPosix
+
+actual fun runtimeEntropy(): ByteArray {
+    return ByteArray(32)
+}


### PR DESCRIPTION
In case of catastrophic failures of the OS `SecureRandom` instance, we add a secondary randomness source that we mix into the random stream.

This is a somewhat weak random source and should not be used on its own, but it doesn't hurt to xor it with the output of `SecureRandom`.

The `runtimeEntropy` should be customized for iOS and Android by fetching all kind of random noise available to the application (available memory, process ID, sensor data, network statistics, etc).