### PR TITLE
Prune legacy recipient routing hints

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -28,11 +28,9 @@ import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
 import kotlinx.coroutines.channels.ReceiveChannel
-import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.flow.*
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
-import kotlin.time.seconds
 
 sealed class PeerEvent
 data class BytesReceived(val data: ByteArray) : PeerEvent()

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/PaymentPacketTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/PaymentPacketTestsCommon.kt
@@ -330,11 +330,12 @@ class PaymentPacketTestsCommon : LightningTestSuite() {
     fun `fail to build a trampoline payment when too much invoice data is provided`() {
         val extraHop = PaymentRequest.TaggedField.ExtraHop(randomKey().publicKey(), ShortChannelId(1), 10.msat, 100, CltvExpiryDelta(12))
         val routingHintOverflow = listOf(extraHop, extraHop, extraHop, extraHop, extraHop, extraHop, extraHop)
+        val featuresOverflow = ByteVector("010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101024100")
         val invoice = PaymentRequest(
             "lnbcrt", finalAmount, currentTimestampSeconds(), e, listOf(
                 PaymentRequest.TaggedField.PaymentHash(paymentHash),
                 PaymentRequest.TaggedField.PaymentSecret(paymentSecret),
-                PaymentRequest.TaggedField.Features(ByteVector("024100")), // var_onion_optin, payment_secret, basic_mpp
+                PaymentRequest.TaggedField.Features(featuresOverflow),
                 PaymentRequest.TaggedField.DescriptionHash(randomBytes32()),
                 PaymentRequest.TaggedField.RoutingInfo(routingHintOverflow)
             ), ByteVector.empty


### PR DESCRIPTION
When sending to a recipient that doesn't support trampoline, we provide the invoice's routing hints to the trampoline node in the onion. If too many routing hints are provided, this will overflow the onion.

We now limit the number of routing hints that are sent to the trampoline node to avoid overflowing the onion.

A better long term solution is to send the routing hints in a tlv in `update_add_htlc` instead of including them in the onion.
An even better long term solution is to support trampoline, which removes the need for these routing hints in the first place.