### PR TITLE
Handle onion creation failure

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
@@ -14,6 +14,7 @@ sealed class FinalFailure {
 
     // @formatter:off
     object AlreadyPaid : FinalFailure() { override fun toString(): String = "this invoice has already been paid" }
+    object InvoiceTooBig : FinalFailure() { override fun toString(): String = "this invoice contains too much metadata to be paid" }
     object InvalidPaymentAmount : FinalFailure() { override fun toString(): String = "payment amount must be positive" }
     object InvalidPaymentId : FinalFailure() { override fun toString(): String = "payment ID must be unique" }
     object NoAvailableChannels : FinalFailure() { override fun toString(): String = "no channels available to send payment" }
@@ -33,7 +34,7 @@ data class OutgoingPaymentFailure(val reason: FinalFailure, val failures: List<O
      * A detailed summary of the all internal errors.
      * This is targeted at users with technical knowledge of the lightning protocol.
      */
-    fun details(): String = failures.foldIndexed("", { index, msg, problem -> msg + "${index + 1}: ${problem.details}\n" })
+    fun details(): String = failures.foldIndexed("") { index, msg, problem -> msg + "${index + 1}: ${problem.details}\n" }
 
     companion object {
         fun convertFailure(failure: Either<ChannelException, FailureMessage>, completedAt: Long = currentTimestampMillis()): OutgoingPayment.Part.Status.Failed = when (failure) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/Either.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/Either.kt
@@ -32,8 +32,16 @@ sealed class Either<out A, out B> {
 }
 
 @Suppress("UNCHECKED_CAST")
-fun <L, R, T> Either<L, R>.flatMap(f: (R) -> Either<L, T>): Either<L, T> =
-    this.fold({ this as Either<L, T> }, f)
+fun <L, R, T> Either<L, R>.flatMap(f: (R) -> Either<L, T>): Either<L, T> = this.fold({ this as Either<L, T> }, f)
 
-fun <L, R, T> Either<L, R>.map(f: (R) -> T): Either<L, T> =
-    flatMap { Either.Right(f(it)) }
+fun <L, R, T> Either<L, R>.map(f: (R) -> T): Either<L, T> = flatMap { Either.Right(f(it)) }
+
+fun <L, R> List<Either<L, R>>.toEither(): Either<L, List<R>> = this.fold(Either.Right(listOf())) { current, element ->
+    when (current) {
+        is Either.Left -> current
+        is Either.Right -> when (element) {
+            is Either.Left -> Either.Left(element.value)
+            is Either.Right -> Either.Right(current.value + element.value)
+        }
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/PaymentOnion.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/PaymentOnion.kt
@@ -312,7 +312,7 @@ object PaymentOnion {
                 // NB: we limit the number of routing hints to ensure we don't overflow the onion.
                 // A better solution is to provide the routing hints outside the onion (in the `update_add_htlc` tlv stream).
                 val prunedRoutingHints = invoice.routingInfo.shuffled().fold(listOf<PaymentRequest.TaggedField.RoutingInfo>()) { previous, current ->
-                    if (previous.flatMap { it.hints }.size + current.hints.size <= 4) {
+                    if (previous.flatMap { it.hints }.size + current.hints.size <= 3) {
                         previous + current
                     } else {
                         previous

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -320,7 +320,7 @@ object TestsHelper {
         val expiry = CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight)
         val dummyKey = PrivateKey(ByteVector32("0101010101010101010101010101010101010101010101010101010101010101")).publicKey()
         val dummyUpdate = ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId(144, 0, 0), 0, 0, 0, CltvExpiryDelta(1), 0.msat, 0.msat, 0, null)
-        val cmd = OutgoingPaymentPacket.buildCommand(paymentId, paymentHash, listOf(ChannelHop(dummyKey, destination, dummyUpdate)), PaymentOnion.FinalPayload.createSinglePartPayload(amount, expiry, randomBytes32(), null)).first.copy(commit = false)
+        val cmd = OutgoingPaymentPacket.buildCommand(paymentId, paymentHash, listOf(ChannelHop(dummyKey, destination, dummyUpdate)), PaymentOnion.FinalPayload.createSinglePartPayload(amount, expiry, randomBytes32(), null)).get().first.copy(commit = false)
         return Pair(paymentPreimage, cmd)
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -184,7 +184,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
                 hops = channelHops(paymentHandler.nodeParams.nodeId),
                 finalPayload = makeMppPayload(defaultAmount, defaultAmount, randomBytes32()),
                 payloadLength = OnionRoutingPacket.PaymentPacketLength
-            ).third.packet
+            ).get().third.packet
         )
         val result = paymentHandler.process(payToOpenRequest, TestConstants.defaultBlockHeight)
 
@@ -312,7 +312,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
                 hops = trampolineHops,
                 finalPayload = makeMppPayload(defaultAmount, defaultAmount, paymentSecret.reversed()), // <-- wrong secret
                 payloadLength = OnionRoutingPacket.TrampolinePacketLength
-            ).third.packet
+            ).get().third.packet
         )
         val result = paymentHandler.process(payToOpenRequest, TestConstants.defaultBlockHeight)
 
@@ -1174,11 +1174,11 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         }
 
         private fun makeCmdAddHtlc(destination: PublicKey, paymentHash: ByteVector32, finalPayload: PaymentOnion.FinalPayload): CMD_ADD_HTLC {
-            return OutgoingPaymentPacket.buildCommand(UUID.randomUUID(), paymentHash, channelHops(destination), finalPayload).first.copy(commit = true)
+            return OutgoingPaymentPacket.buildCommand(UUID.randomUUID(), paymentHash, channelHops(destination), finalPayload).get().first.copy(commit = true)
         }
 
         private fun makeUpdateAddHtlc(id: Long, channelId: ByteVector32, destination: IncomingPaymentHandler, paymentHash: ByteVector32, finalPayload: PaymentOnion.FinalPayload): UpdateAddHtlc {
-            val (_, _, packetAndSecrets) = OutgoingPaymentPacket.buildPacket(paymentHash, channelHops(destination.nodeParams.nodeId), finalPayload, OnionRoutingPacket.PaymentPacketLength)
+            val (_, _, packetAndSecrets) = OutgoingPaymentPacket.buildPacket(paymentHash, channelHops(destination.nodeParams.nodeId), finalPayload, OnionRoutingPacket.PaymentPacketLength).get()
             return UpdateAddHtlc(channelId, id, finalPayload.amount, paymentHash, finalPayload.expiry, packetAndSecrets.packet)
         }
 
@@ -1207,7 +1207,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
                     hops = channelHops(TestConstants.Bob.nodeParams.nodeId),
                     finalPayload = finalPayload,
                     payloadLength = OnionRoutingPacket.PaymentPacketLength
-                ).third.packet
+                ).get().third.packet
             )
         }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/utils/BitFieldTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/utils/BitFieldTestsCommon.kt
