### PR TITLE
Watch tower support

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
@@ -557,6 +557,7 @@ class ElectrumWatcher(
                 is GetScriptHashHistory -> true
                 is GetTransaction -> true
                 is GetMerkle -> true
+                is BroadcastTransaction -> true
                 else -> false
             }
         }.all {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -140,15 +140,13 @@ class Peer(
             }
         }
         launch {
-            val watchNotifications = watcher.openWatchNotificationsSubscription()
-            watchNotifications.consumeEach {
+            watcher.openWatchNotificationsFlow().collect {
                 logger.debug { "n:$remoteNodeId notification: $it" }
                 input.send(WrappedChannelEvent(it.channelId, ChannelEvent.WatchReceived(it)))
             }
         }
         launch {
-            val txNotifications = watcher.openTxNotificationsSubscription()
-            txNotifications.consumeEach {
+            watcher.openTxNotificationsFlow().collect {
                 logger.debug { "n:$remoteNodeId tx: ${it.second} for channel: ${it.first}" }
                 input.send(WrappedChannelEvent(it.first, ChannelEvent.GetFundingTxResponse(it.second)))
             }


### PR DESCRIPTION
This PR adds support for a simple client-side "Watch Tower" task, that can be run on either iOS or Android. For example, iOS may schedule a background operation to run every few days.



The idea is that the client will run a task that:

- connects to the electrum server (_doesn't need to connect to lightning server_)
- receives status of watched transactions
- reacts appropriately if commits have been published

This is all well and good. It just means we connect to the electrum server, and let the existing code do its thing. And we already have unit tests for these code paths.

But, of course, Apple puts restrictions on background tasks. So on iOS, a background task has a limited amount of time to execute. And it needs to explicitly tell the OS when it has finished.

Which creates a new problem: **How do we know when the task has finished ?**

Answering this question is the focus of this PR.

After investigating a few ideas, I realized there was a simple approach we could use to tell us when we've finished syncing with the electrum server:

- after we've connected to electrum server (post handshake)
- when there are no outstanding requests (excluding pings)
- and after a brief delay to ensure we've processed all incoming information

After that point we've finished syncing with the electrum server, and we consider ourselves up-to-date.

The implementation is composed of 2 primary changes:



### ElectrumClient

Previously, we were storing the outgoing requests via:

```kotlin
val requests: MutableMap<Int, ElectrumRequest>
```

So I've added another field to store the timestamps of the responses:

```kotlin
val responseTimestamps: MutableMap<Int, Long?>
```

If the value is null, then we know we have an outstanding request. If non-null, we know how long ago we received the response.



(Note that some requests, such as subscriptions, may receive multiple responses. So this always stores the timestamp of the most recent response.)



### ElectrumWatcher

After connecting (i.e. post handshake), we start a timer that fires every 2 seconds. When the timer fires, we check to see if:

- every request has received a response from the server
- the last response was at least a few seconds ago



Once the criteria is satisfied, we fire a `NotifyUpToDateEvent`, which the client can listen for.

