### PR TITLE
Add support for migration readiness message

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -61,6 +61,7 @@ data class SwapInPendingEvent(val swapInPending: SwapInPending) : PeerListenerEv
 data class SwapInConfirmedEvent(val swapInConfirmed: SwapInConfirmed) : PeerListenerEvent()
 
 data class PhoenixAndroidLegacyInfoEvent(val info: PhoenixAndroidLegacyInfo) : PeerListenerEvent()
+data class SendPhoenixAndroidLegacyMigrate(val newNodeId: PublicKey) : PeerEvent()
 
 /**
  * The peer we establish a connection to. This object contains the TCP socket, a flow of the channels with that peer, and watches
@@ -765,6 +766,11 @@ class Peer(
                     processActions(key, actions)
                     _channels = _channels + (key to state1)
                 }
+            }
+            event is SendPhoenixAndroidLegacyMigrate -> {
+                val msg = PhoenixAndroidLegacyMigrate(newNodeId = event.newNodeId)
+                logger.info { "n:$remoteNodeId sending migration signal ${msg::class}" }
+                sendToPeer(msg)
             }
         }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -737,8 +737,23 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
     @Test
     fun `encode - decode phoenix-android-legacy-info messages`() {
         val testCases = listOf(
-            Pair(PhoenixAndroidLegacyInfo(hasChannels = true), Hex.decode("88cf01")),
+            Pair(PhoenixAndroidLegacyInfo(hasChannels = true), Hex.decode("88cfff")),
             Pair(PhoenixAndroidLegacyInfo(hasChannels = false), Hex.decode("88cf00")),
+        )
+        testCases.forEach {
+            val decoded = LightningMessage.decode(it.second)
+            assertNotNull(decoded)
+            assertEquals(it.first, decoded)
+            val encoded = LightningMessage.encode(decoded)
+            assertArrayEquals(it.second, encoded)
+        }
+    }
+
+    @Test
+    fun `encode - decode phoenix-android-legacy-migrate messages`() {
+        val newNodeId = "033622d7b0326dd18826bc005b956f40ef25a5a55d69f98eb200a7f07179c1ccd9"
+        val testCases = listOf(
+            Pair(PhoenixAndroidLegacyMigrate(newNodeId = PublicKey.fromHex(newNodeId)), Hex.decode("88d1033622d7b0326dd18826bc005b956f40ef25a5a55d69f98eb200a7f07179c1ccd9")),
         )
         testCases.forEach {
             val decoded = LightningMessage.decode(it.second)


### PR DESCRIPTION
This PR adds support for a new custom Lightning message that signals migration readiness to the peer. It also fixes the `PhoenixAndroidLegacyInfo` reader.