### PR TITLE
More flexible mutual close fees

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelCommands.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelCommands.kt
@@ -2,9 +2,11 @@ package fr.acinq.lightning.channel
 
 import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.Satoshi
 import fr.acinq.lightning.CltvExpiry
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
+import fr.acinq.lightning.transactions.Transactions.weight2fee
 import fr.acinq.lightning.utils.UUID
 import fr.acinq.lightning.wire.FailureMessage
 import fr.acinq.lightning.wire.OnionRoutingPacket
@@ -29,6 +31,16 @@ data class CMD_FAIL_HTLC(override val id: Long, val reason: Reason, val commit: 
 object CMD_SIGN : Command()
 data class CMD_UPDATE_FEE(val feerate: FeeratePerKw, val commit: Boolean = false) : Command()
 
+data class ClosingFees(val preferred: Satoshi, val min: Satoshi, val max: Satoshi) {
+    constructor(preferred: Satoshi) : this(preferred, preferred, preferred)
+}
+
+data class ClosingFeerates(val preferred: FeeratePerKw, val min: FeeratePerKw, val max: FeeratePerKw) {
+    constructor(preferred: FeeratePerKw) : this(preferred, preferred / 2, preferred * 2)
+
+    fun computeFees(closingTxWeight: Int): ClosingFees = ClosingFees(weight2fee(preferred, closingTxWeight), weight2fee(min, closingTxWeight), weight2fee(max, closingTxWeight))
+}
+
 sealed class CloseCommand : Command()
-data class CMD_CLOSE(val scriptPubKey: ByteVector?) : CloseCommand()
+data class CMD_CLOSE(val scriptPubKey: ByteVector?, val feerates: ClosingFeerates?) : CloseCommand()
 object CMD_FORCECLOSE : CloseCommand()

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v1/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v1/ChannelState.kt
@@ -731,7 +731,8 @@ data class Normal(
         channelUpdate,
         remoteChannelUpdate,
         localShutdown,
-        remoteShutdown
+        remoteShutdown,
+        null
     )
 }
 
@@ -759,7 +760,8 @@ data class ShuttingDown(
         currentOnChainFeerates.export(),
         commitments.export(nodeParams),
         localShutdown,
-        remoteShutdown
+        remoteShutdown,
+        null
     )
 }
 
@@ -798,7 +800,8 @@ data class Negotiating(
         localShutdown,
         remoteShutdown,
         closingTxProposed.map { x -> x.map { it.export() } },
-        bestUnpublishedClosingTx
+        bestUnpublishedClosingTx,
+        null
     )
 }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
@@ -724,7 +724,8 @@ data class Normal(
         channelUpdate,
         remoteChannelUpdate,
         localShutdown,
-        remoteShutdown
+        remoteShutdown,
+        null
     )
 }
 
@@ -752,7 +753,8 @@ data class ShuttingDown(
         currentOnChainFeerates.export(),
         commitments.export(nodeParams),
         localShutdown,
-        remoteShutdown
+        remoteShutdown,
+        null
     )
 }
 
@@ -791,7 +793,8 @@ data class Negotiating(
         localShutdown,
         remoteShutdown,
         closingTxProposed.map { x -> x.map { it.export() } },
-        bestUnpublishedClosingTx
+        bestUnpublishedClosingTx,
+        null
     )
 }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
