### PR TITLE
Phoenix issue 168 - Show balance/channels at startup even when the wallet has not finished channel reestablish

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 allprojects {
     group = "fr.acinq.lightning"
-    version = "1.0-beta12"
+    version = "snapshot"
 
     repositories {
         mavenLocal()


### PR DESCRIPTION
We've recently encountered various connection issues. One such issue was a problem connecting to the Electrum server. And unfortunately, our code base was written such that, the balance was displayed as zero until the electrum connection was up-and-running. :poop: Thus, during that time we received emails from several panicked users - not because the app couldn't connect ... but because the app was showing them a zero balance!

Lesson learned: If you tell people their balance is zero, they are likely to **freak out**. :exploding_head: And understandably so.

We could simply display the balance as "pending" until the electrum connection is up. However, I find this to be unsatisfactory. It's really just annoying. I should be able to open the app in airplane mode, and it should show me my balance (as of the last time I was connected).

This PR provides a proper solution to the problem, and allows consumers (read: Phoenix app) to display the most-recent balance immediately after the app is launched.

The reason this wasn't possible before, is because the wallet balance is extracted from `Peer.channels`, the publication of which was suspended until the electrum channel had populated certain variables:

```kotlin
launch {
  // we don't restore closed channels
  db.channels.listLocalChannels().filterNot { it is Closed }.map {
    logger.info { "n:$remoteNodeId restoring ${it.channelId}" }
    val state = WaitForInit(
      staticParams = StaticParams(nodeParams, remoteNodeId),
      currentTip = currentTipFlow.filterNotNull().first(), // <= suspends
      currentOnChainFeerates = onChainFeeratesFlow.filterNotNull().first() // <= suspends
    )
    // ...
    _channels = _channels + (it.channelId to state1)
  }
}
```

The interesting thing here is that we already read the channels at boot: `db.channels.listLocalChannels()`. If we simply had access to this information, the UI could solve its problem:

So this PR makes a minor change:

```kotlin
// The channels map, as initially loaded from the database at "boot" (on Peer.init).
// As the channelsFlow is unavailable until the electrum connection is up-and-running,
// this may provide useful information for the UI.
private val _bootChannelsFlow = MutableStateFlow<Map<ByteVector32, ChannelState>?>(null)
val bootChannelsFlow: StateFlow<Map<ByteVector32, ChannelState>?> get() = _bootChannelsFlow

launch {
  // we don't restore closed channels
  val bootChannels = db.channels.listLocalChannels().filterNot { it is Closed }
  _bootChannelsFlow.value = bootChannels.map { it.channelId to it }.toMap()
  // restore channels (nb: suspends on currentTipFlow & onChainFeeratesFlow)
  val channelIds = bootChannels.map {
    logger.info { "n:$remoteNodeId restoring ${it.channelId}" }
    val state = WaitForInit(
      staticParams = StaticParams(nodeParams, remoteNodeId),
      currentTip = currentTipFlow.filterNotNull().first(),
      currentOnChainFeerates = onChainFeeratesFlow.filterNotNull().first()
    )
    // ...
    _channels = _channels + (it.channelId to state1)
  }
}
```

And with the corresponding change in the UI, hopefully this will result in less :cursing_face: and more :sunglasses:


https://user-images.githubusercontent.com/304604/118713280-bbc13400-b7ef-11eb-9604-832d851f6f70.mp4

