### PR TITLE
Use forked version of kodein-log using UTC only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,20 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macOS-latest ]
     steps:
+
+      # 1 - checkout repositories
       - name: Check out
         uses: actions/checkout@v2
         with:
           submodules: 'true'
+      - name: Checkout kodein-log with UTC fork
+        uses: actions/checkout@v2
+        with:
+          repository: dpad85/Kodein-Log
+          ref: utc-timezone
+          path: kodein-log
+
+      # 2 - setup cache and tools
       - name: Cached Konan
         uses: actions/cache@v2
         with:
@@ -52,6 +62,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+
+      # 3 - build dependencies
+      - name: Build kodein-log and publish it to local maven
+        run: |
+          cd kodein-log
+          ./gradlew publishToMavenLocal
+
+      # 4 - tests
       - name: Check with integration
         if: matrix.os == 'ubuntu-latest'
         run: ./gradlew check -PintegrationTests=include

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
         dependencies {
             api("fr.acinq.bitcoin:bitcoin-kmp:0.7.0")
             api("fr.acinq.secp256k1:secp256k1-kmp:$secp256k1Version")
-            api("org.kodein.log:kodein-log:0.10.1")
+            api("org.kodein.log:kodein-log:0.10.1-utc")
             api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion")
             api("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
             api("org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion")


### PR DESCRIPTION
This pull request changes the kodein-log library version to a [forked one](https://github.com/dpad85/Kodein-Log/tree/utc-timezone) (forked from v0.10.1) where the timezone used by the library when printing log timestamp is always UTC.

This fixes [an issue on phoenix iOS](https://github.com/ACINQ/phoenix-kmm/issues/148), where some timezones were not correctly handled by the underlying kotlinx-datetime library and would crash the app.

A fix is available for kotlinx-datetime and is embedded in the latest kodein-log versions, however this would also require to upgrade the whole project to kotlin 1.5, which is not something we want to do just yet.