### PR TITLE
Add support for swap-out payments

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -250,8 +250,10 @@ data class OutgoingPayment(
             override val paymentHash: ByteVector32 = Crypto.sha256(preimage).toByteVector32()
         }
 
-        /** Swaps out send a lightning payment to a swap server, which will send an on-chain transaction to a given address. */
-        data class SwapOut(val address: String, override val paymentHash: ByteVector32) : Details()
+        /** Swap-outs send a lightning payment to a swap server, which will send an on-chain transaction to a given address. */
+        data class SwapOut(val address: String, val paymentRequest: PaymentRequest) : Details() {
+            override val paymentHash: ByteVector32 = paymentRequest.paymentHash
+        }
 
         /** Corresponds to the on-chain payments made when closing a channel. */
         data class ChannelClosing(

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -42,8 +42,24 @@ sealed class PaymentEvent : PeerEvent()
 data class ReceivePayment(val paymentPreimage: ByteVector32, val amount: MilliSatoshi?, val description: String, val expirySeconds: Long? = null, val result: CompletableDeferred<PaymentRequest>) : PaymentEvent()
 object CheckPaymentsTimeout : PaymentEvent()
 data class PayToOpenResponseEvent(val payToOpenResponse: PayToOpenResponse) : PeerEvent()
-data class SendPayment(val paymentId: UUID, val amount: MilliSatoshi, val recipient: PublicKey, val details: OutgoingPayment.Details.Normal, val trampolineFeesOverride: List<TrampolineFees>? = null) : PaymentEvent() {
-    val paymentHash: ByteVector32 = details.paymentHash
+
+interface SendPayment {
+    val paymentId: UUID
+    val amount: MilliSatoshi
+    val recipient: PublicKey
+    val details: OutgoingPayment.Details
+    val trampolineFeesOverride: List<TrampolineFees>?
+    val paymentRequest: PaymentRequest
+
+    val paymentHash: ByteVector32
+        get() = details.paymentHash
+
+}
+data class SendPaymentNormal(override val paymentId: UUID, override val amount: MilliSatoshi, override val recipient: PublicKey, override val details: OutgoingPayment.Details.Normal, override val trampolineFeesOverride: List<TrampolineFees>? = null) : PaymentEvent(), SendPayment {
+    override val paymentRequest = details.paymentRequest
+}
+data class SendPaymentSwapOut(override val paymentId: UUID, override val amount: MilliSatoshi, override val recipient: PublicKey, override val details: OutgoingPayment.Details.SwapOut, override val trampolineFeesOverride: List<TrampolineFees>? = null) : PaymentEvent(), SendPayment {
+    override val paymentRequest = details.paymentRequest
 }
 data class PurgeExpiredPayments(val fromCreatedAt: Long, val toCreatedAt: Long) : PaymentEvent()
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -156,7 +156,6 @@ interface HasEncryptedChannelData : LightningMessage {
 
 interface ChannelMessage
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class Init(@Contextual val features: ByteVector, val tlvs: TlvStream<InitTlv> = TlvStream.empty()) : SetupMessage {
     @Transient
@@ -226,7 +225,6 @@ data class Warning(override val channelId: ByteVector32, val data: ByteVector) :
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 data class Error(override val channelId: ByteVector32, val data: ByteVector) : SetupMessage, HasChannelId {
     constructor(channelId: ByteVector32, message: String?) : this(channelId, ByteVector(message?.encodeToByteArray() ?: ByteArray(0)))
 
@@ -252,7 +250,6 @@ data class Error(override val channelId: ByteVector32, val data: ByteVector) : S
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 data class Ping(val pongLength: Int, val data: ByteVector) : SetupMessage {
     override val type: Long get() = Ping.type
 
@@ -271,7 +268,6 @@ data class Ping(val pongLength: Int, val data: ByteVector) : SetupMessage {
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 data class Pong(val data: ByteVector) : SetupMessage {
     override val type: Long get() = Pong.type
 
@@ -289,7 +285,6 @@ data class Pong(val data: ByteVector) : SetupMessage {
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class OpenChannel(
     @Contextual override val chainHash: ByteVector32,
@@ -381,7 +376,6 @@ data class OpenChannel(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class AcceptChannel(
     @Contextual override val temporaryChannelId: ByteVector32,
@@ -459,7 +453,6 @@ data class AcceptChannel(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class FundingCreated(
     @Contextual override val temporaryChannelId: ByteVector32,
@@ -490,7 +483,6 @@ data class FundingCreated(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class FundingSigned(
     @Contextual override val channelId: ByteVector32,
@@ -524,7 +516,6 @@ data class FundingSigned(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class FundingLocked(
     @Contextual override val channelId: ByteVector32,
@@ -549,7 +540,6 @@ data class FundingLocked(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class UpdateAddHtlc(
     @Contextual override val channelId: ByteVector32,
@@ -585,7 +575,6 @@ data class UpdateAddHtlc(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class UpdateFulfillHtlc(
     @Contextual override val channelId: ByteVector32,
@@ -613,7 +602,6 @@ data class UpdateFulfillHtlc(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class UpdateFailHtlc(
     @Contextual override val channelId: ByteVector32,
@@ -642,7 +630,6 @@ data class UpdateFailHtlc(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class UpdateFailMalformedHtlc(
     @Contextual override val channelId: ByteVector32,
@@ -673,7 +660,6 @@ data class UpdateFailMalformedHtlc(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class CommitSig(
     @Contextual override val channelId: ByteVector32,
@@ -713,7 +699,6 @@ data class CommitSig(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 data class RevokeAndAck(
     override val channelId: ByteVector32,
     val perCommitmentSecret: PrivateKey,
@@ -749,7 +734,6 @@ data class RevokeAndAck(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class UpdateFee(
     @Contextual override val channelId: ByteVector32,
@@ -774,7 +758,6 @@ data class UpdateFee(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class ChannelReestablish(
     @Contextual override val channelId: ByteVector32,
@@ -817,7 +800,6 @@ data class ChannelReestablish(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 data class AnnouncementSignatures(
     override val channelId: ByteVector32,
     val shortChannelId: ShortChannelId,
@@ -847,7 +829,6 @@ data class AnnouncementSignatures(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class ChannelAnnouncement(
     @Contextual val nodeSignature1: ByteVector64,
@@ -916,7 +897,6 @@ data class ChannelAnnouncement(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class ChannelUpdate(
     @Contextual val signature: ByteVector64,
@@ -997,7 +977,6 @@ data class ChannelUpdate(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class Shutdown(
     @Contextual override val channelId: ByteVector32,
@@ -1032,7 +1011,6 @@ data class Shutdown(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 @Serializable
 data class ClosingSigned(
     @Contextual override val channelId: ByteVector32,
@@ -1086,7 +1064,6 @@ data class ClosingSigned(
  * @param expireAt after the proposal expires, our peer will fail the payment and won't open a channel to us.
  * @param finalPacket onion packet that we would have received if there had been a channel to forward the payment to.
  */
-@OptIn(ExperimentalUnsignedTypes::class)
 data class PayToOpenRequest(
     override val chainHash: ByteVector32,
     val fundingSatoshis: Satoshi,
@@ -1129,7 +1106,6 @@ data class PayToOpenRequest(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 data class PayToOpenResponse(override val chainHash: ByteVector32, val paymentHash: ByteVector32, val result: Result) : LightningMessage, HasChainHash {
     override val type: Long get() = PayToOpenResponse.type
 
@@ -1201,7 +1177,6 @@ object UnsetFCMToken : LightningMessage {
     override fun write(out: Output) {}
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 data class SwapInRequest(
     override val chainHash: ByteVector32
 ) : LightningMessage, HasChainHash {
@@ -1220,7 +1195,6 @@ data class SwapInRequest(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 data class SwapInResponse(
     override val chainHash: ByteVector32,
     val bitcoinAddress: String
@@ -1246,7 +1220,6 @@ data class SwapInResponse(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 data class SwapInPending(
     val bitcoinAddress: String,
     val amount: Satoshi
@@ -1272,7 +1245,6 @@ data class SwapInPending(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 data class SwapInConfirmed(
     val bitcoinAddress: String,
     val amount: MilliSatoshi
@@ -1298,7 +1270,6 @@ data class SwapInConfirmed(
     }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 data class PhoenixAndroidLegacyInfo(
     val hasChannels: Boolean
 ) : LightningMessage {

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -78,6 +78,8 @@ interface LightningMessage {
                 SwapInResponse.type -> SwapInResponse.read(stream)
                 SwapInPending.type -> SwapInPending.read(stream)
                 SwapInConfirmed.type -> SwapInConfirmed.read(stream)
+                SwapOutRequest.type -> SwapOutRequest.read(stream)
+                SwapOutResponse.type -> SwapOutResponse.read(stream)
                 PhoenixAndroidLegacyInfo.type -> PhoenixAndroidLegacyInfo.read(stream)
                 PhoenixAndroidLegacyMigrate.type -> PhoenixAndroidLegacyMigrate.read(stream)
                 else -> {
@@ -1265,6 +1267,68 @@ data class SwapInConfirmed(
             return SwapInConfirmed(
                 bitcoinAddress = LightningCodecs.bytes(input, LightningCodecs.u16(input)).decodeToString(),
                 amount = MilliSatoshi(LightningCodecs.u64(input))
+            )
+        }
+    }
+}
+
+data class SwapOutRequest(
+    override val chainHash: ByteVector32,
+    val amount: Satoshi,
+    val bitcoinAddress: String,
+    val feePerKw: Long
+) : LightningMessage, HasChainHash {
+    override val type: Long get() = SwapOutRequest.type
+
+    override fun write(out: Output) {
+        LightningCodecs.writeBytes(chainHash, out)
+        LightningCodecs.writeU64(amount.toLong(), out)
+        val addressBytes = bitcoinAddress.encodeToByteArray()
+        LightningCodecs.writeU16(addressBytes.size, out)
+        LightningCodecs.writeBytes(addressBytes, out)
+        LightningCodecs.writeU32(feePerKw.toInt(), out)
+    }
+
+    companion object : LightningMessageReader<SwapOutRequest> {
+        const val type: Long = 35011
+
+        override fun read(input: Input): SwapOutRequest {
+            return SwapOutRequest(
+                chainHash = LightningCodecs.bytes(input, 32).toByteVector32(),
+                amount = Satoshi(LightningCodecs.u64(input)),
+                bitcoinAddress = LightningCodecs.bytes(input, LightningCodecs.u16(input)).decodeToString(),
+                feePerKw = LightningCodecs.u32(input).toLong(),
+            )
+        }
+    }
+}
+
+data class SwapOutResponse(
+    override val chainHash: ByteVector32,
+    val amount: Satoshi,
+    val fee: Satoshi,
+    val paymentRequest: String
+) : LightningMessage, HasChainHash {
+    override val type: Long get() = SwapOutResponse.type
+
+    override fun write(out: Output) {
+        LightningCodecs.writeBytes(chainHash, out)
+        LightningCodecs.writeU64(amount.toLong(), out)
+        LightningCodecs.writeU64(fee.toLong(), out)
+        val paymentRequestBytes = paymentRequest.encodeToByteArray()
+        LightningCodecs.writeU16(paymentRequestBytes.size, out)
+        LightningCodecs.writeBytes(paymentRequestBytes, out)
+    }
+
+    companion object : LightningMessageReader<SwapOutResponse> {
+        const val type: Long = 35013
+
+        override fun read(input: Input): SwapOutResponse {
+            return SwapOutResponse(
+                chainHash = ByteVector32(LightningCodecs.bytes(input, 32)),
+                amount = Satoshi(LightningCodecs.u64(input)),
+                fee = Satoshi(LightningCodecs.u64(input)),
+                paymentRequest = LightningCodecs.bytes(input, LightningCodecs.u16(input)).decodeToString()
             )
         }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
@@ -434,7 +434,7 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         val pending1 = OutgoingPayment(UUID.randomUUID(), 50_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
         val pending2 = OutgoingPayment(UUID.randomUUID(), 55_000.msat, randomKey().publicKey(), OutgoingPayment.Details.KeySend(randomBytes32()))
         val pending3 = OutgoingPayment(UUID.randomUUID(), 30_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
-        val pending4 = OutgoingPayment(UUID.randomUUID(), 60_000.msat, randomKey().publicKey(), OutgoingPayment.Details.SwapOut("1PwLgmRdDjy5GAKWyp8eyAC4SFzWuboLLb", randomBytes32()))
+        val pending4 = OutgoingPayment(UUID.randomUUID(), 60_000.msat, randomKey().publicKey(), OutgoingPayment.Details.SwapOut("1PwLgmRdDjy5GAKWyp8eyAC4SFzWuboLLb", createInvoice(randomBytes32())))
         val pending5 = OutgoingPayment(UUID.randomUUID(), 55_000.msat, randomKey().publicKey(), OutgoingPayment.Details.KeySend(randomBytes32()))
         val pending6 = OutgoingPayment(UUID.randomUUID(), 45_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
         val pending7 = OutgoingPayment(UUID.randomUUID(), 35_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
@@ -478,7 +478,7 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
 
         val outgoing1 = OutgoingPayment(UUID.randomUUID(), 50_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
         val outgoing2 = OutgoingPayment(UUID.randomUUID(), 55_000.msat, randomKey().publicKey(), OutgoingPayment.Details.KeySend(randomBytes32()))
-        val outgoing3 = OutgoingPayment(UUID.randomUUID(), 60_000.msat, randomKey().publicKey(), OutgoingPayment.Details.SwapOut("1PwLgmRdDjy5GAKWyp8eyAC4SFzWuboLLb", randomBytes32()))
+        val outgoing3 = OutgoingPayment(UUID.randomUUID(), 60_000.msat, randomKey().publicKey(), OutgoingPayment.Details.SwapOut("1PwLgmRdDjy5GAKWyp8eyAC4SFzWuboLLb", createInvoice(randomBytes32())))
         val outgoing4 = OutgoingPayment(UUID.randomUUID(), 45_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
         val outgoing5 = OutgoingPayment(UUID.randomUUID(), 35_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
         listOf(outgoing1, outgoing2, outgoing3, outgoing4, outgoing5).forEach { db.addOutgoingPayment(it) }

--- a/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
@@ -372,6 +372,70 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
     }
 
     @Test
+    fun `outgoing normal payment fee & amount computation`() = runSuspendTest {
+        val (db, preimage, pr) = createFixture()
+        val (a, b, c) = listOf(randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey())
+
+        // test normal payment fee computation
+        val hops1 = listOf(HopDesc(a, c, ShortChannelId(42)), HopDesc(b, c))
+        val hops2 = listOf(HopDesc(a, b))
+        val normalPayment = OutgoingPayment(
+            id = UUID.randomUUID(),
+            recipientAmount = 180_000.msat,
+            recipient = pr.nodeId,
+            details = OutgoingPayment.Details.Normal(pr),
+            parts = listOf(),
+            status = OutgoingPayment.Status.Pending
+        )
+        db.addOutgoingPayment(normalPayment)
+        val normalParts = listOf(
+            OutgoingPayment.LightningPart(UUID.randomUUID(), amount = 115_000.msat, route = hops1, status = OutgoingPayment.LightningPart.Status.Pending, createdAt = 100),
+            OutgoingPayment.LightningPart(UUID.randomUUID(), amount = 75_000.msat, route = hops2, status = OutgoingPayment.LightningPart.Status.Pending, createdAt = 105)
+        )
+        db.addOutgoingLightningParts(parentId = normalPayment.id, parts = normalParts)
+        db.completeOutgoingLightningPart(normalParts[0].id, preimage, 110)
+        db.completeOutgoingLightningPart(normalParts[1].id, preimage, 115)
+        db.completeOutgoingPaymentOffchain(normalPayment.id, preimage, 120)
+        val normalPaymentInDb = db.getOutgoingPayment(normalPayment.id)
+
+        assertNotNull(normalPaymentInDb)
+        assertEquals(10_000.msat, normalPaymentInDb.fees)
+        assertEquals(190_000.msat, normalPaymentInDb.amount)
+    }
+
+    @Test
+    fun `outgoing swap-out payment fee & amount computation`() = runSuspendTest {
+        val (db, preimage, pr) = createFixture()
+        val (a, b, c) = listOf(randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey())
+        val hops = listOf(HopDesc(a, c, ShortChannelId(42)), HopDesc(b, c))
+        // test swap-out payment fee computation
+        val swapOutPayment = OutgoingPayment(
+            id = UUID.randomUUID(),
+            recipientAmount = 150_000.msat,
+            recipient = pr.nodeId,
+            details = OutgoingPayment.Details.SwapOut("2NCnVWgTuCptq1y7Cie4KwSBADcBqXKTNCR", pr, 15.sat),
+            parts = listOf(),
+            status = OutgoingPayment.Status.Pending
+        )
+        db.addOutgoingPayment(swapOutPayment)
+        val swapOutParts = listOf(
+            OutgoingPayment.LightningPart(UUID.randomUUID(), amount = 157_000.msat, route = hops, status = OutgoingPayment.LightningPart.Status.Pending, createdAt = 100),
+        )
+        db.addOutgoingLightningParts(parentId = swapOutPayment.id, parts = swapOutParts)
+        db.completeOutgoingLightningPart(swapOutParts[0].id, preimage, 110)
+        db.completeOutgoingPaymentOffchain(swapOutPayment.id, preimage, 120)
+        val swapOutPaymentInDb = db.getOutgoingPayment(swapOutPayment.id)
+
+        assertNotNull(swapOutPaymentInDb)
+        // the service receives 150 000 msat
+        // the swap amount received by the on-chain address is 135 000 msat
+        // the mining fee are contained in the swap-out service fee
+        // total fees is 7 000 msat for routing with trampoline + 15 000 msat for the swap-out service
+        assertEquals(22_000.msat, swapOutPaymentInDb.fees)
+        assertEquals(157_000.msat, swapOutPaymentInDb.amount)
+    }
+
+    @Test
     fun `fail outgoing payment`() = runSuspendTest {
         val (db, _, pr) = createFixture()
         val initialParts = listOf(
@@ -434,7 +498,7 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         val pending1 = OutgoingPayment(UUID.randomUUID(), 50_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
         val pending2 = OutgoingPayment(UUID.randomUUID(), 55_000.msat, randomKey().publicKey(), OutgoingPayment.Details.KeySend(randomBytes32()))
         val pending3 = OutgoingPayment(UUID.randomUUID(), 30_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
-        val pending4 = OutgoingPayment(UUID.randomUUID(), 60_000.msat, randomKey().publicKey(), OutgoingPayment.Details.SwapOut("1PwLgmRdDjy5GAKWyp8eyAC4SFzWuboLLb", createInvoice(randomBytes32())))
+        val pending4 = OutgoingPayment(UUID.randomUUID(), 60_000.msat, randomKey().publicKey(), OutgoingPayment.Details.SwapOut("1PwLgmRdDjy5GAKWyp8eyAC4SFzWuboLLb", createInvoice(randomBytes32()), 14.sat))
         val pending5 = OutgoingPayment(UUID.randomUUID(), 55_000.msat, randomKey().publicKey(), OutgoingPayment.Details.KeySend(randomBytes32()))
         val pending6 = OutgoingPayment(UUID.randomUUID(), 45_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
         val pending7 = OutgoingPayment(UUID.randomUUID(), 35_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
@@ -478,7 +542,7 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
 
         val outgoing1 = OutgoingPayment(UUID.randomUUID(), 50_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
         val outgoing2 = OutgoingPayment(UUID.randomUUID(), 55_000.msat, randomKey().publicKey(), OutgoingPayment.Details.KeySend(randomBytes32()))
-        val outgoing3 = OutgoingPayment(UUID.randomUUID(), 60_000.msat, randomKey().publicKey(), OutgoingPayment.Details.SwapOut("1PwLgmRdDjy5GAKWyp8eyAC4SFzWuboLLb", createInvoice(randomBytes32())))
+        val outgoing3 = OutgoingPayment(UUID.randomUUID(), 60_000.msat, randomKey().publicKey(), OutgoingPayment.Details.SwapOut("1PwLgmRdDjy5GAKWyp8eyAC4SFzWuboLLb", createInvoice(randomBytes32()), 14.sat))
         val outgoing4 = OutgoingPayment(UUID.randomUUID(), 45_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
         val outgoing5 = OutgoingPayment(UUID.randomUUID(), 35_000.msat, randomKey().publicKey(), OutgoingPayment.Details.Normal(createInvoice(randomBytes32())))
         listOf(outgoing1, outgoing2, outgoing3, outgoing4, outgoing5).forEach { db.addOutgoingPayment(it) }

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -14,6 +14,7 @@ import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.io.BytesReceived
 import fr.acinq.lightning.io.ReceivePayment
 import fr.acinq.lightning.io.SendPayment
+import fr.acinq.lightning.io.SendPaymentNormal
 import fr.acinq.lightning.payment.PaymentRequest
 import fr.acinq.lightning.router.Announcements
 import fr.acinq.lightning.tests.TestConstants
@@ -238,7 +239,7 @@ class PeerTest : LightningTestSuite() {
         bob.send(ReceivePayment(randomBytes32(), 15_000_000.msat, "test invoice", null, deferredInvoice))
         val invoice = deferredInvoice.await()
 
-        alice.send(SendPayment(UUID.randomUUID(), invoice.amount!!, alice.remoteNodeId, OutgoingPayment.Details.Normal(invoice)))
+        alice.send(SendPaymentNormal(UUID.randomUUID(), invoice.amount!!, alice.remoteNodeId, OutgoingPayment.Details.Normal(invoice)))
 
         val updateHtlc = alice2bob.expect<UpdateAddHtlc>()
         val aliceCommitSig = alice2bob.expect<CommitSig>()
@@ -284,7 +285,7 @@ class PeerTest : LightningTestSuite() {
         bob.send(ReceivePayment(randomBytes32(), 15_000_000.msat, "test invoice", null, deferredInvoice))
         val invoice = deferredInvoice.await()
 
-        alice.send(SendPayment(UUID.randomUUID(), invoice.amount!!, alice.remoteNodeId, OutgoingPayment.Details.Normal(invoice)))
+        alice.send(SendPaymentNormal(UUID.randomUUID(), invoice.amount!!, alice.remoteNodeId, OutgoingPayment.Details.Normal(invoice)))
 
         alice.expectState<Normal> { commitments.availableBalanceForReceive() > alice0.commitments.availableBalanceForReceive() }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
@@ -835,7 +835,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val (adds, attempt) = run {
             val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams.nodeId, defaultWalletParams, db)
             val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-            val payment = SendPaymentSwapOut(UUID.randomUUID(), 550_000.msat, invoice.nodeId, OutgoingPayment.Details.SwapOut("1PwLgmRdDjy5GAKWyp8eyAC4SFzWuboLLb", invoice))
+            val payment = SendPaymentSwapOut(UUID.randomUUID(), 550_000.msat, invoice.nodeId, OutgoingPayment.Details.SwapOut("1PwLgmRdDjy5GAKWyp8eyAC4SFzWuboLLb", invoice, 10.sat))
 
             val progress = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
             val attempt = outgoingPaymentHandler.getPendingPayment(payment.paymentId)!!

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -735,6 +735,28 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
     }
 
     @Test
+    fun `encode - decode swap-out messages`() {
+        val testCases = listOf(
+            Pair(
+                SwapOutRequest(chainHash = Block.TestnetGenesisBlock.blockId, amount = 50_000.sat, bitcoinAddress = "mjbGousCmfvwUU5rjjfCqVCPUyJcG4ULTj", feePerKw = 1234),
+                Hex.decode("88c3000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943000000000000c35000226d6a62476f7573436d667677555535726a6a66437156435055794a634734554c546a000004d2")
+            ),
+            Pair(
+                SwapOutResponse(chainHash = Block.TestnetGenesisBlock.blockId, amount = 50_000.sat, fee = 2008.sat, paymentRequest = "lntb10u1p38u3zfpp5asmmcmrn8p67shh0gnlzrn29qe3mdxm3hwa804849px3fvnuevesdq5xysyymr0ddskxcmfdehsxqrrsscqp79qy9qsqsp58zcu2wgulksypzahmfpn9l6z3exrx6arzkn6adfrcq38khphjpjq2jrt699w4jexg0crzl4kr0q8kqpffeqvpchcdcy7tarhnpllpqw85zpxkgg5nwqtckggrvckz5x4mfnd8tecy8cwzwxuak6553j2dxqqr2q2u7"),
+                Hex.decode("88c5000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943000000000000c35000000000000007d801136c6e74623130753170333875337a6670703561736d6d636d726e3870363773686830676e6c7a726e32397165336d64786d3368776138303438343970783366766e756576657364713578797379796d72306464736b78636d66646568737871727273736371703739717939717371737035387a6375327767756c6b7379707a61686d66706e396c367a33657872783661727a6b6e3661646672637133386b6870686a706a71326a727436393977346a6578673063727a6c346b723071386b717066666571767063686364637937746172686e706c6c70717738357a70786b6767356e777174636b67677276636b7a3578346d666e6438746563793863777a777875616b363535336a3264787171723271327537")
+            ),
+        )
+
+        testCases.forEach {
+            val decoded = LightningMessage.decode(it.second)
+            assertNotNull(decoded)
+            assertEquals(it.first, decoded)
+            val encoded = LightningMessage.encode(decoded)
+            assertArrayEquals(it.second, encoded)
+        }
+    }
+
+    @Test
     fun `encode - decode phoenix-android-legacy-info messages`() {
         val testCases = listOf(
             Pair(PhoenixAndroidLegacyInfo(hasChannels = true), Hex.decode("88cfff")),

--- a/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
+++ b/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.io.File
-import java.lang.IllegalArgumentException
 import java.nio.file.Files
 import java.sql.DriverManager
 
@@ -252,7 +251,7 @@ object Node {
                         val request = call.receive<PayInvoiceRequest>()
                         val pr = PaymentRequest.read(request.invoice)
                         val amount = pr.amount ?: request.amount?.let { MilliSatoshi(it) } ?: MilliSatoshi(50000)
-                        peer.send(SendPayment(UUID.randomUUID(), amount, pr.nodeId, OutgoingPayment.Details.Normal(pr)))
+                        peer.send(SendPaymentNormal(UUID.randomUUID(), amount, pr.nodeId, OutgoingPayment.Details.Normal(pr)))
                         call.respond(PayInvoiceResponse("pending"))
                     }
                     post("/invoice/decode") {


### PR DESCRIPTION
This PR adds support for the custom swap-out Lightning messages that let us request a swap-out payment to the peer, and dispatch the response on the peer listener event stream.

### Swap-out details object

We change the `OutgoingPayment.Details.SwapOut` object that now contains a payment request parameter instead of a simple payment hash:

```kotlin
data class SwapOut(val address: String, val paymentRequest: PaymentRequest) : Details() {
    override val paymentHash: ByteVector32 = paymentRequest.paymentHash
}
```

This way, the `OutgoingPaymentHandler` is able to rebuild a `SendPayment` object (with a payment request) in `processPostRestartFailure` and `processPostRestartFulfill` even when the payment is a swap-out. This makes sense because a swap-out is actually a Lightning payment, but with some additional context.

### `SendPayment` event

As mentioned above, the `SendPayment` event object used to only work for `Normal` payments. It can now work for swap-outs :

```kotlin
interface SendPayment {
    val paymentRequest: PaymentRequest
    // other fields...
}

data class SendPaymentNormal(
    override val details: OutgoingPayment.Details.Normal,
    // other fields...
) : PaymentEvent(), SendPayment

data class SendPaymentSwapOut(
    override val details: OutgoingPayment.Details.SwapOut
    // other fields...
) : PaymentEvent(), SendPayment
```
This lets us support swap-outs with minimal changes to the payment handler.
See this commit for details: 90abfb1f27e7c5106eed39912c385ec521976c86