### PR TITLE
Use TlvStream for encrypted channel backup

### DIFF
--- a/lightning-kmp-test-fixtures/src/commonMain/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
+++ b/lightning-kmp-test-fixtures/src/commonMain/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
@@ -146,9 +146,8 @@ public suspend fun CoroutineScope.newPeer(
             nextLocalCommitmentNumber = state.commitments.localCommit.index + 1,
             nextRemoteRevocationNumber = state.commitments.remoteCommit.index,
             yourLastCommitmentSecret = PrivateKey(yourLastPerCommitmentSecret),
-            myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint,
-            state.commitments.remoteChannelData
-        )
+            myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint
+        ).withChannelData(state.commitments.remoteChannelData)
 
         val msg = LightningMessage.encode(channelReestablish)
         peer.send(BytesReceived(msg))

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
@@ -9,6 +9,7 @@ import fr.acinq.lightning.channel.ChannelOrigin
 import fr.acinq.lightning.channel.ChannelVersion
 import fr.acinq.lightning.serialization.ByteVectorKSerializer
 import fr.acinq.lightning.utils.BitField
+import fr.acinq.lightning.utils.toByteVector
 import kotlinx.serialization.Serializable
 
 @OptIn(ExperimentalUnsignedTypes::class)
@@ -96,6 +97,90 @@ sealed class ChannelTlv : Tlv {
                 }
                 return ChannelOriginTlv(origin)
             }
