### PR TITLE
Fixed rare purger test failure

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -96,7 +96,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
             timestampSeconds
         )
         logger.info { "h:$paymentHash generated payment request ${pr.write()}" }
-        db.addIncomingPayment(paymentPreimage, IncomingPayment.Origin.Invoice(pr))
+        db.addIncomingPayment(paymentPreimage, IncomingPayment.Origin.Invoice(pr), timestampSeconds)
         return pr
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -96,7 +96,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
             timestampSeconds
         )
         logger.info { "h:$paymentHash generated payment request ${pr.write()}" }
-        db.addIncomingPayment(paymentPreimage, IncomingPayment.Origin.Invoice(pr), timestampSeconds)
+        db.addIncomingPayment(paymentPreimage, IncomingPayment.Origin.Invoice(pr))
         return pr
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -1154,9 +1154,8 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
     fun `purge expired incoming payments`() = runSuspendTest {
         val paymentHandler = IncomingPaymentHandler(TestConstants.Bob.nodeParams, TestConstants.Bob.walletParams, InMemoryPaymentsDb())
 
-        // create incoming payment that has expired and not been paid
-        val expiredInvoice = paymentHandler.createInvoice(randomBytes32(), defaultAmount, "expired", listOf(), expirySeconds = 3600,
-            timestampSeconds = 1)
+        // create unexpired payment
+        val unexpiredInvoice = paymentHandler.createInvoice(randomBytes32(), defaultAmount, "unexpired", listOf(), expirySeconds = 3600)
 
         // create incoming payment that has expired and been paid
         val paidInvoice = paymentHandler.createInvoice(defaultPreimage, defaultAmount, "paid", listOf(), expirySeconds = 3600,
@@ -1164,8 +1163,9 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         paymentHandler.db.receivePayment(paidInvoice.paymentHash, receivedWith = setOf(IncomingPayment.ReceivedWith.NewChannel(amount = 15_000_000.msat, fees = 1_000_000.msat, null)),
             receivedAt = 101) // simulate incoming payment being paid before it expired
 
-        // create unexpired payment
-        val unexpiredInvoice = paymentHandler.createInvoice(randomBytes32(), defaultAmount, "unexpired", listOf(), expirySeconds = 3600)
+        // create incoming payment that has expired and not been paid
+        val expiredInvoice = paymentHandler.createInvoice(randomBytes32(), defaultAmount, "expired", listOf(), expirySeconds = 3600,
+            timestampSeconds = 1)
 
         val unexpiredPayment = paymentHandler.db.getIncomingPayment(unexpiredInvoice.paymentHash)!!
         val paidPayment = paymentHandler.db.getIncomingPayment(paidInvoice.paymentHash)!!


### PR DESCRIPTION
This was hard to reproduce until I reordered the `createInvoice` calls to be in the reverse of their timestamp order:

1. **unexpiredInvoice** with the default `timestampSeconds=currentTimestampSeconds`
2. **paidInvoice** with `timestampSeconds=100`
3. **expiredInvoice** with `timestampSeconds=1`) . 

This reordering caused an error because `listIncomingPayments` returns payments based on their time stamp, ordered as newest first. Before the fix to `createInvoice`, payments were listed in the order: expiredInvoice, paidInvoice, unexpiredInvoice instead of using the `timestampSeconds` parameter of `createInvoice` to produce the order: unexpiredInvoice, paidInvoice, expiredInvoice.

Now `createInvoice` properly passes the `timestampSeconds` parameter to the `addIncomingPayment` call instead of using the default `currentTimestampSeconds` every time.

I don't think this would have caused any problems in normal operation, but should now fix this test from failing on fast systems were all three invoices were marked as created with the same timestamp.