### PR TITLE
Missing revocation after reestablish

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
@@ -3071,6 +3071,10 @@ object Channel {
                 sendQueue.add(ChannelAction.Message.Send(commitments1.remoteNextCommitInfo.left!!.sent))
                 if (revWasSentLast) resendRevocation()
             }
+            commitments1.remoteNextCommitInfo.isRight && commitments1.remoteCommit.index + 1 == channelReestablish.nextLocalCommitmentNumber -> {
+                // there wasn't any sig in-flight when the disconnection occurred
+                resendRevocation()
+            }
         }
 
         if (commitments1.localHasChanges()) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
@@ -160,6 +160,7 @@ sealed class ChannelState {
             val (newState, actions) = processInternal(event)
             val oldState = when (this) {
                 is Offline -> this.state
+                is Syncing -> this.state
                 else -> this
             }
             val actions1 = when {
@@ -955,30 +956,36 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                                     val fundingLocked = FundingLocked(state.commitments.channelId, nextPerCommitmentPoint)
                                     actions.add(ChannelAction.Message.Send(fundingLocked))
                                 }
-                                val (commitments1, sendQueue1) = handleSync(event.message, state, keyManager, logger)
-                                actions.addAll(sendQueue1)
 
-                                // BOLT 2: A node if it has sent a previous shutdown MUST retransmit shutdown.
-                                state.localShutdown?.let {
-                                    logger.debug { "c:${state.channelId} re-sending local shutdown" }
-                                    actions.add(ChannelAction.Message.Send(it))
+                                try {
+                                    val (commitments1, sendQueue1) = handleSync(event.message, state, keyManager, logger)
+                                    actions.addAll(sendQueue1)
+
+                                    // BOLT 2: A node if it has sent a previous shutdown MUST retransmit shutdown.
+                                    state.localShutdown?.let {
+                                        logger.debug { "c:${state.channelId} re-sending local shutdown" }
+                                        actions.add(ChannelAction.Message.Send(it))
+                                    }
+
+                                    if (!state.buried) {
+                                        // even if we were just disconnected/reconnected, we need to put back the watch because the event may have been
+                                        // fired while we were in OFFLINE (if not, the operation is idempotent anyway)
+                                        val watchConfirmed = WatchConfirmed(
+                                            state.channelId,
+                                            state.commitments.commitInput.outPoint.txid,
+                                            state.commitments.commitInput.txOut.publicKeyScript,
+                                            ANNOUNCEMENTS_MINCONF.toLong(),
+                                            BITCOIN_FUNDING_DEEPLYBURIED
+                                        )
+                                        actions.add(ChannelAction.Blockchain.SendWatch(watchConfirmed))
+                                    }
+
+                                    logger.info { "c:${state.channelId} switching to ${state::class}" }
+                                    Pair(state.copy(commitments = commitments1), actions)
+                                } catch (e: RevocationSyncError) {
+                                    val error = Error(state.channelId, e.message)
+                                    state.spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error)) }
                                 }
-
-                                if (!state.buried) {
-                                    // even if we were just disconnected/reconnected, we need to put back the watch because the event may have been
-                                    // fired while we were in OFFLINE (if not, the operation is idempotent anyway)
-                                    val watchConfirmed = WatchConfirmed(
-                                        state.channelId,
-                                        state.commitments.commitInput.outPoint.txid,
-                                        state.commitments.commitInput.txOut.publicKeyScript,
-                                        ANNOUNCEMENTS_MINCONF.toLong(),
-                                        BITCOIN_FUNDING_DEEPLYBURIED
-                                    )
-                                    actions.add(ChannelAction.Blockchain.SendWatch(watchConfirmed))
-                                }
-
-                                logger.info { "c:${state.channelId} switching to ${state::class}" }
-                                Pair(state.copy(commitments = commitments1), actions)
                             }
                         }
                     }
@@ -3075,6 +3082,7 @@ object Channel {
                 // there wasn't any sig in-flight when the disconnection occurred
                 resendRevocation()
             }
+            else -> throw RevocationSyncError(d.channelId)
         }
 
         if (commitments1.localHasChanges()) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -29,18 +29,18 @@ import kotlin.test.*
 internal inline fun <reified T : LightningMessage> List<ChannelAction>.findOutgoingMessages(): List<T> = filterIsInstance<ChannelAction.Message.Send>().map { it.message }.filterIsInstance<T>()
 internal inline fun <reified T : LightningMessage> List<ChannelAction>.findOutgoingMessageOpt(): T? = findOutgoingMessages<T>().firstOrNull()
 internal inline fun <reified T : LightningMessage> List<ChannelAction>.findOutgoingMessage(): T = findOutgoingMessageOpt<T>() ?: fail("cannot find outgoing message ${T::class}")
-internal inline fun <reified T : LightningMessage> List<ChannelAction>.hasOutgoingMessage() = assertNotNull(findOutgoingMessageOpt<T>())
+internal inline fun <reified T : LightningMessage> List<ChannelAction>.hasOutgoingMessage() = assertNotNull(findOutgoingMessageOpt<T>(), "cannot find outgoing message ${T::class}")
 
 // Blockchain Watches
 internal inline fun <reified T : Watch> List<ChannelAction>.findWatches(): List<T> = filterIsInstance<ChannelAction.Blockchain.SendWatch>().map { it.watch }.filterIsInstance<T>()
 internal inline fun <reified T : Watch> List<ChannelAction>.findWatch(): T = findWatches<T>().firstOrNull() ?: fail("cannot find watch ${T::class}")