+        }
+    }
+}
+
+@Serializable
+sealed class FundingSignedTlv : Tlv {
+    @Serializable
+    data class ChannelData(val ecb: EncryptedChannelData) : FundingSignedTlv() {
+        override val tag: Long get() = ChannelData.tag
+        override fun write(out: Output) = LightningCodecs.writeBytes(ecb.data, out)
+
+        companion object : TlvValueReader<ChannelData> {
+            const val tag: Long = 0x47010000
+            override fun read(input: Input): ChannelData = ChannelData(EncryptedChannelData(LightningCodecs.bytes(input, input.availableBytes).toByteVector()))
+        }
+    }
+}
+
+@Serializable
+sealed class CommitSigTlv : Tlv {
+    @Serializable
+    data class ChannelData(val ecb: EncryptedChannelData) : CommitSigTlv() {
+        override val tag: Long get() = ChannelData.tag
+        override fun write(out: Output) = LightningCodecs.writeBytes(ecb.data, out)
+
+        companion object : TlvValueReader<ChannelData> {
+            const val tag: Long = 0x47010000
+            override fun read(input: Input): ChannelData = ChannelData(EncryptedChannelData(LightningCodecs.bytes(input, input.availableBytes).toByteVector()))
+        }
+    }
+}
+
+@Serializable
+sealed class RevokeAndAckTlv : Tlv {
+    @Serializable
+    data class ChannelData(val ecb: EncryptedChannelData) : RevokeAndAckTlv() {
+        override val tag: Long get() = ChannelData.tag
+        override fun write(out: Output) = LightningCodecs.writeBytes(ecb.data, out)
+
+        companion object : TlvValueReader<ChannelData> {
+            const val tag: Long = 0x47010000
+            override fun read(input: Input): ChannelData = ChannelData(EncryptedChannelData(LightningCodecs.bytes(input, input.availableBytes).toByteVector()))
+        }
+    }
+}
+
+@Serializable
+sealed class ChannelReestablishTlv : Tlv {
+    @Serializable
+    data class ChannelData(val ecb: EncryptedChannelData) : ChannelReestablishTlv() {
+        override val tag: Long get() = ChannelData.tag
+        override fun write(out: Output) = LightningCodecs.writeBytes(ecb.data, out)
+
+        companion object : TlvValueReader<ChannelData> {
+            const val tag: Long = 0x47010000
+            override fun read(input: Input): ChannelData = ChannelData(EncryptedChannelData(LightningCodecs.bytes(input, input.availableBytes).toByteVector()))
+        }
+    }
+}
+
+@Serializable
+sealed class ShutdownTlv : Tlv {
+    @Serializable
+    data class ChannelData(val ecb: EncryptedChannelData) : ShutdownTlv() {
+        override val tag: Long get() = ChannelData.tag
+        override fun write(out: Output) = LightningCodecs.writeBytes(ecb.data, out)
+
+        companion object : TlvValueReader<ChannelData> {
+            const val tag: Long = 0x47010000
+            override fun read(input: Input): ChannelData = ChannelData(EncryptedChannelData(LightningCodecs.bytes(input, input.availableBytes).toByteVector()))
+        }
+    }
+}
+
+@Serializable
+sealed class ClosingSignedTlv : Tlv {
+    @Serializable
+    data class ChannelData(val ecb: EncryptedChannelData) : ClosingSignedTlv() {
+        override val tag: Long get() = ChannelData.tag
+        override fun write(out: Output) = LightningCodecs.writeBytes(ecb.data, out)
+
+        companion object : TlvValueReader<ChannelData> {
+            const val tag: Long = 0x47010000
+            override fun read(input: Input): ChannelData = ChannelData(EncryptedChannelData(LightningCodecs.bytes(input, input.availableBytes).toByteVector()))
         }
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningCodecs.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningCodecs.kt
@@ -7,8 +7,6 @@ import fr.acinq.bitcoin.io.ByteArrayOutput
 import fr.acinq.bitcoin.io.Input
 import fr.acinq.bitcoin.io.Output
 import fr.acinq.lightning.utils.leftPaddedCopyOf
-import fr.acinq.lightning.utils.toByteVector
-import fr.acinq.secp256k1.Hex
 import kotlin.jvm.JvmStatic
 
 @OptIn(ExperimentalUnsignedTypes::class)
@@ -200,26 +198,6 @@ object LightningCodecs {
     fun script(input: Input): ByteArray {
         val length = bigSize(input)
         return bytes(input, length)
-    }
-
-    private val channelDataMagic = Hex.decode("fe 47010000").toByteVector()
-
-    fun writeChannelData(msg: ByteArray, out: Output) {
-        if (msg.isNotEmpty()) {
-            out.write(channelDataMagic.toByteArray())
-            writeBigSize(msg.size.toLong(), out)
-            writeBytes(msg, out)
-        }
-    }
-
-    fun writeChannelData(msg: EncryptedChannelData, out: Output) = writeChannelData(msg.data.toByteArray(), out)
-
-    fun channelData(input: Input): EncryptedChannelData {
-        if (input.availableBytes <= 5) return EncryptedChannelData.empty
-        val magic = bytes(input, 5)
-        if (!channelDataMagic.contentEquals(magic)) return EncryptedChannelData.empty
-        val length = bigSize(input)
-        return EncryptedChannelData(bytes(input, length).toByteVector())
     }
 
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/TlvCodecs.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/TlvCodecs.kt
@@ -154,6 +154,27 @@ data class TlvStream<T : Tlv>(val records: List<T>, val unknown: List<GenericTlv
         return null
     }
 
+    /**
+     * Add a record to the tlv stream.
+     * Only one record of each type is allowed, so this replaced the previous record of the same type.
+     */
+    inline fun <reified R : T> addOrUpdate(r: R): TlvStream<T> {
+        var found = false
+        val updated = records.map {
+            if (it is R) {
+                found = true
+                r
+            } else {
+                it
+            }
+        }
+        return if (found) {
+            copy(records = updated)
+        } else {
+            copy(records = updated + r)
+        }
+    }
+
     companion object {
         fun <T : Tlv> empty() = TlvStream(listOf<T>(), listOf())
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NegotiatingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NegotiatingTestsCommon.kt
@@ -19,6 +19,7 @@ import fr.acinq.lightning.wire.Error
 import fr.acinq.lightning.wire.Shutdown
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class NegotiatingTestsCommon : LightningTestSuite() {
@@ -104,7 +105,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
     @Test
     fun `recv ClosingSigned (theirCloseFee == ourCloseFee, different fee parameters)`() {
-        val (alice, bob, aliceCloseSig) = init(true)
+        val (alice, bob, aliceCloseSig) = init(tweakFees = true)
         assertTrue { converge(alice, bob, aliceCloseSig) != null }
     }
 
@@ -135,6 +136,12 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         actions.hasOutgoingMessage<Error>()
         actions.hasWatch<WatchConfirmed>()
         actions.findTxs().contains(bob.commitments.localCommit.publishableTxs.commitTx.tx)
+    }
+
+    @Test
+    fun `recv ClosingSigned with encrypted channel data`() {
+        val (_, _, aliceCloseSig) = init(ChannelVersion.STANDARD or ChannelVersion.ZERO_RESERVE)
+        assertFalse(aliceCloseSig.channelData.isEmpty())
     }
 
     @Test
@@ -180,8 +187,8 @@ class NegotiatingTestsCommon : LightningTestSuite() {
     }
 
     companion object {
-        fun init(tweakFees: Boolean = false, pushMsat: MilliSatoshi = TestConstants.pushMsat): Triple<Negotiating, Negotiating, ClosingSigned> {
-            val (alice, bob) = reachNormal(pushMsat = pushMsat)
+        fun init(channelVersion: ChannelVersion = ChannelVersion.STANDARD, tweakFees: Boolean = false, pushMsat: MilliSatoshi = TestConstants.pushMsat): Triple<Negotiating, Negotiating, ClosingSigned> {
+            val (alice, bob) = reachNormal(channelVersion = channelVersion, pushMsat = pushMsat)
             return mutualClose(alice, bob, tweakFees)
         }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
@@ -52,7 +52,7 @@ class OfflineTestsCommon : LightningTestSuite() {
         // alice didn't receive any update or sig
         assertEquals(
             ChannelReestablish(alice.channelId, 1, 0, PrivateKey(ByteVector32.Zeroes), aliceCurrentPerCommitmentPoint),
-            channelReestablishA.copy(channelData = EncryptedChannelData.empty)
+            channelReestablishA.copy(tlvStream = TlvStream.empty())
         )
         assertEquals(
             ChannelReestablish(bob.channelId, 1, 0, PrivateKey(ByteVector32.Zeroes), bobCurrentPerCommitmentPoint),

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
@@ -255,9 +255,8 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
                 nextLocalCommitmentNumber = alice.commitments.localCommit.index + 1,
                 nextRemoteRevocationNumber = alice.commitments.remoteCommit.index,
                 yourLastCommitmentSecret = PrivateKey(yourLastPerCommitmentSecret),
-                myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint,
-                alice.commitments.remoteChannelData
-            )
+                myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint
+            ).withChannelData(alice.commitments.remoteChannelData)
         }
 
         val (bob3, actions3) = bob2.processEx(ChannelEvent.MessageReceived(channelReestablishAlice))

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
@@ -6,6 +6,7 @@ import fr.acinq.lightning.blockchain.BITCOIN_FUNDING_SPENT
 import fr.acinq.lightning.blockchain.WatchConfirmed
 import fr.acinq.lightning.blockchain.WatchSpent
 import fr.acinq.lightning.channel.*
+import fr.acinq.lightning.serialization.Serialization
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.utils.sat
@@ -29,6 +30,13 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
         assertEquals(WatchConfirmed(alice1.channelId, fundingTx, 3, BITCOIN_FUNDING_DEPTHOK), watchConfirmed)
         val watchSpent = actions1.findWatch<WatchSpent>()
         assertEquals(WatchSpent(alice1.channelId, fundingTx, 0, BITCOIN_FUNDING_SPENT), watchSpent)
+    }
+
+    @Test
+    fun `recv FundingSigned with encrypted channel data`() {
+        val (_, bob, fundingSigned) = init(ChannelVersion.STANDARD or ChannelVersion.ZERO_RESERVE)
+        val blob = Serialization.encrypt(bob.staticParams.nodeParams.nodePrivateKey.value, bob)
+        assertEquals(blob, fundingSigned.channelData)
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -146,9 +146,8 @@ class PeerTest : LightningTestSuite() {
             nextLocalCommitmentNumber = syncState.state.commitments.localCommit.index + 1,
             nextRemoteRevocationNumber = syncState.state.commitments.remoteCommit.index,
             yourLastCommitmentSecret = PrivateKey(yourLastPerCommitmentSecret),
-            myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint,
-            syncState.state.commitments.remoteChannelData
-        )
+            myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint
+        ).withChannelData(syncState.state.commitments.remoteChannelData)
 
         val reestablishMsg = LightningMessage.encode(channelReestablish)
         peer.send(BytesReceived(reestablishMsg))

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -542,7 +542,6 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
         // @formatter:on
 
         refs.forEach {
-            println(it.key.toByteVector().toHex())
             val decoded = LightningMessage.decode(it.key)
             assertEquals(it.value, decoded)
             val encoded = LightningMessage.encode(it.value)

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/TlvTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/TlvTestsCommon.kt
@@ -307,6 +307,24 @@ class TlvTestsCommon : LightningTestSuite() {
         assertNull(stream.get<TestTlv.TestType2>())
     }
 
+    @Test
+    fun `add TLV field to stream`() {
+        val stream = TlvStream<TestTlv>(listOf(TestTlv.TestType1(561), TestTlv.TestType254(1702)), listOf(GenericTlv(13, ByteVector("2a"))))
+        val updated = stream.addOrUpdate(TestTlv.TestType2(ShortChannelId(561)))
+        assertEquals(TestTlv.TestType2(ShortChannelId(561)), updated.get<TestTlv.TestType2>())
+        val expected = TlvStream<TestTlv>(listOf(TestTlv.TestType1(561), TestTlv.TestType254(1702), TestTlv.TestType2(ShortChannelId(561))), listOf(GenericTlv(13, ByteVector("2a"))))
+        assertEquals(updated, expected)
+    }
+
+    @Test
+    fun `replace TLV field in stream`() {
+        val stream = TlvStream<TestTlv>(listOf(TestTlv.TestType1(561), TestTlv.TestType254(1702)), listOf(GenericTlv(13, ByteVector("2a"))))
+        val updated = stream.addOrUpdate(TestTlv.TestType1(562))
+        assertEquals(TestTlv.TestType1(562), updated.get<TestTlv.TestType1>())
+        val expected = TlvStream<TestTlv>(listOf(TestTlv.TestType1(562), TestTlv.TestType254(1702)), listOf(GenericTlv(13, ByteVector("2a"))))
+        assertEquals(updated, expected)
+    }
+
     // See https://github.com/lightningnetwork/lightning-rfc/blob/master/01-messaging.md#appendix-a-type-length-value-test-vectors
     companion object {
         sealed class TestTlv : Tlv {


### PR DESCRIPTION
In order to support extensions to standard LN messages, we must put our custom fields in a `TlvStream`.
The only field that didn't respect that was the encrypted channel backup.
This change is a required preliminary step to be able to implement https://github.com/lightningnetwork/lightning-rfc/pull/847

We also fix a bug where we didn't send our backup in `shutdown` messages.