@@ -4,7 +4,7 @@ import fr.acinq.lightning.tests.utils.LightningTestSuite
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class BitFieldsCommon : LightningTestSuite() {
+class BitFieldTestsCommon : LightningTestSuite() {
 
     @Test
     fun `Creation and simple get and set from left`() {

--- a/src/commonTest/kotlin/fr/acinq/lightning/utils/ByteArrayTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/utils/ByteArrayTestsCommon.kt
@@ -4,7 +4,7 @@ import fr.acinq.lightning.tests.utils.LightningTestSuite
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
-class ByteArraysCommon : LightningTestSuite() {
+class ByteArrayTestsCommon : LightningTestSuite() {
 
     @Test
     fun `Left pad`() {

--- a/src/commonTest/kotlin/fr/acinq/lightning/utils/EitherTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/utils/EitherTestsCommon.kt
@@ -1,0 +1,28 @@
+package fr.acinq.lightning.utils
+
+import fr.acinq.lightning.tests.utils.LightningTestSuite
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EitherTestsCommon : LightningTestSuite() {
+
+    @Test
+    fun `common operations on either`() {
+        assertEquals(Either.Left<Int, String>(1).fold({ it + 1 }, { 10 }), 2)
+        assertEquals(Either.Right<Int, String>("test").fold({ it + 1 }, { 10 }), 10)
+
+        assertEquals(Either.Left<Int, String>(1).transform({ it.toString() }, { it.toInt() }), Either.Left("1"))
+        assertEquals(Either.Right<Int, String>("1").transform({ it.toString() }, { it.toInt() }), Either.Right(1))
+
+        assertEquals(Either.Left<Int, String>(1).map { it + "_updated" }, Either.Left(1))
+        assertEquals(Either.Right<Int, String>("value").map { it + "_updated" }, Either.Right("value_updated"))
+
+        assertEquals(Either.Left<Int, String>(1).flatMap { v -> if (v.length <= 5) Either.Right(v) else Either.Left("too long") }, Either.Left(1))
+        assertEquals(Either.Right<Int, String>("abc").flatMap { v -> if (v.length <= 5) Either.Right(v) else Either.Left("too long") }, Either.Right("abc"))
+        assertEquals(Either.Right<Int, String>("abcdef").flatMap { v -> if (v.length <= 5) Either.Right(v) else Either.Left("too long") }, Either.Left("too long"))
+
+        assertEquals(listOf<Either<Int, String>>(Either.Left(2), Either.Right("3")).toEither(), Either.Left(2))
+        assertEquals(listOf<Either<Int, String>>(Either.Right("2"), Either.Right("3")).toEither(), Either.Right(listOf("2", "3")))
+    }
+
+}


### PR DESCRIPTION
If we have too much data to include in the onion, its creation will fail.
This wasn't handled explicitly before, as we thought there was no reason we would overflow the onion space.

However, it happened when invoices contained too many route hints, and it can now happen if invoices contain too much payment metadata (or too many features), so we need to handle it explicitly and provide a clear error to the user.

I'm not a huge fan of the complexity it brings to the `OutgoingPaymentHandler`, if you have suggestions on how we could improve it that would be great.

EDIT: once we move to variable-size trampoline onions, we probably don't need that change anymore and can instead set a hard-coded limit on invoice data before creating the onion.
