### PR TITLE
Add support for option_shutdown_anysegwit

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/Features.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/Features.kt
@@ -92,6 +92,12 @@ sealed class Feature {
     }
 
     @Serializable
+    object ShutdownAnySegwit : Feature() {
+        override val rfcName get() = "option_shutdown_anysegwit"
+        override val mandatory get() = 26
+    }
+
+    @Serializable
     object ChannelType : Feature() {
         override val rfcName get() = "option_channel_type"
         override val mandatory get() = 44
@@ -228,6 +234,7 @@ data class Features(val activated: Map<Feature, FeatureSupport>, val unknown: Se
             Feature.BasicMultiPartPayment,
             Feature.Wumbo,
             Feature.AnchorOutputs,
+            Feature.ShutdownAnySegwit,
             Feature.ChannelType,
             Feature.TrampolinePayment,
             Feature.ZeroReserveChannels,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -392,7 +392,8 @@ object Helpers {
                     Script.isPay2sh(script) -> true
                     Script.isPay2wpkh(script) -> true
                     Script.isPay2wsh(script) -> true
-                    Script.isNativeWitnessScript(script) -> allowAnySegwit
+                    // option_shutdown_anysegwit doesn't cover segwit v0
+                    Script.isNativeWitnessScript(script) && script[0] != OP_0 -> allowAnySegwit
                     else -> false
                 }
             }.getOrElse { false }

--- a/src/commonTest/kotlin/fr/acinq/lightning/FeaturesTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/FeaturesTestsCommon.kt
@@ -208,9 +208,10 @@ class FeaturesTestsCommon : LightningTestSuite() {
             byteArrayOf(0x09, 0x00, 0x42, 0x00) to Features(
                 mapOf(
                     VariableLengthOnion to FeatureSupport.Optional,
-                    PaymentSecret to FeatureSupport.Mandatory
+                    PaymentSecret to FeatureSupport.Mandatory,
+                    ShutdownAnySegwit to FeatureSupport.Optional
                 ),
-                setOf(UnknownFeature(24), UnknownFeature(27))
+                setOf(UnknownFeature(24))
             ),
             byteArrayOf(0x52, 0x00, 0x00, 0x00) to Features(
                 mapOf(),


### PR DESCRIPTION
Opt-in to allow any future segwit script in shutdown as long as it complies with BIP 141 (see  lightning/bolts#672).
This is particularly useful to allow wallet users to close channels to a Taproot address.
We can probably make it mandatory in wallets such as Phoenix now that Taproot has been activated.
