### PR TITLE
Correctly set `scriptHashSubscriptions` when (re)connecting

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
@@ -62,7 +62,7 @@ private data class BroadcastTxAction(val tx: Transaction) : WatcherAction()
  * +----------+         +-----+
  *
  */
-private sealed class WatcherState {
+internal sealed class WatcherState {
     abstract fun process(event: WatcherEvent): Pair<WatcherState, List<WatcherAction>>
 }
 
@@ -108,7 +108,7 @@ private data class WatcherDisconnected(
         }
 }
 
-private data class WatcherRunning(
+internal data class WatcherRunning(
     val height: Int,
     val tip: BlockHeader,
     val watches: Set<Watch> = setOf(),
@@ -454,6 +454,7 @@ class ElectrumWatcher(
     }
 
     private var state: WatcherState = WatcherDisconnected()
+    internal val pstate get() = state
 
     private var runJob: Job? = null
     private var timerJob: Job? = null

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
@@ -209,6 +209,9 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
         val msg = listener.first() as WatchEventSpent
         assertEquals(spendingTx.txid, msg.tx.txid)
 
+        val watcherState = watcher.pstate as WatcherRunning
+        assertTrue(watcherState.scriptHashSubscriptions.isNotEmpty())
+
         watcher.stop()
         client.stop()
     }


### PR DESCRIPTION
The field `WatcherRunning.scriptHashSubscriptions`, which keeps track of existing subscriptions in order to not put duplicate watchers, isn't set when transitioning from `WatcherDisconnected`->`WatcherRunning`.

Note: to reproduce the bug in tests I had to increase the visibility of a some classes.