### PR TITLE
Store closing txs as parts in outgoing payments db

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "fr.acinq.lightning"
-    version = "1.3.0"
+    version = "1.4.0-SNAPSHOT"
 
     repositories {
         mavenLocal()

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
@@ -7,7 +7,7 @@ import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.blockchain.fee.OnChainFeerates
 import fr.acinq.lightning.channel.Channel.FUNDING_TIMEOUT_FUNDEE_BLOCK
 import fr.acinq.lightning.crypto.KeyManager
-import fr.acinq.lightning.db.ChannelClosingType
+import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.serialization.Serialization
 import fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.ClosingTx
 import fr.acinq.lightning.transactions.outgoings
@@ -80,7 +80,7 @@ sealed class ChannelAction {
         data class GetHtlcInfos(val revokedCommitTxId: ByteVector32, val commitmentNumber: Long) : Storage()
         data class StoreIncomingAmount(val amount: MilliSatoshi, val origin: ChannelOrigin?) : Storage()
         data class StoreChannelClosing(val amount: MilliSatoshi, val closingAddress: String, val isSentToDefaultAddress: Boolean) : Storage()
-        data class StoreChannelClosed(val txids: List<ByteVector32>, val claimed: Satoshi, val closingType: ChannelClosingType) : Storage()
+        data class StoreChannelClosed(val closingTxs: List<OutgoingPayment.ClosingTxPart>) : Storage()
     }
 
     data class ProcessIncomingHtlc(val add: UpdateAddHtlc) : ChannelAction()

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
@@ -2,7 +2,9 @@ package fr.acinq.lightning.db
 
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto
+import fr.acinq.bitcoin.Satoshi
 import fr.acinq.lightning.channel.ChannelException
+import fr.acinq.lightning.payment.FinalFailure
 import fr.acinq.lightning.payment.OutgoingPaymentFailure
 import fr.acinq.lightning.utils.Either
 import fr.acinq.lightning.utils.UUID
@@ -101,35 +103,55 @@ class InMemoryPaymentsDb : PaymentsDb {
             val parts = outgoingParts.values.filter { it.first == payment.id }.map { it.second }
             return when (payment.status) {
                 is OutgoingPayment.Status.Completed.Succeeded -> {
-                    payment.copy(parts = parts.filter { it.status is OutgoingPayment.Part.Status.Succeeded })
+                    payment.copy(parts = parts.filter {
+                        (it is OutgoingPayment.LightningPart && it.status is OutgoingPayment.LightningPart.Status.Succeeded) || it is OutgoingPayment.ClosingTxPart
+                    })
                 }
                 else -> payment.copy(parts = parts)
             }
         }
     }
 
