### PR TITLE
StartTLS

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "fr.acinq.lightning"
-    version = "1.4.1-SNAPSHOT"
+    version = "1.4.2-SNAPSHOT"
 
     repositories {
         mavenLocal()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "fr.acinq.lightning"
-    version = "1.4.1"
+    version = "1.4.1-SNAPSHOT"
 
     repositories {
         mavenLocal()

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
@@ -8,6 +8,7 @@ import fr.acinq.lightning.blockchain.electrum.ElectrumClient.Companion.logger
 import fr.acinq.lightning.blockchain.electrum.ElectrumClient.Companion.version
 import fr.acinq.lightning.io.TcpSocket
 import fr.acinq.lightning.io.linesFlow
+import fr.acinq.lightning.io.send
 import fr.acinq.lightning.utils.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BroadcastChannel

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
@@ -16,10 +16,12 @@ interface TcpSocket {
         class Unknown(message: String?, cause: Throwable? = null) : IOException(message ?: "Unknown", cause)
     }
 
-    suspend fun send(bytes: ByteArray?, flush: Boolean = true)
+    suspend fun send(bytes: ByteArray?, offset: Int, length: Int, flush: Boolean = true)
 
-    suspend fun receiveFully(buffer: ByteArray)
-    suspend fun receiveAvailable(buffer: ByteArray): Int
+    suspend fun receiveFully(buffer: ByteArray, offset: Int, length: Int)
+    suspend fun receiveAvailable(buffer: ByteArray, offset: Int, length: Int): Int
+
+    suspend fun startTls(tls: TLS): TcpSocket
 
     fun close()
 
@@ -54,6 +56,10 @@ interface TcpSocket {
         }
     }
 }
+
+suspend fun TcpSocket.send(bytes: ByteArray, flush: Boolean = true) = send(bytes, 0, bytes.size, flush)
+suspend fun TcpSocket.receiveFully(buffer: ByteArray) = receiveFully(buffer, 0, buffer.size)
+suspend fun TcpSocket.receiveAvailable(buffer: ByteArray) = receiveAvailable(buffer, 0, buffer.size)
 
 internal expect object PlatformSocketBuilder : TcpSocket.Builder
 