@@ -220,6 +220,21 @@ sealed class ShutdownTlv : Tlv {
 @Serializable
 sealed class ClosingSignedTlv : Tlv {
     @Serializable
+    data class FeeRange(@Contextual val min: Satoshi, @Contextual val max: Satoshi) : ClosingSignedTlv() {
+        override val tag: Long get() = FeeRange.tag
+
+        override fun write(out: Output) {
+            LightningCodecs.writeU64(min.toLong(), out)
+            LightningCodecs.writeU64(max.toLong(), out)
+        }
+
+        companion object : TlvValueReader<FeeRange> {
+            const val tag: Long = 1
+            override fun read(input: Input): FeeRange = FeeRange(Satoshi(LightningCodecs.u64(input)), Satoshi(LightningCodecs.u64(input)))
+        }
+    }
+
+    @Serializable
     data class ChannelData(@Contextual val ecb: EncryptedChannelData) : ClosingSignedTlv() {
         override val tag: Long get() = ChannelData.tag
         override fun write(out: Output) = LightningCodecs.writeBytes(ecb.data, out)

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -1050,7 +1050,10 @@ data class ClosingSigned(
         const val type: Long = 39
 
         @Suppress("UNCHECKED_CAST")
-        val readers = mapOf(ClosingSignedTlv.ChannelData.tag to ClosingSignedTlv.ChannelData.Companion as TlvValueReader<ClosingSignedTlv>)
+        val readers = mapOf(
+            ClosingSignedTlv.FeeRange.tag to ClosingSignedTlv.FeeRange.Companion as TlvValueReader<ClosingSignedTlv>,
+            ClosingSignedTlv.ChannelData.tag to ClosingSignedTlv.ChannelData.Companion as TlvValueReader<ClosingSignedTlv>
+        )
 
         override fun read(input: Input): ClosingSigned {
             return ClosingSigned(

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
@@ -19,7 +19,8 @@ import fr.acinq.lightning.channel.TestsHelper.htlcSuccessTxs
 import fr.acinq.lightning.channel.TestsHelper.htlcTimeoutTxs
 import fr.acinq.lightning.channel.TestsHelper.localClose
 import fr.acinq.lightning.channel.TestsHelper.makeCmdAdd
-import fr.acinq.lightning.channel.TestsHelper.mutualClose
+import fr.acinq.lightning.channel.TestsHelper.mutualCloseAlice
+import fr.acinq.lightning.channel.TestsHelper.mutualCloseBob
 import fr.acinq.lightning.channel.TestsHelper.processEx
 import fr.acinq.lightning.channel.TestsHelper.reachNormal
 import fr.acinq.lightning.channel.TestsHelper.remoteClose
@@ -33,24 +34,6 @@ import fr.acinq.lightning.wire.*
 import kotlin.test.*
 
 class ClosingTestsCommon : LightningTestSuite() {
-
-    @Test
-    fun `start fee negotiation from configured block target`() {
-        val (alice, bob) = reachNormal()
-        val (alice1, actions) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null)))
-        val shutdown = actions.findOutgoingMessage<Shutdown>()
-        val (_, actions1) = bob.processEx(ChannelEvent.MessageReceived(shutdown))
-        val shutdown1 = actions1.findOutgoingMessage<Shutdown>()
-        val (alice2, actions2) = alice1.processEx(ChannelEvent.MessageReceived(shutdown1))
-        val closingSigned = actions2.findOutgoingMessage<ClosingSigned>()
-        val expectedProposedFee = Helpers.Closing.firstClosingFee(
-            (alice2 as Negotiating).commitments,
-            alice2.localShutdown.scriptPubKey.toByteArray(),
-            alice2.remoteShutdown.scriptPubKey.toByteArray(),
-            alice2.currentOnChainFeerates.mutualCloseFeerate
-        )
-        assertEquals(closingSigned.feeSatoshis, expectedProposedFee)
-    }
 
     @Test
     fun `recv CMD_ADD_HTLC`() {
@@ -80,43 +63,39 @@ class ClosingTestsCommon : LightningTestSuite() {
     @Test
     fun `recv BITCOIN_FUNDING_SPENT (mutual close before converging)`() {
         val (alice0, bob0) = reachNormal()
-        // alice initiates a closing
-        val (alice1, aliceActions1) = alice0.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null)))
+        // alice initiates a closing with a low fee
+        val (alice1, aliceActions1) = alice0.process(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, ClosingFeerates(FeeratePerKw(500.sat), FeeratePerKw(250.sat), FeeratePerKw(1000.sat)))))
         val shutdown0 = aliceActions1.findOutgoingMessage<Shutdown>()
         val (bob1, bobActions1) = bob0.processEx(ChannelEvent.MessageReceived(shutdown0))
+        assertTrue(bob1 is Negotiating)
         val shutdown1 = bobActions1.findOutgoingMessage<Shutdown>()
-        val (alice2, aliceActions2) = alice1.processEx(ChannelEvent.MessageReceived(shutdown1))
-
-        // agreeing on a closing fee
+        val (alice2, aliceActions2) = alice1.process(ChannelEvent.MessageReceived(shutdown1))
+        assertTrue(alice2 is Negotiating)
         val closingSigned0 = aliceActions2.findOutgoingMessage<ClosingSigned>()
-        val aliceCloseFee = closingSigned0.feeSatoshis
-        val bob2 = (bob1 as Negotiating).updateFeerate(FeeratePerKw(5_000.sat))
-        val (_, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(closingSigned0))
-        val closingSigned1 = bobActions3.findOutgoingMessage<ClosingSigned>()
-        val bobCloseFee = closingSigned1.feeSatoshis
-        val (alice3, _) = alice2.processEx(ChannelEvent.MessageReceived(closingSigned1))
 
-        // they don't converge yet, but alice has a publishable commit tx now
-        assertNotEquals(aliceCloseFee, bobCloseFee)
-        val mutualCloseTx = (alice3 as Negotiating).bestUnpublishedClosingTx
+        // they don't converge yet, but bob has a publishable commit tx now
+        val (bob2, bobActions2) = bob1.processEx(ChannelEvent.MessageReceived(closingSigned0))
+        assertTrue(bob2 is Negotiating)
+        val mutualCloseTx = bob2.bestUnpublishedClosingTx
         assertNotNull(mutualCloseTx)
+        val closingSigned1 = bobActions2.findOutgoingMessage<ClosingSigned>()
+        assertNotEquals(closingSigned0.feeSatoshis, closingSigned1.feeSatoshis)
 
-        // let's make alice publish this closing tx
-        val (alice4, aliceActions4) = alice3.processEx(ChannelEvent.MessageReceived(Error(ByteVector32.Zeroes, "")))
-        assertTrue { alice4 is Closing }
-        assertEquals(ChannelAction.Blockchain.PublishTx(mutualCloseTx.tx), aliceActions4.filterIsInstance<ChannelAction.Blockchain.PublishTx>().first())
-        assertEquals(mutualCloseTx, (alice4 as Closing).mutualClosePublished.last())
-        aliceActions4.has<ChannelAction.Storage.StoreChannelClosing>()
+        // let's make bob publish this closing tx
+        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(Error(ByteVector32.Zeroes, "")))
+        assertTrue(bob3 is Closing)
+        assertEquals(ChannelAction.Blockchain.PublishTx(mutualCloseTx.tx), bobActions3.filterIsInstance<ChannelAction.Blockchain.PublishTx>().first())
+        assertEquals(mutualCloseTx, bob3.mutualClosePublished.last())
+        bobActions3.has<ChannelAction.Storage.StoreChannelClosing>()
 
         // actual test starts here
-        val (alice5, _) = alice4.processEx(ChannelEvent.WatchReceived(WatchEventSpent(ByteVector32.Zeroes, BITCOIN_FUNDING_SPENT, mutualCloseTx.tx)))
-        val (alice6, aliceActions6) = alice5.processEx(ChannelEvent.WatchReceived(WatchEventConfirmed(ByteVector32.Zeroes, BITCOIN_TX_CONFIRMED(mutualCloseTx.tx), 0, 0, mutualCloseTx.tx)))
-
-        assertTrue { alice6 is Closed }
-        val storeChannelClosed = aliceActions6.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull()
+        val (bob4, _) = bob3.processEx(ChannelEvent.WatchReceived(WatchEventSpent(ByteVector32.Zeroes, BITCOIN_FUNDING_SPENT, mutualCloseTx.tx)))
+        val (bob5, bobActions5) = bob4.processEx(ChannelEvent.WatchReceived(WatchEventConfirmed(ByteVector32.Zeroes, BITCOIN_TX_CONFIRMED(mutualCloseTx.tx), 0, 0, mutualCloseTx.tx)))
+        assertTrue(bob5 is Closed)
+        val storeChannelClosed = bobActions5.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull()
         assertNotNull(storeChannelClosed)
-        assertTrue { storeChannelClosed.closingType == ChannelClosingType.Mutual }
-        assertTrue { storeChannelClosed.txids == listOf(mutualCloseTx.tx.txid) }
+        assertEquals(storeChannelClosed.closingType, ChannelClosingType.Mutual)
+        assertEquals(storeChannelClosed.txids, listOf(mutualCloseTx.tx.txid))
     }
 
     @Test
@@ -126,11 +105,11 @@ class ClosingTestsCommon : LightningTestSuite() {
 
         // actual test starts here
         val (alice1, actions1) = alice0.processEx(ChannelEvent.WatchReceived(WatchEventConfirmed(ByteVector32.Zeroes, BITCOIN_TX_CONFIRMED(mutualCloseTx.tx), 0, 0, mutualCloseTx.tx)))
-        assertTrue { alice1 is Closed }
+        assertTrue(alice1 is Closed)
         val storeChannelClosed = actions1.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull()
         assertNotNull(storeChannelClosed)
-        assertTrue { storeChannelClosed.closingType == ChannelClosingType.Mutual }
-        assertTrue { storeChannelClosed.txids == listOf(mutualCloseTx.tx.txid) }
+        assertEquals(storeChannelClosed.closingType, ChannelClosingType.Mutual)
+        assertEquals(storeChannelClosed.txids, listOf(mutualCloseTx.tx.txid))
     }
 
     @Test
@@ -140,23 +119,16 @@ class ClosingTestsCommon : LightningTestSuite() {
         val bobFinalScript = Script.write(Script.pay2pkh(pubKey)).toByteVector()
 
         val (alice1, bob1) = reachNormal()
-        val (alice2, bob2, aliceClosingSigned1) = mutualClose(alice1, bob1, tweakFees = true, scriptPubKey = bobFinalScript)
+        val (_, bob2, aliceClosingSigned) = mutualCloseBob(alice1, bob1, scriptPubKey = bobFinalScript)
 
-        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceClosingSigned1))
+        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceClosingSigned))
+        assertTrue(bob3 is Closing)
         val bobClosingSigned = bobActions3.findOutgoingMessageOpt<ClosingSigned>()
         assertNotNull(bobClosingSigned)
-
-        val (alice4, aliceActions4) = alice2.processEx(ChannelEvent.MessageReceived(bobClosingSigned))
-        assertTrue { alice4 is Closing }
-        val aliceClosingSigned2 = aliceActions4.findOutgoingMessageOpt<ClosingSigned>()
-        assertNotNull(aliceClosingSigned2)
-
-        val (bob5, bobActions5) = bob3.processEx(ChannelEvent.MessageReceived(aliceClosingSigned2))
-        assertTrue { bob5 is Closing }
-        val storeChannelClosing = bobActions5.filterIsInstance<ChannelAction.Storage.StoreChannelClosing>().firstOrNull()
+        val storeChannelClosing = bobActions3.filterIsInstance<ChannelAction.Storage.StoreChannelClosing>().firstOrNull()
         assertNotNull(storeChannelClosing)
-        assertFalse { storeChannelClosing.isSentToDefaultAddress }
-        assertTrue { storeChannelClosing.closingAddress == bobBtcAddr }
+        assertFalse(storeChannelClosing.isSentToDefaultAddress)
+        assertEquals(storeChannelClosing.closingAddress, bobBtcAddr)
     }
 
     @Test
