### PR TITLE
Add UUID to `ReceivedWith.NewChannel` to ensure unicity

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "fr.acinq.lightning"
-    version = "1.4.0"
+    version = "1.4.1-SNAPSHOT"
 
     repositories {
         mavenLocal()

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -175,11 +175,12 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
         /**
          * Payment was received via a new channel opened to us.
          *
+         * @param id identifies each parts that contributed to creating a new channel. A single channel may be created by several payment parts.
          * @param amount Our side of the balance of this channel when it's created. This is the amount pushed to us once the creation fees are applied.
          * @param fees Fees paid to open this channel.
          * @param channelId the long id of the channel created to receive this payment. May be null if the channel id is not known.
          */
-        data class NewChannel(override val amount: MilliSatoshi, override val fees: MilliSatoshi, val channelId: ByteVector32?) : ReceivedWith()
+        data class NewChannel(val id: UUID, override val amount: MilliSatoshi, override val fees: MilliSatoshi, val channelId: ByteVector32?) : ReceivedWith()
     }
 
     /** A payment expires if its origin is [Origin.Invoice] and its invoice has expired. [Origin.KeySend] or [Origin.SwapIn] do not expire. */

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -116,7 +116,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
                 db.addAndReceivePayment(
                     preimage = fakePreimage,
                     origin = IncomingPayment.Origin.SwapIn(address = ""),
-                    receivedWith = setOf(IncomingPayment.ReceivedWith.NewChannel(amount = action.amount, fees = 0.msat, channelId = channelId))
+                    receivedWith = setOf(IncomingPayment.ReceivedWith.NewChannel(id = UUID.randomUUID(), amount = action.amount, fees = 0.msat, channelId = channelId))
                 )
             }
             is ChannelOrigin.PayToOpenOrigin -> {
@@ -130,7 +130,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
                 db.addAndReceivePayment(
                     preimage = fakePreimage,
                     origin = IncomingPayment.Origin.SwapIn(address = action.origin.bitcoinAddress),
-                    receivedWith = setOf(IncomingPayment.ReceivedWith.NewChannel(amount = action.amount, fees = action.origin.fee.toMilliSatoshi(), channelId = channelId))
+                    receivedWith = setOf(IncomingPayment.ReceivedWith.NewChannel(id = UUID.randomUUID(), amount = action.amount, fees = action.origin.fee.toMilliSatoshi(), channelId = channelId))
                 )
             }
         }
@@ -277,6 +277,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
                                         )
                                     ) to IncomingPayment.ReceivedWith.NewChannel(
                                         // The part's amount is the full amount, including the fee. The fee must be subtracted.
+                                        id = UUID.randomUUID(),
                                         amount = part.amount - part.payToOpenRequest.payToOpenFeeSatoshis.toMilliSatoshi(),
                                         fees = part.payToOpenRequest.payToOpenFeeSatoshis.toMilliSatoshi(),
                                         // At that point we do not know the channel's id. It will be set later on.


### PR DESCRIPTION
This PR adds a new `id: UUID` field to the `IncomingPayment.ReceivedWith.NewChannel` object. This makes sure that no pay-to-open part that contributed to receive a payment is trimmed as a duplicate.

## The problem

Following https://github.com/ACINQ/phoenix-kmm/issues/100, we store each part of an incoming payment in the database. This list of part is a set, to make sure that we don't store duplicate htlc entries. This works well for `IncomingPayment.ReceivedWith.LightningPayment` because it contains a `(channelId, htlcId)` tuple that identifies a part. 

However for `NewChannel` there's no such options. If an incoming payment is received via several `NewChannel` on the same channel id and with the same amount, then we will only keep one entry (since we use a `Set`) and we will lose information. Consequently, since the payment's `amount` calculation uses the payment's parts, the payment amount is now wrong (the computed value would be less than what we actually received, which is the balance of the newly created channel). It's quite uncommon but it's a very bad UX issue.

## Solutions

The solution proposed is to add a random identifier to each `NewChannel` part when the payment is processed by the `IncomingPaymentHandler`. Backward compatibility is easy to achieve, by rolling a random uuid for legacy payments using old `NewChannel` types.