### PR TITLE
Update build documentation with missing log dependency

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -16,6 +16,26 @@ brew install libtool
 brew install gmp
 ```
 
+## Required dependency
+
+This project currently depends on a fork of the `kodein-logs` library. This lib must be built manually and deployed to the local maven repository before being able to build `lightning-kmp`. To do so:
+1. clone [the GitHub repo](https://github.com/dpad85/Kodein-Log)
+```
+ git clone git@github.com:dpad85/Kodein-Log.git
+ cd Kodein-Log
+```
+2. checkout the `0.10.1-utc` tag
+```
+git checkout 0.10.1-utc
+```
+4. build and deploy the library:
+```
+./gradlew build
+./gradlew publishToMavenLocal
+```
+
+Note: this dependency is a temporary workaround and will be removed as soon as possible.
+
 ## Build
 
 You should start by cloning the repository locally:


### PR DESCRIPTION
The project has a dependency on a kodein-log fork, which has to be built manually before being able to build `lightning-kmp`.

Reminder: this kodein-log fork is a workaround that was made because:
1) there's an issue with kodein-log on some time zones, leading to crashes on phoenix ;
2) the official fix for that issue is locked behind an upgrade to kotlin 1.5, which `lightning-kmp` does not support yet.

This fork will eventually be removed.