@@ -1590,7 +1562,7 @@ class ClosingTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_CLOSE`() {
         val (alice0, _, _) = initMutualClose()
-        val cmdClose = CMD_CLOSE(null)
+        val cmdClose = CMD_CLOSE(null, null)
         val (_, actions) = alice0.processEx(ChannelEvent.ExecuteCommand(cmdClose))
         val commandError = actions.filterIsInstance<ChannelAction.ProcessCmdRes.NotExecuted>().first()
         assertEquals(cmdClose, commandError.cmd)
@@ -1763,7 +1735,7 @@ class ClosingTestsCommon : LightningTestSuite() {
                 }.flatten()
             }
 
-            val (alice1, bob1, aliceCloseSig) = mutualClose(mutableAlice, mutableBob)
+            val (alice1, bob1, aliceCloseSig) = mutualCloseAlice(mutableAlice, mutableBob)
             val (alice2, bob2) = NegotiatingTestsCommon.converge(alice1, bob1, aliceCloseSig) ?: error("converge should not return null")
 
             return Triple(alice2, bob2, bobCommitTxs)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NegotiatingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NegotiatingTestsCommon.kt
@@ -5,9 +5,11 @@ import fr.acinq.lightning.Feature
 import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.blockchain.*
+import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.channel.TestsHelper.makeCmdAdd
-import fr.acinq.lightning.channel.TestsHelper.mutualClose
+import fr.acinq.lightning.channel.TestsHelper.mutualCloseAlice
+import fr.acinq.lightning.channel.TestsHelper.mutualCloseBob
 import fr.acinq.lightning.channel.TestsHelper.processEx
 import fr.acinq.lightning.channel.TestsHelper.reachNormal
 import fr.acinq.lightning.tests.TestConstants
@@ -15,25 +17,349 @@ import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.utils.msat
 import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.utils.toByteVector
-import fr.acinq.lightning.wire.ClosingSigned
-import fr.acinq.lightning.wire.Error
-import fr.acinq.lightning.wire.Shutdown
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import fr.acinq.lightning.wire.*
+import kotlin.test.*
 
 class NegotiatingTestsCommon : LightningTestSuite() {
 
     @Test
-    fun `correctly sign and detect closing tx`() {
-        // we're fundee here, not funder !!
+    fun `recv CMD_ADD_HTLC`() {
+        val (alice, _, _) = init()
+        val (_, add) = makeCmdAdd(500_000.msat, alice.staticParams.remoteNodeId, TestConstants.defaultBlockHeight.toLong())
+        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(add))
+        assertTrue(alice1 is Negotiating)
+        assertEquals(1, actions1.size)
+        actions1.hasCommandError<ChannelUnavailable>()
+    }
+
+    private fun testClosingSignedDifferentFees(alice: Normal, bob: Normal, bobInitiates: Boolean = false) {
+        // alice and bob see different on-chain feerates
+        val alice1 = alice.updateFeerate(FeeratePerKw(5_000.sat))
+        val bob1 = bob.updateFeerate(FeeratePerKw(7_500.sat))
+        val (alice2, bob2, aliceCloseSig1) = if (bobInitiates) mutualCloseBob(alice1, bob1) else mutualCloseAlice(alice1, bob1)
+
+        // alice is funder so she initiates the negotiation
+        assertEquals(aliceCloseSig1.feeSatoshis, 3370.sat) // matches a feerate of 5000 sat/kw
+        val aliceFeeRange = aliceCloseSig1.tlvStream.get<ClosingSignedTlv.FeeRange>()
+        assertNotNull(aliceFeeRange)
+        assertTrue(aliceFeeRange.min < aliceCloseSig1.feeSatoshis)
+        assertTrue(aliceCloseSig1.feeSatoshis < aliceFeeRange.max)
+        assertEquals(alice2.closingTxProposed.size, 1)
+        assertEquals(alice2.closingTxProposed.last().size, 1)
+        assertNull(alice2.bestUnpublishedClosingTx)
+
+        // bob answers with a counter proposition in alice's fee range
+        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig1))
+        assertTrue(bob3 is Negotiating)
+        val bobCloseSig1 = bobActions3.findOutgoingMessage<ClosingSigned>()
+        assertTrue(aliceFeeRange.min < bobCloseSig1.feeSatoshis)
+        assertTrue(bobCloseSig1.feeSatoshis < aliceFeeRange.max)
+        assertNotNull(bobCloseSig1.tlvStream.get<ClosingSignedTlv.FeeRange>())
+        assertTrue(aliceCloseSig1.feeSatoshis < bobCloseSig1.feeSatoshis)
+        assertNotNull(bob3.bestUnpublishedClosingTx)
+
+        // alice accepts this proposition
+        val (alice3, aliceActions3) = alice2.processEx(ChannelEvent.MessageReceived(bobCloseSig1))
+        assertTrue(alice3 is Closing)
+        val mutualCloseTx = aliceActions3.findTxs().first()
+        assertEquals(aliceActions3.findWatch<WatchConfirmed>().txId, mutualCloseTx.txid)
+        assertEquals(mutualCloseTx.txOut.size, 2) // NB: anchors are removed from the closing tx
+        val aliceCloseSig2 = aliceActions3.findOutgoingMessage<ClosingSigned>()
+        assertEquals(aliceCloseSig2.feeSatoshis, bobCloseSig1.feeSatoshis)
+        val (bob4, bobActions4) = bob3.processEx(ChannelEvent.MessageReceived(aliceCloseSig2))
+        assertTrue(bob4 is Closing)
+        bobActions4.hasTx(mutualCloseTx)
+        assertEquals(bobActions4.findWatch<WatchConfirmed>().txId, mutualCloseTx.txid)
+        assertEquals(alice3.mutualClosePublished.map { it.tx }, listOf(mutualCloseTx))
+        assertEquals(bob4.mutualClosePublished.map { it.tx }, listOf(mutualCloseTx))
+    }
+
+    @Test
+    fun `recv ClosingSigned (theirCloseFee != ourCloseFee)`() {
+        val (alice, bob) = reachNormal()
+        testClosingSignedDifferentFees(alice, bob)
+    }
+
+    @Test
+    fun `recv ClosingSigned (theirCloseFee != ourCloseFee, bob starts closing)`() {
+        val (alice, bob) = reachNormal()
+        testClosingSignedDifferentFees(alice, bob, bobInitiates = true)
+    }
+
+    @Test
+    fun `recv ClosingSigned (theirMinCloseFee greater than ourCloseFee)`() {
+        val (alice, bob) = reachNormal()
+        val alice1 = alice.updateFeerate(FeeratePerKw(10_000.sat))
+        val bob1 = bob.updateFeerate(FeeratePerKw(2_500.sat))
+
+        val (_, bob2, aliceCloseSig) = mutualCloseAlice(alice1, bob1)
+        val (bob3, actions) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
+        assertTrue(bob3 is Closing)
+        val bobCloseSig = actions.findOutgoingMessage<ClosingSigned>()
+        assertEquals(bobCloseSig.feeSatoshis, aliceCloseSig.feeSatoshis)
+    }
+
+    @Test
+    fun `recv ClosingSigned (theirMaxCloseFee smaller than ourCloseFee)`() {
+        val (alice, bob) = reachNormal()
+        val alice1 = alice.updateFeerate(FeeratePerKw(5_000.sat))
+        val bob1 = bob.updateFeerate(FeeratePerKw(20_000.sat))
+
+        val (_, bob2, aliceCloseSig) = mutualCloseAlice(alice1, bob1)
+        val (_, actions) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
+        val bobCloseSig = actions.findOutgoingMessage<ClosingSigned>()
+        assertEquals(bobCloseSig.feeSatoshis, aliceCloseSig.tlvStream.get<ClosingSignedTlv.FeeRange>()!!.max)
+    }
+
+    private fun testClosingSignedSameFees(alice: Normal, bob: Normal, bobInitiates: Boolean = false) {
+        val alice1 = alice.updateFeerate(FeeratePerKw(5_000.sat))
+        val bob1 = bob.updateFeerate(FeeratePerKw(5_000.sat))
+        val (alice2, bob2, aliceCloseSig1) = if (bobInitiates) mutualCloseBob(alice1, bob1) else mutualCloseAlice(alice1, bob1)
+
+        // alice is funder so she initiates the negotiation
+        assertEquals(aliceCloseSig1.feeSatoshis, 3370.sat) // matches a feerate of 5000 sat/kw
+        val aliceFeeRange = aliceCloseSig1.tlvStream.get<ClosingSignedTlv.FeeRange>()
+        assertNotNull(aliceFeeRange)
+
+        // bob agrees with that proposal
+        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig1))
+        assertTrue(bob3 is Closing)
+        val bobCloseSig1 = bobActions3.findOutgoingMessage<ClosingSigned>()
+        assertNotNull(bobCloseSig1.tlvStream.get<ClosingSignedTlv.FeeRange>())
+        assertEquals(aliceCloseSig1.feeSatoshis, bobCloseSig1.feeSatoshis)
+        val mutualCloseTx = bobActions3.findTxs().first()
+        assertEquals(mutualCloseTx.txOut.size, 2) // NB: anchors are removed from the closing tx
+
+        val (alice3, aliceActions3) = alice2.processEx(ChannelEvent.MessageReceived(bobCloseSig1))
+        assertTrue(alice3 is Closing)
+        aliceActions3.hasTx(mutualCloseTx)
+    }
+
+    @Test
+    fun `recv ClosingSigned (theirCloseFee == ourCloseFee)`() {
+        val (alice, bob) = reachNormal()
+        testClosingSignedSameFees(alice, bob)
+    }
+
+    @Test
+    fun `recv ClosingSigned (theirCloseFee == ourCloseFee, bob starts closing)`() {
+        val (alice, bob) = reachNormal()
+        testClosingSignedSameFees(alice, bob, bobInitiates = true)
+    }
+
+    @Test
+    fun `override on-chain fee estimator (funder)`() {
+        val (alice, bob) = reachNormal()
+        val alice1 = alice.updateFeerate(FeeratePerKw(10_000.sat))
+        val bob1 = bob.updateFeerate(FeeratePerKw(10_000.sat))
+
+        // alice initiates the negotiation with a very low feerate
+        val (alice2, bob2, aliceCloseSig) = mutualCloseAlice(alice1, bob1, feerates = ClosingFeerates(FeeratePerKw(2_500.sat), FeeratePerKw(2_000.sat), FeeratePerKw(3_000.sat)))
+        assertEquals(aliceCloseSig.feeSatoshis, 1685.sat)
+        assertEquals(aliceCloseSig.tlvStream.get<ClosingSignedTlv.FeeRange>(), ClosingSignedTlv.FeeRange(1348.sat, 2022.sat))
+
+        // bob chooses alice's highest fee
+        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
+        val bobCloseSig = bobActions3.findOutgoingMessage<ClosingSigned>()
+        assertEquals(bobCloseSig.feeSatoshis, 2022.sat)
+
+        // alice accepts this proposition
+        val (alice3, aliceActions3) = alice2.processEx(ChannelEvent.MessageReceived(bobCloseSig))
+        assertTrue(alice3 is Closing)
+        val mutualCloseTx = aliceActions3.findTxs().first()
+        val aliceCloseSig2 = aliceActions3.findOutgoingMessage<ClosingSigned>()
+        assertEquals(aliceCloseSig2.feeSatoshis, 2022.sat)
+
+        val (bob4, bobActions4) = bob3.processEx(ChannelEvent.MessageReceived(aliceCloseSig2))
+        assertTrue(bob4 is Closing)
+        bobActions4.hasTx(mutualCloseTx)
+    }
+
+    @Test
+    fun `override on-chain fee estimator (fundee)`() {
+        val (alice, bob) = reachNormal()
+        val alice1 = alice.updateFeerate(FeeratePerKw(10_000.sat))
+        val bob1 = bob.updateFeerate(FeeratePerKw(10_000.sat))
+
+        // alice is funder, so bob's override will simply be ignored
+        val (alice2, bob2, aliceCloseSig) = mutualCloseBob(alice1, bob1, feerates = ClosingFeerates(FeeratePerKw(2_500.sat), FeeratePerKw(2_000.sat), FeeratePerKw(3_000.sat)))
+        assertEquals(aliceCloseSig.feeSatoshis, 6740.sat) // matches a feerate of 10 000 sat/kw
+
+        // bob directly agrees because their fee estimator matches
+        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
+        assertTrue(bob3 is Closing)
+        val mutualCloseTx = bobActions3.findTxs().first()
+        val bobCloseSig = bobActions3.findOutgoingMessage<ClosingSigned>()
+        assertEquals(bobCloseSig.feeSatoshis, aliceCloseSig.feeSatoshis)
+
+        // alice accepts this proposition
+        val (alice3, aliceActions3) = alice2.processEx(ChannelEvent.MessageReceived(bobCloseSig))
+        assertTrue(alice3 is Closing)
+        aliceActions3.hasTx(mutualCloseTx)
+    }
+
+    @Test
+    fun `recv ClosingSigned (nothing at stake)`() {
+        val (alice, bob) = reachNormal(pushMsat = 0.msat)
+        val alice1 = alice.updateFeerate(FeeratePerKw(5_000.sat))
+        val bob1 = bob.updateFeerate(FeeratePerKw(10_000.sat))
+
+        // Bob has nothing at stake
+        val (_, bob2, aliceCloseSig) = mutualCloseBob(alice1, bob1)
+        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
+        assertTrue(bob3 is Closing)
+        val mutualCloseTx = bobActions3.findTxs().first()
+        assertEquals(bob3.mutualClosePublished.map { it.tx }, listOf(mutualCloseTx))
+        assertEquals(bobActions3.findWatches<WatchConfirmed>().map { it.event }, listOf(BITCOIN_TX_CONFIRMED(mutualCloseTx)))
+    }
+
+    @Test
+    fun `recv ClosingSigned (other side ignores our fee range, funder)`() {
+        val (alice, bob) = reachNormal()
+        val alice1 = alice.updateFeerate(FeeratePerKw(1_000.sat))
+        val (alice2, bob2, aliceCloseSig1) = mutualCloseAlice(alice1, bob)
+        val aliceFeeRange = aliceCloseSig1.tlvStream.get<ClosingSignedTlv.FeeRange>()
+        assertNotNull(aliceFeeRange)
+        assertEquals(aliceCloseSig1.feeSatoshis, 674.sat)
+        assertEquals(aliceFeeRange.max, 1348.sat)
+        assertEquals(alice2.closingTxProposed.last().size, 1)
+        assertNull(alice2.bestUnpublishedClosingTx)
+
+        // bob makes a proposal outside our fee range
+        val (_, bobCloseSig1) = makeLegacyClosingSigned(alice2, bob2, 2_500.sat)
+        val (alice3, actions3) = alice2.processEx(ChannelEvent.MessageReceived(bobCloseSig1))
+        assertTrue(alice3 is Negotiating)
+        val aliceCloseSig2 = actions3.findOutgoingMessage<ClosingSigned>()
+        assertTrue(aliceCloseSig1.feeSatoshis < aliceCloseSig2.feeSatoshis)
+        assertTrue(aliceCloseSig2.feeSatoshis < 1600.sat)
+        assertEquals(alice3.closingTxProposed.last().size, 2)
+        assertNotNull(alice3.bestUnpublishedClosingTx)
+
+        val (_, bobCloseSig2) = makeLegacyClosingSigned(alice2, bob2, 2_000.sat)
+        val (alice4, actions4) = alice3.processEx(ChannelEvent.MessageReceived(bobCloseSig2))
+        assertTrue(alice4 is Negotiating)
+        val aliceCloseSig3 = actions4.findOutgoingMessage<ClosingSigned>()
+        assertTrue(aliceCloseSig2.feeSatoshis < aliceCloseSig3.feeSatoshis)
+        assertTrue(aliceCloseSig3.feeSatoshis < 1800.sat)
+        assertEquals(alice4.closingTxProposed.last().size, 3)
+        assertNotNull(alice4.bestUnpublishedClosingTx)
+
+        val (_, bobCloseSig3) = makeLegacyClosingSigned(alice2, bob2, 1_800.sat)
+        val (alice5, actions5) = alice4.processEx(ChannelEvent.MessageReceived(bobCloseSig3))
+        assertTrue(alice5 is Negotiating)
+        val aliceCloseSig4 = actions5.findOutgoingMessage<ClosingSigned>()
+        assertTrue(aliceCloseSig3.feeSatoshis < aliceCloseSig4.feeSatoshis)
+        assertTrue(aliceCloseSig4.feeSatoshis < 1800.sat)
+        assertEquals(alice5.closingTxProposed.last().size, 4)
+        assertNotNull(alice5.bestUnpublishedClosingTx)
+
+        val (_, bobCloseSig4) = makeLegacyClosingSigned(alice2, bob2, aliceCloseSig4.feeSatoshis)
+        val (alice6, actions6) = alice5.processEx(ChannelEvent.MessageReceived(bobCloseSig4))
+        assertTrue(alice6 is Closing)
+        val mutualCloseTx = actions6.findTxs().first()
+        assertEquals(alice6.mutualClosePublished.size, 1)
+        assertEquals(mutualCloseTx, alice6.mutualClosePublished.first().tx)
+    }
+
+    @Test
+    fun `recv ClosingSigned (other side ignores our fee range, fundee)`() {
+        val (alice, bob) = reachNormal()
+        val bob1 = bob.updateFeerate(FeeratePerKw(10_000.sat))
+        val (alice2, bob2, _) = mutualCloseBob(alice, bob1)
+
+        // alice starts with a very low proposal
+        val (aliceCloseSig1, _) = makeLegacyClosingSigned(alice2, bob2, 500.sat)
+        val (bob3, actions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig1))
+        assertTrue(bob3 is Negotiating)
+        val bobCloseSig1 = actions3.findOutgoingMessage<ClosingSigned>()
+        assertTrue(3000.sat < bobCloseSig1.feeSatoshis)
+        assertEquals(bob3.closingTxProposed.last().size, 1)
+        assertNotNull(bob3.bestUnpublishedClosingTx)
+
+        val (aliceCloseSig2, _) = makeLegacyClosingSigned(alice2, bob2, 750.sat)
+        val (bob4, actions4) = bob3.processEx(ChannelEvent.MessageReceived(aliceCloseSig2))
+        assertTrue(bob4 is Negotiating)
+        val bobCloseSig2 = actions4.findOutgoingMessage<ClosingSigned>()
+        assertTrue(2000.sat < bobCloseSig2.feeSatoshis)
+        assertEquals(bob4.closingTxProposed.last().size, 2)
+        assertNotNull(bob4.bestUnpublishedClosingTx)
+
+        val (aliceCloseSig3, _) = makeLegacyClosingSigned(alice2, bob2, 1000.sat)
+        val (bob5, actions5) = bob4.processEx(ChannelEvent.MessageReceived(aliceCloseSig3))
+        assertTrue(bob5 is Negotiating)
+        val bobCloseSig3 = actions5.findOutgoingMessage<ClosingSigned>()
+        assertTrue(1500.sat < bobCloseSig3.feeSatoshis)
+        assertEquals(bob5.closingTxProposed.last().size, 3)
+        assertNotNull(bob5.bestUnpublishedClosingTx)
+
+        val (aliceCloseSig4, _) = makeLegacyClosingSigned(alice2, bob2, 1300.sat)
+        val (bob6, actions6) = bob5.processEx(ChannelEvent.MessageReceived(aliceCloseSig4))
+        assertTrue(bob6 is Negotiating)
+        val bobCloseSig4 = actions6.findOutgoingMessage<ClosingSigned>()
+        assertTrue(1300.sat < bobCloseSig4.feeSatoshis)
+        assertEquals(bob6.closingTxProposed.last().size, 4)
+        assertNotNull(bob6.bestUnpublishedClosingTx)
+
+        val (aliceCloseSig5, _) = makeLegacyClosingSigned(alice2, bob2, bobCloseSig4.feeSatoshis)
+        val (bob7, actions7) = bob6.processEx(ChannelEvent.MessageReceived(aliceCloseSig5))
+        assertTrue(bob7 is Closing)
+        val mutualCloseTx = actions7.findTxs().first()
+        assertEquals(bob7.mutualClosePublished.size, 1)
+        assertEquals(mutualCloseTx, bob7.mutualClosePublished.first().tx)
+    }
+
+    @Test
+    fun `recv ClosingSigned (other side ignores our fee range, max iterations reached)`() {
+        val (alice, bob) = reachNormal()
+        val alice1 = alice.updateFeerate(FeeratePerKw(1_000.sat))
+        val (alice2, bob2, aliceCloseSig1) = mutualCloseAlice(alice1, bob)
+        var mutableAlice = alice2 as ChannelStateWithCommitments
+        var aliceCloseSig = aliceCloseSig1
+
+        for (i in 1..Channel.MAX_NEGOTIATION_ITERATIONS) {
+            val feeRange = aliceCloseSig.tlvStream.get<ClosingSignedTlv.FeeRange>()
+            assertNotNull(feeRange)
+            val bobNextFee = (aliceCloseSig.feeSatoshis + 500.sat).max(feeRange.max + 1.sat)
+            val (_, bobClosing) = makeLegacyClosingSigned(alice2, bob2, bobNextFee)
+            val (aliceNew, actions) = mutableAlice.processEx(ChannelEvent.MessageReceived(bobClosing))
+            aliceCloseSig = actions.findOutgoingMessage<ClosingSigned>()
+            mutableAlice = aliceNew as ChannelStateWithCommitments
+        }
+
+        assertTrue(mutableAlice is Closing)
+        assertEquals(mutableAlice.mutualClosePublished.size, 1)
+    }
+
+    @Test
+    fun `recv ClosingSigned (invalid signature)`() {
+        val (_, bob, aliceCloseSig) = init()
+        val (bob1, actions) = bob.processEx(ChannelEvent.MessageReceived(aliceCloseSig.copy(feeSatoshis = 99_000.sat)))
+        assertTrue(bob1 is Closing)
+        actions.hasOutgoingMessage<Error>()
+        actions.hasWatch<WatchConfirmed>()
+        actions.findTxs().contains(bob.commitments.localCommit.publishableTxs.commitTx.tx)
+    }
+
+    @Test
+    fun `recv ClosingSigned with encrypted channel data`() {
+        val (alice, bob, aliceCloseSig) = init()
+        assertTrue(alice.commitments.localParams.features.hasFeature(Feature.ChannelBackupProvider))
+        assertTrue(bob.commitments.localParams.features.hasFeature(Feature.ChannelBackupClient))
+        assertTrue(aliceCloseSig.channelData.isEmpty())
+        val (_, actions1) = bob.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
+        val bobCloseSig = actions1.hasOutgoingMessage<ClosingSigned>()
+        assertFalse(bobCloseSig.channelData.isEmpty())
+    }
+
+    @Test
+    fun `recv BITCOIN_FUNDING_SPENT (counterparty's mutual close)`() {
+        // NB: we're fundee here, not funder
         val (bob, alice) = reachNormal()
         val priv = randomKey()
 
         // Alice initiates a mutual close with a custom final script
         val finalScript = Script.write(Script.pay2pkh(priv.publicKey())).toByteVector()
-        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(finalScript)))
+        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(finalScript, null)))
         val shutdownA = actions1.findOutgoingMessage<Shutdown>()
 
         // Bob replies with Shutdown + ClosingSigned
