### PR TITLE
Release v1.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "fr.acinq.lightning"
-    version = "1.3.0-SNAPSHOT"
+    version = "1.3.0"
 
     repositories {
         mavenLocal()


### PR DESCRIPTION
**List of commits since the last release:**
https://github.com/ACINQ/lightning-kmp/compare/v1.2.1...release-v1.3.0

This version can be used as-is by the current Phoenix master. Next release of lightning-kmp should contain breaking changes (closing transactions as parts).