### PR TITLE
Subtract fees from pay-to-open amounts in database

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
@@ -61,7 +61,7 @@ class InMemoryPaymentsDb : PaymentsDb {
         incoming.values
             .asSequence()
             .filter { it.received != null && it.origin.matchesFilters(filters) }
-            .sortedByDescending { WalletPayment.completedAt(it) }
+            .sortedByDescending { it.completedAt() }
             .drop(skip)
             .take(count)
             .toList()
@@ -127,7 +127,7 @@ class InMemoryPaymentsDb : PaymentsDb {
         outgoing.values
             .asSequence()
             .filter { it.details.matchesFilters(filters) && (it.status is OutgoingPayment.Status.Completed) }
-            .sortedByDescending { WalletPayment.completedAt(it) }
+            .sortedByDescending { it.completedAt() }
             .drop(skip)
             .take(count)
             .toList()
@@ -136,7 +136,7 @@ class InMemoryPaymentsDb : PaymentsDb {
         val incoming: List<WalletPayment> = listReceivedPayments(count + skip, 0, filters)
         val outgoing: List<WalletPayment> = listOutgoingPayments(count + skip, 0, filters)
         return (incoming + outgoing)
-            .sortedByDescending { WalletPayment.completedAt(it) }
+            .sortedByDescending { it.completedAt() }
             .drop(skip)
             .take(count)
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -268,8 +268,10 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
                                             result = PayToOpenResponse.Result.Success(incomingPayment.preimage)
                                         )
                                     ) to IncomingPayment.ReceivedWith.NewChannel(
-                                        amount = part.amount,
+                                        // The part's amount is the full amount, including the fee. The fee must be subtracted.
+                                        amount = part.amount - part.payToOpenRequest.payToOpenFeeSatoshis.toMilliSatoshi(),
                                         fees = part.payToOpenRequest.payToOpenFeeSatoshis.toMilliSatoshi(),
+                                        // At that point we do not know the channel's id. It will be set later on.
                                         channelId = null
                                     )
                                 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
@@ -59,11 +59,12 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         db.receivePayment(pr.paymentHash, setOf(
             IncomingPayment.ReceivedWith.LightningPayment(amount = 57_000.msat, channelId = channelId1, htlcId = 1L),
             IncomingPayment.ReceivedWith.LightningPayment(amount = 43_000.msat, channelId = channelId2, htlcId = 54L),
-            IncomingPayment.ReceivedWith.NewChannel(amount = 100_000.msat, channelId = channelId3, fees = 1_000.msat)
+            IncomingPayment.ReceivedWith.NewChannel(amount = 99_000.msat, channelId = channelId3, fees = 1_000.msat)
         ), 110)
         val received = db.getIncomingPayment(pr.paymentHash)
         assertNotNull(received)
-        assertEquals(199_000.msat, received.received!!.amount)
+        assertEquals(199_000.msat, received.amount)
+        assertEquals(1_000.msat, received.fees)
         assertEquals(3, received.received!!.receivedWith.size)
         assertEquals(57_000.msat, received.received!!.receivedWith.elementAt(0).amount)
         assertEquals(0.msat, received.received!!.receivedWith.elementAt(0).fees)
@@ -86,7 +87,7 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         val received1 = db.getIncomingPayment(pr.paymentHash)
         assertNotNull(received1)
         assertNotNull(received1.received)
-        assertEquals(200_000.msat, received1.received!!.amount)
+        assertEquals(200_000.msat, received1.amount)
 
         db.receivePayment(pr.paymentHash, setOf(IncomingPayment.ReceivedWith.LightningPayment(
             amount = 100_000.msat,
@@ -96,7 +97,7 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         val received2 = db.getIncomingPayment(pr.paymentHash)
         assertNotNull(received2)
         assertNotNull(received2.received)
-        assertEquals(300_000.msat, received2.received!!.amount)
+        assertEquals(300_000.msat, received2.amount)
         assertEquals(150, received2.received!!.receivedAt)
         assertEquals(setOf(
             IncomingPayment.ReceivedWith.LightningPayment(
@@ -123,7 +124,8 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         )), 110)
         val received1 = db.getIncomingPayment(pr.paymentHash)
         assertNotNull(received1?.received)
-        assertEquals(485_000.msat, received1!!.received!!.amount)
+        assertEquals(500_000.msat, received1!!.amount)
+        assertEquals(15_000.msat, received1.fees)
     }
 
     @Test
@@ -141,7 +143,8 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         assertEquals(origin, payment.origin)
         assertNotNull(payment.received)
         assertEquals(receivedWith, payment.received?.receivedWith)
-        assertEquals(49_998_766.msat, payment.received!!.amount)
+        assertEquals(50_000_000.msat, payment.amount)
+        assertEquals(1234.msat, payment.fees)
     }
 
     @Test


### PR DESCRIPTION
The `WalletPayment.amount` field now always reflects the change in the wallet's balance, that is after applying the fees required to complete the payment:
- for outgoing payments, this the total amount that left the wallet, including the fees.
- for incoming payments, this is the total amount that ended up in the wallet, after applying fees if any (e.g for creating a channel)

This changes the way the amount of a pay-to-open is stored in the database: the channel creation fee is now subtracted for the amount when processing the payment in the `IncomingPaymentHandler`. For swap-ins, there are no changes since the channel event's amount was already the actual amount pushed to the channel.

The `WalletPayment` companion object has been removed.

See https://github.com/ACINQ/phoenix/issues/170