### PR TITLE
Display only failed and skipped tests by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       # 4 - tests
       - name: Check with integration
         if: matrix.os == 'ubuntu-latest'
-        run: ./gradlew check -PintegrationTests=include
+        run: ./gradlew check -PintegrationTests=include -PverboseTests=ON
       - name: Check without integration
         if: matrix.os != 'ubuntu-latest'
-        run: ./gradlew check
+        run: ./gradlew check -PverboseTests=ON

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -160,11 +160,22 @@ afterEvaluate {
 }
 
 afterEvaluate {
-    tasks.withType<AbstractTestTask>() {
+    tasks.withType<AbstractTestTask> {
+        val verboseTests = project.findProperty("verboseTests") == "ON"
         testLogging {
-            events("passed", "skipped", "failed", "standard_out", "standard_error")
             showExceptions = true
             showStackTraces = true
+            if (verboseTests) {
+                events("passed", "skipped", "failed")
+                showStandardStreams = true
+            } else {
+                events("skipped", "failed")
+            }
+            afterSuite(KotlinClosure2({ desc: TestDescriptor, result: TestResult ->
+                if (desc.parent == null && result.failedTestCount == 0L) {
+                    println("${result.testCount} tests completed: ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped")
+                }
+            }))
         }
     }
     tasks.withType<org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest> {


### PR DESCRIPTION
The purpose of this PR is to limit build spam while keeping pertinent information. Passed tests are not displayed by default, only skipped and failed tests. Also, a summary of passed, failed and skipped tests is displayed at then end of the build.

This behaviour can be overridden using the property `-PverboseTests=ON`. In that case, passed tests will be displayed, alongside the tests logs (which can be very spammy).

Example:

![image](https://user-images.githubusercontent.com/5765435/134222774-ee548b7d-6aa8-4f49-904f-7fb92f2d7edc.png)

This PR replaces #97 and #100.