@@ -60,7 +386,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         // check that our closing tx is correctly signed
         Transaction.correctlySpends(closingTxA, fundingTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
-        // Bob published his closing tx (which should be the same as Alice's !!!)
+        // Bob published his closing tx (which should be the same as Alice's)
         val (bob2, actions5) = bob1.processEx(ChannelEvent.MessageReceived(closingSignedA))
         assertTrue(bob2 is Closing)
         val closingTxB = actions5.filterIsInstance<ChannelAction.Blockchain.PublishTx>().first().tx
@@ -75,112 +401,42 @@ class NegotiatingTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv CMD_ADD_HTLC`() {
-        val (alice, _, _) = init()
-        val (_, add) = makeCmdAdd(500_000.msat, alice.staticParams.remoteNodeId, TestConstants.defaultBlockHeight.toLong())
-        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(add))
-        assertTrue(alice1 is Negotiating)
-        assertEquals(1, actions1.size)
-        actions1.hasCommandError<ChannelUnavailable>()
-    }
-
-    @Test
-    fun `recv ClosingSigned (theirCloseFee != ourCloseFee)`() {
-        val (alice, bob, aliceCloseSig) = init()
-        val (_, actions) = bob.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
-        // Bob answers with a counter proposition
-        val bobCloseSig = actions.findOutgoingMessage<ClosingSigned>()
-        assertTrue { aliceCloseSig.feeSatoshis > bobCloseSig.feeSatoshis }
-        val (alice1, actions1) = alice.processEx(ChannelEvent.MessageReceived(bobCloseSig))
-        val aliceCloseSig1 = actions1.findOutgoingMessage<ClosingSigned>()
-        // BOLT 2: If the receiver [doesn't agree with the fee] it SHOULD propose a value strictly between the received fee-satoshis and its previously-sent fee-satoshis
-        assertTrue { aliceCloseSig1.feeSatoshis < aliceCloseSig.feeSatoshis && aliceCloseSig1.feeSatoshis > bobCloseSig.feeSatoshis }
-        assertEquals((alice1 as Negotiating).closingTxProposed.last().map { it.localClosingSigned }, alice.closingTxProposed.last().map { it.localClosingSigned } + listOf(aliceCloseSig1))
-    }
-
-    @Test
-    fun `recv ClosingSigned (theirCloseFee == ourCloseFee)`() {
-        val (alice, bob, aliceCloseSig) = init()
-        assertTrue { converge(alice, bob, aliceCloseSig) != null }
-    }
-
-    @Test
-    fun `recv ClosingSigned (theirCloseFee == ourCloseFee, different fee parameters)`() {
-        val (alice, bob, aliceCloseSig) = init(tweakFees = true)
-        assertTrue { converge(alice, bob, aliceCloseSig) != null }
-    }
-
-    @Test
-    fun `recv ClosingSigned (nothing at stake)`() {
-        val (alice, bob, aliceCloseSig) = init(pushMsat = 0.msat)
-        // Bob has nothing at stake
-        val (bob1, actions) = bob.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
-        assertTrue(bob1 is Closing)
-        val mutualCloseTxBob = actions.findTxs().first()
-        val bobCloseSig = actions.findOutgoingMessage<ClosingSigned>()
-        assertEquals(aliceCloseSig.feeSatoshis, bobCloseSig.feeSatoshis)
-        val (alice1, actions1) = alice.processEx(ChannelEvent.MessageReceived(bobCloseSig))
-        assertTrue(alice1 is Closing)
-        val mutualCloseTxAlice = actions1.findTxs().first()
-        assertEquals(mutualCloseTxAlice, mutualCloseTxBob)
-        assertEquals(actions.findWatches<WatchConfirmed>().map { it.event }, listOf(BITCOIN_TX_CONFIRMED(mutualCloseTxBob)))
-        assertEquals(actions1.findWatches<WatchConfirmed>().map { it.event }, listOf(BITCOIN_TX_CONFIRMED(mutualCloseTxBob)))
-        assertEquals(bob1.mutualClosePublished.map { it.tx }, listOf(mutualCloseTxBob))
-        assertEquals(alice1.mutualClosePublished.map { it.tx }, listOf(mutualCloseTxBob))
-    }
-
-    @Test
-    fun `recv ClosingSigned (invalid signature)`() {
-        val (_, bob, aliceCloseSig) = init()
-        val (bob1, actions) = bob.processEx(ChannelEvent.MessageReceived(aliceCloseSig.copy(feeSatoshis = 99000.sat)))
-        assertTrue(bob1 is Closing)
-        actions.hasOutgoingMessage<Error>()
-        actions.hasWatch<WatchConfirmed>()
-        actions.findTxs().contains(bob.commitments.localCommit.publishableTxs.commitTx.tx)
-    }
-
-    @Test
-    fun `recv ClosingSigned with encrypted channel data`() {
-        val (alice, bob, aliceCloseSig) = init()
-        assertTrue(alice.commitments.localParams.features.hasFeature(Feature.ChannelBackupProvider))
-        assertTrue(bob.commitments.localParams.features.hasFeature(Feature.ChannelBackupClient))
-        assertTrue(aliceCloseSig.channelData.isEmpty())
-        val (_, actions1) = bob.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
-        val bobCloseSig = actions1.hasOutgoingMessage<ClosingSigned>()
-        assertFalse(bobCloseSig.channelData.isEmpty())
-    }
-
-    @Test
     fun `recv BITCOIN_FUNDING_SPENT (an older mutual close)`() {
-        val (alice, bob, aliceCloseSig) = init()
-        val (bob1, actions) = bob.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
-        assertTrue(bob1 is Negotiating)
-        val bobCloseSig = actions.findOutgoingMessage<ClosingSigned>()
-        val (alice1, actions1) = alice.processEx(ChannelEvent.MessageReceived(bobCloseSig))
-        val aliceCloseSig1 = actions1.findOutgoingMessage<ClosingSigned>()
-        assertTrue(bobCloseSig.feeSatoshis != aliceCloseSig1.feeSatoshis)
-        // at this point alice and bob have not yet converged on closing fees, but bob decides to publish a mutual close with one of the previous sigs
-        val bobClosingTx = Helpers.Closing.checkClosingSignature(
-            bob1.keyManager,
-            bob1.commitments,
-            bob1.localShutdown.scriptPubKey.toByteArray(),
-            bob1.remoteShutdown.scriptPubKey.toByteArray(),
-            aliceCloseSig1.feeSatoshis,
-            aliceCloseSig1.signature
-        ).right!!
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, bobClosingTx.tx)))
-        assertTrue(alice2 is Closing)
-        actionsAlice2.has<ChannelAction.Storage.StoreState>()
-        actionsAlice2.hasTx(bobClosingTx.tx)
-        assertEquals(actionsAlice2.hasWatch<WatchConfirmed>().txId, bobClosingTx.tx.txid)
+        val (alice, bob) = reachNormal()
+        val alice1 = alice.updateFeerate(FeeratePerKw(1_000.sat))
+        val bob1 = bob.updateFeerate(FeeratePerKw(10_000.sat))
+        val (alice2, bob2, aliceCloseSig1) = mutualCloseAlice(alice1, bob1)
+
+        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig1))
+        assertTrue(bob3 is Negotiating)
+        bobActions3.findOutgoingMessage<ClosingSigned>()
+        val firstMutualCloseTx = bob3.bestUnpublishedClosingTx
+        assertNotNull(firstMutualCloseTx)
+
+        val (_, bobCloseSig1) = makeLegacyClosingSigned(alice2, bob2, 3_000.sat)
+        assertNotEquals(bobCloseSig1.feeSatoshis, aliceCloseSig1.feeSatoshis)
+        val (alice3, aliceActions3) = alice2.processEx(ChannelEvent.MessageReceived(bobCloseSig1))
+        assertTrue(alice3 is Negotiating)
+        val aliceCloseSig2 = aliceActions3.findOutgoingMessage<ClosingSigned>()
+        assertNotEquals(aliceCloseSig2.feeSatoshis, bobCloseSig1.feeSatoshis)
+        val latestMutualCloseTx = alice3.bestUnpublishedClosingTx
+        assertNotNull(latestMutualCloseTx)
+        assertNotEquals(firstMutualCloseTx.tx.txid, latestMutualCloseTx.tx.txid)
+
+        // at this point bob will receive a new signature, but he decides instead to publish the first mutual close
+        val (alice4, aliceActions4) = alice3.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice3.channelId, BITCOIN_FUNDING_SPENT, firstMutualCloseTx.tx)))
+        assertTrue(alice4 is Closing)
+        aliceActions4.has<ChannelAction.Storage.StoreState>()
+        aliceActions4.hasTx(firstMutualCloseTx.tx)
+        assertEquals(aliceActions4.hasWatch<WatchConfirmed>().txId, firstMutualCloseTx.tx.txid)
     }
 
     @Test
     fun `recv CMD_CLOSE`() {
         val (alice, _, _) = init()
-        val (alice1, actions) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null)))
+        val (alice1, actions) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
         assertEquals(alice1, alice)
-        assertEquals(actions, listOf(ChannelAction.ProcessCmdRes.NotExecuted(CMD_CLOSE(null), ClosingAlreadyInProgress(alice.channelId))))
+        assertEquals(actions, listOf(ChannelAction.ProcessCmdRes.NotExecuted(CMD_CLOSE(null, null), ClosingAlreadyInProgress(alice.channelId))))
     }
 
     @Test
@@ -188,14 +444,22 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         val (alice, _, _) = init()
         val (alice1, actions) = alice.processEx(ChannelEvent.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
         assertTrue(alice1 is Closing)
-        assertTrue(actions.findTxs().contains(alice.commitments.localCommit.publishableTxs.commitTx.tx))
+        actions.hasTx(alice.commitments.localCommit.publishableTxs.commitTx.tx)
         assertTrue(actions.findWatches<WatchConfirmed>().map { it.event }.contains(BITCOIN_TX_CONFIRMED(alice.commitments.localCommit.publishableTxs.commitTx.tx)))
     }
 
     companion object {
-        fun init(channelType: ChannelType.SupportedChannelType = ChannelType.SupportedChannelType.AnchorOutputs, tweakFees: Boolean = false, pushMsat: MilliSatoshi = TestConstants.pushMsat): Triple<Negotiating, Negotiating, ClosingSigned> {
+        fun init(channelType: ChannelType.SupportedChannelType = ChannelType.SupportedChannelType.AnchorOutputs, pushMsat: MilliSatoshi = TestConstants.pushMsat): Triple<Negotiating, Negotiating, ClosingSigned> {
             val (alice, bob) = reachNormal(channelType = channelType, pushMsat = pushMsat)
-            return mutualClose(alice, bob, tweakFees)
+            return mutualCloseAlice(alice, bob)
+        }
+
+        private fun makeLegacyClosingSigned(alice: Negotiating, bob: Negotiating, closingFee: Satoshi): Pair<ClosingSigned, ClosingSigned> {
+            val aliceScript = alice.localShutdown.scriptPubKey.toByteArray()
+            val bobScript = bob.localShutdown.scriptPubKey.toByteArray()
+            val (_, aliceClosingSigned) = Helpers.Closing.makeClosingTx(alice.keyManager, alice.commitments, aliceScript, bobScript, ClosingFees(closingFee, closingFee, closingFee))
+            val (_, bobClosingSigned) = Helpers.Closing.makeClosingTx(bob.keyManager, bob.commitments, bobScript, aliceScript, ClosingFees(closingFee, closingFee, closingFee))
+            return Pair(aliceClosingSigned.copy(tlvStream = TlvStream.empty()), bobClosingSigned.copy(tlvStream = TlvStream.empty()))
         }
 
         tailrec fun converge(a: ChannelState, b: ChannelState, aliceCloseSig: ClosingSigned?): Pair<Closing, Closing>? {

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ShutdownTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ShutdownTestsCommon.kt
@@ -361,7 +361,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
         val (_, bob0) = reachNormal()
         assertTrue(bob0.commitments.localParams.features.hasFeature(Feature.ChannelBackupClient))
         assertFalse(bob0.commitments.channelFeatures.hasFeature(Feature.ChannelBackupClient)) // this isn't a permanent channel feature
-        val (bob1, actions1) = bob0.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null)))
+        val (bob1, actions1) = bob0.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
         assertTrue(bob1 is Normal)
         val blob = Serialization.encrypt(bob1.staticParams.nodeParams.nodePrivateKey.value, bob1)
         val shutdown = actions1.findOutgoingMessage<Shutdown>()
@@ -479,9 +479,9 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_CLOSE`() {
         val (alice, _) = init()
-        val (alice1, actions) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null)))
+        val (alice1, actions) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
         assertEquals(alice1, alice)
