### PR TITLE
TcpSocket now supports pinning publicKeys for TLS

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
@@ -344,7 +344,7 @@ private data class WatcherRunning(
                 else -> unhandled(event)
             }
             is ClientStateUpdate -> {
-                if (event.connection == Connection.CLOSED) newState(
+                if (event.connection is Connection.CLOSED) newState(
                     WatcherDisconnected(
                         watches = watches,
                         publishQueue = sent.map { PublishAsap(it) }.toSet(),

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -243,7 +243,11 @@ class Peer(
         logger.info { "n:$remoteNodeId connecting to ${walletParams.trampolineNode.host}" }
         _connectionState.value = Connection.ESTABLISHING
         socket = try {
-            socketBuilder?.connect(walletParams.trampolineNode.host, walletParams.trampolineNode.port) ?: error("socket builder is null.")
+            socketBuilder?.connect(
+                host = walletParams.trampolineNode.host,
+                port = walletParams.trampolineNode.port,
+                tls = TcpSocket.TLS.DISABLED
+            ) ?: error("socket builder is null.")
         } catch (ex: Throwable) {
             logger.warning { "n:$remoteNodeId TCP connect: ${ex.message}" }
             _connectionState.value = Connection.CLOSED

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
@@ -23,12 +23,19 @@ interface TcpSocket {
 
     fun close()
 
-    enum class TLS {
-        SAFE, UNSAFE_CERTIFICATES
+    sealed class TLS {
+        object DISABLED: TLS()
+        object TRUSTED_CERTIFICATES: TLS()
+        object UNSAFE_CERTIFICATES: TLS()
+        data class PINNED_PUBLIC_KEY(
+            // DER-encoded publicKey as base64 string.
+            // (I.e. same as PEM format, without BEGIN/END header/footer)
+            val pubKey: String
+        ): TLS()
     }
 
     interface Builder {
-        suspend fun connect(host: String, port: Int, tls: TLS? = null): TcpSocket
+        suspend fun connect(host: String, port: Int, tls: TLS): TcpSocket
 
         companion object {
             operator fun invoke(): Builder = PlatformSocketBuilder
@@ -49,5 +56,5 @@ fun TcpSocket.linesFlow(): Flow<String> =
             emit(buffer.subArray(size))
         }
     }
-        .decodeToString()
-        .splitByLines()
+    .decodeToString()
+    .splitByLines()

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
@@ -24,17 +24,21 @@ interface TcpSocket {
     fun close()
 
     sealed class TLS {
-        // used for Lightning connections
+        /** used for Lightning connections */
         object DISABLED: TLS()
-        // used for Electrum servers when expecting a valid certificate
+        /** used for Electrum servers when expecting a valid certificate */
         object TRUSTED_CERTIFICATES: TLS()
-        // only used in unit tests
+        /** only used in unit tests */
         object UNSAFE_CERTIFICATES: TLS()
-        // used for Electrum servers when expecting a specific public key
-        // (for example self-signed certificates)
+        /**
+         * used for Electrum servers when expecting a specific public key
+         * (for example self-signed certificates)
+         */
         data class PINNED_PUBLIC_KEY(
-            // DER-encoded publicKey as base64 string.
-            // (I.e. same as PEM format, without BEGIN/END header/footer)
+            /**
+             *  DER-encoded publicKey as base64 string.
+             * (I.e. same as PEM format, without BEGIN/END header/footer)
+             */
             val pubKey: String
         ): TLS()
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
@@ -24,23 +24,26 @@ interface TcpSocket {
     fun close()
 
     sealed class TLS {
-        /** used for Lightning connections */
-        object DISABLED: TLS()
-        /** used for Electrum servers when expecting a valid certificate */
-        object TRUSTED_CERTIFICATES: TLS()
-        /** only used in unit tests */
-        object UNSAFE_CERTIFICATES: TLS()
+        /** Used for Lightning connections */
+        object DISABLED : TLS()
+
+        /** Used for Electrum servers when expecting a valid certificate */
+        object TRUSTED_CERTIFICATES : TLS()
+
+        /** Only used in unit tests */
+        object UNSAFE_CERTIFICATES : TLS()
+
         /**
-         * used for Electrum servers when expecting a specific public key
+         * Used for Electrum servers when expecting a specific public key
          * (for example self-signed certificates)
          */
         data class PINNED_PUBLIC_KEY(
             /**
-             *  DER-encoded publicKey as base64 string.
+             * DER-encoded publicKey as base64 string.
              * (I.e. same as PEM format, without BEGIN/END header/footer)
              */
             val pubKey: String
-        ): TLS()
+        ) : TLS()
     }
 
     interface Builder {
@@ -65,5 +68,5 @@ fun TcpSocket.linesFlow(): Flow<String> =
             emit(buffer.subArray(size))
         }
     }
-    .decodeToString()
-    .splitByLines()
+        .decodeToString()
+        .splitByLines()

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
@@ -24,9 +24,14 @@ interface TcpSocket {
     fun close()
 
     sealed class TLS {
+        // used for Lightning connections
         object DISABLED: TLS()
+        // used for Electrum servers when expecting a valid certificate
         object TRUSTED_CERTIFICATES: TLS()
+        // only used in unit tests
         object UNSAFE_CERTIFICATES: TLS()
+        // used for Electrum servers when expecting a specific public key
+        // (for example self-signed certificates)
         data class PINNED_PUBLIC_KEY(
             // DER-encoded publicKey as base64 string.
             // (I.e. same as PEM format, without BEGIN/END header/footer)

--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/Connection.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/Connection.kt
@@ -2,5 +2,10 @@ package fr.acinq.lightning.utils
 
 import fr.acinq.lightning.io.TcpSocket
 
-enum class Connection { CLOSED, ESTABLISHING, ESTABLISHED }
+sealed class Connection {
+    data class CLOSED(val reason: TcpSocket.IOException?): Connection()
+    object ESTABLISHING: Connection()
+    object ESTABLISHED: Connection()
+}
+
 data class ServerAddress(val host: String, val port: Int, val tls: TcpSocket.TLS)

--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/Connection.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/Connection.kt
@@ -3,4 +3,4 @@ package fr.acinq.lightning.utils
 import fr.acinq.lightning.io.TcpSocket
 
 enum class Connection { CLOSED, ESTABLISHING, ESTABLISHED }
-data class ServerAddress(val host: String, val port: Int, val tls: TcpSocket.TLS? = null)
+data class ServerAddress(val host: String, val port: Int, val tls: TcpSocket.TLS)

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientIntegrationTest.kt
@@ -49,9 +49,9 @@ class ElectrumClientIntegrationTest : LightningTestSuite() {
         val client =
             ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES)) }
 
-        client.connectionState.first { it == Connection.CLOSED }
-        client.connectionState.first { it == Connection.ESTABLISHING }
-        client.connectionState.first { it == Connection.ESTABLISHED }
+        client.connectionState.first { it is Connection.CLOSED }
+        client.connectionState.first { it is Connection.ESTABLISHING }
+        client.connectionState.first { it is Connection.ESTABLISHED }
 
         return client
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
@@ -14,7 +14,6 @@ import fr.acinq.lightning.utils.currentTimestampSeconds
 import fr.acinq.lightning.utils.runTrying
 import fr.acinq.lightning.utils.sat
 import fr.acinq.secp256k1.Hex
-import io.ktor.util.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.consume
@@ -27,8 +26,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
-import kotlin.time.minutes
-import kotlin.time.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class, ObsoleteCoroutinesApi::class)
 class ElectrumWatcherIntegrationTest : LightningTestSuite() {
@@ -47,7 +44,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `watch for confirmed transactions`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED)) }
         val watcher = ElectrumWatcher(client, this)
 
         val (address, _) = bitcoincli.getNewAddress()
@@ -74,7 +71,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `watch for confirmed transactions created while being offline`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED)) }
         val watcher = ElectrumWatcher(client, this)
 
         val (address, _) = bitcoincli.getNewAddress()
@@ -102,7 +99,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `watch for spent transactions`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED)) }
         val watcher = ElectrumWatcher(client, this)
 
         val (address, privateKey) = bitcoincli.getNewAddress()
@@ -207,7 +204,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
         assertEquals(spendingTx, sentTx)
         bitcoincli.generateBlocks(2)
 
-        client.connect(ServerAddress("localhost", 51001, null))
+        client.connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED))
 
         val msg = listener.first() as WatchEventSpent
         assertEquals(spendingTx.txid, msg.tx.txid)
