### PR TITLE
Add a simple on-chain wallet

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
@@ -83,7 +83,7 @@ internal object WaitingForTip : ClientState() {
                     is Either.Right ->
                         when (val response = parseJsonResponse(HeaderSubscription, rpcResponse.value)) {
                             is HeaderSubscriptionResponse -> newState {
-                                state = ClientRunning(height = response.height, tip = response.header)
+                                state = ClientRunning(height = response.blockHeight, tip = response.header)
                                 actions = listOf(BroadcastStatus(Connection.ESTABLISHED), SendResponse(response))
                             }
                             else -> returnState()
@@ -108,7 +108,7 @@ internal data class ClientRunning(
         is ReceivedResponse -> when (val response = event.response) {
             is Either.Left -> when (val electrumResponse = response.value) {
                 is HeaderSubscriptionResponse -> newState {
-                    state = copy(height = electrumResponse.height, tip = electrumResponse.header)
+                    state = copy(height = electrumResponse.blockHeight, tip = electrumResponse.header)
                     actions = listOf(SendResponse(electrumResponse))
                 }
                 is ScriptHashSubscriptionResponse -> returnState(SendResponse(electrumResponse))

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -10,41 +10,48 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlin.native.concurrent.ThreadLocal
 
-data class WalletState(val addresses: Map<String, Pair<List<UnspentItem>, PrivateKey?>>) {
-    val utxos: List<UnspentItem> = addresses.flatMap { it.value.first }
+data class WalletState(val addresses: Map<String, List<UnspentItem>>, val privateKeys: Map<String, PrivateKey>) {
+    val utxos: List<UnspentItem> = addresses.flatMap { it.value }
     val balance: Satoshi = utxos.sumOf { it.value }.sat
 
     fun spendable(): List<UnspentItem> {
         return addresses
-            .filter { it.value.second != null }
-            .flatMap { it.value.first }
+            .filter { privateKeys.containsKey(it.key) }
+            .flatMap { it.value }
     }
+
+    private val outPoint2Address = addresses.entries.flatMap { entry -> entry.value.map { it.outPoint to entry.key } }.toMap()
 
     /** Sign the inputs owned by this wallet (only works for P2WPKH scripts) */
     fun sign(tx: Transaction): Transaction {
         return tx.txIn.foldIndexed(tx) { index, wipTx, txIn ->
-            when (val utxo = spendable().find { it.outPoint == txIn.outPoint }) {
-                is UnspentItem -> {
-                    // we know this utxo and have the private key
-                    val privateKey = addresses.values.find { it.first.contains(utxo) }!!.second!! // TODO improve that
-                    // mind this: the pubkey script used for signing is not the prevout pubscript (which is just a push
-                    // of the pubkey hash), but the actual script that is evaluated by the script engine, in this case a PAY2PKH script
-                    val publicKey = privateKey.publicKey()
-                    val pubKeyScript = Script.pay2pkh(publicKey)
-                    val sig = Transaction.signInput(
-                        tx,
-                        index,
-                        pubKeyScript,
-                        SigHash.SIGHASH_ALL,
-                        utxo.value.sat,
-                        SigVersion.SIGVERSION_WITNESS_V0,
-                        privateKey
-                    )
-                    // update the signature for the corresponding input
-                    val witness = ScriptWitness(listOf(sig.byteVector(), publicKey.value))
-                    wipTx.updateWitness(index, witness)
+            val witness = outPoint2Address[txIn.outPoint]?.let { address ->
+                addresses[address]?.find { it.outPoint == txIn.outPoint }?.let { utxo ->
+                    privateKeys[address]?.let { privateKey ->
+                        // mind this: the pubkey script used for signing is not the prevout pubscript (which is just a push
+                        // of the pubkey hash), but the actual script that is evaluated by the script engine, in this case a PAY2PKH script
+                        val publicKey = privateKey.publicKey()
+                        val pubKeyScript = Script.pay2pkh(publicKey)
+                        val sig = Transaction.signInput(
+                            tx,
+                            index,
+                            pubKeyScript,
+                            SigHash.SIGHASH_ALL,
+                            utxo.value.sat,
+                            SigVersion.SIGVERSION_WITNESS_V0,
+                            privateKey
+                        )
+                        ScriptWitness(listOf(sig.byteVector(), publicKey.value))
+                    }
                 }
-                else -> wipTx // we don't know how to sign this input
+            }
+            when (witness) {
+                is ScriptWitness ->
+                    // update the signature for the corresponding input
+                    wipTx.updateWitness(index, witness)
+                else ->
+                    // we don't know how to sign this input
+                    wipTx
             }
         }
     }
@@ -55,7 +62,6 @@ private sealed interface WalletCommand {
         object ElectrumConnected : WalletCommand
         data class ElectrumNotification(val msg: ElectrumResponse) : WalletCommand
         data class AddAddress(val bitcoinAddress: String, val privateKey: PrivateKey?) : WalletCommand
-        data class AddPubkeyScript(val pubkeyScript: ByteVector, val privateKey: PrivateKey?) : WalletCommand
     }
 }
 
@@ -70,7 +76,7 @@ class ElectrumMiniWallet(
 ) : CoroutineScope by scope {
 
     // state flow with the current balance
-    private val _walletStateFlow = MutableStateFlow(WalletState(emptyMap()))
+    private val _walletStateFlow = MutableStateFlow(WalletState(emptyMap(), emptyMap()))
     val walletStateFlow get() = _walletStateFlow.asStateFlow()
 
     // all currently watched script hashes and their corresponding bitcoin address
@@ -82,12 +88,6 @@ class ElectrumMiniWallet(
     fun addAddress(bitcoinAddress: String, privateKey: PrivateKey? = null) {
         launch {
             mailbox.send(WalletCommand.Companion.AddAddress(bitcoinAddress, privateKey))
-        }
-    }
-
-    fun addPubkeyScript(pubkeyScript: ByteVector, privateKey: PrivateKey? = null) {
-        launch {
-            mailbox.send(WalletCommand.Companion.AddPubkeyScript(pubkeyScript, privateKey))
         }
     }
 
@@ -125,10 +125,7 @@ class ElectrumMiniWallet(
                             }
                             is ScriptHashListUnspentResponse -> {
                                 scriptHashes[msg.scriptHash]?.let { address ->
-                                    val newValue = _walletStateFlow.value.addresses
-                                        .getOrElse(address, defaultValue = { emptyList<UnspentItem>() to null }) // default value
-                                        .let { v -> msg.unspents to v.second } // update the utxos, keep the private key
-                                    val walletState = WalletState(_walletStateFlow.value.addresses + (address to newValue))
+                                    val walletState = _walletStateFlow.value.copy(addresses = _walletStateFlow.value.addresses + (address to msg.unspents))
                                     logger.info { "${msg.unspents.size} utxo(s) for address=$address balance=${walletState.balance}" }
                                     msg.unspents.forEach { logger.debug { "utxo=${it.outPoint.txid}:${it.outPoint.index} amount=${it.value} sat" } }
                                     // publish the updated balance
@@ -141,10 +138,9 @@ class ElectrumMiniWallet(
                     is WalletCommand.Companion.AddAddress -> {
                         logger.info { "adding new address=${it.bitcoinAddress}" }
                         scriptHashes = scriptHashes + subscribe(it.bitcoinAddress)
-                    }
-                    is WalletCommand.Companion.AddPubkeyScript -> {
-                        logger.info { "adding new pubkeyScript=${it.pubkeyScript}" }
-                        scriptHashes = scriptHashes + subscribe(it.pubkeyScript)
+                        it.privateKey?.let { privateKey ->
+                            _walletStateFlow.value = _walletStateFlow.value.copy(privateKeys = _walletStateFlow.value.privateKeys + (it.bitcoinAddress to privateKey))
+                        }
                     }
                 }
             }
@@ -153,11 +149,6 @@ class ElectrumMiniWallet(
 
     private fun subscribe(bitcoinAddress: String): Pair<ByteVector32, String> {
         val pubkeyScript = ByteVector(Script.write(Bitcoin.addressToPublicKeyScript(chainHash, bitcoinAddress)))
-        return subscribe(pubkeyScript)
-    }
-
-    private fun subscribe(pubkeyScript: ByteVector): Pair<ByteVector32, String> {
-        val bitcoinAddress = Bitcoin.addressFromPublicKeyScript(chainHash, pubkeyScript.toByteArray())!!
         val scriptHash = ElectrumClient.computeScriptHash(pubkeyScript)
         logger.info { "subscribing to address=$bitcoinAddress pubkeyScript=$pubkeyScript scriptHash=$scriptHash" }
         client.sendElectrumRequest(ScriptHashSubscription(scriptHash))

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -58,6 +58,12 @@ class ElectrumMiniWallet(
         }
     }
 
+    fun addPubkeyScript(pubkeyScript: ByteVector, privateKey: PrivateKey? = null) {
+        launch {
+            mailbox.send(WalletCommand.Companion.AddPubkeyScript(pubkeyScript, privateKey))
+        }
+    }
+
     init {
         launch {
             // listen to connection events

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -83,9 +83,7 @@ class ElectrumMiniWallet(
                             }
                             is ScriptHashListUnspentResponse -> {
                                 scriptHashes[msg.scriptHash]?.let { bitcoinAddress ->
-                                    println("state1=${_walletStateFlow.value}")
                                     val walletState = WalletState(_walletStateFlow.value.addresses + (bitcoinAddress to msg.unspents))
-                                    println("state2=${walletState}")
                                     logger.info { "${msg.unspents.size} utxo(s) for address=$bitcoinAddress, balance=${walletState.balance}" }
                                     msg.unspents.forEach { logger.debug { "utxo=${it.outPoint.txid}:${it.outPoint.index} amount=${it.value} sat" } }
                                     // publish the updated balance

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -5,72 +5,111 @@ import fr.acinq.lightning.utils.Connection
 import fr.acinq.lightning.utils.lightningLogger
 import fr.acinq.lightning.utils.sat
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlin.native.concurrent.ThreadLocal
 
-data class WalletState(val utxos: List<UnspentItem>) {
-    val balance: Satoshi = utxos.map { it.value }.sum().sat
+data class WalletState(val addresses: Map<String, List<UnspentItem>>) {
+    val utxos: List<UnspentItem> = addresses.flatMap { it.value }
+    val balance: Satoshi = utxos.sumOf { it.value }.sat
 }
+
+private sealed interface WalletCommand {
+    companion object {
+        object ElectrumConnected : WalletCommand
+        data class ElectrumNotification(val msg: ElectrumResponse) : WalletCommand
+        data class AddAddress(val bitcoinAddress: String) : WalletCommand
+    }
+}
+
 
 /**
  * A very simple wallet that only watches one address and publishes its utxos.
  */
 class ElectrumMiniWallet(
-    val bitcoinAddress: String,
     val chainHash: ByteVector32,
     private val client: ElectrumClient,
     private val scope: CoroutineScope
 ) : CoroutineScope by scope {
 
     // state flow with the current balance
-    private val _walletStateFlow = MutableStateFlow<WalletState?>(null)
+    private val _walletStateFlow = MutableStateFlow(WalletState(emptyMap()))
     val walletStateFlow get() = _walletStateFlow.asStateFlow()
 
-    private val pubkeyScript = ByteVector(Script.write(Bitcoin.addressToPublicKeyScript(chainHash, bitcoinAddress)))
-    private val scriptHash = ElectrumClient.computeScriptHash(pubkeyScript)
+    // all currently watched bitcoin addresses and their corresponding script hash
+    private var scriptHashes: Map<ByteVector32, String> = emptyMap()
+
+    // the mailbox of this "actor"
+    private val mailbox: Channel<WalletCommand> = Channel(Channel.BUFFERED)
+
+    fun addAddress(bitcoinAddress: String) {
+        launch {
+            mailbox.send(WalletCommand.Companion.AddAddress(bitcoinAddress))
+        }
+    }
 
     init {
         launch {
             // listen to connection events
-            client.connectionState.collect {
-                when (it) {
-                    is Connection.ESTABLISHING -> {}
-                    is Connection.ESTABLISHED -> {
-                        // electrum is connected, we register to changes to our address
-                        logger.info { "electrum connected, registering to address=$bitcoinAddress scriptHash=$scriptHash" }
-                        client.sendElectrumRequest(ScriptHashSubscription(scriptHash))
-                    }
-                    is Connection.CLOSED -> {}
-                }
-            }
+            client.connectionState
+                .filterIsInstance<Connection.ESTABLISHED>()
+                .collect { mailbox.send(WalletCommand.Companion.ElectrumConnected) }
         }
         launch {
             // listen to subscriptions events
-            // NB: we ignore responses for unknown script_hashes (electrum client doesn't maintain a list of subscribers so we receive all subscriptions)
-            client.notifications.collect {
+            client.notifications
+                .filterIsInstance<ElectrumResponse>()
+                .collect { mailbox.send(WalletCommand.Companion.ElectrumNotification(it)) }
+        }
+
+        launch {
+            mailbox.consumeAsFlow().collect {
                 when (it) {
-                    is ScriptHashSubscriptionResponse -> {
-                        if (it.scriptHash == scriptHash && it.status.isNotEmpty()) {
-                            logger.info { "non-empty status for address=$bitcoinAddress, requesting utxos" }
-                            client.sendElectrumRequest(ScriptHashListUnspent(it.scriptHash))
+                    is WalletCommand.Companion.ElectrumConnected -> {
+                        logger.info { "electrum connected" }
+                        scriptHashes.values.forEach { subscribe(it) }
+                    }
+                    is WalletCommand.Companion.ElectrumNotification -> {
+                        // NB: we ignore responses for unknown script_hashes (electrum client doesn't maintain a list of subscribers so we receive all subscriptions)
+                        when (val msg = it.msg) {
+                            is ScriptHashSubscriptionResponse -> {
+                                scriptHashes[msg.scriptHash]?.let { bitcoinAddress ->
+                                    if (msg.status.isNotEmpty()) {
+                                        logger.info { "non-empty status for address=$bitcoinAddress, requesting utxos" }
+                                        client.sendElectrumRequest(ScriptHashListUnspent(msg.scriptHash))
+                                    }
+                                }
+                            }
+                            is ScriptHashListUnspentResponse -> {
+                                scriptHashes[msg.scriptHash]?.let { bitcoinAddress ->
+                                    println("state1=${_walletStateFlow.value}")
+                                    val walletState = WalletState(_walletStateFlow.value.addresses + (bitcoinAddress to msg.unspents))
+                                    println("state2=${walletState}")
+                                    logger.info { "${msg.unspents.size} utxo(s) for address=$bitcoinAddress, balance=${walletState.balance}" }
+                                    msg.unspents.forEach { logger.debug { "utxo=${it.outPoint.txid}:${it.outPoint.index} amount=${it.value} sat" } }
+                                    // publish the updated balance
+                                    _walletStateFlow.value = walletState
+                                }
+                            }
+                            else -> {} // ignore other electrum msgs
                         }
                     }
-                    is ScriptHashListUnspentResponse -> {
-                        if (it.scriptHash == scriptHash) {
-                            val walletState = WalletState(it.unspents)
-                            logger.info { "${it.unspents.size} utxo(s) for address=$bitcoinAddress, balance=${walletState.balance}" }
-                            it.unspents.forEach { logger.debug { "utxo=${it.outPoint.txid}:${it.outPoint.index} amount=${it.value} sat" } }
-                            // publish the updated balance
-                            _walletStateFlow.value = walletState
-                        }
+                    is WalletCommand.Companion.AddAddress -> {
+                        logger.info { "adding new address=${it.bitcoinAddress}" }
+                        scriptHashes = scriptHashes + subscribe(it.bitcoinAddress)
                     }
-                    else -> {}
                 }
             }
         }
+    }
+
+    private fun subscribe(bitcoinAddress: String): Pair<ByteVector32, String> {
+        val pubkeyScript = ByteVector(Script.write(Bitcoin.addressToPublicKeyScript(chainHash, bitcoinAddress)))
+        val scriptHash = ElectrumClient.computeScriptHash(pubkeyScript)
+        logger.info { "subscribing to address=$bitcoinAddress scriptHash=$scriptHash" }
+        client.sendElectrumRequest(ScriptHashSubscription(scriptHash))
+        return scriptHash to bitcoinAddress
     }
 
     @ThreadLocal

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -85,10 +85,21 @@ class ElectrumMiniWallet(
     // the mailbox of this "actor"
     private val mailbox: Channel<WalletCommand> = Channel(Channel.BUFFERED)
 
-    fun addAddress(bitcoinAddress: String, privateKey: PrivateKey? = null) {
+    internal fun addAddress(bitcoinAddress: String, privateKey: PrivateKey? = null) {
         launch {
             mailbox.send(WalletCommand.Companion.AddAddress(bitcoinAddress, privateKey))
         }
+    }
+
+    fun addPay2wpkhAddress(privateKey: PrivateKey) {
+        launch {
+            val bitcoinAddress = Bitcoin.computeP2WpkhAddress(privateKey.publicKey(), Block.TestnetGenesisBlock.hash)
+            mailbox.send(WalletCommand.Companion.AddAddress(bitcoinAddress, privateKey))
+        }
+    }
+
+    fun addWatchOnlyAddress(bitcoinAddress: String) {
+        addAddress(bitcoinAddress)
     }
 
     init {

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -41,7 +41,7 @@ data class WalletState(val addresses: Map<String, List<UnspentItem>>, val privat
                             SigVersion.SIGVERSION_WITNESS_V0,
                             privateKey
                         )
-                        ScriptWitness(listOf(sig.byteVector(), publicKey.value))
+                        Script.witnessPay2wpkh(publicKey, sig.byteVector())
                     }
                 }
             }

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -1,0 +1,76 @@
+package fr.acinq.lightning.blockchain.electrum
+
+import fr.acinq.bitcoin.Bitcoin
+import fr.acinq.bitcoin.Block
+import fr.acinq.bitcoin.ByteVector
+import fr.acinq.bitcoin.Script
+import fr.acinq.lightning.utils.Connection
+import fr.acinq.lightning.utils.lightningLogger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.launch
+import kotlin.native.concurrent.ThreadLocal
+
+data class Balance(val utxos: List<UnspentItem>)
+
+/**
+ * A very simple wallet that only watches one address and publishes its utxos.
+ */
+class ElectrumMiniWallet(
+    val bitcoinAddress: String,
+    private val client: ElectrumClient,
+    private val scope: CoroutineScope
+) : CoroutineScope by scope {
+
+    // state flow with the current balance
+    private val _balanceFlow = MutableStateFlow<Balance?>(null)
+    val balanceFlow get() = _balanceFlow.asStateFlow()
+
+    init {
+        launch {
+            // listen to connection events
+            client.connectionState.collect {
+                when (it) {
+                    is Connection.ESTABLISHING -> {}
+                    is Connection.ESTABLISHED -> {
+                        // electrum is connected, we register to changes to our address
+                        val pubkeyScript = ByteVector(Script.write(Bitcoin.addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, bitcoinAddress)))
+                        val scriptHash = ElectrumClient.computeScriptHash(pubkeyScript)
+                        logger.info { "electrum connected, registering to address=$bitcoinAddress scriptHash=$scriptHash" }
+                        client.sendElectrumRequest(ScriptHashSubscription(scriptHash))
+                    }
+                    is Connection.CLOSED -> {}
+                }
+            }
+        }
+        launch {
+            // listen to subscriptions events
+            client.notifications.collect {
+                when (it) {
+                    is ScriptHashSubscriptionResponse -> {
+                        if (it.status.isNotEmpty()) {
+                            logger.info { "non-empty status for address=$bitcoinAddress, requesting utxos" }
+                            client.sendElectrumRequest(ScriptHashListUnspent(it.scriptHash))
+                        }
+                    }
+                    is ScriptHashListUnspentResponse -> {
+                        logger.info { "${it.unspents.size} utxo(s) for address=$bitcoinAddress" }
+                        it.unspents.forEach {
+                            logger.info { "utxo=${it.outPoint.txid}:${it.outPoint.index} amount=${it.value} sat" }
+                        }
+                        // publish the updated balance
+                        _balanceFlow.value = Balance(it.unspents)
+                    }
+                }
+            }
+        }
+    }
+
+    @ThreadLocal
+    companion object {
+        val logger by lightningLogger<ElectrumMiniWallet>()
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
 import kotlin.native.concurrent.ThreadLocal
 
@@ -29,6 +28,9 @@ class ElectrumMiniWallet(
     private val _balanceFlow = MutableStateFlow<Balance?>(null)
     val balanceFlow get() = _balanceFlow.asStateFlow()
 
+    private val pubkeyScript = ByteVector(Script.write(Bitcoin.addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, bitcoinAddress)))
+    private val scriptHash = ElectrumClient.computeScriptHash(pubkeyScript)
+
     init {
         launch {
             // listen to connection events
@@ -37,8 +39,6 @@ class ElectrumMiniWallet(
                     is Connection.ESTABLISHING -> {}
                     is Connection.ESTABLISHED -> {
                         // electrum is connected, we register to changes to our address
-                        val pubkeyScript = ByteVector(Script.write(Bitcoin.addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, bitcoinAddress)))
-                        val scriptHash = ElectrumClient.computeScriptHash(pubkeyScript)
                         logger.info { "electrum connected, registering to address=$bitcoinAddress scriptHash=$scriptHash" }
                         client.sendElectrumRequest(ScriptHashSubscription(scriptHash))
                     }
@@ -48,22 +48,26 @@ class ElectrumMiniWallet(
         }
         launch {
             // listen to subscriptions events
+            // NB: we ignore responses for unknown script_hashes (electrum client doesn't maintain a list of subscribers so we receive all subscriptions)
             client.notifications.collect {
                 when (it) {
                     is ScriptHashSubscriptionResponse -> {
-                        if (it.status.isNotEmpty()) {
+                        if (it.scriptHash == scriptHash && it.status.isNotEmpty()) {
                             logger.info { "non-empty status for address=$bitcoinAddress, requesting utxos" }
                             client.sendElectrumRequest(ScriptHashListUnspent(it.scriptHash))
                         }
                     }
                     is ScriptHashListUnspentResponse -> {
-                        logger.info { "${it.unspents.size} utxo(s) for address=$bitcoinAddress" }
-                        it.unspents.forEach {
-                            logger.info { "utxo=${it.outPoint.txid}:${it.outPoint.index} amount=${it.value} sat" }
+                        if (it.scriptHash == scriptHash) {
+                            logger.info { "${it.unspents.size} utxo(s) for address=$bitcoinAddress" }
+                            it.unspents.forEach {
+                                logger.info { "utxo=${it.outPoint.txid}:${it.outPoint.index} amount=${it.value} sat" }
+                            }
+                            // publish the updated balance
+                            _balanceFlow.value = Balance(it.unspents)
                         }
-                        // publish the updated balance
-                        _balanceFlow.value = Balance(it.unspents)
                     }
+                    else -> {}
                 }
             }
         }

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -100,7 +100,7 @@ class ElectrumMiniWallet(
 
     fun addPay2wpkhAddress(privateKey: PrivateKey) {
         launch {
-            val bitcoinAddress = Bitcoin.computeP2WpkhAddress(privateKey.publicKey(), Block.TestnetGenesisBlock.hash)
+            val bitcoinAddress = Bitcoin.computeP2WpkhAddress(privateKey.publicKey(), chainHash)
             mailbox.send(WalletCommand.Companion.AddAddress(bitcoinAddress, privateKey))
         }
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -1,8 +1,8 @@
 package fr.acinq.lightning.blockchain.electrum
 
 import fr.acinq.bitcoin.Bitcoin
-import fr.acinq.bitcoin.Block
 import fr.acinq.bitcoin.ByteVector
+import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Script
 import fr.acinq.lightning.utils.Connection
 import fr.acinq.lightning.utils.lightningLogger
@@ -20,6 +20,7 @@ data class Balance(val utxos: List<UnspentItem>)
  */
 class ElectrumMiniWallet(
     val bitcoinAddress: String,
+    val chainHash: ByteVector32,
     private val client: ElectrumClient,
     private val scope: CoroutineScope
 ) : CoroutineScope by scope {
@@ -28,7 +29,7 @@ class ElectrumMiniWallet(
     private val _balanceFlow = MutableStateFlow<Balance?>(null)
     val balanceFlow get() = _balanceFlow.asStateFlow()
 
-    private val pubkeyScript = ByteVector(Script.write(Bitcoin.addressToPublicKeyScript(Block.TestnetGenesisBlock.hash, bitcoinAddress)))
+    private val pubkeyScript = ByteVector(Script.write(Bitcoin.addressToPublicKeyScript(chainHash, bitcoinAddress)))
     private val scriptHash = ElectrumClient.computeScriptHash(pubkeyScript)
 
     init {

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
@@ -154,10 +154,10 @@ internal data class WatcherRunning(
                             val existingStatus = scriptHashStatus[scriptHash]
 
                             newState {
-                            state = copy(scriptHashStatus = scriptHashStatus + (scriptHash to status))
+                                state = copy(scriptHashStatus = scriptHashStatus + (scriptHash to status))
                                 actions = buildList {
                                     when {
-                                    existingStatus == status -> logger.debug { "already have status=$status for scriptHash=$scriptHash" }
+                                        existingStatus == status -> logger.debug { "already have status=$status for scriptHash=$scriptHash" }
                                         status.isEmpty() -> logger.debug { "empty status for scriptHash=$scriptHash" }
                                         else -> {
                                             logger.debug { "scriptHash=$scriptHash at height=$height" }

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
@@ -90,7 +90,7 @@ private data class WatcherDisconnected(
                             getTxQueue.forEach { add(AskForTransaction(it.txid, it.channelId)) }
                         }
                         state = WatcherRunning(
-                            height = message.height,
+                            height = message.blockHeight,
                             tip = message.header,
                             block2tx = block2tx,
                             watches = watches,
@@ -175,8 +175,8 @@ internal data class WatcherRunning(
                         // we retrieve the transaction before checking watches
                         // NB: height=-1 means that the tx is unconfirmed and at least one of its inputs is also unconfirmed.
                         // we need to take them into consideration if we want to handle unconfirmed txes (which is the case for turbo channels)
-                        val getTransactionList = message.history.filter { it.height >= -1 }.map {
-                            AskForTransaction(it.tx_hash, it)
+                        val getTransactionList = message.history.filter { it.blockHeight >= -1 }.map {
+                            AskForTransaction(it.txid, it)
                         }
                         returnState(actions = getTransactionList)
                     }
@@ -223,8 +223,8 @@ internal data class WatcherRunning(
                                                 )
                                             )
                                             watchConfirmedTriggered.add(w)
-                                        } else if (w.minDepth > 0L && item.height > 0) {
-                                            val txHeight = item.height
+                                        } else if (w.minDepth > 0L && item.blockHeight > 0) {
+                                            val txHeight = item.blockHeight
                                             val confirmations = height - txHeight + 1
                                             logger.info { "txid=${w.txId} was confirmed at height=$txHeight and now has confirmations=$confirmations (currentHeight=$height)" }
                                             if (confirmations >= w.minDepth) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -174,8 +174,8 @@ class Peer(
         launch {
             watcher.client.notifications.filterIsInstance<HeaderSubscriptionResponse>()
                 .collect { msg ->
-                    currentTipFlow.value = msg.height to msg.header
-                    input.send(WrappedChannelEvent(ByteVector32.Zeroes, ChannelEvent.NewBlock(msg.height, msg.header)))
+                    currentTipFlow.value = msg.blockHeight to msg.header
+                    input.send(WrappedChannelEvent(ByteVector32.Zeroes, ChannelEvent.NewBlock(msg.blockHeight, msg.header)))
                 }
         }
         launch {

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
@@ -34,7 +34,7 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
     fun `connect to an electrumx mainnet server`() = runSuspendTest(timeout = Duration.seconds(15)) { connectToMainnetServer().stop() }
 
     @Test
-    fun `query address with no utxos`() = runSuspendTest(timeout = Duration.seconds(15)) {
+    fun `single address with no utxos`() = runSuspendTest(timeout = Duration.seconds(15)) {
         val client = connectToMainnetServer()
         val wallet = ElectrumMiniWallet(Block.LivenetGenesisBlock.hash, client, this)
         wallet.addAddress("bc1qyjmhaptq78vh5j7tnzu7ujayd8sftjahphxppz")
@@ -50,7 +50,7 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
     }
 
     @Test
-    fun `query address with existing utxos`() = runSuspendTest(timeout = Duration.seconds(15)) {
+    fun `single address with existing utxos`() = runSuspendTest(timeout = Duration.seconds(15)) {
         val client = connectToMainnetServer()
         val wallet = ElectrumMiniWallet(Block.LivenetGenesisBlock.hash, client, this)
         wallet.addAddress("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2")
@@ -66,7 +66,7 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
     }
 
     @Test
-    fun `handle reconnections`() = runSuspendTest(timeout = Duration.seconds(15)) {
+    fun `multiple addresses`() = runSuspendTest(timeout = Duration.seconds(15)) {
         val client = connectToMainnetServer()
         val wallet = ElectrumMiniWallet(Block.LivenetGenesisBlock.hash, client, this)
         wallet.addAddress("16MmJT8VqW465GEyckWae547jKVfMB14P8")
@@ -77,9 +77,9 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
             .filter { it.addresses.size == 3 }
             .first()
 
-        assertEquals(6 + 4 + 1, walletState.utxos.size)
+        assertEquals(4 + 6 + 1, walletState.utxos.size)
         assertEquals(72_000_000.sat + 30_000_000.sat + 5_000_000.sat, walletState.balance)
-        assertEquals(2, walletState.spendable().size)
+        assertEquals(7, walletState.spendable().size)
 
         client.stop()
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
@@ -1,6 +1,7 @@
 package fr.acinq.lightning.blockchain.electrum
 
 import fr.acinq.bitcoin.Block
+import fr.acinq.bitcoin.Transaction
 import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.io.TcpSocket
 import fr.acinq.lightning.tests.utils.LightningTestSuite
@@ -12,6 +13,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
@@ -74,13 +76,20 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
         wallet.addAddress("19b3QuFuYSSYPoLt1AxVQmG3LifgSSPNyA", randomKey())
 
         val walletState = wallet.walletStateFlow
-            .filter { it.addresses.size == 3 }
+            .filter { it.parentTxs.size == 11 }
             .first()
 
         assertEquals(4 + 6 + 1, walletState.utxos.size)
         assertEquals(72_000_000.sat + 30_000_000.sat + 5_000_000.sat, walletState.balance)
         assertEquals(7, walletState.spendable().size)
-
+        assertContains(
+            walletState.spendable(),
+            WalletState.Utxo(
+                previousTx = Transaction.read("0100000001758713310361270b5ec4cae9b0196cb84fdb2f174d29f9367ad341963fa83e56010000008b483045022100d7b8759aeffe9d829a5df062420eb25017d7341244e49cfede16136a0c0b8dd2022031b42048e66b1f82f7fa99a22954e2709269838ef587c20118e493ced0d63e21014104b9251638d1475b9c62e1cf03129c835bcd5ab843aa0016412e8b39e3f8f7188d3b59023bce2002a2e409ea070c7070392b65d9ae8c8631ae2672a8fbb4f62bbdffffffff02404b4c00000000001976a9143675767783fdf1922f57ab4bb783f3a88dfa609488ac404b4c00000000001976a9142b6ba7c9d796b75eef7942fc9288edd37c32f5c388ac00000000"),
+                outputIndex = 1,
+                blockHeight = 100_003
+            )
+        )
         client.stop()
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
@@ -1,6 +1,7 @@
 package fr.acinq.lightning.blockchain.electrum
 
 import fr.acinq.bitcoin.Block
+import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.io.TcpSocket
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.tests.utils.runSuspendTest
@@ -39,7 +40,7 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
         wallet.addAddress("bc1qyjmhaptq78vh5j7tnzu7ujayd8sftjahphxppz")
 
         val walletState = wallet.walletStateFlow
-            .filter { it.addresses.size == 1 }
+            .filter { it.pubKeyScripts.size == 1 }
             .first()
 
         assertEquals(0, walletState.utxos.size)
@@ -55,7 +56,7 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
         wallet.addAddress("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2")
 
         val walletState = wallet.walletStateFlow
-            .filter { it.addresses.size == 1 }
+            .filter { it.pubKeyScripts.size == 1 }
             .first()
 
         assertEquals(6, walletState.utxos.size)
@@ -69,15 +70,16 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val wallet = ElectrumMiniWallet(Block.LivenetGenesisBlock.hash, client, this)
         wallet.addAddress("16MmJT8VqW465GEyckWae547jKVfMB14P8")
-        wallet.addAddress("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2")
-        wallet.addAddress("19b3QuFuYSSYPoLt1AxVQmG3LifgSSPNyA")
+        wallet.addAddress("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", randomKey())
+        wallet.addAddress("19b3QuFuYSSYPoLt1AxVQmG3LifgSSPNyA", randomKey())
 
         val walletState = wallet.walletStateFlow
-            .filter { it.addresses.size == 3 }
+            .filter { it.pubKeyScripts.size == 3 }
             .first()
 
         assertEquals(6 + 4 + 1, walletState.utxos.size)
         assertEquals(72_000_000.sat + 30_000_000.sat + 5_000_000.sat, walletState.balance)
+        assertEquals(2, walletState.spendable.size)
 
         client.stop()
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
@@ -1,6 +1,8 @@
 package fr.acinq.lightning.blockchain.electrum
 
+import fr.acinq.bitcoin.Bitcoin
 import fr.acinq.bitcoin.Block
+import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Transaction
 import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.io.TcpSocket
@@ -73,15 +75,18 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
         val wallet = ElectrumMiniWallet(Block.LivenetGenesisBlock.hash, client, this)
         wallet.addAddress("16MmJT8VqW465GEyckWae547jKVfMB14P8")
         wallet.addAddress("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", randomKey())
-        wallet.addAddress("19b3QuFuYSSYPoLt1AxVQmG3LifgSSPNyA", randomKey())
+        wallet.addAddress("1NHFyu1uJ1UoDjtPjqZ4Et3wNCyMGCJ1qV", randomKey())
 
         val walletState = wallet.walletStateFlow
             .filter { it.parentTxs.size == 11 }
             .first()
 
+        // this has been checked on the blockchain
         assertEquals(4 + 6 + 1, walletState.utxos.size)
-        assertEquals(72_000_000.sat + 30_000_000.sat + 5_000_000.sat, walletState.balance)
+        assertEquals(72_000_000.sat + 30_000_000.sat + 2_000_000.sat, walletState.balance)
         assertEquals(7, walletState.spendable().size)
+        // make sure txid is correct has electrum api is confusing
+        walletState.parentTxs.forEach { assertEquals(it.key, it.value.txid) }
         assertContains(
             walletState.spendable(),
             WalletState.Utxo(
@@ -90,6 +95,24 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
                 blockHeight = 100_003
             )
         )
+
+        assertEquals(
+            expected = setOf(
+                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", ByteVector32.fromValidHex("71b3dbaca67e9f9189dad3617138c19725ab541ef0b49c05a94913e9f28e3f4e") to 0, 5_000_000.sat),
+                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", ByteVector32.fromValidHex("21d2eb195736af2a40d42107e6abd59c97eb6cffd4a5a7a7709e86590ae61987") to 0, 5_000_000.sat),
+                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", ByteVector32.fromValidHex("74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20") to 1, 5_000_000.sat),
+                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", ByteVector32.fromValidHex("563ea83f9641d37a36f9294d172fdb4fb86c19b0e9cac45e0b27610331138775") to 0, 5_000_000.sat),
+                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", ByteVector32.fromValidHex("971af80218684017722429be08548d1f30a2f1f220abc064380cbca5cabf7623") to 1, 5_000_000.sat),
+                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", ByteVector32.fromValidHex("b1ec9c44009147f3cee26caba45abec2610c74df9751fad14074119b5314da21") to 0, 5_000_000.sat),
+                Triple("1NHFyu1uJ1UoDjtPjqZ4Et3wNCyMGCJ1qV", ByteVector32.fromValidHex("602839d82ac6c9aafd1a20fff5b23e11a99271e7cc238d2e48b352219b2b87ab") to 1, 2_000_000.sat),
+            ),
+            actual = walletState.spendable().map {
+                val txOut = it.previousTx.txOut[it.outputIndex]
+                val address = Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, txOut.publicKeyScript.toByteArray())
+                Triple(address, it.previousTx.txid to it.outputIndex, txOut.amount)
+            }.toSet()
+        )
+
         client.stop()
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
@@ -40,7 +40,7 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
         wallet.addAddress("bc1qyjmhaptq78vh5j7tnzu7ujayd8sftjahphxppz")
 
         val walletState = wallet.walletStateFlow
-            .filter { it.pubKeyScripts.size == 1 }
+            .filter { it.addresses.size == 1 }
             .first()
 
         assertEquals(0, walletState.utxos.size)
@@ -56,7 +56,7 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
         wallet.addAddress("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2")
 
         val walletState = wallet.walletStateFlow
-            .filter { it.pubKeyScripts.size == 1 }
+            .filter { it.addresses.size == 1 }
             .first()
 
         assertEquals(6, walletState.utxos.size)
@@ -74,7 +74,7 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
         wallet.addAddress("19b3QuFuYSSYPoLt1AxVQmG3LifgSSPNyA", randomKey())
 
         val walletState = wallet.walletStateFlow
-            .filter { it.pubKeyScripts.size == 3 }
+            .filter { it.addresses.size == 3 }
             .first()
 
         assertEquals(6 + 4 + 1, walletState.utxos.size)

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
@@ -1,0 +1,55 @@
+package fr.acinq.lightning.blockchain.electrum
+
+import fr.acinq.bitcoin.Block
+import fr.acinq.lightning.io.TcpSocket
+import fr.acinq.lightning.tests.utils.LightningTestSuite
+import fr.acinq.lightning.tests.utils.runSuspendTest
+import fr.acinq.lightning.utils.Connection
+import fr.acinq.lightning.utils.ServerAddress
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
+
+    private suspend fun CoroutineScope.connectToMainnetServer(): ElectrumClient {
+        val client =
+            ElectrumClient(TcpSocket.Builder(), this).apply { connect(ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES)) }
+
+        client.connectionState.first { it is Connection.CLOSED }
+        client.connectionState.first { it is Connection.ESTABLISHING }
+        client.connectionState.first { it is Connection.ESTABLISHED }
+
+        return client
+    }
+
+    @Test
+    fun `connect to an electrumx mainnet server`() = runSuspendTest(timeout = Duration.seconds(15)) { connectToMainnetServer().stop() }
+
+    @Test
+    fun `query address with no utxos`() = runSuspendTest(timeout = Duration.seconds(15)) {
+        val client = connectToMainnetServer()
+        val wallet = ElectrumMiniWallet("bc1qyjmhaptq78vh5j7tnzu7ujayd8sftjahphxppz", Block.LivenetGenesisBlock.hash, client, this)
+
+        val balance = wallet.balanceFlow.filterIsInstance<Balance>().first()
+        assertEquals(0, balance.utxos.size)
+
+        client.stop()
+    }
+
+    @Test
+    fun `query address with existing utxos`() = runSuspendTest(timeout = Duration.seconds(15)) {
+        val client = connectToMainnetServer()
+        val wallet = ElectrumMiniWallet("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", Block.LivenetGenesisBlock.hash, client, this)
+
+        val balance = wallet.balanceFlow.filterIsInstance<Balance>().first()
+        assertEquals(6, balance.utxos.size)
+
+        client.stop()
+    }
+}

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
@@ -6,6 +6,7 @@ import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.tests.utils.runSuspendTest
 import fr.acinq.lightning.utils.Connection
 import fr.acinq.lightning.utils.ServerAddress
+import fr.acinq.lightning.utils.sat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
@@ -36,8 +37,9 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val wallet = ElectrumMiniWallet("bc1qyjmhaptq78vh5j7tnzu7ujayd8sftjahphxppz", Block.LivenetGenesisBlock.hash, client, this)
 
-        val balance = wallet.balanceFlow.filterIsInstance<Balance>().first()
-        assertEquals(0, balance.utxos.size)
+        val walletState = wallet.walletStateFlow.filterIsInstance<WalletState>().first()
+        assertEquals(0, walletState.utxos.size)
+        assertEquals(0.sat, walletState.balance)
 
         client.stop()
     }
@@ -47,8 +49,9 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val wallet = ElectrumMiniWallet("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", Block.LivenetGenesisBlock.hash, client, this)
 
-        val balance = wallet.balanceFlow.filterIsInstance<Balance>().first()
-        assertEquals(6, balance.utxos.size)
+        val walletState = wallet.walletStateFlow.filterIsInstance<WalletState>().first()
+        assertEquals(6, walletState.utxos.size)
+        assertEquals(30_000_000.sat, walletState.balance)
 
         client.stop()
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
@@ -79,7 +79,7 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
 
         assertEquals(6 + 4 + 1, walletState.utxos.size)
         assertEquals(72_000_000.sat + 30_000_000.sat + 5_000_000.sat, walletState.balance)
-        assertEquals(2, walletState.spendable.size)
+        assertEquals(2, walletState.spendable().size)
 
         client.stop()
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
@@ -37,7 +37,7 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
     fun `single address with no utxos`() = runSuspendTest(timeout = Duration.seconds(15)) {
         val client = connectToMainnetServer()
         val wallet = ElectrumMiniWallet(Block.LivenetGenesisBlock.hash, client, this)
-        wallet.addAddress("bc1qyjmhaptq78vh5j7tnzu7ujayd8sftjahphxppz")
+        wallet.addWatchOnlyAddress("bc1qyjmhaptq78vh5j7tnzu7ujayd8sftjahphxppz")
 
         val walletState = wallet.walletStateFlow
             .filter { it.addresses.size == 1 }
@@ -53,7 +53,7 @@ class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
     fun `single address with existing utxos`() = runSuspendTest(timeout = Duration.seconds(15)) {
         val client = connectToMainnetServer()
         val wallet = ElectrumMiniWallet(Block.LivenetGenesisBlock.hash, client, this)
-        wallet.addAddress("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2")
+        wallet.addWatchOnlyAddress("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2")
 
         val walletState = wallet.walletStateFlow
             .filter { it.addresses.size == 1 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumRequestTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumRequestTest.kt
@@ -51,7 +51,7 @@ class ElectrumRequestTest : LightningTestSuite() {
         }
         val response = json.decodeFromString(ElectrumResponseDeserializer, jsonRpc)
         assertEquals(
-            Either.Left(HeaderSubscriptionResponse(height = 520481, BlockHeader(
+            Either.Left(HeaderSubscriptionResponse(blockHeight = 520481, BlockHeader(
                 version = 536870912,
                 hashPreviousBlock = ByteVector32.fromValidHex("890208a0ae3a3892aa047c5468725846577cfcd9b512b5000000000000000000"),
                 hashMerkleRoot = ByteVector32.fromValidHex("5dc2b02f2d297a9064ee103036c14d678f9afc7e3d9409cf53fd58b82e938e8e"),

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
@@ -296,7 +296,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
             val msg = this.receive()
             if (msg is GetScriptHashHistoryResponse) {
                 val (_, history) = msg
-                if (history.map { it.tx_hash }.toSet() == setOf(tx.txid, tx1.txid, tx2.txid)) this.cancel()
+                if (history.map { it.txid }.toSet() == setOf(tx.txid, tx1.txid, tx2.txid)) this.cancel()
             }
         }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
@@ -1,0 +1,52 @@
+package fr.acinq.lightning.blockchain.electrum
+
+import fr.acinq.bitcoin.*
+import fr.acinq.lightning.Lightning.randomKey
+import fr.acinq.lightning.tests.utils.LightningTestSuite
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WalletStateUnitTest : LightningTestSuite() {
+
+    @Test
+    fun `sign a p2wpkh tx`() {
+
+        // this tx pays 0.038 BTC to p2wpkh tb1qtkl49wxh4a8mt7dhtwqg7z5zs3yn2vdn6qcz7p
+        val parentTx =
+            Transaction.Companion.read("01000000000101c37055af18a2ab1714e648fe5140982ceec74b6ed9376292662465c9ec3f5bf20000000000ffffffff01c0fb3900000000001600145dbf52b8d7af4fb5f9b75b808f0a8284493531b302483045022100966d17538e775b45bc1a995ff21871e0ecd428895bfe685f9016b1ea0cc2ff810220277e8f64b3827b8c79db34cfaf06af5660d9c3ebcb3f8ae857cf44a138b3cf620121030533e1d2e9b7576fef26de1f34d67887158b7af1b040850aab6024b07925d70a00000000")
+        val utxo = UnspentItem(parentTx.txid, 0, 3800000, 0)
+
+        val priv1 = PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet).first
+        val pub1 = priv1.publicKey()
+        val address1 = Bitcoin.computeP2WpkhAddress(pub1, Block.TestnetGenesisBlock.hash)
+        assertEquals(address1, "tb1qtkl49wxh4a8mt7dhtwqg7z5zs3yn2vdn6qcz7p")
+        val scriptPubKey1 = ByteVector(Script.write(Script.pay2wpkh(pub1)))
+        assertEquals(scriptPubKey1, ByteVector.fromHex("00145dbf52b8d7af4fb5f9b75b808f0a8284493531b3"))
+
+
+        val walletState = WalletState(
+            mapOf(
+                scriptPubKey1 to (listOf(utxo) to priv1),
+                ByteVector(Script.write(Script.pay2wpkh(randomKey().publicKey()))) to (emptyList<UnspentItem>() to randomKey()),
+                ByteVector(Script.write(Script.pay2wpkh(randomKey().publicKey()))) to (emptyList<UnspentItem>() to null)
+            )
+        )
+
+        val unsignedTx = Transaction(
+            version = 1,
+            txIn = listOf(TxIn(utxo.outPoint, sequence = 0xffffffffL)),
+            txOut = listOf(
+                TxOut(
+                    3700000L.toSatoshi(),
+                    scriptPubKey1
+                )
+            ), // we reuse the same output script but if could be anything else
+            lockTime = 0
+        )
+
+        val signedTx = walletState.sign(unsignedTx)
+        Transaction.correctlySpends(signedTx, listOf(parentTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+        assertEquals(signedTx.txid, ByteVector32.fromValidHex("fe94ff363b534adb1b880cedbbfab4ebdf2d7b4752614071446cb1fb28658696"))
+        // this tx was published on testnet
+    }
+}

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
@@ -3,6 +3,7 @@ package fr.acinq.lightning.blockchain.electrum
 import fr.acinq.bitcoin.*
 import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.tests.utils.LightningTestSuite
+import fr.acinq.lightning.utils.sat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -11,11 +12,6 @@ class WalletStateUnitTest : LightningTestSuite() {
     @Test
     fun `sign a p2wpkh tx`() {
 
-        // this tx pays 0.038 BTC to p2wpkh tb1qtkl49wxh4a8mt7dhtwqg7z5zs3yn2vdn6qcz7p
-        val parentTx =
-            Transaction.Companion.read("01000000000101c37055af18a2ab1714e648fe5140982ceec74b6ed9376292662465c9ec3f5bf20000000000ffffffff01c0fb3900000000001600145dbf52b8d7af4fb5f9b75b808f0a8284493531b302483045022100966d17538e775b45bc1a995ff21871e0ecd428895bfe685f9016b1ea0cc2ff810220277e8f64b3827b8c79db34cfaf06af5660d9c3ebcb3f8ae857cf44a138b3cf620121030533e1d2e9b7576fef26de1f34d67887158b7af1b040850aab6024b07925d70a00000000")
-        val utxo = UnspentItem(parentTx.txid, 0, 3800000, 0)
-
         val priv1 = PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet).first
         val pub1 = priv1.publicKey()
         val address1 = Bitcoin.computeP2WpkhAddress(pub1, Block.TestnetGenesisBlock.hash)
@@ -23,6 +19,11 @@ class WalletStateUnitTest : LightningTestSuite() {
         val scriptPubKey1 = ByteVector(Script.write(Script.pay2wpkh(pub1)))
         assertEquals(scriptPubKey1, ByteVector.fromHex("00145dbf52b8d7af4fb5f9b75b808f0a8284493531b3"))
 
+        // the parent tx pays 0.038 BTC to p2wpkh tb1qtkl49wxh4a8mt7dhtwqg7z5zs3yn2vdn6qcz7p
+        val parentTx =
+            Transaction.read("01000000000101c37055af18a2ab1714e648fe5140982ceec74b6ed9376292662465c9ec3f5bf20000000000ffffffff01c0fb3900000000001600145dbf52b8d7af4fb5f9b75b808f0a8284493531b302483045022100966d17538e775b45bc1a995ff21871e0ecd428895bfe685f9016b1ea0cc2ff810220277e8f64b3827b8c79db34cfaf06af5660d9c3ebcb3f8ae857cf44a138b3cf620121030533e1d2e9b7576fef26de1f34d67887158b7af1b040850aab6024b07925d70a00000000")
+        assertEquals(parentTx.txOut.first(), TxOut(3_800_000L.sat, scriptPubKey1))
+        val utxo = UnspentItem(parentTx.txid, 0, 3_800_000, 0)
 
         val walletState = WalletState(
             addresses = mapOf(
@@ -38,7 +39,7 @@ class WalletStateUnitTest : LightningTestSuite() {
             txIn = listOf(TxIn(utxo.outPoint, sequence = 0xffffffffL)),
             txOut = listOf(
                 TxOut(
-                    3700000L.toSatoshi(),
+                    3_700_000L.sat,
                     scriptPubKey1
                 )
             ), // we reuse the same output script but it could be anything else

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
@@ -31,7 +31,8 @@ class WalletStateUnitTest : LightningTestSuite() {
                 Bitcoin.computeP2WpkhAddress(randomKey().publicKey(), Block.TestnetGenesisBlock.hash) to emptyList(),
                 Bitcoin.computeP2WpkhAddress(randomKey().publicKey(), Block.TestnetGenesisBlock.hash) to emptyList()
             ),
-            privateKeys = mapOf(address1 to priv1)
+            privateKeys = mapOf(address1 to priv1),
+            parentTxs = emptyMap()
         )
 
         val unsignedTx = Transaction(

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
@@ -11,7 +11,6 @@ class WalletStateUnitTest : LightningTestSuite() {
 
     @Test
     fun `sign a p2wpkh tx`() {
-
         val priv1 = PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet).first
         val pub1 = priv1.publicKey()
         val address1 = Bitcoin.computeP2WpkhAddress(pub1, Block.TestnetGenesisBlock.hash)

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
@@ -26,9 +26,9 @@ class WalletStateUnitTest : LightningTestSuite() {
 
         val walletState = WalletState(
             mapOf(
-                scriptPubKey1 to (listOf(utxo) to priv1),
-                ByteVector(Script.write(Script.pay2wpkh(randomKey().publicKey()))) to (emptyList<UnspentItem>() to randomKey()),
-                ByteVector(Script.write(Script.pay2wpkh(randomKey().publicKey()))) to (emptyList<UnspentItem>() to null)
+                address1 to (listOf(utxo) to priv1),
+                Bitcoin.computeP2WpkhAddress(randomKey().publicKey(), Block.TestnetGenesisBlock.hash) to (emptyList<UnspentItem>() to randomKey()),
+                Bitcoin.computeP2WpkhAddress(randomKey().publicKey(), Block.TestnetGenesisBlock.hash) to (emptyList<UnspentItem>() to null)
             )
         )
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
@@ -25,11 +25,12 @@ class WalletStateUnitTest : LightningTestSuite() {
 
 
         val walletState = WalletState(
-            mapOf(
-                address1 to (listOf(utxo) to priv1),
-                Bitcoin.computeP2WpkhAddress(randomKey().publicKey(), Block.TestnetGenesisBlock.hash) to (emptyList<UnspentItem>() to randomKey()),
-                Bitcoin.computeP2WpkhAddress(randomKey().publicKey(), Block.TestnetGenesisBlock.hash) to (emptyList<UnspentItem>() to null)
-            )
+            addresses = mapOf(
+                address1 to listOf(utxo),
+                Bitcoin.computeP2WpkhAddress(randomKey().publicKey(), Block.TestnetGenesisBlock.hash) to emptyList<UnspentItem>(),
+                Bitcoin.computeP2WpkhAddress(randomKey().publicKey(), Block.TestnetGenesisBlock.hash) to emptyList<UnspentItem>()
+            ),
+            privateKeys = mapOf(address1 to priv1)
         )
 
         val unsignedTx = Transaction(

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/WalletStateUnitTest.kt
@@ -27,8 +27,8 @@ class WalletStateUnitTest : LightningTestSuite() {
         val walletState = WalletState(
             addresses = mapOf(
                 address1 to listOf(utxo),
-                Bitcoin.computeP2WpkhAddress(randomKey().publicKey(), Block.TestnetGenesisBlock.hash) to emptyList<UnspentItem>(),
-                Bitcoin.computeP2WpkhAddress(randomKey().publicKey(), Block.TestnetGenesisBlock.hash) to emptyList<UnspentItem>()
+                Bitcoin.computeP2WpkhAddress(randomKey().publicKey(), Block.TestnetGenesisBlock.hash) to emptyList(),
+                Bitcoin.computeP2WpkhAddress(randomKey().publicKey(), Block.TestnetGenesisBlock.hash) to emptyList()
             ),
             privateKeys = mapOf(address1 to priv1)
         )
@@ -41,7 +41,7 @@ class WalletStateUnitTest : LightningTestSuite() {
                     3700000L.toSatoshi(),
                     scriptPubKey1
                 )
-            ), // we reuse the same output script but if could be anything else
+            ), // we reuse the same output script but it could be anything else
             lockTime = 0
         )
 


### PR DESCRIPTION
Usage:
```kotlin
val client = ElectrumClient(...)
val wallet = ElectrumMiniWallet(Block.LivenetGenesisBlock.hash, client, this)

// watch-only
wallet.addAddress("16MmJT8VqW465GEyckWae547jKVfMB14P8")
// spendable p2wpkh
wallet.addPay2wpkhAddress(randomKey())

wallet.walletStateFlow
  .collect { println("balance=${it.balance} utxos=${it.utxos.size}") }
```

Example to watch funds on the final addresses (@dpad85):
```kotlin
val nodeParams: NodeParams = ...
val wallet: ElectrumMiniWallet = ...
val channels: List<ChannelStateWithCommitments> = ...

channels.forEach { data ->
  val bitcoinAddress = Bitcoin.addressFromPublicKeyScript(nodeParams.chainHash, data.commitments.localParams.defaultFinalScriptPubKey.toByteArray())!!
  wallet.addAddress(bitcoinAddress)
}
```