--- a/src/iosMain/kotlin/fr/acinq/lightning/utils/FoundationUtils.kt
+++ b/src/iosMain/kotlin/fr/acinq/lightning/utils/FoundationUtils.kt
@@ -20,6 +20,11 @@ fun NSData.toByteArray(): ByteArray {
 }
 
 fun NSData.copyTo(buffer: ByteArray, offset: Int = 0) {
+    if (offset + length.toInt() > buffer.size) {
+        throw IllegalArgumentException(
+            "offset($offset) + length(${length.toInt()}) > buffer.size(${buffer.size})"
+        )
+    }
     buffer.usePinned { pinned ->
         autoreleasepool {
             val src = this.bytes
@@ -28,6 +33,21 @@ fun NSData.copyTo(buffer: ByteArray, offset: Int = 0) {
         }
         true
     }
+}
+
+fun ByteArray.toNSData(offset: Int, length: Int): NSData {
+    if (offset + length > size) {
+        throw IllegalArgumentException(
+            "offset($offset) + length($length) > size($size)"
+        )
+    }
+    if (length == 0) return NSData()
+    val pinned = pin()
+    return NSData.create(
+        bytesNoCopy = pinned.addressOf(offset),
+        length = length.toULong(),
+        deallocator = { _, _ -> pinned.unpin() }
+    )
 }
 
 fun ByteArray.toNSData(): NSData {

--- a/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
+++ b/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
@@ -4,7 +4,6 @@ import fr.acinq.lightning.utils.lightningLogger
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
 import io.ktor.network.tls.*
-import io.ktor.utils.io.*
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
@@ -22,14 +21,13 @@ import javax.net.ssl.X509TrustManager
 
 
 class JvmTcpSocket(val socket: Socket) : TcpSocket {
-    private val readChannel = socket.openReadChannel()
-    private val writeChannel = socket.openWriteChannel()
+    private val connection = socket.connection()
 
-    override suspend fun send(bytes: ByteArray?, flush: Boolean) =
+    override suspend fun send(bytes: ByteArray?, offset: Int, length: Int, flush: Boolean) =
         withContext(Dispatchers.IO) {
             try {
-                if (bytes != null) writeChannel.writeFully(bytes, 0, bytes.size)
-                if (flush) writeChannel.flush()
+                if (bytes != null) connection.output.writeFully(bytes, offset, length)
+                if (flush) connection.output.flush()
             } catch (ex: java.io.IOException) {
                 throw TcpSocket.IOException.ConnectionClosed(ex)
             } catch (ex: Throwable) {
@@ -54,11 +52,33 @@ class JvmTcpSocket(val socket: Socket) : TcpSocket {
             tryReceive { read() }
         }
 
-    override suspend fun receiveFully(buffer: ByteArray): Unit = receive { readChannel.readFully(buffer) }
+    override suspend fun receiveFully(buffer: ByteArray, offset: Int, length: Int): Unit {
+        receive { connection.input.readFully(buffer, offset, length) }
+    }
 
-    override suspend fun receiveAvailable(buffer: ByteArray): Int {
-        return tryReceive { readChannel.readAvailable(buffer) }
+    override suspend fun receiveAvailable(buffer: ByteArray, offset: Int, length: Int): Int {
+        return tryReceive { connection.input.readAvailable(buffer, offset, length) }
             .takeUnless { it == -1 } ?: throw TcpSocket.IOException.ConnectionClosed()
+    }
+
+    override suspend fun startTls(tls: TcpSocket.TLS): TcpSocket = try {
+        JvmTcpSocket(when (tls) {
+            TcpSocket.TLS.TRUSTED_CERTIFICATES -> connection.tls(Dispatchers.IO)
+            TcpSocket.TLS.UNSAFE_CERTIFICATES -> connection.tls(Dispatchers.IO) {
+                logger.warning { "using unsafe TLS!" }
+                trustManager = unsafeX509TrustManager
+            }
+            is TcpSocket.TLS.PINNED_PUBLIC_KEY -> {
+                connection.tls(Dispatchers.IO, tlsConfigForPinnedCert(tls.pubKey))
+            }
+            else -> socket
+        })
+    } catch (e: Exception) {
+        throw when (e) {
+            is ConnectException -> TcpSocket.IOException.ConnectionRefused()
+            is SocketException -> TcpSocket.IOException.Unknown(e.message)
+            else -> e
+        }
     }
 
     override fun close() {
@@ -67,6 +87,13 @@ class JvmTcpSocket(val socket: Socket) : TcpSocket {
 
     companion object {
         private val logger by lightningLogger<JvmTcpSocket>()
+
+        val unsafeX509TrustManager = object : X509TrustManager {
+            override fun checkClientTrusted(p0: Array<out X509Certificate>?, p1: String?) {}
+            override fun checkServerTrusted(p0: Array<out X509Certificate>?, p1: String?) {}
+            override fun getAcceptedIssuers(): Array<X509Certificate>? = null
+        }
+
         fun buildPublicKey(encodedKey: ByteArray): java.security.PublicKey {
             val spec = X509EncodedKeySpec(encodedKey)
             val algorithms = listOf("RSA", "EC", "DiffieHellman", "DSA", "RSASSA-PSS", "XDH", "X25519", "X448")
@@ -79,6 +106,45 @@ class JvmTcpSocket(val socket: Socket) : TcpSocket {
             }
             throw IllegalArgumentException("unsupported key's algorithm, only $algorithms")
         }
+
+        fun tlsConfigForPinnedCert(pinnedPubkey: String): TLSConfig = TLSConfigBuilder().apply {
+            // build a default X509 trust manager.
+            val factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())!!
+            factory.init(null as KeyStore?)
+            val defaultX509TrustManager = factory.trustManagers!!.filterIsInstance<X509TrustManager>().first()
+
+            // create a new trust manager that always accepts certificates for the pinned public key, or falls back to standard procedure.
+            trustManager = object : X509TrustManager {
+                override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+                    defaultX509TrustManager.checkClientTrusted(chain, authType)
+                }
+
+                override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+                    val serverKey = try {
+                        buildPublicKey(chain?.asList()?.firstOrNull()?.publicKey?.encoded ?: throw RuntimeException("certificate missing"))
+                    } catch (e: Exception) {
+                        logger.error(e) { "failed to read server's pubkey=${pinnedPubkey}" }
+                        throw e
+                    }
+
+                    val pinnedKey = try {
+                        buildPublicKey(Base64.getDecoder().decode(pinnedPubkey))
+                    } catch (e: Exception) {
+                        logger.error(e) { "failed to read pinned pubkey=${pinnedPubkey}" }
+                        throw e
+                    }
+
+                    if (serverKey == pinnedKey) {
+                        logger.info { "successfully checked server's certificate against pinned pubkey" }
+                    } else {
+                        logger.warning { "server's certificate does not match pinned pubkey, fallback to default check" }
+                        throw TcpSocket.IOException.ConnectionClosed(CertificateException("certificate does not match pinned key"))
+                    }
+                }
+
+                override fun getAcceptedIssuers(): Array<X509Certificate> = defaultX509TrustManager.acceptedIssuers
+            }
+        }.build()
     }
 }
 
@@ -92,7 +158,7 @@ internal actual object PlatformSocketBuilder : TcpSocket.Builder {
             throw when (e) {
                 is ConnectException -> TcpSocket.IOException.ConnectionRefused()
                 is SocketException -> TcpSocket.IOException.Unknown(e.message)
-                else -> throw e
+                else -> e
             }
         }) {
             JvmTcpSocket(aSocket(selectorManager).tcp().connect(host, port).let { socket ->
@@ -100,52 +166,11 @@ internal actual object PlatformSocketBuilder : TcpSocket.Builder {
                     TcpSocket.TLS.TRUSTED_CERTIFICATES -> socket.tls(Dispatchers.IO)
                     TcpSocket.TLS.UNSAFE_CERTIFICATES -> socket.tls(Dispatchers.IO) {
                         logger.warning { "using unsafe TLS!" }
-                        trustManager = object : X509TrustManager {
-                            override fun checkClientTrusted(p0: Array<out X509Certificate>?, p1: String?) {}
-                            override fun checkServerTrusted(p0: Array<out X509Certificate>?, p1: String?) {}
-                            override fun getAcceptedIssuers(): Array<X509Certificate>? = null
-                        }
+                        trustManager = JvmTcpSocket.unsafeX509TrustManager
                     }
                     is TcpSocket.TLS.PINNED_PUBLIC_KEY -> {
                         logger.info { "using certificate pinning for connections with $host" }
-                        socket.tls(coroutineContext, TLSConfigBuilder().apply {
-                            // build a default X509 trust manager.
-                            val factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())!!
-                            factory.init(null as KeyStore?)
-                            val defaultX509TrustManager = factory.trustManagers!!.filterIsInstance<X509TrustManager>().first()
-
-                            // create a new trust manager that always accepts certificates for the pinned public key, or falls back to standard procedure.
-                            trustManager = object : X509TrustManager {
-                                override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
-                                    defaultX509TrustManager.checkClientTrusted(chain, authType)
-                                }
-
-                                override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
-                                    val serverKey = try {
-                                        JvmTcpSocket.buildPublicKey(chain?.asList()?.firstOrNull()?.publicKey?.encoded ?: throw RuntimeException("certificate missing"))
-                                    } catch (e: Exception) {
-                                        logger.error(e) { "failed to read server's pubkey=${tls.pubKey}" }
-                                        throw e
-                                    }
-
-                                    val pinnedKey = try {
-                                        JvmTcpSocket.buildPublicKey(Base64.getDecoder().decode(tls.pubKey))
-                                    } catch (e: Exception) {
-                                        logger.error(e) { "failed to read pinned pubkey=${tls.pubKey}" }
-                                        throw e
-                                    }
-
-                                    if (serverKey == pinnedKey) {
-                                        logger.info { "successfully checked server's certificate against pinned pubkey" }
-                                    } else {
-                                        logger.warning { "server's certificate does not match pinned pubkey, fallback to default check" }
-                                        throw TcpSocket.IOException.ConnectionClosed(CertificateException("certificate does not match pinned key"))
-                                    }
-                                }
-
-                                override fun getAcceptedIssuers(): Array<X509Certificate> = defaultX509TrustManager.acceptedIssuers
-                            }
-                        }.build())
+                        socket.tls(coroutineContext, JvmTcpSocket.tlsConfigForPinnedCert(tls.pubKey))
                     }
                     else -> socket
                 }


### PR DESCRIPTION
This is a rebase of PR #190, which is now over 18 months old. So there were many merge issues with it.

Note that many of the changes from #190 were implemented via #196. The remaining changes were strictly related to StartTLS support. So that's what we see in this PR.

@dpad85 I took JvmTcpSocket from your `feature/socket-starttls-merge` branch. But I made a small change to function `receiveAvailable`

```kotlin
// Old:
connection.input.readAvailable(buffer, 0, maxLength)
// New:
connection.input.readAvailable(buffer, offset, length)
```

We forgot to take the `offset` parameter into account. And the compiler complained about the `maxLength` parameter name being different from the `length` parameter name in TcpSocket's interface declaration.

Also, in the original PR we were forced to decrease security during TLS verification for StartTLS. This is no longer necessary as I found a workaround for the problem. (However I'm not sure if this would have affected its use strictly for Tor...)

One other interesting change in this PR, not directly related to StartTLS:

I discovered that Apple's NWConnection doesn't "fail" if a standard TLS handshake fails. Instead of transitioning to a `NWConnection.state.failed` (as one would expect), it instead transitions to `NWConnection.state.waiting(err)` with a TLS error. This was unexpected, and would result in the connection never failing. (Or perhaps only after a 2 minute timeout.)