### PR TITLE
Fixing fees calculation for closing-channel payment

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 allprojects {
     group = "fr.acinq.lightning"
-    version = "1.0-beta16"
+    version = "snapshot"
 
     repositories {
         mavenLocal()

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -182,8 +182,11 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
     val fees: MilliSatoshi = when (status) {
         is Status.Pending -> 0.msat
         is Status.Completed.Failed -> 0.msat
-        is Status.Completed.Succeeded -> {
+        is Status.Completed.Succeeded.OffChain -> {
             parts.filter { it.status is Part.Status.Succeeded }.map { it.amount }.sum() - recipientAmount
+        }
+        is Status.Completed.Succeeded.OnChain -> {
+            recipientAmount - status.claimed.toMilliSatoshi()
         }
     }
 


### PR DESCRIPTION
This is related to https://github.com/ACINQ/phoenix-kmm/issues/188

When a channel is closed, a corresponding `OutgoingPayment` is automatically injected into the database. The `payment.recipientAmount` is set to the channel's local balance, and the payment remains in a pending state until the corresponding transactions are settled on the blockchain.

The bug: Once the payment is marked as `Completed.Succeeded.OnChain`, the fees were incorrectly reported. Specifically, they were reported as `-payment.recipientAmount`, which also caused the payment's amount to be reported as zero.