### PR TITLE
Lower minimum remote dust limit

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
@@ -3009,8 +3009,10 @@ object Channel {
     val MAX_FUNDING = 10.btc
     const val MAX_ACCEPTED_HTLCS = 483
 
-    // we don't want the counterparty to use a dust limit lower than that, because they wouldn't only hurt themselves we may need them to publish their commit tx in certain cases (backup/restore)
-    val MIN_DUSTLIMIT = 546.sat
+    // We may need to rely on our peer's commit tx in certain cases (backup/restore) so we must ensure their transactions
+    // can propagate through the bitcoin network (assuming bitcoin core nodes with default policies).
+    // A minimal spend of a p2wsh output is 110 bytes and bitcoin core's dust-relay-fee is 3000 sat/kb, which amounts to 330 sat.
+    val MIN_DUST_LIMIT = 330.sat
 
     // we won't exchange more than this many signatures when negotiating the closing fee
     const val MAX_NEGOTIATION_ITERATIONS = 20

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -117,8 +117,8 @@ object Helpers {
         }
 
         // only enforce dust limit check on mainnet
-        if (nodeParams.chainHash == Block.LivenetGenesisBlock.hash && open.dustLimitSatoshis < Channel.MIN_DUSTLIMIT) {
-            return Either.Left(DustLimitTooSmall(open.temporaryChannelId, open.dustLimitSatoshis, Channel.MIN_DUSTLIMIT))
+        if (nodeParams.chainHash == Block.LivenetGenesisBlock.hash && open.dustLimitSatoshis < Channel.MIN_DUST_LIMIT) {
+            return Either.Left(DustLimitTooSmall(open.temporaryChannelId, open.dustLimitSatoshis, Channel.MIN_DUST_LIMIT))
         }
 
         // we don't check that the funder's amount for the initial commitment transaction is sufficient for full fee payment
@@ -137,8 +137,8 @@ object Helpers {
             return Either.Left(InvalidMaxAcceptedHtlcs(accept.temporaryChannelId, accept.maxAcceptedHtlcs, Channel.MAX_ACCEPTED_HTLCS))
         }
         // only enforce dust limit check on mainnet
-        if (nodeParams.chainHash == Block.LivenetGenesisBlock.hash && accept.dustLimitSatoshis < Channel.MIN_DUSTLIMIT) {
-            return Either.Left(DustLimitTooSmall(accept.temporaryChannelId, accept.dustLimitSatoshis, Channel.MIN_DUSTLIMIT))
+        if (nodeParams.chainHash == Block.LivenetGenesisBlock.hash && accept.dustLimitSatoshis < Channel.MIN_DUST_LIMIT) {
+            return Either.Left(DustLimitTooSmall(accept.temporaryChannelId, accept.dustLimitSatoshis, Channel.MIN_DUST_LIMIT))
         }
 
         if (accept.dustLimitSatoshis > nodeParams.maxRemoteDustLimit) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannelTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannelTestsCommon.kt
@@ -41,14 +41,14 @@ class WaitForAcceptChannelTestsCommon : LightningTestSuite() {
     @Test
     fun `recv AcceptChannel (dust limit too low)`() {
         val (alice, _, accept) = init()
-        // we don't want their dust limit to be below 546
-        val lowDustLimitSatoshis = 545.sat
+        // we don't want their dust limit to be below 330
+        val lowDustLimitSatoshis = 329.sat
         // but we only enforce it on mainnet
         val aliceMainnet = alice.copy(staticParams = alice.staticParams.copy(nodeParams = alice.staticParams.nodeParams.copy(chainHash = Block.LivenetGenesisBlock.hash)))
         val (alice1, actions1) = aliceMainnet.process(ChannelEvent.MessageReceived(accept.copy(dustLimitSatoshis = lowDustLimitSatoshis)))
         assertTrue(alice1 is Aborted)
         val error = actions1.hasOutgoingMessage<Error>()
-        assertEquals(error, Error(accept.temporaryChannelId, DustLimitTooSmall(accept.temporaryChannelId, lowDustLimitSatoshis, Channel.MIN_DUSTLIMIT).message))
+        assertEquals(error, Error(accept.temporaryChannelId, DustLimitTooSmall(accept.temporaryChannelId, lowDustLimitSatoshis, Channel.MIN_DUST_LIMIT).message))
     }
 
     @Test


### PR DESCRIPTION
Rust-lightning uses a dust limit of 330 sat, which is perfectly acceptable for P2WSH outputs.
There's no reason to constrain it and all other implementations allow it.