@@ -218,7 +215,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `watch for spent transactions while being offline`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED)) }
         val watcher = ElectrumWatcher(client, this)
 
         val (address, privateKey) = bitcoincli.getNewAddress()
@@ -277,7 +274,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `watch for mempool transactions (txs in mempool before we set the watch)`() = runSuspendTest(timeout = Duration.seconds(50)) {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED)) }
         val watcher = ElectrumWatcher(client, this)
 
         val (address, privateKey) = bitcoincli.getNewAddress()
@@ -322,7 +319,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `watch for mempool transactions (txs not yet in the mempool when we set the watch)`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED)) }
         val watcher = ElectrumWatcher(client, this)
 
         val (address, privateKey) = bitcoincli.getNewAddress()
@@ -355,7 +352,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `publish transactions with relative and absolute delays`() = runSuspendTest(timeout = Duration.minutes(2)) {
-        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, null)) }
+        val client = ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED)) }
         val watcher = ElectrumWatcher(client, this)
         val watcherNotifications = watcher.openWatchNotificationsFlow()
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/TcpSocketIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/TcpSocketIntegrationTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
-import kotlin.time.seconds
 
 @OptIn(ExperimentalTime::class)
 class TcpSocketIntegrationTest : LightningTestSuite() {
@@ -19,7 +18,7 @@ class TcpSocketIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `TCP connection IntegrationTest`() = runSuspendTest(timeout = Duration.seconds(250)) {
-        val socket = TcpSocket.Builder().connect("localhost", 51001)
+        val socket = TcpSocket.Builder().connect("localhost", 51001, TcpSocket.TLS.DISABLED)
         socket.send(serverVersionRpc)
         val ba = ByteArray(8192)
         val size = socket.receiveAvailable(ba)

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
@@ -15,7 +15,13 @@ suspend inline fun <reified LNMessage : LightningMessage> Flow<LightningMessage>
 suspend inline fun Peer.forward(message: LightningMessage) = send((BytesReceived(LightningMessage.encode(message))))
 
 @OptIn(ObsoleteCoroutinesApi::class)
-suspend inline fun Peer.expectStatus(await: Connection) = connectionState.first { it == await }
+suspend inline fun Peer.expectStatus(await: Connection) = connectionState.first {
+    when (await) {
+        is Connection.ESTABLISHED -> it is Connection.ESTABLISHED
+        is Connection.ESTABLISHING -> it is Connection.ESTABLISHING
+        is Connection.CLOSED -> it is Connection.CLOSED
+    }
+}
 
 @OptIn(ObsoleteCoroutinesApi::class)
 suspend inline fun <reified Status : ChannelState> Peer.expectState(

--- a/src/iosMain/kotlin/fr/acinq/lightning/io/IosTcpSocket.kt
+++ b/src/iosMain/kotlin/fr/acinq/lightning/io/IosTcpSocket.kt
@@ -1,7 +1,6 @@
 package fr.acinq.lightning.io
 
 import fr.acinq.lightning.utils.*
-import fr.acinq.lightning.utils.lightningLogger
 import kotlinx.cinterop.*
 import kotlinx.coroutines.suspendCancellableCoroutine
 import platform.Foundation.NSData
@@ -29,7 +28,7 @@ class IosTcpSocket(private val socket: NativeSocket) : TcpSocket {
         //   completion: (swift.phoenix_crypto.NativeSocketError?) -> kotlin.Unit
         // ): kotlin.Unit { /* compiled code */ }
 
-        val data = bytes?.let { it.toNSData() } ?: NSData()
+        val data = bytes?.toNSData() ?: NSData()
         socket.sendWithData(
             data = data,
             completion = { error ->
@@ -88,7 +87,7 @@ class IosTcpSocket(private val socket: NativeSocket) : TcpSocket {
         )
     }
 
-    override fun close(): Unit {
+    override fun close() {
 
         // @kotlinx.cinterop.ObjCMethod
         // public open external fun close(): kotlin.Unit { /* compiled code */ }
@@ -99,13 +98,13 @@ class IosTcpSocket(private val socket: NativeSocket) : TcpSocket {
 
 @ThreadLocal
 internal actual object PlatformSocketBuilder : TcpSocket.Builder {
-    private val logger by lightningLogger<IosTcpSocket>()
+//  private val logger by lightningLogger<IosTcpSocket>()
 
     @OptIn(ExperimentalUnsignedTypes::class)
     override suspend fun connect(
         host: String,
         port: Int,
-        tls: TcpSocket.TLS?
+        tls: TcpSocket.TLS
     ): TcpSocket = suspendCancellableCoroutine { continuation ->
 
         // @kotlinx.cinterop.ObjCMethod
@@ -118,12 +117,14 @@ internal actual object PlatformSocketBuilder : TcpSocket.Builder {
         // ): kotlin.Unit { /* compiled code */ }
 
         val tlsOptions = when (tls) {
-            TcpSocket.TLS.SAFE ->
-                NativeSocketTLS(disabled = false, allowUntrustedCerts = false)
+            TcpSocket.TLS.DISABLED ->
+                NativeSocketTLS.disabled()
+            TcpSocket.TLS.TRUSTED_CERTIFICATES ->
+                NativeSocketTLS.trustedCertificates()
             TcpSocket.TLS.UNSAFE_CERTIFICATES ->
-                NativeSocketTLS(disabled = false, allowUntrustedCerts = true)
-            else ->
-                NativeSocketTLS(disabled = true, allowUntrustedCerts = false)
+                NativeSocketTLS.allowUnsafeCertificates()
+            is TcpSocket.TLS.PINNED_PUBLIC_KEY ->
+                NativeSocketTLS.pinnedPublicKey(tls.pubKey)
         }
 
         NativeSocket.connectWithHost(

--- a/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
+++ b/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
@@ -4,15 +4,21 @@ import fr.acinq.lightning.utils.lightningLogger
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.network.tls.*
-import io.ktor.util.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.withContext
 import java.net.ConnectException
 import java.net.SocketException
+import java.security.KeyFactory
+import java.security.KeyStore
 import java.security.cert.X509Certificate
+import java.security.spec.X509EncodedKeySpec
+import java.util.*
+import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
+
 
 class JvmTcpSocket(val socket: Socket) : TcpSocket {
     private val readChannel = socket.openReadChannel()
@@ -58,6 +64,22 @@ class JvmTcpSocket(val socket: Socket) : TcpSocket {
         socket.close()
     }
 
+
+    companion object {
+        private val logger by lightningLogger<JvmTcpSocket>()
+        fun buildPublicKey(encodedKey: ByteArray): java.security.PublicKey {
+            val spec = X509EncodedKeySpec(encodedKey)
+            val algorithms = listOf("RSA", "EC")
+            algorithms.map {
+                try {
+                    return KeyFactory.getInstance(it).generatePublic(spec)
+                } catch (e: Exception) {
+                    logger.debug { "key does not use $it algorithm" }
+                }
+            }
+            throw IllegalArgumentException("unsupported key's algorithm, only $algorithms")
+        }
+    }
 }
 
 internal actual object PlatformSocketBuilder : TcpSocket.Builder {
@@ -65,31 +87,67 @@ internal actual object PlatformSocketBuilder : TcpSocket.Builder {
     private val selectorManager = ActorSelectorManager(Dispatchers.IO)
     private val logger by lightningLogger<JvmTcpSocket>()
 
-    override suspend fun connect(host: String, port: Int, tls: TcpSocket.TLS): TcpSocket =
-        withContext(Dispatchers.IO) {
-            try {
-                JvmTcpSocket(aSocket(selectorManager).tcp().connect(host, port).let { socket ->
-                    when (tls) {
-                        TcpSocket.TLS.DISABLED -> socket
-                        TcpSocket.TLS.TRUSTED_CERTIFICATES -> socket.tls(Dispatchers.IO)
-                        TcpSocket.TLS.UNSAFE_CERTIFICATES -> socket.tls(Dispatchers.IO) {
-                            logger.warning { "Using unsafe TLS!" }
-                            trustManager = object : X509TrustManager {
-                                override fun checkClientTrusted(p0: Array<out X509Certificate>?, p1: String?) {}
-                                override fun checkServerTrusted(p0: Array<out X509Certificate>?, p1: String?) {}
-                                override fun getAcceptedIssuers(): Array<X509Certificate>? = null
+    override suspend fun connect(host: String, port: Int, tls: TcpSocket.TLS): TcpSocket = withContext(Dispatchers.IO + CoroutineExceptionHandler { _, e ->
+        throw when (e) {
+            is ConnectException -> TcpSocket.IOException.ConnectionRefused()
+            is SocketException -> TcpSocket.IOException.Unknown(e.message)
+            else -> throw e
+        }
+    }) {
+        val socket = aSocket(selectorManager).tcp().connect(host, port)
+        when (tls) {
+            TcpSocket.TLS.TRUSTED_CERTIFICATES -> socket.tls(Dispatchers.IO)
+            TcpSocket.TLS.UNSAFE_CERTIFICATES -> socket.tls(Dispatchers.IO) {
+                logger.warning { "using unsafe TLS!" }
+                trustManager = object : X509TrustManager {
+                    override fun checkClientTrusted(p0: Array<out X509Certificate>?, p1: String?) {}
+                    override fun checkServerTrusted(p0: Array<out X509Certificate>?, p1: String?) {}
+                    override fun getAcceptedIssuers(): Array<X509Certificate>? = null
+                }
+            }
+            is TcpSocket.TLS.PINNED_PUBLIC_KEY -> {
+                logger.info { "using certificate pinning for connections with $host" }
+                socket.tls(coroutineContext, TLSConfigBuilder().apply {
+                    // build a default X509 trust manager.
+                    val factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())!!
+                    factory.init(null as KeyStore?)
+                    val defaultX509TrustManager = factory.trustManagers!!.filterIsInstance<X509TrustManager>().first()
+
+                    // create a new trust manager that always accepts certificates for the pinned public key, or falls back to standard procedure.
+                    trustManager = object : X509TrustManager {
+                        override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+                            defaultX509TrustManager.checkClientTrusted(chain, authType)
+                        }
+
+                        override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+                            val serverKey = try {
+                                JvmTcpSocket.buildPublicKey(chain?.asList()?.firstOrNull()?.publicKey?.encoded ?: throw RuntimeException("certificate missing"))
+                            } catch (e: Exception) {
+                                logger.error(e) { "failed to read server's pubkey=${tls.pubKey}" }
+                                throw e
+                            }
+
+                            val pinnedKey = try {
+                                JvmTcpSocket.buildPublicKey(Base64.getDecoder().decode(tls.pubKey))
+                            } catch (e: Exception) {
+                                logger.error(e) { "failed to read pinned pubkey=${tls.pubKey}" }
+                                throw e
+                            }
+
+                            if (serverKey == pinnedKey) {
+                                logger.info { "successfully checked server's certificate against pinned pubkey" }
+                            } else {
+                                logger.warning { "server's certificate does not match pinned pubkey, fallback to default check" }
+                                defaultX509TrustManager.checkServerTrusted(chain, authType)
                             }
                         }
-                        is TcpSocket.TLS.PINNED_PUBLIC_KEY -> {
-                            logger.warning { "JvmTcpSocket: TLS.PINNED_PUBLIC_KEY: Not implemented!" }
-                            throw TcpSocket.IOException.Unknown("Not implemented")
-                        }
+
+                        override fun getAcceptedIssuers(): Array<X509Certificate> = defaultX509TrustManager.acceptedIssuers
                     }
-                })
-            } catch (ex: ConnectException) {
-                throw TcpSocket.IOException.ConnectionRefused()
-            } catch (ex: SocketException) {
-                throw TcpSocket.IOException.Unknown(ex.message)
+                }.build())
             }
+            else -> Unit
         }
+        JvmTcpSocket(socket)
+    }
 }

--- a/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
+++ b/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
@@ -13,6 +13,7 @@ import java.net.ConnectException
 import java.net.SocketException
 import java.security.KeyFactory
 import java.security.KeyStore
+import java.security.cert.CertificateException
 import java.security.cert.X509Certificate
 import java.security.spec.X509EncodedKeySpec
 import java.util.*
@@ -138,7 +139,7 @@ internal actual object PlatformSocketBuilder : TcpSocket.Builder {
                                         logger.info { "successfully checked server's certificate against pinned pubkey" }
                                     } else {
                                         logger.warning { "server's certificate does not match pinned pubkey, fallback to default check" }
-                                        defaultX509TrustManager.checkServerTrusted(chain, authType)
+                                        throw TcpSocket.IOException.ConnectionClosed(CertificateException("certificate does not match pinned key"))
                                     }
                                 }
 

--- a/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
+++ b/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
@@ -64,12 +64,11 @@ class JvmTcpSocket(val socket: Socket) : TcpSocket {
         socket.close()
     }
 
-
     companion object {
         private val logger by lightningLogger<JvmTcpSocket>()
         fun buildPublicKey(encodedKey: ByteArray): java.security.PublicKey {
             val spec = X509EncodedKeySpec(encodedKey)
-            val algorithms = listOf("RSA", "EC")
+            val algorithms = listOf("RSA", "EC", "DiffieHellman", "DSA", "RSASSA-PSS", "XDH", "X25519", "X448")
             algorithms.map {
                 try {
                     return KeyFactory.getInstance(it).generatePublic(spec)

--- a/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
+++ b/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.io.File
+import java.lang.IllegalArgumentException
 import java.nio.file.Files
 import java.sql.DriverManager
 
@@ -77,10 +78,11 @@ object Node {
 
     fun parseElectrumServerAddress(address: String): ServerAddress {
         val a = address.split(':')
-        require(a.size == 3) { "invalid server address: $address" }
-        val tls = when (a[2]) {
-            "tls" -> TcpSocket.TLS.UNSAFE_CERTIFICATES
-            else -> TcpSocket.TLS.DISABLED
+        val tls = when (a.size) {
+            2 -> TcpSocket.TLS.TRUSTED_CERTIFICATES
+            3 -> TcpSocket.TLS.UNSAFE_CERTIFICATES
+            4 -> TcpSocket.TLS.PINNED_PUBLIC_KEY(a[3])
+            else -> throw IllegalArgumentException("invalid server address=$address")
         }
         return ServerAddress(a[0], a[1].toInt(), tls)
     }

--- a/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
+++ b/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
@@ -80,7 +80,7 @@ object Node {
         require(a.size == 3) { "invalid server address: $address" }
         val tls = when (a[2]) {
             "tls" -> TcpSocket.TLS.UNSAFE_CERTIFICATES
-            else -> null
+            else -> TcpSocket.TLS.DISABLED
         }
         return ServerAddress(a[0], a[1].toInt(), tls)
     }

--- a/src/jvmTest/kotlin/fr/acinq/lightning/io/JvmTcpSocketTests.kt
+++ b/src/jvmTest/kotlin/fr/acinq/lightning/io/JvmTcpSocketTests.kt
@@ -1,0 +1,29 @@
+package fr.acinq.lightning.io
+
+import fr.acinq.lightning.tests.utils.LightningTestSuite
+import org.junit.Test
+import java.util.*
+import kotlin.test.assertEquals
+
+
+class JvmTcpSocketTests : LightningTestSuite() {
+
+    @Test
+    fun `build public key from base64`() {
+        val testCases = listOf(
+            // testnet.qtornado.com
+            "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAwkLgqNkkTbwpV3gMdgDA+jJFdzrOp8vIDT/qxVIox8NZ53pxPc2N44aeY1NJx4TyfpHUGcI7l+gxZfLr8a13o3CIQSotDbZZdJhS6Ir5tT4iRqwZJch+HayTQf9rztv8OQWgrflWDzCiYtBA5PGx6LEQWyah/xPPUbeANe/ndEzlfAhXjNcynSfrkikzTgFNBqnc5CcTkHjYgzCXqMwyZCD6kQTQG+eqIHSHul21dwUougfCWCR+P0zFA7LeUfPz2mLZktmGXjqTyYZ+0ZTUgJz/MMZt9PDWGJZsHQzoFSCMicukKtnvZ4Q0gbPOoYp8+WjD4SH+WmC3MZdLagsi05hUDdm7PHIM1VHQTALLGRnW3yTOaqhsvYGAM5UOkDcmgUqIr6IztHGWCKldfbhSc4l7BIgvwW2M6FxYlSAcavIodNfvEC1ythdMzl8bZsBjGIOZ39WtiM0grgcg7bb8W5ovZpLOXpzZBjS0zB0sZJnumjS+3jCSjy9rZXGUn3JmMdqtTV8RQxkB8OBJhFf5qtMSZXiJIr9RH71VoJKjnds/hoILHuCKU3HOJeo0+4KSD8+q4g3tZLr/haIrsHg5uifT9db6tDML1PTKpbHkW+f3w9PdhSmsNUUXrgNmQ0MoBhxV7U2Qcug3jX3xaf1PgwWDg3nZZizhuvBceY0IYLECAwEAAQ==",
+            // tn.not.fyi
+            "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA7/z3CDZ2d6gJ/7mEt9yI9KNKxs5dbwzhKB99uYdWp1QogMHEo9Jg+uYGg2M7UhO76vOFaf1Hp2gstd1Q0n2GLwtq3a0JSam3EIaC7QuX8V190IexyPSVdwaPtPBzN4KCZd8smfiR01oMJkhCH2MKaCrJKL7PJrSZMmrLMzo5yYTnHtBZVR9gL0T5bJeO3NTNuQBV1ft6kYaKa30d5zMO7j/CkzclQkh6d07RrS/YnkZNswfnqKdEqNNGa3FfuZ8vwSwRtpEQRAdkjxSFsLSoIv+HoTx1nFhbmaqdZasFIxmn9Zp30KMb328k5j9fszcAn78y7tVodiddODBMgGSpofq+nJDkNlKD0NVNLML50IB2U2BL/62+7c2RguvLYljNkTSB3HhF+b6DiGLZDbg48ea12Hr+9Nxf4lW+hIKO3s/88MMlrB2lORORiuFtmiqYiiTc5YzJPXzXGhoCCmgQxij6XYi0v4bpFr8wANtDobZhziWZSHm6T+u5RsSSkMGHc6hJaZmVg9xGznsD7RmRa+Wmf/Tl4sY0hI+nea4YyrN7+i1KT04EA9HrG6nBUKgKJkp2OciKmGGrINmdSCvkZ9laCxcGpEuAL0sI/WalmAXDTm/rjNdMZ0AClD3gCweqsblKZ07Ewtzh0DE65B7vtZWgWZM/wz4dnMYwY9VIrcUCAwEAAQ==",
+            // testnet.aranguren.org
+            "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+RL/AH7wn08YKlRCswERM0JBdGycRuGBgQbM0guzDxi7Ov01WB9AM0DX7GC09pAOefbRP8QzXEhyKO0qpnin+5Vz4jKS+xv4zPGx2MpTqjJxzom/6v13cumZxWXMzVSeNUTjVp2sOPQ1JQaHqqjs2lTgShWu+pAgKUH1KPWxMSz21cI+AQkT8NuuXe0USYYIeiXzyTpciIaBf50j6185u+4bUwA3hvdPZyrkJDtSluJ0HiJzCSFlmNYNHLqbvZNAYrgUM3qJRTsvmD0JK6mm8m7iXW4m6mKX22VgR93meD/3rdcrJ8FbMbVlkS3wimzcYezls9JytaXupyeRKhQjTQIDAQAB",
+            // electrum.emzy.de
+            "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAufqDv0nJICJPoP86wOPYM/XIfFs6vmVrGEeBZmy9MmMNubulhnyE+sWuFhnIX+0uuFlJ18LJYFOIg0fAaFdN5xh4vagBNXP9dCcxfVfMGfv9xBQZfWhKrDjC4DCJ82n3K+Q4RqpK/yS9GIZIcqrG3rxELBZ8NHVPIXveW0PnagGeQ31NDdOAq9MBKiKRcmfKem5daUEo/xM4nTt+tOTxl5sHicdQSCePHXewMXzmkM/Vw1rMJZKeTwnLX44TsppEi47fXUFcduB2+A1xHQIgE9wa4Bqc2ZoUtKKBayeeU02C2SBFgVxtAWT6YESdcPP8u+pR7lADA7QZNUVNKMvMNwIDAQAB",
+        )
+
+        testCases.forEach { keyBase64 ->
+            val key = JvmTcpSocket.buildPublicKey(Base64.getDecoder().decode(keyBase64))
+            assertEquals(keyBase64, String(Base64.getEncoder().encode(key.encoded)))
+        }
+    }
+}

--- a/src/jvmTest/resources/application.conf
+++ b/src/jvmTest/resources/application.conf
@@ -1,6 +1,6 @@
 phoenix {
-    chain = "testnet"
-    #trampoline-node-uri = "02413957815d05abb7fc6d885622d5cdc5b7714db1478cb05813a8474179b83c5c@51.77.223.203:19735"
-    trampoline-node-uri = "03933884aaf1d6b108397e5efe5c86bcf2d8ca8d2f700eda99db9214fc2712b134@13.248.222.197:9735"
-    electrum-server = "testnet1.electrum.acinq.co:51002:tls"
+  chain = "testnet"
+  #trampoline-node-uri = "02413957815d05abb7fc6d885622d5cdc5b7714db1478cb05813a8474179b83c5c@51.77.223.203:19735"
+  trampoline-node-uri = "03933884aaf1d6b108397e5efe5c86bcf2d8ca8d2f700eda99db9214fc2712b134@13.248.222.197:9735"
+  electrum-server = "testnet1.electrum.acinq.co:51002:tls:MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOPjvLNI/D4hDmtqUw3efT7pXOyStOhL0rJeSotKlBPLFqrUvrOIDndKUkQl+V5Oow4aA+DW/HI4pTRlqZaTXO42OBytFXdYyymgYCqWTpmKgUg72vWcHGok7JwK/JusMf0eCG+mETzF0fNdPLniIJ8OeiEgeeVcIqTXtT+sr/u/71Hb1BJfy9Azqe/B/W1WFIgob44vLNv7G7r12o4/T7X87QvgW2u09LSNMg37vd5wa5uQ+R/30aAzq+WxVKPm9qmBZL4Uxyk/JNGDHR9PE85gG1mLPZ6bk0ht46SZXPY6rx0C7KTHtvkUnXoAPkzHGghC2Z3tV/G94G1pRxHOAQIDAQAB"
 }

--- a/src/linuxMain/kotlin/fr/acinq/lightning/io/linuxTcpSocket.kt
+++ b/src/linuxMain/kotlin/fr/acinq/lightning/io/linuxTcpSocket.kt
@@ -1,6 +1,6 @@
 package fr.acinq.lightning.io
 
 internal actual object PlatformSocketBuilder : TcpSocket.Builder {
-    override suspend fun connect(host: String, port: Int, tls: TcpSocket.TLS?): TcpSocket =
+    override suspend fun connect(host: String, port: Int, tls: TcpSocket.TLS): TcpSocket =
         error("Not implemented")
 }


### PR DESCRIPTION
The TcpSocket previously only supported 2 types of TLS connections:

```kotlin
enum class TLS {
   SAFE, UNSAFE_CERTIFICATES
}
```

This PR adds support for pinning. The motivation is to increase security for Electrum connections. Since many (most?) of them are using self-signed certificates.

```kotlin
sealed class TLS {
   object DISABLED: TLS()
   object TRUSTED_CERTIFICATES: TLS()
   object UNSAFE_CERTIFICATES: TLS()
   data class PINNED_PUBLIC_KEY(
      // DER-encoded publicKey as base64 string.
      // (I.e. same as PEM format, without BEGIN/END header/footer)
      val pubKey: String
   ): TLS()
}
```

One other minor change I made was to make the TLS parameter required.

```kotlin
suspend fun connect(host: String, port: Int, tls: TLS): TcpSocket
//                                           ^^^^^^^^
```

Seems safer - no longer possible to forget the parameter, and end up with a non-secure connection when a secure connection was expected.

#### Important
The initial commit only includes support for the iOS socket. We need another commit to add support for the Android socket.