-        assertEquals(actions, listOf(ChannelAction.ProcessCmdRes.NotExecuted(CMD_CLOSE(null), ClosingAlreadyInProgress(alice.channelId))))
+        assertEquals(actions, listOf(ChannelAction.ProcessCmdRes.NotExecuted(CMD_CLOSE(null, null), ClosingAlreadyInProgress(alice.channelId))))
     }
 
     private fun testLocalForceClose(alice: ChannelState, actions: List<ChannelAction>) {
@@ -566,7 +566,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
 
         fun shutdown(alice: ChannelState, bob: ChannelState): Pair<ShuttingDown, ShuttingDown> {
             // Alice initiates a closing
-            val (alice1, actionsAlice) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null)))
+            val (alice1, actionsAlice) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
             val shutdown = actionsAlice.findOutgoingMessage<Shutdown>()
             val (bob1, actionsBob) = bob.processEx(ChannelEvent.MessageReceived(shutdown))
             val shutdown1 = actionsBob.findOutgoingMessage<Shutdown>()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannelTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannelTestsCommon.kt
@@ -179,7 +179,7 @@ class WaitForAcceptChannelTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_CLOSE`() {
         val (alice, _, _) = init()
-        val (alice1, actions1) = alice.process(ChannelEvent.ExecuteCommand(CMD_CLOSE(null)))
+        val (alice1, actions1) = alice.process(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
         assertTrue(alice1 is Aborted)
         assertTrue(actions1.isEmpty())
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
@@ -146,7 +146,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
     fun `recv CMD_CLOSE`() {
         val (alice, bob) = init(ChannelType.SupportedChannelType.AnchorOutputs, TestConstants.fundingAmount, TestConstants.pushMsat)
         listOf(alice, bob).forEach { state ->
-            val (state1, actions1) = state.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null)))
+            val (state1, actions1) = state.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
             assertEquals(state, state1)
             actions1.hasCommandError<CommandUnavailableInThisState>()
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreatedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreatedTestsCommon.kt
@@ -62,7 +62,7 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_CLOSE`() {
         val (_, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, TestConstants.fundingAmount, TestConstants.pushMsat)
-        val (bob1, actions1) = bob.process(ChannelEvent.ExecuteCommand(CMD_CLOSE(null)))
+        val (bob1, actions1) = bob.process(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
         assertTrue { bob1 is Aborted }
         assertTrue { actions1.isEmpty() }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingLockedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingLockedTestsCommon.kt
@@ -80,7 +80,7 @@ class WaitForFundingLockedTestsCommon : LightningTestSuite() {
     fun `recv CMD_CLOSE`() {
         val (alice, bob, _) = init()
         listOf(alice, bob).forEach { state ->
-            val (state1, actions1) = state.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null)))
+            val (state1, actions1) = state.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
             assertEquals(state, state1)
             assertEquals(1, actions1.size)
             actions1.hasCommandError<CommandUnavailableInThisState>()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
@@ -62,7 +62,7 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_CLOSE`() {
         val (alice, _, _) = init()
-        val (alice1, actions1) = alice.process(ChannelEvent.ExecuteCommand(CMD_CLOSE(null)))
+        val (alice1, actions1) = alice.process(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
         assertTrue(alice1 is Aborted)
         assertNull(actions1.findOutgoingMessageOpt<Error>())
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannelTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannelTestsCommon.kt
@@ -242,7 +242,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_CLOSE`() {
         val (_, bob, _) = TestsHelper.init()
-        val (bob1, actions) = bob.process(ChannelEvent.ExecuteCommand(CMD_CLOSE(null)))
+        val (bob1, actions) = bob.process(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
         assertTrue { bob1 is Aborted }
         assertTrue { actions.isEmpty() }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -587,6 +587,54 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
     }
 
     @Test
+    fun `encode - decode closing_signed`() {
+        val defaultSig = ByteVector64("01010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101")
+        val testCases = listOf(
+            Hex.decode("0027 0100000000000000000000000000000000000000000000000000000000000000 0000000000000000 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000") to ClosingSigned(
+                ByteVector32.One,
+                0.sat,
+                ByteVector64.Zeroes
+            ),
+            Hex.decode("0027 0100000000000000000000000000000000000000000000000000000000000000 00000000000003e8 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000") to ClosingSigned(
+                ByteVector32.One,
+                1000.sat,
+                ByteVector64.Zeroes
+            ),
+            Hex.decode("0027 0100000000000000000000000000000000000000000000000000000000000000 00000000000005dc 01010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101") to ClosingSigned(
+                ByteVector32.One,
+                1500.sat,
+                defaultSig
+            ),
+            Hex.decode("0027 0100000000000000000000000000000000000000000000000000000000000000 00000000000005dc 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 0110000000000000006400000000000007d0") to ClosingSigned(
+                ByteVector32.One,
+                1500.sat,
+                ByteVector64.Zeroes,
+                TlvStream(listOf(ClosingSignedTlv.FeeRange(100.sat, 2000.sat)))
+            ),
+            Hex.decode("0027 0100000000000000000000000000000000000000000000000000000000000000 00000000000003e8 01010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101 0110000000000000006400000000000007d0") to ClosingSigned(
+                ByteVector32.One,
+                1000.sat,
+                defaultSig,
+                TlvStream(listOf(ClosingSignedTlv.FeeRange(100.sat, 2000.sat)))
+            ),
+            Hex.decode("0027 0100000000000000000000000000000000000000000000000000000000000000 0000000000000064 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 0110000000000000006400000000000003e8 030401020304") to ClosingSigned(
+                ByteVector32.One,
+                100.sat,
+                ByteVector64.Zeroes,
+                TlvStream(listOf(ClosingSignedTlv.FeeRange(100.sat, 1000.sat)), listOf(GenericTlv(3, ByteVector("01020304"))))
+            ),
+        )
+
+        testCases.forEach {
+            val decoded = LightningMessage.decode(it.first)
+            assertNotNull(decoded)
+            assertEquals(decoded, it.second)
+            val reEncoded = LightningMessage.encode(decoded)
+            assertArrayEquals(reEncoded, it.first)
+        }
+    }
+
+    @Test
     fun `nonreg backup channel data`() {
         val channelId = randomBytes32()
         val signature = randomBytes64()
@@ -632,11 +680,11 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
             Hex.decode("0026") + channelId.toByteArray() + Hex.decode("002a") + randomData + Hex.decode("01 02 0102") + Hex.decode("fe47010000 07 cccccccccccccc") to Shutdown(channelId, randomData.toByteVector(), TlvStream(listOf(ShutdownTlv.ChannelData(EncryptedChannelData(ByteVector("cccccccccccccc")))), listOf(GenericTlv(1, ByteVector("0102"))))),
 
             Hex.decode("0027") + channelId.toByteArray() + Hex.decode("00000000075bcd15") + signature.toByteArray() to ClosingSigned(channelId, 123456789.sat, signature),
-            Hex.decode("0027") + channelId.toByteArray() + Hex.decode("00000000075bcd15") + signature.toByteArray() + Hex.decode("01 02 0102") to ClosingSigned(channelId, 123456789.sat, signature, TlvStream(listOf(), listOf(GenericTlv(1, ByteVector("0102"))))),
+            Hex.decode("0027") + channelId.toByteArray() + Hex.decode("00000000075bcd15") + signature.toByteArray() + Hex.decode("03 02 0102") to ClosingSigned(channelId, 123456789.sat, signature, TlvStream(listOf(), listOf(GenericTlv(3, ByteVector("0102"))))),
             Hex.decode("0027") + channelId.toByteArray() + Hex.decode("00000000075bcd15") + signature.toByteArray() + Hex.decode("fe47010000 00") to ClosingSigned(channelId, 123456789.sat, signature, TlvStream(listOf(ClosingSignedTlv.ChannelData(EncryptedChannelData.empty)))),
-            Hex.decode("0027") + channelId.toByteArray() + Hex.decode("00000000075bcd15") + signature.toByteArray() + Hex.decode("01 02 0102") + Hex.decode("fe47010000 00") to ClosingSigned(channelId, 123456789.sat, signature, TlvStream(listOf(ClosingSignedTlv.ChannelData(EncryptedChannelData.empty)), listOf(GenericTlv(1, ByteVector("0102"))))),
+            Hex.decode("0027") + channelId.toByteArray() + Hex.decode("00000000075bcd15") + signature.toByteArray() + Hex.decode("03 02 0102") + Hex.decode("fe47010000 00") to ClosingSigned(channelId, 123456789.sat, signature, TlvStream(listOf(ClosingSignedTlv.ChannelData(EncryptedChannelData.empty)), listOf(GenericTlv(3, ByteVector("0102"))))),
             Hex.decode("0027") + channelId.toByteArray() + Hex.decode("00000000075bcd15") + signature.toByteArray() + Hex.decode("fe47010000 07 cccccccccccccc") to ClosingSigned(channelId, 123456789.sat, signature).withChannelData(ByteVector("cccccccccccccc")),
-            Hex.decode("0027") + channelId.toByteArray() + Hex.decode("00000000075bcd15") + signature.toByteArray() + Hex.decode("01 02 0102") + Hex.decode("fe47010000 07 cccccccccccccc") to ClosingSigned(channelId, 123456789.sat, signature, TlvStream(listOf(ClosingSignedTlv.ChannelData(EncryptedChannelData(ByteVector("cccccccccccccc")))), listOf(GenericTlv(1, ByteVector("0102")))))
+            Hex.decode("0027") + channelId.toByteArray() + Hex.decode("00000000075bcd15") + signature.toByteArray() + Hex.decode("03 02 0102") + Hex.decode("fe47010000 07 cccccccccccccc") to ClosingSigned(channelId, 123456789.sat, signature, TlvStream(listOf(ClosingSignedTlv.ChannelData(EncryptedChannelData(ByteVector("cccccccccccccc")))), listOf(GenericTlv(3, ByteVector("0102")))))
         )
         // @formatter:on
 

--- a/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
+++ b/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
@@ -265,7 +265,7 @@ object Node {
                     }
                     post("/channels/{channelId}/close") {
                         val channelId = ByteVector32(call.parameters["channelId"] ?: error("channelId not provided"))
-                        peer.send(WrappedChannelEvent(channelId, ChannelEvent.ExecuteCommand(CMD_CLOSE(null))))
+                        peer.send(WrappedChannelEvent(channelId, ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null))))
                         call.respond(CloseChannelResponse("pending"))
                     }
                 }


### PR DESCRIPTION
Add support for https://github.com/lightningnetwork/lightning-rfc#847

With legacy nodes, we will keep the existing behavior (slowly converge on a fee).
But for nodes that support closing `fee_range`s, mutual close will take much less round-trips.
This has also been implemented in eclair: https://github.com/ACINQ/eclair/pull/1768

**Open question: should we drop support for the old negotiation and greatly simplify that code?**

NB: this builds on #277 to leverage the new `ChannelState` version, and should be included in the same release.