-internal inline fun <reified T : Watch> List<ChannelAction>.hasWatch() = assertNotNull(findWatches<T>().firstOrNull())
+internal inline fun <reified T : Watch> List<ChannelAction>.hasWatch() = assertNotNull(findWatches<T>().firstOrNull(), "cannot find watch ${T::class}")
 
 // Commands
 internal inline fun <reified T : Command> List<ChannelAction>.findCommands(): List<T> = filterIsInstance<ChannelAction.Message.SendToSelf>().map { it.command }.filterIsInstance<T>()
 internal inline fun <reified T : Command> List<ChannelAction>.findCommandOpt(): T? = findCommands<T>().firstOrNull()
 internal inline fun <reified T : Command> List<ChannelAction>.findCommand(): T = findCommandOpt<T>() ?: fail("cannot find command ${T::class}")
-internal inline fun <reified T : Command> List<ChannelAction>.hasCommand() = assertNotNull(findCommandOpt<T>())
+internal inline fun <reified T : Command> List<ChannelAction>.hasCommand() = assertNotNull(findCommandOpt<T>(), "cannot find command ${T::class}")
 
 // Transactions
 internal fun List<ChannelAction>.findTxs(): List<Transaction> = filterIsInstance<ChannelAction.Blockchain.PublishTx>().map { it.tx }
@@ -49,7 +49,7 @@ internal fun List<ChannelAction>.hasTx(tx: Transaction) = assertTrue(findTxs().c
 // Errors
 internal inline fun <reified T : Throwable> List<ChannelAction>.findErrorOpt(): T? = filterIsInstance<ChannelAction.ProcessLocalError>().map { it.error }.filterIsInstance<T>().firstOrNull()
 internal inline fun <reified T : Throwable> List<ChannelAction>.findError(): T = findErrorOpt<T>() ?: fail("cannot find error ${T::class}")
-internal inline fun <reified T : Throwable> List<ChannelAction>.hasError() = assertNotNull(findErrorOpt<T>())
+internal inline fun <reified T : Throwable> List<ChannelAction>.hasError() = assertNotNull(findErrorOpt<T>(), "cannot find error ${T::class}")
 
 internal inline fun <reified T : ChannelException> List<ChannelAction>.findCommandErrorOpt(): T? {
     val cmdAddError = filterIsInstance<ChannelAction.ProcessCmdRes.AddFailed>().map { it.error }.filterIsInstance<T>().firstOrNull()
@@ -58,7 +58,7 @@ internal inline fun <reified T : ChannelException> List<ChannelAction>.findComma
 }
 
 internal inline fun <reified T : ChannelException> List<ChannelAction>.findCommandError(): T = findCommandErrorOpt<T>() ?: fail("cannot find command error ${T::class}")
-internal inline fun <reified T : ChannelException> List<ChannelAction>.hasCommandError() = assertNotNull(findCommandErrorOpt<T>())
+internal inline fun <reified T : ChannelException> List<ChannelAction>.hasCommandError() = assertNotNull(findCommandErrorOpt<T>(), "cannot find command error ${T::class}")
 
 internal inline fun <reified T : ChannelAction> List<ChannelAction>.findOpt(): T? = filterIsInstance<T>().firstOrNull()
 internal inline fun <reified T : ChannelAction> List<ChannelAction>.find() = findOpt<T>() ?: fail("cannot find action ${T::class}")

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
@@ -332,13 +332,12 @@ class OfflineTestsCommon : LightningTestSuite() {
         assertEquals(error.toAscii(), PleasePublishYourCommitment(aliceOld.channelId).message)
         assertTrue(alice3 is WaitForRemotePublishFutureCommitment)
 
-        // bob is nice and publishes its commitment
-        val (bob3, _) = bob2.processEx(ChannelEvent.MessageReceived(channelReestablishA))
-        val (bob4, actionsBob4) = bob3.processEx(ChannelEvent.MessageReceived(error))
-        assertTrue(bob4 is Closing)
-        assertNotNull(bob4.localCommitPublished)
-        val bobCommitTx = bob4.localCommitPublished!!.commitTx
-        actionsBob4.hasTx(bobCommitTx)
+        // bob is nice and publishes its commitment as soon as it detects that alice has an outdated commitment
+        val (bob3, actionsBob3) = bob2.processEx(ChannelEvent.MessageReceived(channelReestablishA))
+        assertTrue(bob3 is Closing)
+        assertNotNull(bob3.localCommitPublished)
+        val bobCommitTx = bob3.localCommitPublished!!.commitTx
+        actionsBob3.hasTx(bobCommitTx)
 
         // alice is able to claim her main output
         val (alice4, actionsAlice4) = alice3.processEx(ChannelEvent.WatchReceived(WatchEventSpent(aliceOld.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)))


### PR DESCRIPTION
We were missing a case in our syncing logic, which means that we would not resend our revocation if we disconnected after receiving a signature when we didn't have one pending on our side.