### PR TITLE
Allow for user-configurable fee options

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -42,7 +42,7 @@ sealed class PaymentEvent : PeerEvent()
 data class ReceivePayment(val paymentPreimage: ByteVector32, val amount: MilliSatoshi?, val description: String, val expirySeconds: Long? = null, val result: CompletableDeferred<PaymentRequest>) : PaymentEvent()
 object CheckPaymentsTimeout : PaymentEvent()
 data class PayToOpenResponseEvent(val payToOpenResponse: PayToOpenResponse) : PeerEvent()
-data class SendPayment(val paymentId: UUID, val amount: MilliSatoshi, val recipient: PublicKey, val details: OutgoingPayment.Details.Normal, val trampolineFees: List<TrampolineFees>? = null) : PaymentEvent() {
+data class SendPayment(val paymentId: UUID, val amount: MilliSatoshi, val recipient: PublicKey, val details: OutgoingPayment.Details.Normal, val trampolineFeesOverride: List<TrampolineFees>? = null) : PaymentEvent() {
     val paymentHash: ByteVector32 = details.paymentHash
 }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -42,7 +42,7 @@ sealed class PaymentEvent : PeerEvent()
 data class ReceivePayment(val paymentPreimage: ByteVector32, val amount: MilliSatoshi?, val description: String, val expirySeconds: Long? = null, val result: CompletableDeferred<PaymentRequest>) : PaymentEvent()
 object CheckPaymentsTimeout : PaymentEvent()
 data class PayToOpenResponseEvent(val payToOpenResponse: PayToOpenResponse) : PeerEvent()
-data class SendPayment(val paymentId: UUID, val amount: MilliSatoshi, val recipient: PublicKey, val details: OutgoingPayment.Details.Normal) : PaymentEvent() {
+data class SendPayment(val paymentId: UUID, val amount: MilliSatoshi, val recipient: PublicKey, val details: OutgoingPayment.Details.Normal, val trampolineFees: List<TrampolineFees>? = null) : PaymentEvent() {
     val paymentHash: ByteVector32 = details.paymentHash
 }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
@@ -58,7 +58,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
             logger.error { "h:${request.paymentHash} p:${request.paymentId} invoice has already been paid" }
             return Failure(request, FinalFailure.AlreadyPaid.toPaymentFailure())
         }
-        val trampolineFees = request.trampolineFees ?: walletParams.trampolineFees
+        val trampolineFees = request.trampolineFeesOverride ?: walletParams.trampolineFees
         val (trampolineAmount, trampolineExpiry, trampolinePacket) = createTrampolinePayload(request, trampolineFees.first(), currentBlockHeight)
         return when (val result = RouteCalculation.findRoutes(request.paymentId, trampolineAmount, channels)) {
             is Either.Left -> {
@@ -138,7 +138,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
 
         val (updated, result) = when (payment) {
             is PaymentAttempt.PaymentInProgress -> {
-                val trampolineFees = payment.request.trampolineFees ?: walletParams.trampolineFees
+                val trampolineFees = payment.request.trampolineFeesOverride ?: walletParams.trampolineFees
                 val finalError = when {
                     trampolineFees.size <= payment.attemptNumber + 1 -> FinalFailure.RetryExhausted
                     failure == UnknownNextPeer -> FinalFailure.RecipientUnreachable

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
@@ -58,8 +58,8 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
             logger.error { "h:${request.paymentHash} p:${request.paymentId} invoice has already been paid" }
             return Failure(request, FinalFailure.AlreadyPaid.toPaymentFailure())
         }
-
-        val (trampolineAmount, trampolineExpiry, trampolinePacket) = createTrampolinePayload(request, walletParams.trampolineFees.first(), currentBlockHeight)
+        val trampolineFees = request.trampolineFees ?: walletParams.trampolineFees
+        val (trampolineAmount, trampolineExpiry, trampolinePacket) = createTrampolinePayload(request, trampolineFees.first(), currentBlockHeight)
         return when (val result = RouteCalculation.findRoutes(request.paymentId, trampolineAmount, channels)) {
             is Either.Left -> {
                 logger.warning { "h:${request.paymentHash} p:${request.paymentId} payment failed: ${result.value}" }
@@ -138,8 +138,9 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
 
         val (updated, result) = when (payment) {
             is PaymentAttempt.PaymentInProgress -> {
+                val trampolineFees = payment.request.trampolineFees ?: walletParams.trampolineFees
                 val finalError = when {
-                    walletParams.trampolineFees.size <= payment.attemptNumber + 1 -> FinalFailure.RetryExhausted
+                    trampolineFees.size <= payment.attemptNumber + 1 -> FinalFailure.RetryExhausted
                     failure == UnknownNextPeer -> FinalFailure.RecipientUnreachable
                     failure != TrampolineExpiryTooSoon && failure != TrampolineFeeInsufficient -> FinalFailure.UnknownError // non-retriable error
                     else -> null
@@ -155,9 +156,9 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                         // NB: we don't update failures here to avoid duplicate trampoline errors
                         Pair(updated, null)
                     } else {
-                        val trampolineFees = walletParams.trampolineFees[payment.attemptNumber + 1]
-                        logger.info { "h:${payment.request.paymentHash} p:${payment.request.paymentId} retrying payment with higher fees (base=${trampolineFees.feeBase}, proportional=${trampolineFees.feeProportional})..." }
-                        val (trampolineAmount, trampolineExpiry, trampolinePacket) = createTrampolinePayload(payment.request, trampolineFees, currentBlockHeight)
+                        val nextFees = trampolineFees[payment.attemptNumber + 1]
+                        logger.info { "h:${payment.request.paymentHash} p:${payment.request.paymentId} retrying payment with higher fees (base=${nextFees.feeBase}, proportional=${nextFees.feeProportional})..." }
+                        val (trampolineAmount, trampolineExpiry, trampolinePacket) = createTrampolinePayload(payment.request, nextFees, currentBlockHeight)
                         when (val routes = RouteCalculation.findRoutes(payment.request.paymentId, trampolineAmount, channels)) {
                             is Either.Left -> {
                                 logger.warning { "h:${payment.request.paymentHash} p:${payment.request.paymentId} payment failed: ${routes.value}" }


### PR DESCRIPTION
Phoenix allows the user to configure the maximum allowable fee ([Issue 191](https://github.com/ACINQ/phoenix/issues/191))

However, we need more flexibility in lightning-kmp to allow for this.

In the current version, the fee schedule (`List<TrampolineFee>`) is configured when the Peer is created, and isn't configurable. This PR allows the default fee schedule to be overriden when making a payment.