-    override suspend fun completeOutgoingPayment(id: UUID, completed: OutgoingPayment.Status.Completed) {
+    override suspend fun completeOutgoingPaymentOnchain(id: UUID, completedAt: Long) {
         require(outgoing.contains(id)) { "outgoing payment with id=$id doesn't exist" }
         val payment = outgoing[id]!!
-        outgoing[id] = payment.copy(status = completed)
+        outgoing[id] = payment.copy(status = OutgoingPayment.Status.Completed.Succeeded.OnChain(completedAt))
     }
 
-    override suspend fun addOutgoingParts(parentId: UUID, parts: List<OutgoingPayment.Part>) {
+    override suspend fun completeOutgoingPaymentOffchain(id: UUID, preimage: ByteVector32, completedAt: Long) {
+        require(outgoing.contains(id)) { "outgoing payment with id=$id doesn't exist" }
+        val payment = outgoing[id]!!
+        outgoing[id] = payment.copy(status = OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage = preimage, completedAt = completedAt))
+    }
+
+    override suspend fun completeOutgoingPaymentFailed(id: UUID, finalFailure: FinalFailure, completedAt: Long) {
+        require(outgoing.contains(id)) { "outgoing payment with id=$id doesn't exist" }
+        val payment = outgoing[id]!!
+        outgoing[id] = payment.copy(status = OutgoingPayment.Status.Completed.Failed(reason = finalFailure, completedAt = completedAt))
+    }
+
+    override suspend fun addOutgoingLightningParts(parentId: UUID, parts: List<OutgoingPayment.LightningPart>) {
         require(outgoing.contains(parentId)) { "parent outgoing payment with id=$parentId doesn't exist" }
         parts.forEach { require(!outgoingParts.contains(it.id)) { "an outgoing payment part with id=${it.id} already exists" } }
         parts.forEach { outgoingParts[it.id] = Pair(parentId, it) }
     }
 
-    override suspend fun updateOutgoingPart(partId: UUID, failure: Either<ChannelException, FailureMessage>, completedAt: Long) {
-        require(outgoingParts.contains(partId)) { "outgoing payment part with id=$partId doesn't exist" }
-        val (parentId, part) = outgoingParts[partId]!!
-        outgoingParts[partId] = Pair(parentId, part.copy(status = OutgoingPaymentFailure.convertFailure(failure, completedAt)))
+    override suspend fun addOutgoingClosingTxParts(parentId: UUID, parts: List<OutgoingPayment.ClosingTxPart>) {
+        require(outgoing.contains(parentId)) { "parent outgoing payment with id=$parentId doesn't exist" }
+        parts.forEach { require(!outgoingParts.contains(it.id)) { "an outgoing payment part with id=${it.id} already exists" } }
+        parts.forEach { outgoingParts[it.id] = Pair(parentId, it) }
     }
 
-    override suspend fun updateOutgoingPart(partId: UUID, preimage: ByteVector32, completedAt: Long) {
+    override suspend fun completeOutgoingLightningPart(partId: UUID, failure: Either<ChannelException, FailureMessage>, completedAt: Long) {
         require(outgoingParts.contains(partId)) { "outgoing payment part with id=$partId doesn't exist" }
         val (parentId, part) = outgoingParts[partId]!!
-        outgoingParts[partId] = Pair(parentId, part.copy(status = OutgoingPayment.Part.Status.Succeeded(preimage, completedAt)))
+        outgoingParts[partId] = Pair(parentId, (part as OutgoingPayment.LightningPart).copy(status = OutgoingPaymentFailure.convertFailure(failure, completedAt)))
+    }
+
+    override suspend fun completeOutgoingLightningPart(partId: UUID, preimage: ByteVector32, completedAt: Long) {
+        require(outgoingParts.contains(partId)) { "outgoing payment part with id=$partId doesn't exist" }
+        val (parentId, part) = outgoingParts[partId]!!
+        outgoingParts[partId] = Pair(parentId, (part as OutgoingPayment.LightningPart).copy(status = OutgoingPayment.LightningPart.Status.Succeeded(preimage, completedAt)))
     }
 
     override suspend fun getOutgoingPart(partId: UUID): OutgoingPayment? {

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
@@ -128,7 +128,7 @@ class InMemoryPaymentsDb : PaymentsDb {
         outgoing[id] = payment.copy(status = OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage = preimage, completedAt = completedAt))
     }
 
-    override suspend fun completeOutgoingPaymentFailed(id: UUID, finalFailure: FinalFailure, completedAt: Long) {
+    override suspend fun completeOutgoingPaymentOffchain(id: UUID, finalFailure: FinalFailure, completedAt: Long) {
         require(outgoing.contains(id)) { "outgoing payment with id=$id doesn't exist" }
         val payment = outgoing[id]!!
         outgoing[id] = payment.copy(status = OutgoingPayment.Status.Completed.Failed(reason = finalFailure, completedAt = completedAt))

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
@@ -152,7 +152,7 @@ class InMemoryPaymentsDb : PaymentsDb {
         outgoingParts[partId] = Pair(parentId, (part as OutgoingPayment.LightningPart).copy(status = OutgoingPayment.LightningPart.Status.Succeeded(preimage, completedAt)))
     }
 
-    override suspend fun getOutgoingPart(partId: UUID): OutgoingPayment? {
+    override suspend fun getOutgoingPaymentFromPartId(partId: UUID): OutgoingPayment? {
         return outgoingParts[partId]?.let { (parentId, _) ->
             require(outgoing.contains(parentId)) { "parent outgoing payment with id=$parentId doesn't exist" }
             getOutgoingPayment(parentId)

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -70,7 +70,7 @@ interface OutgoingPaymentsDb {
     suspend fun completeOutgoingPaymentOffchain(id: UUID, preimage: ByteVector32, completedAt: Long = currentTimestampMillis())
 
     /** Mark an outgoing payment as failed. */
-    suspend fun completeOutgoingPaymentFailed(id: UUID, finalFailure: FinalFailure, completedAt: Long = currentTimestampMillis())
+    suspend fun completeOutgoingPaymentOffchain(id: UUID, finalFailure: FinalFailure, completedAt: Long = currentTimestampMillis())
 
     /** Add new partial payments to a pending outgoing payment. */
     suspend fun addOutgoingLightningParts(parentId: UUID, parts: List<OutgoingPayment.LightningPart>)

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -63,8 +63,8 @@ interface OutgoingPaymentsDb {
     /** Get information about an outgoing payment (settled or not). */
     suspend fun getOutgoingPayment(id: UUID): OutgoingPayment?
 
-    /** Mark an outgoing payment as completed on-chain. */
-    suspend fun completeOutgoingPaymentOnchain(id: UUID, completedAt: Long = currentTimestampMillis())
+    /** Mark an outgoing payment as completed for closing a Lightning channel on-chain with a list of on-chain txs. */
+    suspend fun completeOutgoingPaymentForClosing(id: UUID, parts: List<OutgoingPayment.ClosingTxPart>, completedAt: Long = currentTimestampMillis())
 
     /** Mark an outgoing payment as completed over Lightning. */
     suspend fun completeOutgoingPaymentOffchain(id: UUID, preimage: ByteVector32, completedAt: Long = currentTimestampMillis())
@@ -74,9 +74,6 @@ interface OutgoingPaymentsDb {
 
     /** Add new partial payments to a pending outgoing payment. */
     suspend fun addOutgoingLightningParts(parentId: UUID, parts: List<OutgoingPayment.LightningPart>)
-
-    /** Add parts of closing transaction. */
-    suspend fun addOutgoingClosingTxParts(parentId: UUID, parts: List<OutgoingPayment.ClosingTxPart>)
 
     /** Mark an outgoing payment part as failed. */
     suspend fun completeOutgoingLightningPart(partId: UUID, failure: Either<ChannelException, FailureMessage>, completedAt: Long = currentTimestampMillis())

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -82,7 +82,7 @@ interface OutgoingPaymentsDb {
     suspend fun completeOutgoingLightningPart(partId: UUID, preimage: ByteVector32, completedAt: Long = currentTimestampMillis())
 
     /** Get information about an outgoing payment from the id of one of its parts. */
-    suspend fun getOutgoingPart(partId: UUID): OutgoingPayment?
+    suspend fun getOutgoingPaymentFromPartId(partId: UUID): OutgoingPayment?
 
     /** List all the outgoing payment attempts that tried to pay the given payment hash. */
     suspend fun listOutgoingPayments(paymentHash: ByteVector32): List<OutgoingPayment>

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -425,7 +425,7 @@ class Peer(
                             closingAddress = action.closingAddress,
                             isSentToDefaultAddress = action.isSentToDefaultAddress
                         ),
-                        parts = listOf<OutgoingPayment.Part>(),
+                        parts = emptyList(),
                         status = OutgoingPayment.Status.Pending
                     )
                     db.payments.addOutgoingPayment(payment)
@@ -433,8 +433,8 @@ class Peer(
                 }
                 action is ChannelAction.Storage.StoreChannelClosed -> {
                     val dbId = UUID.fromBytes(channelId.take(16).toByteArray())
-                    val completed = OutgoingPayment.Status.Completed.Succeeded.OnChain(action.txids, action.claimed, action.closingType)
-                    db.payments.completeOutgoingPayment(dbId, completed)
+                    db.payments.addOutgoingClosingTxParts(parentId = dbId, parts = action.closingTxs)
+                    db.payments.completeOutgoingPaymentOnchain(id = dbId, completedAt = currentTimestampMillis())
                     listenerEventChannel.send(ChannelClosing(channelId))
                 }
                 action is ChannelAction.ChannelId.IdSwitch -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -433,8 +433,7 @@ class Peer(
                 }
                 action is ChannelAction.Storage.StoreChannelClosed -> {
                     val dbId = UUID.fromBytes(channelId.take(16).toByteArray())
-                    db.payments.addOutgoingClosingTxParts(parentId = dbId, parts = action.closingTxs)
-                    db.payments.completeOutgoingPaymentOnchain(id = dbId, completedAt = currentTimestampMillis())
+                    db.payments.completeOutgoingPaymentForClosing(id = dbId, parts = action.closingTxs, completedAt = currentTimestampMillis())
                     listenerEventChannel.send(ChannelClosing(channelId))
                 }
                 action is ChannelAction.ChannelId.IdSwitch -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
@@ -198,7 +198,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
     }
 
     private suspend fun processPostRestartFailure(partId: UUID, failure: Either<ChannelException, FailureMessage>): ProcessFailureResult? {
-        when (val payment = db.getOutgoingPart(partId)) {
+        when (val payment = db.getOutgoingPaymentFromPartId(partId)) {
             null -> {
                 logger.error { "i:$partId paymentId doesn't match any known payment attempt" }
                 return null
@@ -257,7 +257,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
     }
 
     private suspend fun processPostRestartFulfill(partId: UUID, preimage: ByteVector32): ProcessFulfillResult? {
-        when (val payment = db.getOutgoingPart(partId)) {
+        when (val payment = db.getOutgoingPaymentFromPartId(partId)) {
             null -> {
                 logger.error { "i:$partId paymentId doesn't match any known payment attempt" }
                 return null

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
@@ -65,7 +65,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                 logger.warning { "h:${request.paymentHash} p:${request.paymentId} payment failed: ${result.value}" }
                 db.addOutgoingPayment(OutgoingPayment(request.paymentId, request.amount, request.recipient, request.details))
                 val finalFailure = result.value
-                db.completeOutgoingPayment(request.paymentId, finalFailure)
+                db.completeOutgoingPaymentFailed(request.paymentId, finalFailure)
                 Failure(request, finalFailure.toPaymentFailure())
             }
             is Either.Right -> {
@@ -81,7 +81,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
         }
     }
 
-    private fun createChildPayments(request: SendPayment, routes: List<RouteCalculation.Route>, trampolinePayload: PaymentAttempt.TrampolinePayload): List<Triple<OutgoingPayment.Part, SharedSecrets, WrappedChannelEvent>> {
+    private fun createChildPayments(request: SendPayment, routes: List<RouteCalculation.Route>, trampolinePayload: PaymentAttempt.TrampolinePayload): List<Triple<OutgoingPayment.LightningPart, SharedSecrets, WrappedChannelEvent>> {
         val childPayments = routes.map { createOutgoingPart(request, it, trampolinePayload) }
         childToParentId.putAll(childPayments.map { it.first.id to request.paymentId })
         childPayments.forEach { logger.info { "h:${request.paymentHash} p:${request.paymentId} i:${it.first.id} sending ${it.first.amount} to channel ${it.third.channelId}" } }
@@ -93,7 +93,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
         val payment = getPaymentAttempt(add.paymentId) ?: return processPostRestartFailure(add.paymentId, Either.Left(event.error))
 
         logger.debug { "h:${add.paymentHash} p:${payment.request.paymentId} i:${add.paymentId} could not send HTLC: ${event.error.message}" }
-        db.updateOutgoingPart(add.paymentId, Either.Left(event.error))
+        db.completeOutgoingLightningPart(add.paymentId, Either.Left(event.error))
 
         val (updated, result) = when (payment) {
             is PaymentAttempt.PaymentInProgress -> {
@@ -102,7 +102,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                     is Either.Left -> PaymentAttempt.PaymentAborted(payment.request, routes.value, payment.pending, payment.failures).failChild(add.paymentId, Either.Left(event.error), db, logger)
                     is Either.Right -> {
                         val newPayments = createChildPayments(payment.request, routes.value, payment.trampolinePayload)
-                        db.addOutgoingParts(payment.request.paymentId, newPayments.map { it.first })
+                        db.addOutgoingLightningParts(payment.request.paymentId, newPayments.map { it.first })
                         val updatedPayments = payment.pending - add.paymentId + newPayments.map { it.first.id to Pair(it.first, it.second) }
                         val updated = payment.copy(ignore = ignore, failures = payment.failures + Either.Left(event.error), pending = updatedPayments)
                         val result = Progress(payment.request, updated.fees, newPayments.map { it.third })
@@ -134,7 +134,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
         }
 
         logger.debug { "h:${payment.request.paymentHash} p:${payment.request.paymentId} i:${event.paymentId} HTLC failed: ${failure.message}" }
-        db.updateOutgoingPart(event.paymentId, Either.Right(failure))
+        db.completeOutgoingLightningPart(event.paymentId, Either.Right(failure))
 
         val (updated, result) = when (payment) {
             is PaymentAttempt.PaymentInProgress -> {
@@ -164,7 +164,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                                 logger.warning { "h:${payment.request.paymentHash} p:${payment.request.paymentId} payment failed: ${routes.value}" }
                                 val aborted = PaymentAttempt.PaymentAborted(payment.request, routes.value, mapOf(), payment.failures + Either.Right(failure))
                                 val result = Failure(payment.request, OutgoingPaymentFailure(aborted.reason, aborted.failures))
-                                db.completeOutgoingPayment(payment.request.paymentId, result.failure.reason)
+                                db.completeOutgoingPaymentFailed(payment.request.paymentId, result.failure.reason)
                                 Pair(aborted, result)
                             }
                             is Either.Right -> {
@@ -172,7 +172,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                                 val trampolinePaymentSecret = Lightning.randomBytes32()
                                 val trampolinePayload = PaymentAttempt.TrampolinePayload(trampolineAmount, trampolineExpiry, trampolinePaymentSecret, trampolinePacket)
                                 val childPayments = createChildPayments(payment.request, routes.value, trampolinePayload)
-                                db.addOutgoingParts(payment.request.paymentId, childPayments.map { it.first })
+                                db.addOutgoingLightningParts(payment.request.paymentId, childPayments.map { it.first })
                                 val newAttempt = PaymentAttempt.PaymentInProgress(
                                     payment.request,
                                     payment.attemptNumber + 1,
@@ -205,14 +205,18 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
             }
             else -> {
                 logger.debug { "h:${payment.paymentHash} p:${payment.id} i:$partId could not send HTLC (wallet restart): ${failure.fold({ it.message }, { it.message })}" }
-                db.updateOutgoingPart(partId, failure)
-                val hasMorePendingParts = payment.parts.any { it.status == OutgoingPayment.Part.Status.Pending && it.id != partId }
+                db.completeOutgoingLightningPart(partId, failure)
+                val parts = payment.parts.filterIsInstance<OutgoingPayment.LightningPart>()
+                val hasMorePendingParts = parts.any { it.status == OutgoingPayment.LightningPart.Status.Pending && it.id != partId }
                 return if (!hasMorePendingParts) {
                     logger.warning { "h:${payment.paymentHash} p:${payment.id} payment failed: ${FinalFailure.WalletRestarted}" }
-                    db.completeOutgoingPayment(payment.id, FinalFailure.WalletRestarted)
+                    db.completeOutgoingPaymentFailed(payment.id, FinalFailure.WalletRestarted)
                     Failure(
-                        SendPayment(payment.id, payment.recipientAmount, payment.recipient, payment.details as OutgoingPayment.Details.Normal),
-                        OutgoingPaymentFailure(FinalFailure.WalletRestarted, payment.parts.map { it.status }.filterIsInstance<OutgoingPayment.Part.Status.Failed>() + OutgoingPaymentFailure.convertFailure(failure))
+                        request = SendPayment(payment.id, payment.recipientAmount, payment.recipient, payment.details as OutgoingPayment.Details.Normal),
+                        failure = OutgoingPaymentFailure(
+                            reason = FinalFailure.WalletRestarted,
+                            failures = parts.map { it.status }.filterIsInstance<OutgoingPayment.LightningPart.Status.Failed>() + OutgoingPaymentFailure.convertFailure(failure)
+                        )
                     )
                 } else {
                     null
@@ -226,8 +230,8 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
         val payment = getPaymentAttempt(event.paymentId) ?: return processPostRestartFulfill(event.paymentId, preimage)
 
         logger.debug { "h:${payment.request.paymentHash} p:${payment.request.paymentId} i:${event.paymentId} HTLC fulfilled" }
-        val part = payment.pending[event.paymentId]?.first?.copy(status = OutgoingPayment.Part.Status.Succeeded(preimage))
-        db.updateOutgoingPart(event.paymentId, preimage)
+        val part = payment.pending[event.paymentId]?.first?.copy(status = OutgoingPayment.LightningPart.Status.Succeeded(preimage))
+        db.completeOutgoingLightningPart(event.paymentId, preimage)
 
         val updated = when (payment) {
             is PaymentAttempt.PaymentInProgress -> PaymentAttempt.PaymentSucceeded(payment.request, preimage, part?.let { listOf(it) } ?: listOf(), payment.pending - event.paymentId)
@@ -244,7 +248,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
 
         return if (updated.isComplete()) {
             logger.info { "h:${payment.request.paymentHash} p:${payment.request.paymentId} payment successfully sent (fees=${updated.fees})" }
-            db.completeOutgoingPayment(payment.request.paymentId, preimage)
+            db.completeOutgoingPaymentOffchain(payment.request.paymentId, preimage)
             val r = payment.request
             Success(r, OutgoingPayment(r.paymentId, r.amount, r.recipient, r.details, updated.parts, OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage)), preimage)
         } else {
@@ -260,13 +264,13 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
             }
             else -> {
                 logger.debug { "h:${payment.paymentHash} p:${payment.id} i:$partId HTLC succeeded (wallet restart): $preimage" }
-                db.updateOutgoingPart(partId, preimage)
+                db.completeOutgoingLightningPart(partId, preimage)
                 // We can re-create the request from what we have in the DB.
                 val request = SendPayment(payment.id, payment.recipientAmount, payment.recipient, payment.details as OutgoingPayment.Details.Normal)
-                val hasMorePendingParts = payment.parts.any { it.status == OutgoingPayment.Part.Status.Pending && it.id != partId }
+                val hasMorePendingParts = payment.parts.filterIsInstance<OutgoingPayment.LightningPart>().any { it.status == OutgoingPayment.LightningPart.Status.Pending && it.id != partId }
                 return if (!hasMorePendingParts) {
                     logger.info { "h:${payment.paymentHash} p:${payment.id} payment successfully sent (wallet restart)" }
-                    db.completeOutgoingPayment(payment.id, preimage)
+                    db.completeOutgoingPaymentOffchain(payment.id, preimage)
                     val succeeded = db.getOutgoingPayment(payment.id)!! //  NB: we reload the payment to ensure all parts status are updated
                     Success(request, succeeded, preimage)
                 } else {
@@ -285,13 +289,13 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
         }
     }
 
-    private fun createOutgoingPart(request: SendPayment, route: RouteCalculation.Route, trampolinePayload: PaymentAttempt.TrampolinePayload): Triple<OutgoingPayment.Part, SharedSecrets, WrappedChannelEvent> {
+    private fun createOutgoingPart(request: SendPayment, route: RouteCalculation.Route, trampolinePayload: PaymentAttempt.TrampolinePayload): Triple<OutgoingPayment.LightningPart, SharedSecrets, WrappedChannelEvent> {
         val childId = UUID.randomUUID()
-        val outgoingPayment = OutgoingPayment.Part(
-            childId,
-            route.amount,
-            listOf(HopDesc(nodeId, route.channel.staticParams.remoteNodeId, route.channel.shortChannelId), HopDesc(route.channel.staticParams.remoteNodeId, request.recipient)),
-            OutgoingPayment.Part.Status.Pending
+        val outgoingPayment = OutgoingPayment.LightningPart(
+            id = childId,
+            amount = route.amount,
+            route = listOf(HopDesc(nodeId, route.channel.staticParams.remoteNodeId, route.channel.shortChannelId), HopDesc(route.channel.staticParams.remoteNodeId, request.recipient)),
+            status = OutgoingPayment.LightningPart.Status.Pending
         )
         val channelHops: List<ChannelHop> = listOf(ChannelHop(nodeId, route.channel.staticParams.remoteNodeId, route.channel.channelUpdate))
         val (add, secrets) = OutgoingPaymentPacket.buildCommand(childId, request.paymentHash, channelHops, trampolinePayload.createFinalPayload(route.amount))
@@ -325,7 +329,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
 
     sealed class PaymentAttempt {
         abstract val request: SendPayment
-        abstract val pending: Map<UUID, Pair<OutgoingPayment.Part, SharedSecrets>>
+        abstract val pending: Map<UUID, Pair<OutgoingPayment.LightningPart, SharedSecrets>>
         abstract val fees: MilliSatoshi
 
         fun isComplete(): Boolean = pending.isEmpty()
@@ -355,7 +359,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
             override val request: SendPayment,
             val attemptNumber: Int,
             val trampolinePayload: TrampolinePayload,
-            override val pending: Map<UUID, Pair<OutgoingPayment.Part, SharedSecrets>>,
+            override val pending: Map<UUID, Pair<OutgoingPayment.LightningPart, SharedSecrets>>,
             val ignore: Set<ByteVector32>,
             val failures: List<Either<ChannelException, FailureMessage>>
         ) : PaymentAttempt() {
@@ -374,7 +378,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
         data class PaymentAborted(
             override val request: SendPayment,
             val reason: FinalFailure,
-            override val pending: Map<UUID, Pair<OutgoingPayment.Part, SharedSecrets>>,
+            override val pending: Map<UUID, Pair<OutgoingPayment.LightningPart, SharedSecrets>>,
             val failures: List<Either<ChannelException, FailureMessage>>
         ) : PaymentAttempt() {
             override val fees: MilliSatoshi = 0.msat
@@ -383,7 +387,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                 val updated = copy(pending = pending - childId, failures = failures + failure)
                 val result = if (updated.isComplete()) {
                     logger.warning { "h:${request.paymentHash} p:${request.paymentId} payment failed: ${updated.reason}" }
-                    db.completeOutgoingPayment(request.paymentId, updated.reason)
+                    db.completeOutgoingPaymentFailed(request.paymentId, updated.reason)
                     Failure(request, OutgoingPaymentFailure(updated.reason, updated.failures))
                 } else {
                     null
@@ -405,8 +409,8 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
         data class PaymentSucceeded(
             override val request: SendPayment,
             val preimage: ByteVector32,
-            val parts: List<OutgoingPayment.Part>,
-            override val pending: Map<UUID, Pair<OutgoingPayment.Part, SharedSecrets>>
+            val parts: List<OutgoingPayment.LightningPart>,
+            override val pending: Map<UUID, Pair<OutgoingPayment.LightningPart, SharedSecrets>>
         ) : PaymentAttempt() {
             override val fees: MilliSatoshi = parts.map { it.amount }.sum() + pending.values.map { it.first.amount }.sum() - request.amount
 
@@ -417,7 +421,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                 val updated = copy(pending = pending - childId)
                 val result = if (updated.isComplete()) {
                     logger.info { "h:${request.paymentHash} p:${request.paymentId} payment successfully sent (fees=${updated.fees})" }
-                    db.completeOutgoingPayment(request.paymentId, preimage)
+                    db.completeOutgoingPaymentOffchain(request.paymentId, preimage)
                     Success(request, OutgoingPayment(request.paymentId, request.amount, request.recipient, request.details, parts, OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage)), preimage)
                 } else {
                     null

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
@@ -94,8 +94,8 @@ class ClosingTestsCommon : LightningTestSuite() {
         assertTrue(bob5 is Closed)
         val storeChannelClosed = bobActions5.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull()
         assertNotNull(storeChannelClosed)
-        assertEquals(storeChannelClosed.closingType, ChannelClosingType.Mutual)
-        assertEquals(storeChannelClosed.txids, listOf(mutualCloseTx.tx.txid))
+        assertTrue(storeChannelClosed.closingTxs.all { it.closingType == ChannelClosingType.Mutual })
+        assertEquals(listOf(mutualCloseTx.tx.txid), storeChannelClosed.closingTxs.map { it.txId })
     }
 
     @Test
@@ -108,8 +108,8 @@ class ClosingTestsCommon : LightningTestSuite() {
         assertTrue(alice1 is Closed)
         val storeChannelClosed = actions1.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull()
         assertNotNull(storeChannelClosed)
-        assertEquals(storeChannelClosed.closingType, ChannelClosingType.Mutual)
-        assertEquals(storeChannelClosed.txids, listOf(mutualCloseTx.tx.txid))
+        assertTrue(storeChannelClosed.closingTxs.all { it.closingType == ChannelClosingType.Mutual })
+        assertEquals(listOf(mutualCloseTx.tx.txid), storeChannelClosed.closingTxs.map { it.txId })
     }
 
     @Test
@@ -198,14 +198,14 @@ class ClosingTestsCommon : LightningTestSuite() {
         )
         val storeChannelClosed = actions.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull()
         assertNotNull(storeChannelClosed)
-        assertTrue { storeChannelClosed.closingType == ChannelClosingType.Local }
-        assertTrue {
-            storeChannelClosed.txids.toSet() ==
-                    listOfNotNull(
-                        localCommitPublished.claimMainDelayedOutputTx,
-                        localCommitPublished.claimHtlcDelayedTxs.firstOrNull()
-                    ).map { it.tx.txid }.toSet()
-        }
+        assertTrue(storeChannelClosed.closingTxs.all { it.closingType == ChannelClosingType.Local })
+        assertEquals(
+            expected = listOfNotNull(
+                localCommitPublished.claimMainDelayedOutputTx,
+                localCommitPublished.claimHtlcDelayedTxs.firstOrNull()
+            ).map { it.tx.txid }.toSet(),
+            actual = storeChannelClosed.closingTxs.map { it.txId }.toSet()
+        )
     }
 
     @Test
@@ -540,14 +540,11 @@ class ClosingTestsCommon : LightningTestSuite() {
         assertTrue(actions.contains(ChannelAction.Storage.StoreState(aliceClosed)))
         val storeChannelClosed = actions.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull()
         assertNotNull(storeChannelClosed)
-        assertTrue { storeChannelClosed.closingType == ChannelClosingType.Remote }
-        assertTrue {
-            storeChannelClosed.txids.toSet() ==
-                    listOfNotNull(
-                        remoteCommitPublished.claimMainOutputTx,
-                        remoteCommitPublished.claimHtlcTimeoutTxs().firstOrNull()
-                    ).map { it.tx.txid }.toSet()
-        }
+        assertTrue(storeChannelClosed.closingTxs.all { it.closingType == ChannelClosingType.Remote })
+        assertEquals(
+            expected = listOfNotNull(remoteCommitPublished.claimMainOutputTx, remoteCommitPublished.claimHtlcTimeoutTxs().firstOrNull()).map { it.tx.txid }.toSet(),
+            actual = storeChannelClosed.closingTxs.map { it.txId }.toSet()
+        )
         // We notify the payment handler that the non-dust htlc has been failed.
         val htlcFail = actions.filterIsInstance<ChannelAction.ProcessCmdRes.AddSettledFail>().first()
         assertEquals(htlcs[0], htlcFail.htlc)
@@ -1119,8 +1116,8 @@ class ClosingTestsCommon : LightningTestSuite() {
         )
         val storeChannelClosed = aliceActions5.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull()
         assertNotNull(storeChannelClosed)
-        assertTrue { storeChannelClosed.closingType == ChannelClosingType.Remote }
-        assertTrue { storeChannelClosed.txids.toSet() == aliceTxs.map { it.txid }.toSet() }
+        assertTrue(storeChannelClosed.closingTxs.all { it.closingType == ChannelClosingType.Remote })
+        assertEquals(aliceTxs.map { it.txid }.toSet(), storeChannelClosed.closingTxs.map { it.txId }.toSet())
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
@@ -376,8 +376,8 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         initialPayment.parts.forEach { assertEquals(partsFailed, db.getOutgoingPaymentFromPartId(it.id)) }
 
         val paymentFailed = partsFailed.copy(status = OutgoingPayment.Status.Completed.Failed(FinalFailure.NoRouteToRecipient, 120))
-        db.completeOutgoingPaymentFailed(initialPayment.id, FinalFailure.NoRouteToRecipient, 120)
-        assertFails { db.completeOutgoingPaymentFailed(UUID.randomUUID(), FinalFailure.NoRouteToRecipient, 120) }
+        db.completeOutgoingPaymentOffchain(initialPayment.id, FinalFailure.NoRouteToRecipient, 120)
+        assertFails { db.completeOutgoingPaymentOffchain(UUID.randomUUID(), FinalFailure.NoRouteToRecipient, 120) }
         assertEquals(paymentFailed, db.getOutgoingPayment(initialPayment.id))
         initialPayment.parts.forEach { assertEquals(paymentFailed, db.getOutgoingPaymentFromPartId(it.id)) }
     }
@@ -419,10 +419,10 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
 
         db.completeOutgoingPaymentOffchain(pending1.id, randomBytes32(), completedAt = 100)
         val payment1 = db.getOutgoingPayment(pending1.id)!!
-        db.completeOutgoingPaymentFailed(pending2.id, FinalFailure.NoRouteToRecipient, completedAt = 101)
+        db.completeOutgoingPaymentOffchain(pending2.id, FinalFailure.NoRouteToRecipient, completedAt = 101)
         val payment2 = db.getOutgoingPayment(pending2.id)!!
         // payment3 is still pending
-        db.completeOutgoingPaymentFailed(pending4.id, FinalFailure.InsufficientBalance, completedAt = 102)
+        db.completeOutgoingPaymentOffchain(pending4.id, FinalFailure.InsufficientBalance, completedAt = 102)
         val payment4 = db.getOutgoingPayment(pending4.id)!!
         db.completeOutgoingPaymentOffchain(pending5.id, randomBytes32(), completedAt = 103)
         val payment5 = db.getOutgoingPayment(pending5.id)!!
@@ -465,7 +465,7 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         val inFinal1 = incoming1.copy(received = IncomingPayment.Received(setOf(IncomingPayment.ReceivedWith.LightningPayment(amount = 20_000.msat, channelId = channelId1, 1)), 100))
         db.completeOutgoingPaymentOffchain(outgoing1.id, randomBytes32(), completedAt = 102)
         val outFinal1 = db.getOutgoingPayment(outgoing1.id)!!
-        db.completeOutgoingPaymentFailed(outgoing2.id, FinalFailure.UnknownError, completedAt = 103)
+        db.completeOutgoingPaymentOffchain(outgoing2.id, FinalFailure.UnknownError, completedAt = 103)
         val outFinal2 = db.getOutgoingPayment(outgoing2.id)!!
         db.receivePayment(incoming2.paymentHash, setOf(IncomingPayment.ReceivedWith.NewChannel(amount = 25_000.msat, 2_500.msat, channelId = null)), receivedAt = 105)
         val inFinal2 = incoming2.copy(received = IncomingPayment.Received(setOf(IncomingPayment.ReceivedWith.NewChannel(amount = 25_000.msat, 2_500.msat, channelId = null)), 105))

--- a/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
@@ -332,8 +332,7 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
             closingType = ChannelClosingType.Mutual,
             createdAt = currentTimestampMillis()
         )
-        db.addOutgoingClosingTxParts(parentId = paymentId, parts = listOf(closingTx))
-        db.completeOutgoingPaymentOnchain(id = paymentId, completedAt = currentTimestampMillis())
+        db.completeOutgoingPaymentForClosing(id = paymentId, parts = listOf(closingTx), completedAt = currentTimestampMillis())
 
         val completedPayment = db.getOutgoingPayment(paymentId)
         assertNotNull(completedPayment)

--- a/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
@@ -218,21 +218,22 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
     fun `send outgoing payment`() = runSuspendTest {
         val (db, _, pr) = createFixture()
         val (a, b, c) = listOf(randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey())
+        val initialParts = listOf(
+            OutgoingPayment.LightningPart(UUID.randomUUID(), 20_000.msat, listOf(HopDesc(a, c, ShortChannelId(42))), OutgoingPayment.LightningPart.Status.Pending, 100),
+            OutgoingPayment.LightningPart(UUID.randomUUID(), 30_000.msat, listOf(HopDesc(a, b), HopDesc(b, c)), OutgoingPayment.LightningPart.Status.Pending, 105)
+        )
         val initialPayment = OutgoingPayment(
-            UUID.randomUUID(),
-            50_000.msat,
-            pr.nodeId,
-            OutgoingPayment.Details.Normal(pr),
-            listOf(
-                OutgoingPayment.Part(UUID.randomUUID(), 20_000.msat, listOf(HopDesc(a, c, ShortChannelId(42))), OutgoingPayment.Part.Status.Pending, 100),
-                OutgoingPayment.Part(UUID.randomUUID(), 30_000.msat, listOf(HopDesc(a, b), HopDesc(b, c)), OutgoingPayment.Part.Status.Pending, 105)
-            ),
-            OutgoingPayment.Status.Pending
+            id = UUID.randomUUID(),
+            recipientAmount = 50_000.msat,
+            recipient = pr.nodeId,
+            details = OutgoingPayment.Details.Normal(pr),
+            parts = initialParts,
+            status = OutgoingPayment.Status.Pending
         )
         db.addOutgoingPayment(initialPayment)
         // We should never re-use ids.
         assertFails { db.addOutgoingPayment(initialPayment.copy(recipientAmount = 60_000.msat)) }
-        assertFails { db.addOutgoingPayment(initialPayment.copy(id = UUID.randomUUID(), parts = initialPayment.parts.map { it.copy(id = initialPayment.parts[0].id) })) }
+        assertFails { db.addOutgoingPayment(initialPayment.copy(id = UUID.randomUUID(), parts = initialParts.map { it.copy(id = initialPayment.parts[0].id) })) }
 
         assertEquals(initialPayment, db.getOutgoingPayment(initialPayment.id))
         assertNull(db.getOutgoingPayment(UUID.randomUUID()))
@@ -242,27 +243,27 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         // One of the parts fails.
         val onePartFailed = initialPayment.copy(
             parts = listOf(
-                initialPayment.parts[0].copy(status = OutgoingPayment.Part.Status.Failed(TemporaryNodeFailure.code, TemporaryNodeFailure.message, 110)),
-                initialPayment.parts[1]
+                initialParts[0].copy(status = OutgoingPayment.LightningPart.Status.Failed(TemporaryNodeFailure.code, TemporaryNodeFailure.message, 110)),
+                initialParts[1]
             )
         )
-        db.updateOutgoingPart(initialPayment.parts[0].id, Either.Right(TemporaryNodeFailure), 110)
+        db.completeOutgoingLightningPart(initialPayment.parts[0].id, Either.Right(TemporaryNodeFailure), 110)
         assertEquals(onePartFailed, db.getOutgoingPayment(initialPayment.id))
         initialPayment.parts.forEach { assertEquals(onePartFailed, db.getOutgoingPart(it.id)) }
 
         // We should never update non-existing parts.
-        assertFails { db.updateOutgoingPart(UUID.randomUUID(), Either.Right(TemporaryNodeFailure)) }
-        assertFails { db.updateOutgoingPart(UUID.randomUUID(), randomBytes32()) }
+        assertFails { db.completeOutgoingLightningPart(UUID.randomUUID(), Either.Right(TemporaryNodeFailure)) }
+        assertFails { db.completeOutgoingLightningPart(UUID.randomUUID(), randomBytes32()) }
 
         // Other payment parts are added.
         val newParts = listOf(
-            OutgoingPayment.Part(UUID.randomUUID(), 5_000.msat, listOf(HopDesc(a, c)), OutgoingPayment.Part.Status.Pending, 115),
-            OutgoingPayment.Part(UUID.randomUUID(), 10_000.msat, listOf(HopDesc(a, b)), OutgoingPayment.Part.Status.Pending, 120),
+            OutgoingPayment.LightningPart(UUID.randomUUID(), 5_000.msat, listOf(HopDesc(a, c)), OutgoingPayment.LightningPart.Status.Pending, 115),
+            OutgoingPayment.LightningPart(UUID.randomUUID(), 10_000.msat, listOf(HopDesc(a, b)), OutgoingPayment.LightningPart.Status.Pending, 120),
         )
-        assertFails { db.addOutgoingParts(UUID.randomUUID(), newParts) }
-        assertFails { db.addOutgoingParts(onePartFailed.id, newParts.map { it.copy(id = initialPayment.parts[0].id) }) }
+        assertFails { db.addOutgoingLightningParts(UUID.randomUUID(), newParts) }
+        assertFails { db.addOutgoingLightningParts(onePartFailed.id, newParts.map { it.copy(id = initialPayment.parts[0].id) }) }
         val withMoreParts = onePartFailed.copy(parts = onePartFailed.parts + newParts)
-        db.addOutgoingParts(onePartFailed.id, newParts)
+        db.addOutgoingLightningParts(onePartFailed.id, newParts)
         assertEquals(withMoreParts, db.getOutgoingPayment(initialPayment.id))
         withMoreParts.parts.forEach { assertEquals(withMoreParts, db.getOutgoingPart(it.id)) }
 
@@ -271,15 +272,15 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         val partsSettled = withMoreParts.copy(
             parts = listOf(
                 withMoreParts.parts[0], // this one was failed
-                withMoreParts.parts[1].copy(status = OutgoingPayment.Part.Status.Succeeded(preimage, 125)),
-                withMoreParts.parts[2].copy(status = OutgoingPayment.Part.Status.Succeeded(preimage, 126)),
-                withMoreParts.parts[3].copy(status = OutgoingPayment.Part.Status.Succeeded(preimage, 127)),
+                (withMoreParts.parts[1] as OutgoingPayment.LightningPart).copy(status = OutgoingPayment.LightningPart.Status.Succeeded(preimage, 125)),
+                (withMoreParts.parts[2] as OutgoingPayment.LightningPart).copy(status = OutgoingPayment.LightningPart.Status.Succeeded(preimage, 126)),
+                (withMoreParts.parts[3] as OutgoingPayment.LightningPart).copy(status = OutgoingPayment.LightningPart.Status.Succeeded(preimage, 127)),
             )
         )
         assertEquals(OutgoingPayment.Status.Pending, partsSettled.status)
-        db.updateOutgoingPart(withMoreParts.parts[1].id, preimage, 125)
-        db.updateOutgoingPart(withMoreParts.parts[2].id, preimage, 126)
-        db.updateOutgoingPart(withMoreParts.parts[3].id, preimage, 127)
+        db.completeOutgoingLightningPart(withMoreParts.parts[1].id, preimage, 125)
+        db.completeOutgoingLightningPart(withMoreParts.parts[2].id, preimage, 126)
+        db.completeOutgoingLightningPart(withMoreParts.parts[3].id, preimage, 127)
         assertEquals(partsSettled, db.getOutgoingPayment(initialPayment.id))
         partsSettled.parts.forEach { assertEquals(partsSettled, db.getOutgoingPart(it.id)) }
 
@@ -288,8 +289,8 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
             status = OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage, 130),
             parts = partsSettled.parts.drop(1)
         )
-        db.completeOutgoingPayment(initialPayment.id, preimage, 130)
-        assertFails { db.completeOutgoingPayment(UUID.randomUUID(), preimage, 130) }
+        db.completeOutgoingPaymentOffchain(initialPayment.id, preimage, 130)
+        assertFails { db.completeOutgoingPaymentOffchain(UUID.randomUUID(), preimage, 130) }
         assertEquals(paymentSucceeded, db.getOutgoingPayment(initialPayment.id))
         partsSettled.parts.forEach { assertEquals(paymentSucceeded, db.getOutgoingPart(it.id)) }
     }
@@ -324,17 +325,19 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         assertEquals(pendingPayment.fees, MilliSatoshi(0))
 
         val fundsLost = Satoshi(100)
-        db.completeOutgoingPayment(
-            id = paymentId,
-            completed = OutgoingPayment.Status.Completed.Succeeded.OnChain(
-                txids = listOf(),
-                claimed = channelBalance.truncateToSatoshi() - fundsLost,
-                closingType = ChannelClosingType.Mutual
-            )
+        val closingTx = OutgoingPayment.ClosingTxPart(
+            id = UUID.randomUUID(),
+            txId = randomBytes32(),
+            claimed = channelBalance.truncateToSatoshi() - fundsLost,
+            closingType = ChannelClosingType.Mutual,
+            createdAt = currentTimestampMillis()
         )
+        db.addOutgoingClosingTxParts(parentId = paymentId, parts = listOf(closingTx))
+        db.completeOutgoingPaymentOnchain(id = paymentId, completedAt = currentTimestampMillis())
 
         val completedPayment = db.getOutgoingPayment(paymentId)
         assertNotNull(completedPayment)
+        assertEquals(listOf(closingTx), completedPayment.parts)
 
         // Now that the payment has been settled on-chain, the fees can be calculated.
         // If we failed to claim any amount of the channel balance,
@@ -346,16 +349,17 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
     @Test
     fun `fail outgoing payment`() = runSuspendTest {
         val (db, _, pr) = createFixture()
+        val initialParts = listOf(
+            OutgoingPayment.LightningPart(UUID.randomUUID(), 20_000.msat, listOf(HopDesc(randomKey().publicKey(), randomKey().publicKey())), OutgoingPayment.LightningPart.Status.Pending, 100),
+            OutgoingPayment.LightningPart(UUID.randomUUID(), 30_000.msat, listOf(HopDesc(randomKey().publicKey(), randomKey().publicKey())), OutgoingPayment.LightningPart.Status.Pending, 105)
+        )
         val initialPayment = OutgoingPayment(
-            UUID.randomUUID(),
-            50_000.msat,
-            pr.nodeId,
-            OutgoingPayment.Details.Normal(pr),
-            listOf(
-                OutgoingPayment.Part(UUID.randomUUID(), 20_000.msat, listOf(HopDesc(randomKey().publicKey(), randomKey().publicKey())), OutgoingPayment.Part.Status.Pending, 100),
-                OutgoingPayment.Part(UUID.randomUUID(), 30_000.msat, listOf(HopDesc(randomKey().publicKey(), randomKey().publicKey())), OutgoingPayment.Part.Status.Pending, 105)
-            ),
-            OutgoingPayment.Status.Pending
+            id = UUID.randomUUID(),
+            recipientAmount = 50_000.msat,
+            recipient = pr.nodeId,
+            details = OutgoingPayment.Details.Normal(pr),
+            parts = initialParts,
+            status = OutgoingPayment.Status.Pending
         )
         db.addOutgoingPayment(initialPayment)
         assertEquals(initialPayment, db.getOutgoingPayment(initialPayment.id))
@@ -363,18 +367,18 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         val channelId = randomBytes32()
         val partsFailed = initialPayment.copy(
             parts = listOf(
-                initialPayment.parts[0].copy(status = OutgoingPayment.Part.Status.Failed(TemporaryNodeFailure.code, TemporaryNodeFailure.message, 110)),
-                initialPayment.parts[1].copy(status = OutgoingPayment.Part.Status.Failed(null, TooManyAcceptedHtlcs(channelId, 10).details(), 111)),
+                initialParts[0].copy(status = OutgoingPayment.LightningPart.Status.Failed(TemporaryNodeFailure.code, TemporaryNodeFailure.message, 110)),
+                initialParts[1].copy(status = OutgoingPayment.LightningPart.Status.Failed(null, TooManyAcceptedHtlcs(channelId, 10).details(), 111)),
             )
         )
-        db.updateOutgoingPart(initialPayment.parts[0].id, Either.Right(TemporaryNodeFailure), 110)
-        db.updateOutgoingPart(initialPayment.parts[1].id, Either.Left(TooManyAcceptedHtlcs(channelId, 10)), 111)
+        db.completeOutgoingLightningPart(initialPayment.parts[0].id, Either.Right(TemporaryNodeFailure), 110)
+        db.completeOutgoingLightningPart(initialPayment.parts[1].id, Either.Left(TooManyAcceptedHtlcs(channelId, 10)), 111)
         assertEquals(partsFailed, db.getOutgoingPayment(initialPayment.id))
         initialPayment.parts.forEach { assertEquals(partsFailed, db.getOutgoingPart(it.id)) }
 
         val paymentFailed = partsFailed.copy(status = OutgoingPayment.Status.Completed.Failed(FinalFailure.NoRouteToRecipient, 120))
-        db.completeOutgoingPayment(initialPayment.id, FinalFailure.NoRouteToRecipient, 120)
-        assertFails { db.completeOutgoingPayment(UUID.randomUUID(), FinalFailure.NoRouteToRecipient, 120) }
+        db.completeOutgoingPaymentFailed(initialPayment.id, FinalFailure.NoRouteToRecipient, 120)
+        assertFails { db.completeOutgoingPaymentFailed(UUID.randomUUID(), FinalFailure.NoRouteToRecipient, 120) }
         assertEquals(paymentFailed, db.getOutgoingPayment(initialPayment.id))
         initialPayment.parts.forEach { assertEquals(paymentFailed, db.getOutgoingPart(it.id)) }
     }
@@ -390,7 +394,7 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
 
         val payment2 = payment1.copy(
             id = UUID.randomUUID(),
-            parts = listOf(OutgoingPayment.Part(UUID.randomUUID(), 50_000.msat, listOf(), OutgoingPayment.Part.Status.Pending, 100))
+            parts = listOf(OutgoingPayment.LightningPart(UUID.randomUUID(), 50_000.msat, listOf(), OutgoingPayment.LightningPart.Status.Pending, 100))
         )
         db.addOutgoingPayment(payment2)
         assertEquals(setOf(payment1, payment2), db.listOutgoingPayments(pr.paymentHash).toSet())
@@ -414,18 +418,18 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         // Pending payments should not be listed.
         assertTrue(db.listOutgoingPayments(count = 10, skip = 0).isEmpty())
 
-        db.completeOutgoingPayment(pending1.id, randomBytes32(), completedAt = 100)
+        db.completeOutgoingPaymentOffchain(pending1.id, randomBytes32(), completedAt = 100)
         val payment1 = db.getOutgoingPayment(pending1.id)!!
-        db.completeOutgoingPayment(pending2.id, FinalFailure.NoRouteToRecipient, completedAt = 101)
+        db.completeOutgoingPaymentFailed(pending2.id, FinalFailure.NoRouteToRecipient, completedAt = 101)
         val payment2 = db.getOutgoingPayment(pending2.id)!!
         // payment3 is still pending
-        db.completeOutgoingPayment(pending4.id, FinalFailure.InsufficientBalance, completedAt = 102)
+        db.completeOutgoingPaymentFailed(pending4.id, FinalFailure.InsufficientBalance, completedAt = 102)
         val payment4 = db.getOutgoingPayment(pending4.id)!!
-        db.completeOutgoingPayment(pending5.id, randomBytes32(), completedAt = 103)
+        db.completeOutgoingPaymentOffchain(pending5.id, randomBytes32(), completedAt = 103)
         val payment5 = db.getOutgoingPayment(pending5.id)!!
-        db.completeOutgoingPayment(pending6.id, randomBytes32(), completedAt = 104)
+        db.completeOutgoingPaymentOffchain(pending6.id, randomBytes32(), completedAt = 104)
         val payment6 = db.getOutgoingPayment(pending6.id)!!
-        db.completeOutgoingPayment(pending7.id, randomBytes32(), completedAt = 105)
+        db.completeOutgoingPaymentOffchain(pending7.id, randomBytes32(), completedAt = 105)
         val payment7 = db.getOutgoingPayment(pending7.id)!!
 
         assertEquals(listOf(payment7, payment6, payment5, payment4, payment2, payment1), db.listOutgoingPayments(count = 10, skip = 0))
@@ -460,18 +464,18 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         val channelId1 = randomBytes32()
         db.receivePayment(incoming1.paymentHash, setOf(IncomingPayment.ReceivedWith.LightningPayment(amount = 20_000.msat, channelId = channelId1, 1)), receivedAt = 100)
         val inFinal1 = incoming1.copy(received = IncomingPayment.Received(setOf(IncomingPayment.ReceivedWith.LightningPayment(amount = 20_000.msat, channelId = channelId1, 1)), 100))
-        db.completeOutgoingPayment(outgoing1.id, randomBytes32(), completedAt = 102)
+        db.completeOutgoingPaymentOffchain(outgoing1.id, randomBytes32(), completedAt = 102)
         val outFinal1 = db.getOutgoingPayment(outgoing1.id)!!
-        db.completeOutgoingPayment(outgoing2.id, FinalFailure.UnknownError, completedAt = 103)
+        db.completeOutgoingPaymentFailed(outgoing2.id, FinalFailure.UnknownError, completedAt = 103)
         val outFinal2 = db.getOutgoingPayment(outgoing2.id)!!
         db.receivePayment(incoming2.paymentHash, setOf(IncomingPayment.ReceivedWith.NewChannel(amount = 25_000.msat, 2_500.msat, channelId = null)), receivedAt = 105)
         val inFinal2 = incoming2.copy(received = IncomingPayment.Received(setOf(IncomingPayment.ReceivedWith.NewChannel(amount = 25_000.msat, 2_500.msat, channelId = null)), 105))
-        db.completeOutgoingPayment(outgoing3.id, randomBytes32(), completedAt = 106)
+        db.completeOutgoingPaymentOffchain(outgoing3.id, randomBytes32(), completedAt = 106)
         val outFinal3 = db.getOutgoingPayment(outgoing3.id)!!
         val channelId4 = randomBytes32()
         db.receivePayment(incoming4.paymentHash, setOf(IncomingPayment.ReceivedWith.LightningPayment(amount = 10_000.msat, channelId = channelId4, 1)), receivedAt = 110)
         val inFinal4 = incoming4.copy(received = IncomingPayment.Received(setOf(IncomingPayment.ReceivedWith.LightningPayment(amount = 10_000.msat, channelId = channelId4, 1)), 110))
-        db.completeOutgoingPayment(outgoing5.id, randomBytes32(), completedAt = 112)
+        db.completeOutgoingPaymentOffchain(outgoing5.id, randomBytes32(), completedAt = 112)
         val outFinal5 = db.getOutgoingPayment(outgoing5.id)!!
         // outgoing4 and incoming3 are still pending.
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
@@ -119,7 +119,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertNotNull(dbPayment)
             assertEquals(OutgoingPayment.Status.Pending, dbPayment.status)
             assertEquals(1, dbPayment.parts.size)
-            assertTrue(dbPayment.parts.all { it.status is OutgoingPayment.Part.Status.Pending })
+            assertTrue(dbPayment.parts.all { (it as OutgoingPayment.LightningPart).status is OutgoingPayment.LightningPart.Status.Pending })
         }
         run {
             // Send payment 2 of 2: this should exceed the configured maxAcceptedHtlcs.
@@ -173,7 +173,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertNotNull(dbPayment)
             assertEquals(OutgoingPayment.Status.Pending, dbPayment.status)
             assertEquals(1, dbPayment.parts.size)
-            assertTrue(dbPayment.parts.all { it.status is OutgoingPayment.Part.Status.Pending })
+            assertTrue(dbPayment.parts.all { (it as OutgoingPayment.LightningPart).status is OutgoingPayment.LightningPart.Status.Pending })
         }
         run {
             // Send payment 2 of 2: this should exceed the configured maxHtlcValueInFlightMsat.
@@ -276,10 +276,10 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(OutgoingPayment.Details.Normal(invoice), success.payment.details)
         assertEquals(preimage, (success.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(1, success.payment.parts.size)
-        val part = success.payment.parts.first()
+        val part = success.payment.parts.first() as OutgoingPayment.LightningPart
         assertNotEquals(part.id, payment.paymentId)
         assertEquals(205_000.msat, part.amount)
-        assertEquals(preimage, (part.status as OutgoingPayment.Part.Status.Succeeded).preimage)
+        assertEquals(preimage, (part.status as OutgoingPayment.LightningPart.Status.Succeeded).preimage)
 
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
         assertDbPaymentSucceeded(outgoingPaymentHandler.db, payment.paymentId, amount = 200_000.msat, fees = 5_000.msat, partsCount = 1)
@@ -338,8 +338,8 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
         assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
-        assertEquals(310_000.msat, success2.payment.parts.map { it.amount }.sum())
-        assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
+        assertEquals(310_000.msat, success2.payment.parts.map { (it as OutgoingPayment.LightningPart).amount }.sum())
+        assertEquals(setOf(preimage), success2.payment.parts.map { ((it as OutgoingPayment.LightningPart).status as OutgoingPayment.LightningPart.Status.Succeeded).preimage }.toSet())
 
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
         assertDbPaymentSucceeded(outgoingPaymentHandler.db, payment.paymentId, amount = 300_000.msat, fees = 10_000.msat, partsCount = 2)
@@ -390,8 +390,8 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
         assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
-        assertEquals(310_000.msat, success2.payment.parts.map { it.amount }.sum())
-        assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
+        assertEquals(310_000.msat, success2.payment.parts.map { (it as OutgoingPayment.LightningPart).amount }.sum())
+        assertEquals(setOf(preimage), success2.payment.parts.map { ((it as OutgoingPayment.LightningPart).status as OutgoingPayment.LightningPart.Status.Succeeded).preimage }.toSet())
 
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
         assertDbPaymentSucceeded(outgoingPaymentHandler.db, payment.paymentId, amount = 300_000.msat, fees = 10_000.msat, partsCount = 2)
@@ -483,8 +483,8 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
         assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
-        assertEquals(300_000.msat, success2.payment.parts.map { it.amount }.sum())
-        assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
+        assertEquals(300_000.msat, success2.payment.parts.map { (it as OutgoingPayment.LightningPart).amount }.sum())
+        assertEquals(setOf(preimage), success2.payment.parts.map { ((it as OutgoingPayment.LightningPart).status as OutgoingPayment.LightningPart.Status.Succeeded).preimage }.toSet())
 
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
         assertDbPaymentSucceeded(outgoingPaymentHandler.db, payment.paymentId, amount = 300_000.msat, fees = 0.msat, partsCount = 2)
@@ -537,8 +537,8 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val dbPayment1 = outgoingPaymentHandler.db.getOutgoingPayment(payment.paymentId)
         assertNotNull(dbPayment1)
         assertTrue(dbPayment1.status is OutgoingPayment.Status.Pending)
-        assertEquals(2, dbPayment1.parts.filter { it.status is OutgoingPayment.Part.Status.Failed }.size)
-        assertEquals(2, dbPayment1.parts.filter { it.status is OutgoingPayment.Part.Status.Pending }.size)
+        assertEquals(2, dbPayment1.parts.filter { (it as OutgoingPayment.LightningPart).status is OutgoingPayment.LightningPart.Status.Failed }.size)
+        assertEquals(2, dbPayment1.parts.filter { (it as OutgoingPayment.LightningPart).status is OutgoingPayment.LightningPart.Status.Pending }.size)
 
         // The second attempt succeeds.
         val preimage = randomBytes32()
@@ -554,15 +554,15 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
         assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
-        assertEquals(301_030.msat, success2.payment.parts.map { it.amount }.sum())
-        assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
+        assertEquals(301_030.msat, success2.payment.parts.map { (it as OutgoingPayment.LightningPart).amount }.sum())
+        assertEquals(setOf(preimage), success2.payment.parts.map { ((it as OutgoingPayment.LightningPart).status as OutgoingPayment.LightningPart.Status.Succeeded).preimage }.toSet())
 
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
         val dbPayment2 = outgoingPaymentHandler.db.getOutgoingPayment(payment.paymentId)
         assertNotNull(dbPayment2)
         assertTrue(dbPayment2.status is OutgoingPayment.Status.Completed.Succeeded.OffChain)
         assertEquals(2, dbPayment2.parts.size)
-        assertTrue(dbPayment2.parts.all { it.status is OutgoingPayment.Part.Status.Succeeded })
+        assertTrue(dbPayment2.parts.all { (it as OutgoingPayment.LightningPart).status is OutgoingPayment.LightningPart.Status.Succeeded })
     }
 
     @Test
@@ -600,8 +600,9 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
         assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
-        assertEquals(300_000.msat, success2.payment.parts.map { it.amount }.sum())
-        assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
+        assertTrue(success2.payment.parts.all { it is OutgoingPayment.LightningPart })
+        assertEquals(300_000.msat, success2.payment.parts.map { (it as OutgoingPayment.LightningPart).amount }.sum())
+        assertEquals(setOf(preimage), success2.payment.parts.map { ((it as OutgoingPayment.LightningPart).status as OutgoingPayment.LightningPart.Status.Succeeded).preimage }.toSet())
 
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
         assertDbPaymentSucceeded(outgoingPaymentHandler.db, payment.paymentId, amount = 300_000.msat, fees = 0.msat, partsCount = 2)
@@ -973,7 +974,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertNotNull(dbPayment)
         assertTrue(dbPayment.status is OutgoingPayment.Status.Completed.Failed)
         assertEquals(partsCount, dbPayment.parts.size)
-        assertTrue(dbPayment.parts.all { it.status is OutgoingPayment.Part.Status.Failed })
+        assertTrue(dbPayment.parts.all { (it as OutgoingPayment.LightningPart).status is OutgoingPayment.LightningPart.Status.Failed })
     }
 
     private suspend fun assertDbPaymentSucceeded(db: OutgoingPaymentsDb, paymentId: UUID, amount: MilliSatoshi, fees: MilliSatoshi, partsCount: Int) {
@@ -983,7 +984,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(fees, dbPayment.fees)
         assertTrue(dbPayment.status is OutgoingPayment.Status.Completed.Succeeded.OffChain)
         assertEquals(partsCount, dbPayment.parts.size)
-        assertTrue(dbPayment.parts.all { it.status is OutgoingPayment.Part.Status.Succeeded })
+        assertTrue(dbPayment.parts.all { (it as OutgoingPayment.LightningPart).status is OutgoingPayment.LightningPart.Status.Succeeded })
     }
 
     private fun assertFailureEquals(f1: OutgoingPaymentHandler.Failure, f2: OutgoingPaymentHandler.Failure) {


### PR DESCRIPTION
When closing a channel, we used to aggregate the ids of the closing transactions and their amount, and store them in the status field for on-chain payments. With this PR, we instead store each of those closing transaction, their amount and their closing type as parts in the outgoing payments database.

- Status for on-chain payments do not contain any field related to closing channels anymore
```kotlin
// status for outgoing payments
sealed class Status {
    ...
    sealed class Succeeded : Completed() {
        data class OffChain...
    
        data class OnChain(
            override val completedAt: Long = currentTimestampMillis()
        ) : Succeeded()
```

- Lightning parts now extend a generic `Part` sealed class:
```kotlin
data class LightningPart(
    override val id: UUID,
    val amount: MilliSatoshi,
    val route: List<HopDesc>,
    val status: Status,
    override val createdAt: Long = currentTimestampMillis()
) : Part() {
```

- A new Part for closing transactions has been added:
```kotlin
data class ClosingTxPart(
    override val id: UUID,
    val txId: ByteVector32,
    val claimed: Satoshi,
    val closingType: ChannelClosingType,
    override val createdAt: Long,
) : Part()
```

Also, some methods have been renamed to make the code a bit more readable:
- `completeOutgoingPayment` => `completeOutgoingPaymentOnchain`, `completeOutgoingPaymentOffchain`.
- `addOutgoingPart` => `completeOutgoingLightningPart`
