### PR TITLE
Delete expired payments

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
@@ -81,11 +81,11 @@ class InMemoryPaymentsDb : PaymentsDb {
             .sortedByDescending { it.createdAt }
             .toList()
 
-    override suspend fun removeIncomingPayment(paymentHash: ByteVector32) {
+    override suspend fun removeIncomingPayment(paymentHash: ByteVector32): Boolean {
         val payment = getIncomingPayment(paymentHash)
-        when (payment?.received) {
-            null -> incoming.remove(paymentHash)
-            else -> Unit // do nothing if payment already received
+        return when (payment?.received) {
+            null -> incoming.remove(paymentHash) != null
+            else -> false // do nothing if payment already partially paid
         }
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
@@ -63,6 +63,15 @@ class InMemoryPaymentsDb : PaymentsDb {
             .take(count)
             .toList()
 
+    override suspend fun listIncomingPayments(count: Int, skip: Int, filters: Set<PaymentTypeFilter>): List<IncomingPayment> =
+        incoming.values
+            .asSequence()
+            .filter { it.origin.matchesFilters(filters) }
+            .sortedByDescending { it.createdAt }
+            .drop(skip)
+            .take(count)
+            .toList()
+    
     override suspend fun listExpiredPayments(fromCreatedAt: Long, toCreatedAt: Long): List<IncomingPayment> =
         incoming.values
             .asSequence()

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -54,7 +54,7 @@ interface IncomingPaymentsDb {
     suspend fun listExpiredPayments(fromCreatedAt: Long = 0, toCreatedAt: Long = currentTimestampMillis()): List<IncomingPayment>
 
     /** Remove a pending incoming payment.*/
-    suspend fun removeIncomingPayment(paymentHash: ByteVector32)
+    suspend fun removeIncomingPayment(paymentHash: ByteVector32): Boolean
 }
 
 interface OutgoingPaymentsDb {

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -46,6 +46,12 @@ interface IncomingPaymentsDb {
 
     /** List received payments (with most recent payments first). */
     suspend fun listReceivedPayments(count: Int, skip: Int, filters: Set<PaymentTypeFilter> = setOf()): List<IncomingPayment>
+
+    /** List expired unpaid normal payments created within specified time range (with the most recent payments first). */
+    suspend fun listExpiredPayments(fromCreatedAt: Long = 0, toCreatedAt: Long = currentTimestampMillis()): List<IncomingPayment>
+
+    /** Remove a pending incoming payment.*/
+    suspend fun removeIncomingPayment(paymentHash: ByteVector32)
 }
 
 interface OutgoingPaymentsDb {

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -47,6 +47,9 @@ interface IncomingPaymentsDb {
     /** List received payments (with most recent payments first). */
     suspend fun listReceivedPayments(count: Int, skip: Int, filters: Set<PaymentTypeFilter> = setOf()): List<IncomingPayment>
 
+    /** List incoming payments (with the most recent payments first). */
+    suspend fun listIncomingPayments(count: Int, skip: Int, filters: Set<PaymentTypeFilter> = setOf()): List<IncomingPayment>
+
     /** List expired unpaid normal payments created within specified time range (with the most recent payments first). */
     suspend fun listExpiredPayments(fromCreatedAt: Long = 0, toCreatedAt: Long = currentTimestampMillis()): List<IncomingPayment>
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -391,11 +391,9 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
      * @return number of invoices purged
      */
     suspend fun purgeExpiredPayments(fromCreatedAt: Long = 0, toCreatedAt: Long = currentTimestampMillis()): Int {
-        val expiredInvoices = db.listExpiredPayments(fromCreatedAt, toCreatedAt)
-        expiredInvoices.forEach { payment ->
-            db.removeIncomingPayment(payment.paymentHash)
-        }
-        return expiredInvoices.size
+        return db.listExpiredPayments(fromCreatedAt, toCreatedAt).map {
+            db.removeIncomingPayment(it.paymentHash)
+        }.count()
     }
 
     companion object {

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -391,9 +391,9 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
      * @return number of invoices purged
      */
     suspend fun purgeExpiredPayments(fromCreatedAt: Long = 0, toCreatedAt: Long = currentTimestampMillis()): Int {
-        return db.listExpiredPayments(fromCreatedAt, toCreatedAt).map {
+        return db.listExpiredPayments(fromCreatedAt, toCreatedAt).count {
             db.removeIncomingPayment(it.paymentHash)
-        }.count()
+        }
     }
 
     companion object {


### PR DESCRIPTION
This is the first step to bring automatic purging of expired incoming payments to projects built on lightning-kmp. This ability was requested in issue [#2078](https://github.com/ACINQ/eclair/issues/2078)  in Eclair.

This PR adds functions to find and remove expired incoming payments similar to Eclair PR [#2174](https://github.com/ACINQ/eclair/pull/2174). This PR does not launch an automatic thread for purging expired invoices like in Eclair because mobile implementations may not always be running and may want to purge invoices using a platform specific trigger.

Additional tasks are needed to bring this to Phoenix, including:
[  ] add  platform specific database support for new functions added to `InMemoryPaymentsDb` eg. [SqlitePaymentsDb.kt](https://github.com/ACINQ/phoenix/blob/master/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt)
[  ] add platform specific tests
[  ] add platform specific triggers to call PurgeExpiredPayments