### PR TITLE
Schedule `checkPaymentsTimeout` every 10s instead of 30s

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -282,7 +282,7 @@ class Peer(
 
         suspend fun checkPaymentsTimeout() {
             while (isActive) {
-                delay(Duration.seconds(30))
+                delay(Duration.seconds(10)) // we schedule a check every 10 seconds
                 input.send(CheckPaymentsTimeout)
             }
         }


### PR DESCRIPTION
With the previous interval of 30s, a payment could stay pending for up
to 90s in the worst case scenario. This opens edge cases with the
pay-to-open logic.