### PR TITLE
Workaround cinterop issue with PhoenixCrypto

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -223,3 +223,10 @@ if (currentOs.isLinux) {
         filter.excludeTestsMatching("*IntegrationTest")
     }
 }
+
+// Make NS_FORMAT_ARGUMENT(1) a no-op
+// This fixes an issue when building PhoenixCrypto using XCode 13
+// More on this: https://youtrack.jetbrains.com/issue/KT-48807#focus=Comments-27-5210791.0-0
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.CInteropProcess::class.java) {
+    settings.compilerOpts("-DNS_FORMAT_ARGUMENT(A)=")
+}


### PR DESCRIPTION
There's an incompatibility between XCode 13 (recently released) and the clang shipped with
Kotlin/Native, causing issues when building `PhoenixCrypto`. The workaround
is to make `NS_FORMAT_ARGUMENT` a noop.

More on this here:
https://youtrack.jetbrains.com/issue/KT-48807#focus=Comments-27-5210791.0-0