### PR TITLE
Fix min-funding check for pay-to-open

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 allprojects {
     group = "fr.acinq.lightning"
-    version = "1.0-beta15"
+    version = "snapshot"
 
     repositories {
         mavenLocal()

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -1084,23 +1084,6 @@ data class PayToOpenRequest(
                 finalPacket = OnionRoutingPacketSerializer(LightningCodecs.u16(input)).read(input)
             )
         }
-
-        /**
-         * We use this method for non-trampoline multipart payments.
-         * The aggregation is done by the wallet, which may receive several pay-to-open requests for the same payment.
-         * Combining the requests allows us to create a single channel.
-         *
-         * We return the total amount for this set of pay-to-open requests, and the fee that will be deducted when the channel will be opened.
-         */
-        fun combine(requests: List<PayToOpenRequest>): Pair<MilliSatoshi, Satoshi> {
-            require(requests.isNotEmpty()) { "there needs to be at least one pay-to-open request" }
-            require(requests.map { it.chainHash }.toSet().size == 1) { "all pay-to-open chain hash must be equal" }
-            require(requests.map { it.paymentHash }.toSet().size == 1) { "all pay-to-open payment hash must be equal" }
-            require(requests.map { it.payToOpenMinAmountMsat }.toSet().size == 1) { "all pay-to-open min amounts must be equal" }
-            val totalAmount = requests.map { it.amountMsat }.sum()
-            val fees = requests.map { it.payToOpenFeeSatoshis }.sum()
-            return Pair(totalAmount, fees)
-        }
     }
 }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -259,6 +259,39 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
     }
 
     @Test
+    fun `receive pay-to-open payment with a funding amount too low`() = runSuspendTest {
+        val (paymentHandler, incomingPayment, paymentSecret) = run {
+            val (paymentHandler, incomingPayment, paymentSecret) = createFixture(defaultAmount)
+            val paymentHandler1 = IncomingPaymentHandler(paymentHandler.nodeParams.copy(minFundingSatoshis = 200_000.sat), paymentHandler.walletParams, paymentHandler.db)
+            Triple(paymentHandler1, incomingPayment, paymentSecret)
+        }
+
+        val payToOpenRequest = makePayToOpenRequest(incomingPayment, makeMppPayload(defaultAmount, defaultAmount, paymentSecret))
+        // we make sure that the pay-to-open funding amount is invalid
+        assertTrue { payToOpenRequest.fundingSatoshis < paymentHandler.nodeParams.minFundingSatoshis }
+        val result = paymentHandler.process(payToOpenRequest, TestConstants.defaultBlockHeight)
+
+        assertTrue { result is IncomingPaymentHandler.ProcessAddResult.Rejected }
+        result as IncomingPaymentHandler.ProcessAddResult.Rejected
+        assertEquals(incomingPayment, result.incomingPayment)
+        val expected = PayToOpenResponseEvent(
+            PayToOpenResponse(
+                payToOpenRequest.chainHash,
+                payToOpenRequest.paymentHash,
+                PayToOpenResponse.Result.Failure(
+                    OutgoingPacket.buildHtlcFailure(
+                        paymentHandler.nodeParams.nodePrivateKey,
+                        payToOpenRequest.paymentHash,
+                        payToOpenRequest.finalPacket,
+                        CMD_FAIL_HTLC.Reason.Failure(IncorrectOrUnknownPaymentDetails(payToOpenRequest.amountMsat, TestConstants.defaultBlockHeight.toLong()))
+                    ).right!!
+                )
+            )
+        )
+        assertEquals(setOf(expected), result.actions.toSet())
+    }
+
+    @Test
     fun `receive pay-to-open trampoline payment with an incorrect payment secret`() = runSuspendTest {
         val (paymentHandler, incomingPayment, paymentSecret) = createFixture(defaultAmount)
         val trampolineHops = listOf(
@@ -587,83 +620,6 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         // - Bob has received the complete MPP set
         run {
             val payToOpenRequest2 = makePayToOpenRequest(incomingPayment, makeMppPayload(amount3, totalAmount, paymentSecret), payToOpenMinAmount = 75_000.msat)
-            val result = paymentHandler.process(payToOpenRequest2, TestConstants.defaultBlockHeight)
-            assertTrue { result is IncomingPaymentHandler.ProcessAddResult.Rejected }
-            val expected = setOf(
-                WrappedChannelEvent(
-                    channelId,
-                    ChannelEvent.ExecuteCommand(CMD_FAIL_HTLC(0, CMD_FAIL_HTLC.Reason.Failure(IncorrectOrUnknownPaymentDetails(totalAmount, TestConstants.defaultBlockHeight.toLong())), commit = true))
-                ),
-                PayToOpenResponseEvent(
-                    PayToOpenResponse(
-                        payToOpenRequest1.chainHash,
-                        payToOpenRequest1.paymentHash,
-                        PayToOpenResponse.Result.Failure(
-                            OutgoingPacket.buildHtlcFailure(
-                                paymentHandler.nodeParams.nodePrivateKey,
-                                payToOpenRequest1.paymentHash,
-                                payToOpenRequest1.finalPacket,
-                                CMD_FAIL_HTLC.Reason.Failure(IncorrectOrUnknownPaymentDetails(totalAmount, TestConstants.defaultBlockHeight.toLong()))
-                            ).right!!
-                        )
-                    )
-                ),
-                PayToOpenResponseEvent(
-                    PayToOpenResponse(
-                        payToOpenRequest2.chainHash,
-                        payToOpenRequest2.paymentHash,
-                        PayToOpenResponse.Result.Failure(
-                            OutgoingPacket.buildHtlcFailure(
-                                paymentHandler.nodeParams.nodePrivateKey,
-                                payToOpenRequest2.paymentHash,
-                                payToOpenRequest2.finalPacket,
-                                CMD_FAIL_HTLC.Reason.Failure(IncorrectOrUnknownPaymentDetails(totalAmount, TestConstants.defaultBlockHeight.toLong()))
-                            ).right!!
-                        )
-                    )
-                ),
-            )
-            assertEquals(expected, result.actions.toSet())
-        }
-    }
-
-    @Test
-    fun `receive multipart payment with a mix of HTLC and pay-to-open (amount of the pay-to-open parts lower than minimum funding)`() = runSuspendTest {
-        val channelId = randomBytes32()
-        val (amount1, amount2, amount3) = Triple(100_000.msat, 30_000.msat, 20_000.msat)
-        val totalAmount = amount1 + amount2 + amount3
-        val (paymentHandler, incomingPayment, paymentSecret) = run {
-            val (paymentHandler, incomingPayment, paymentSecret) = createFixture(totalAmount)
-            val paymentHandler1 = IncomingPaymentHandler(paymentHandler.nodeParams.copy(minFundingSatoshis = 75.sat), paymentHandler.walletParams, paymentHandler.db)
-            Triple(paymentHandler1, incomingPayment, paymentSecret)
-        }
-
-        // Step 1 of 3:
-        // - Alice sends first multipart htlc to Bob
-        // - Bob doesn't accept the MPP set yet
-        run {
-            val add = makeUpdateAddHtlc(0, channelId, paymentHandler, incomingPayment.paymentHash, makeMppPayload(amount1, totalAmount, paymentSecret))
-            val result = paymentHandler.process(add, TestConstants.defaultBlockHeight)
-            assertTrue { result is IncomingPaymentHandler.ProcessAddResult.Pending }
-            assertTrue { result.actions.isEmpty() }
-        }
-
-        // Step 2 of 3:
-        // - Alice sends second multipart htlc to Bob
-        // - Bob doesn't accept the MPP set yet
-        val payToOpenRequest1 = run {
-            val payToOpenRequest = makePayToOpenRequest(incomingPayment, makeMppPayload(amount2, totalAmount, paymentSecret), payToOpenMinAmount = 25_000.msat)
-            val result = paymentHandler.process(payToOpenRequest, TestConstants.defaultBlockHeight)
-            assertTrue { result is IncomingPaymentHandler.ProcessAddResult.Pending }
-            assertTrue { result.actions.isEmpty() }
-            payToOpenRequest
-        }
-
-        // Step 3 of 3:
-        // - Alice sends last multipart htlc to Bob
-        // - Bob has received the complete MPP set
-        run {
-            val payToOpenRequest2 = makePayToOpenRequest(incomingPayment, makeMppPayload(amount3, totalAmount, paymentSecret), payToOpenMinAmount = 25_000.msat)
             val result = paymentHandler.process(payToOpenRequest2, TestConstants.defaultBlockHeight)
             assertTrue { result is IncomingPaymentHandler.ProcessAddResult.Rejected }
             val expected = setOf(


### PR DESCRIPTION
This is a regression introduced by #283. We should use
`PayToOpenRequest.fundingSatoshis`, not `PayToOpenRequest.amountMsat`
when comparing to `nodeParams.minFundingSatoshis`.

NB: this operates on a per-payment-part basis, and in the case of an AMP
payment, the final funding amount will be different, but it won't be
smaller than the one of each single part. If it were, because of a bug in
the peer, the channel would be rejected by Phoenix at opening and that's
okay. The peer would retry until a correct parameter is set and Phoenix
accepts the channel.

In theory we could rely on the `PayToOpenRequest.combine` method to
compute the final `fundingSatoshi`, but there is no guarantee that
Phoenix has the same implementation than the peer so it's not better.
The `combine()` wasn't used and has been removed.

The second commit just improves consistency in logs.