### PR TITLE
Rename funder to initiator

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
@@ -22,7 +22,7 @@ import org.kodein.log.Logger
 
 /** Channel Events (inputs to be fed to the state machine). */
 sealed class ChannelEvent {
-    data class InitFunder(
+    data class InitInitiator(
         val temporaryChannelId: ByteVector32,
         val fundingAmount: Satoshi,
         val pushAmount: MilliSatoshi,
@@ -36,7 +36,13 @@ sealed class ChannelEvent {
         val channelOrigin: ChannelOrigin? = null
     ) : ChannelEvent()
 
-    data class InitFundee(val temporaryChannelId: ByteVector32, val localParams: LocalParams, val channelConfig: ChannelConfig, val remoteInit: Init) : ChannelEvent()
+    data class InitNonInitiator(
+        val temporaryChannelId: ByteVector32,
+        val localParams: LocalParams,
+        val channelConfig: ChannelConfig,
+        val remoteInit: Init
+    ) : ChannelEvent()
+
     data class Restore(val state: ChannelState) : ChannelEvent()
     object CheckHtlcTimeout : ChannelEvent()
     data class MessageReceived(val message: LightningMessage) : ChannelEvent()

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelData.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelData.kt
@@ -388,7 +388,7 @@ data class LocalParams(
     val htlcMinimum: MilliSatoshi,
     val toSelfDelay: CltvExpiryDelta,
     val maxAcceptedHtlcs: Int,
-    val isFunder: Boolean,
+    val isInitiator: Boolean,
     val defaultFinalScriptPubKey: ByteVector,
     val features: Features
 )

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelException.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelException.kt
@@ -16,7 +16,6 @@ open class ChannelException(open val channelId: ByteVector32, override val messa
 }
 
 // @formatter:off
-data class DebugTriggeredException                 (override val channelId: ByteVector32) : ChannelException(channelId, "debug-mode triggered failure")
 data class InvalidChainHash                        (override val channelId: ByteVector32, val local: ByteVector32, val remote: ByteVector32) : ChannelException(channelId, "invalid chainHash (local=$local remote=$remote)")
 data class InvalidFundingAmount                    (override val channelId: ByteVector32, val fundingAmount: Satoshi, val min: Satoshi, val max: Satoshi) : ChannelException(channelId, "invalid funding_satoshis=$fundingAmount (min=$min max=$max)")
 data class InvalidPushAmount                       (override val channelId: ByteVector32, val pushAmount: MilliSatoshi, val max: MilliSatoshi) : ChannelException(channelId, "invalid pushAmount=$pushAmount (max=$max)")
@@ -66,7 +65,7 @@ data class RemoteCannotAffordFeesForNewHtlc        (override val channelId: Byte
 data class InvalidHtlcPreimage                     (override val channelId: ByteVector32, val id: Long) : ChannelException(channelId, "invalid htlc preimage for htlc id=$id")
 data class UnknownHtlcId                           (override val channelId: ByteVector32, val id: Long) : ChannelException(channelId, "unknown htlc id=$id")
 data class CannotExtractSharedSecret               (override val channelId: ByteVector32, val htlc: UpdateAddHtlc) : ChannelException(channelId, "can't extract shared secret: paymentHash=${htlc.paymentHash} onion=${htlc.onionRoutingPacket}")
-data class FundeeCannotSendUpdateFee               (override val channelId: ByteVector32) : ChannelException(channelId, "only the funder should send update_fee message")
+data class NonInitiatorCannotSendUpdateFee         (override val channelId: ByteVector32) : ChannelException(channelId, "only the initiator should send update_fee message")
 data class CannotAffordFees                        (override val channelId: ByteVector32, val missing: Satoshi, val reserve: Satoshi, val fees: Satoshi) : ChannelException(channelId, "can't pay the fee: missing=$missing reserve=$reserve fees=$fees")
 data class CannotSignWithoutChanges                (override val channelId: ByteVector32) : ChannelException(channelId, "cannot sign when there are no change")
 data class CannotSignBeforeRevocation              (override val channelId: ByteVector32) : ChannelException(channelId, "cannot sign until next revocation hash is received")

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -147,7 +147,7 @@ object Helpers {
     }
 
     /** Called by the initiator. */
-    fun validateParamsInitiator(nodeParams: NodeParams, init: ChannelEvent.InitFunder, open: OpenChannel, accept: AcceptChannel): Either<ChannelException, ChannelFeatures> {
+    fun validateParamsInitiator(nodeParams: NodeParams, init: ChannelEvent.InitInitiator, open: OpenChannel, accept: AcceptChannel): Either<ChannelException, ChannelFeatures> {
         require(open.channelType != null) { "we should have sent a channel type in open_channel" }
         if (accept.channelType == null) {
             // We only open channels to peers who support explicit channel type negotiation.

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -56,8 +56,8 @@ object Helpers {
             max(nodeParams.minDepthBlocks, blocksToReachFunding)
         }
 
-    /** Called by the fundee. */
-    fun validateParamsFundee(nodeParams: NodeParams, open: OpenChannel, localParams: LocalParams, remoteFeatures: Features): Either<ChannelException, ChannelFeatures> {
+    /** Called by the non-initiator. */
+    fun validateParamsNonInitiator(nodeParams: NodeParams, open: OpenChannel, localParams: LocalParams, remoteFeatures: Features): Either<ChannelException, ChannelFeatures> {
         // NB: we only accept channels from peers who support explicit channel type negotiation.
         val channelType = open.channelType ?: return Either.Left(MissingChannelType(open.temporaryChannelId))
         if (!setOf(ChannelType.SupportedChannelType.AnchorOutputs, ChannelType.SupportedChannelType.AnchorOutputsZeroConfZeroReserve).contains(channelType)) {
@@ -104,7 +104,7 @@ object Helpers {
         }
 
         if (open.channelReserveSatoshis == 0.sat && localParams.features.hasFeature(Feature.ZeroReserveChannels)) {
-            // NB: if the funder doesn't require us to have a reserve, we can't ensure that dust_limit_satoshis is greater than our reserve.
+            // NB: if the initiator doesn't require us to have a reserve, we can't ensure that dust_limit_satoshis is greater than our reserve.
         } else {
             // BOLT #2: The receiving node MUST fail the channel if: dust_limit_satoshis is greater than channel_reserve_satoshis.
             if (open.dustLimitSatoshis > open.channelReserveSatoshis) {
@@ -128,7 +128,7 @@ object Helpers {
             return Either.Left(DustLimitTooSmall(open.temporaryChannelId, open.dustLimitSatoshis, Channel.MIN_DUST_LIMIT))
         }
 
-        // we don't check that the funder's amount for the initial commitment transaction is sufficient for full fee payment
+        // we don't check that the initiator's amount for the initial commitment transaction is sufficient for full fee payment
         // now, but it will be done later when we receive `funding_created`
         val reserveToFundingRatio = open.channelReserveSatoshis.toLong().toDouble() / max(open.fundingSatoshis.toLong(), 1)
         if (reserveToFundingRatio > nodeParams.maxReserveToFundingRatio) {
@@ -146,8 +146,8 @@ object Helpers {
         return Either.Right(channelFeatures)
     }
 
-    /** Called by the funder. */
-    fun validateParamsFunder(nodeParams: NodeParams, init: ChannelEvent.InitFunder, open: OpenChannel, accept: AcceptChannel): Either<ChannelException, ChannelFeatures> {
+    /** Called by the initiator. */
+    fun validateParamsInitiator(nodeParams: NodeParams, init: ChannelEvent.InitFunder, open: OpenChannel, accept: AcceptChannel): Either<ChannelException, ChannelFeatures> {
         require(open.channelType != null) { "we should have sent a channel type in open_channel" }
         if (accept.channelType == null) {
             // We only open channels to peers who support explicit channel type negotiation.
@@ -354,14 +354,14 @@ object Helpers {
             fundingTxOutputIndex: Int,
             remoteFirstPerCommitmentPoint: PublicKey
         ): Either<ChannelException, FirstCommitTx> {
-            val toLocalMsat = if (localParams.isFunder) MilliSatoshi(fundingAmount) - pushMsat else pushMsat
-            val toRemoteMsat = if (localParams.isFunder) pushMsat else MilliSatoshi(fundingAmount) - pushMsat
+            val toLocalMsat = if (localParams.isInitiator) MilliSatoshi(fundingAmount) - pushMsat else pushMsat
+            val toRemoteMsat = if (localParams.isInitiator) pushMsat else MilliSatoshi(fundingAmount) - pushMsat
 
             val localSpec = CommitmentSpec(setOf(), feerate = initialFeerate, toLocal = toLocalMsat, toRemote = toRemoteMsat)
             val remoteSpec = CommitmentSpec(setOf(), feerate = initialFeerate, toLocal = toRemoteMsat, toRemote = toLocalMsat)
 
-            if (!localParams.isFunder) {
-                // they are funder, therefore they pay the fee: we need to make sure they can afford it!
+            if (!localParams.isInitiator) {
+                // they are the initiator, therefore they pay the fee: we need to make sure they can afford it!
                 val localToRemoteMsat = remoteSpec.toLocal
                 val fees = commitTxFee(remoteParams.dustLimit, remoteSpec)
                 val missing = localToRemoteMsat.truncateToSatoshi() - localParams.channelReserve - fees
@@ -445,7 +445,7 @@ object Helpers {
 
         fun firstClosingFee(commitments: Commitments, localScriptPubkey: ByteArray, remoteScriptPubkey: ByteArray, requestedFeerate: ClosingFeerates): ClosingFees {
             // this is just to estimate the weight which depends on the size of the pubkey scripts
-            val dummyClosingTx = Transactions.makeClosingTx(commitments.commitInput, localScriptPubkey, remoteScriptPubkey, commitments.localParams.isFunder, Satoshi(0), Satoshi(0), commitments.localCommit.spec)
+            val dummyClosingTx = Transactions.makeClosingTx(commitments.commitInput, localScriptPubkey, remoteScriptPubkey, commitments.localParams.isInitiator, Satoshi(0), Satoshi(0), commitments.localCommit.spec)
             val closingWeight = Transaction.weight(Transactions.addSigs(dummyClosingTx, dummyPublicKey, commitments.remoteParams.fundingPubKey, Transactions.PlaceHolderSig, Transactions.PlaceHolderSig).tx)
             return requestedFeerate.computeFees(closingWeight)
         }
@@ -477,7 +477,7 @@ object Helpers {
             require(isValidFinalScriptPubkey(localScriptPubkey, allowAnySegwit)) { "invalid localScriptPubkey" }
             require(isValidFinalScriptPubkey(remoteScriptPubkey, allowAnySegwit)) { "invalid remoteScriptPubkey" }
             val dustLimit = commitments.localParams.dustLimit.max(commitments.remoteParams.dustLimit)
-            val closingTx = Transactions.makeClosingTx(commitments.commitInput, localScriptPubkey, remoteScriptPubkey, commitments.localParams.isFunder, dustLimit, closingFees.preferred, commitments.localCommit.spec)
+            val closingTx = Transactions.makeClosingTx(commitments.commitInput, localScriptPubkey, remoteScriptPubkey, commitments.localParams.isInitiator, dustLimit, closingFees.preferred, commitments.localCommit.spec)
             val localClosingSig = keyManager.sign(closingTx, commitments.localParams.channelKeys.fundingPrivateKey)
             val closingSigned = ClosingSigned(commitments.channelId, closingFees.preferred, localClosingSig, TlvStream(listOf(ClosingSignedTlv.FeeRange(closingFees.min, closingFees.max))))
             return Pair(closingTx, closingSigned)
@@ -628,7 +628,7 @@ object Helpers {
             val outputs = makeCommitTxOutputs(
                 commitments.remoteParams.fundingPubKey,
                 commitments.localParams.channelKeys.fundingPubKey,
-                !localParams.isFunder,
+                !localParams.isInitiator,
                 remoteParams.dustLimit,
                 remoteRevocationPubkey,
                 localParams.toSelfDelay,
@@ -737,7 +737,7 @@ object Helpers {
             val obscuredTxNumber = Transactions.decodeTxNumber(tx.txIn.first().sequence, tx.lockTime)
             val localPaymentPoint = keyManager.paymentPoint(channelKeyPath)
             // this tx has been published by remote, so we need to invert local/remote params
-            val txNumber = Transactions.obscuredCommitTxNumber(obscuredTxNumber, !commitments.localParams.isFunder, commitments.remoteParams.paymentBasepoint, localPaymentPoint.publicKey)
+            val txNumber = Transactions.obscuredCommitTxNumber(obscuredTxNumber, !commitments.localParams.isInitiator, commitments.remoteParams.paymentBasepoint, localPaymentPoint.publicKey)
             require(txNumber <= 0xffffffffffffL) { "txNumber must be lesser than 48 bits long" }
             logger.warning { "c:${commitments.channelId} a revoked commit has been published with txNumber=$txNumber" }
             return txNumber

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
@@ -157,7 +157,7 @@ data class Normal(
                                     ShuttingDown(staticParams, currentTip, currentOnChainFeerates, commitments1, localShutdown, remoteShutdown, closingFeerates)
                                 } else {
                                     logger.warning { "c:$channelId we have no htlcs but have not replied with our Shutdown yet, this should never happen" }
-                                    val closingTxProposed = if (isFunder) {
+                                    val closingTxProposed = if (isInitiator) {
                                         val (closingTx, closingSigned) = Helpers.Closing.makeFirstClosingTx(
                                             keyManager,
                                             commitments1,
@@ -230,7 +230,7 @@ data class Normal(
                                 if (this.localShutdown == null) actions.add(ChannelAction.Message.Send(localShutdown))
                                 val commitments1 = commitments.copy(remoteChannelData = event.message.channelData)
                                 when {
-                                    commitments1.hasNoPendingHtlcsOrFeeUpdate() && commitments1.localParams.isFunder -> {
+                                    commitments1.hasNoPendingHtlcsOrFeeUpdate() && commitments1.localParams.isInitiator -> {
                                         val (closingTx, closingSigned) = Helpers.Closing.makeFirstClosingTx(
                                             keyManager,
                                             commitments1,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ShuttingDown.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ShuttingDown.kt
@@ -47,7 +47,7 @@ data class ShuttingDown(
                         is Either.Right -> {
                             val (commitments1, revocation) = result.value
                             when {
-                                commitments1.hasNoPendingHtlcsOrFeeUpdate() && commitments1.localParams.isFunder -> {
+                                commitments1.hasNoPendingHtlcsOrFeeUpdate() && commitments1.localParams.isInitiator -> {
                                     val (closingTx, closingSigned) = Helpers.Closing.makeFirstClosingTx(
                                         keyManager,
                                         commitments1,
@@ -96,7 +96,7 @@ data class ShuttingDown(
                             val (commitments1, actions) = result.value
                             val actions1 = actions.toMutableList()
                             when {
-                                commitments1.hasNoPendingHtlcsOrFeeUpdate() && commitments1.localParams.isFunder -> {
+                                commitments1.hasNoPendingHtlcsOrFeeUpdate() && commitments1.localParams.isInitiator -> {
                                     val (closingTx, closingSigned) = Helpers.Closing.makeFirstClosingTx(
                                         keyManager,
                                         commitments1,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
@@ -69,10 +69,10 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                         Pair(nextState1, actions + actions1)
                     }
                     state is WaitForFundingConfirmed -> {
-                        val minDepth = if (state.commitments.localParams.isFunder) {
+                        val minDepth = if (state.commitments.localParams.isInitiator) {
                             staticParams.nodeParams.minDepthBlocks
                         } else {
-                            // when we're fundee we scale the min_depth confirmations depending on the funding amount
+                            // when we're not the initiator we scale the min_depth confirmations depending on the funding amount
                             if (state.commitments.channelFeatures.hasFeature(Feature.ZeroConfChannels)) 0 else Helpers.minDepthForFunding(staticParams.nodeParams, state.commitments.commitInput.txOut.amount)
                         }
                         // we put back the watch (operation is idempotent) because the event may have been fired while we were in OFFLINE
@@ -181,9 +181,9 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                         }
                     }
                     // BOLT 2: A node if it has sent a previous shutdown MUST retransmit shutdown.
-                    // negotiation restarts from the beginning, and is initialized by the funder
+                    // negotiation restarts from the beginning, and is initialized by the initiator
                     // note: in any case we still need to keep all previously sent closing_signed, because they may publish one of them
-                    state is Negotiating && state.commitments.localParams.isFunder -> {
+                    state is Negotiating && state.commitments.localParams.isInitiator -> {
                         // we could use the last closing_signed we sent, but network fees may have changed while we were offline so it is better to restart from scratch
                         val (closingTx, closingSigned) = Helpers.Closing.makeFirstClosingTx(
                             keyManager,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForAcceptChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForAcceptChannel.kt
@@ -24,7 +24,7 @@ data class WaitForAcceptChannel(
     override fun processInternal(event: ChannelEvent): Pair<ChannelState, List<ChannelAction>> {
         return when {
             event is ChannelEvent.MessageReceived && event.message is AcceptChannel -> {
-                when (val res = Helpers.validateParamsFunder(staticParams.nodeParams, initFunder, lastSent, event.message)) {
+                when (val res = Helpers.validateParamsInitiator(staticParams.nodeParams, initFunder, lastSent, event.message)) {
                     is Either.Right -> {
                         val channelFeatures = res.value
                         val remoteParams = RemoteParams(

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForOpenChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForOpenChannel.kt
@@ -23,7 +23,7 @@ data class WaitForOpenChannel(
             event is ChannelEvent.MessageReceived ->
                 when (event.message) {
                     is OpenChannel -> {
-                        when (val res = Helpers.validateParamsFundee(staticParams.nodeParams, event.message, localParams, Features(remoteInit.features))) {
+                        when (val res = Helpers.validateParamsNonInitiator(staticParams.nodeParams, event.message, localParams, Features(remoteInit.features))) {
                             is Either.Right -> {
                                 val channelFeatures = res.value
                                 val channelOrigin = event.message.tlvStream.records.filterIsInstance<ChannelTlv.ChannelOriginTlv>().firstOrNull()?.channelOrigin

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
@@ -45,12 +45,12 @@ interface KeyManager {
 
     /**
      *
-     * @param isFunder true if we're funding this channel
+     * @param isInitiator true if we are the channel initiator
      * @return a partial key path for a new funding public key. This key path will be extended:
      *         - with a specific "chain" prefix
      *         - with a specific "funding pubkey" suffix
      */
-    fun newFundingKeyPath(isFunder: Boolean): KeyPath
+    fun newFundingKeyPath(isInitiator: Boolean): KeyPath
 
     /**
      * generate channel-specific keys and secrets

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
@@ -57,8 +57,8 @@ data class LocalKeyManager(val seed: ByteVector, val chainHash: ByteVector32) : 
         return Pair(pub, Script.write(script))
     }
 
-    override fun newFundingKeyPath(isFunder: Boolean): KeyPath {
-        val last = hardened(if (isFunder) 1 else 0)
+    override fun newFundingKeyPath(isInitiator: Boolean): KeyPath {
+        val last = hardened(if (isInitiator) 1 else 0)
         fun next() = secureRandom.nextInt().toLong() and 0xFFFFFFFF
         return KeyPath(listOf(next(), next(), next(), next(), next(), next(), next(), next(), last))
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -55,12 +55,27 @@ interface SendPayment {
         get() = details.paymentHash
 
 }
-data class SendPaymentNormal(override val paymentId: UUID, override val amount: MilliSatoshi, override val recipient: PublicKey, override val details: OutgoingPayment.Details.Normal, override val trampolineFeesOverride: List<TrampolineFees>? = null) : PaymentEvent(), SendPayment {
+
+data class SendPaymentNormal(
+    override val paymentId: UUID,
+    override val amount: MilliSatoshi,
+    override val recipient: PublicKey,
+    override val details: OutgoingPayment.Details.Normal,
+    override val trampolineFeesOverride: List<TrampolineFees>? = null
+) : PaymentEvent(), SendPayment {
     override val paymentRequest = details.paymentRequest
 }
-data class SendPaymentSwapOut(override val paymentId: UUID, override val amount: MilliSatoshi, override val recipient: PublicKey, override val details: OutgoingPayment.Details.SwapOut, override val trampolineFeesOverride: List<TrampolineFees>? = null) : PaymentEvent(), SendPayment {
+
+data class SendPaymentSwapOut(
+    override val paymentId: UUID,
+    override val amount: MilliSatoshi,
+    override val recipient: PublicKey,
+    override val details: OutgoingPayment.Details.SwapOut,
+    override val trampolineFeesOverride: List<TrampolineFees>? = null
+) : PaymentEvent(), SendPayment {
     override val paymentRequest = details.paymentRequest
 }
+
 data class PurgeExpiredPayments(val fromCreatedAt: Long, val toCreatedAt: Long) : PaymentEvent()
 
 sealed class PeerListenerEvent
@@ -600,7 +615,7 @@ class Peer(
                             onChainFeeratesFlow.filterNotNull().first()
                         )
                         val channelConfig = ChannelConfig.standard
-                        val (state1, actions1) = state.process(ChannelEvent.InitFundee(msg.temporaryChannelId, localParams, channelConfig, theirInit!!))
+                        val (state1, actions1) = state.process(ChannelEvent.InitNonInitiator(msg.temporaryChannelId, localParams, channelConfig, theirInit!!))
                         val (state2, actions2) = state1.process(ChannelEvent.MessageReceived(msg))
                         processActions(msg.temporaryChannelId, actions1 + actions2)
                         _channels = _channels + (msg.temporaryChannelId to state2)

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/PeerChannels.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/PeerChannels.kt
@@ -8,13 +8,13 @@ import fr.acinq.lightning.NodeParams
 import fr.acinq.lightning.channel.LocalParams
 
 object PeerChannels {
-    fun makeChannelParams(nodeParams: NodeParams, defaultFinalScriptPubkey: ByteVector, isFunder: Boolean, fundingAmount: Satoshi): LocalParams {
-        // we make sure that funder and fundee key path end differently
-        val fundingKeyPath = nodeParams.keyManager.newFundingKeyPath(isFunder)
-        return makeChannelParams(nodeParams, defaultFinalScriptPubkey, isFunder, fundingAmount, fundingKeyPath)
+    fun makeChannelParams(nodeParams: NodeParams, defaultFinalScriptPubkey: ByteVector, isInitiator: Boolean, fundingAmount: Satoshi): LocalParams {
+        // we make sure that initiator and non-initiator key path end differently
+        val fundingKeyPath = nodeParams.keyManager.newFundingKeyPath(isInitiator)
+        return makeChannelParams(nodeParams, defaultFinalScriptPubkey, isInitiator, fundingAmount, fundingKeyPath)
     }
 
-    fun makeChannelParams(nodeParams: NodeParams, defaultFinalScriptPubkey: ByteVector, isFunder: Boolean, fundingAmount: Satoshi, fundingKeyPath: KeyPath): LocalParams {
+    fun makeChannelParams(nodeParams: NodeParams, defaultFinalScriptPubkey: ByteVector, isInitiator: Boolean, fundingAmount: Satoshi, fundingKeyPath: KeyPath): LocalParams {
         return LocalParams(
             nodeParams.nodeId,
             nodeParams.keyManager.channelKeys(fundingKeyPath),
@@ -24,7 +24,7 @@ object PeerChannels {
             htlcMinimum = nodeParams.htlcMinimum,
             toSelfDelay = nodeParams.toRemoteDelayBlocks, // we choose their delay
             maxAcceptedHtlcs = nodeParams.maxAcceptedHtlcs,
-            isFunder = isFunder,
+            isInitiator = isInitiator,
             defaultFinalScriptPubKey = defaultFinalScriptPubkey,
             features = nodeParams.features
         )

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v1/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v1/ChannelState.kt
@@ -534,7 +534,7 @@ data class InitFunder(
     val channelFlags: Byte,
     val channelVersion: ChannelVersion
 ) {
-    constructor(from: fr.acinq.lightning.channel.ChannelEvent.InitFunder) : this(
+    constructor(from: fr.acinq.lightning.channel.ChannelEvent.InitInitiator) : this(
         from.temporaryChannelId,
         from.fundingAmount,
         from.pushAmount,
@@ -559,7 +559,7 @@ data class WaitForAcceptChannel(
         StaticParams(from.staticParams),
         from.currentTip,
         OnChainFeerates(from.currentOnChainFeerates),
-        InitFunder(from.initFunder),
+        InitFunder(from.init),
         from.lastSent
     )
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v1/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v1/ChannelState.kt
@@ -189,7 +189,7 @@ data class LocalParams constructor(
         from.htlcMinimum,
         from.toSelfDelay,
         from.maxAcceptedHtlcs,
-        from.isFunder,
+        from.isInitiator,
         from.defaultFinalScriptPubKey,
         from.features
     )
@@ -778,7 +778,7 @@ data class Negotiating(
 ) : ChannelStateWithCommitments() {
     init {
         require(closingTxProposed.isNotEmpty()) { "there must always be a list for the current negotiation" }
-        require(!commitments.localParams.isFunder || !closingTxProposed.any { it.isEmpty() }) { "funder must have at least one closing signature for every negotiation attempt because it initiates the closing" }
+        require(!commitments.localParams.isFunder || !closingTxProposed.any { it.isEmpty() }) { "initiator must have at least one closing signature for every negotiation attempt because it initiates the closing" }
     }
 
     constructor(from: fr.acinq.lightning.channel.Negotiating) : this(

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
@@ -527,7 +527,7 @@ data class InitFunder(
     val channelFlags: Byte,
     val channelVersion: ChannelVersion
 ) {
-    constructor(from: fr.acinq.lightning.channel.ChannelEvent.InitFunder) : this(
+    constructor(from: fr.acinq.lightning.channel.ChannelEvent.InitInitiator) : this(
         from.temporaryChannelId,
         from.fundingAmount,
         from.pushAmount,
@@ -552,7 +552,7 @@ data class WaitForAcceptChannel(
         StaticParams(from.staticParams),
         from.currentTip,
         OnChainFeerates(from.currentOnChainFeerates),
-        InitFunder(from.initFunder),
+        InitFunder(from.init),
         from.lastSent
     )
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
@@ -182,7 +182,7 @@ data class LocalParams constructor(
         from.htlcMinimum,
         from.toSelfDelay,
         from.maxAcceptedHtlcs,
-        from.isFunder,
+        from.isInitiator,
         from.defaultFinalScriptPubKey,
         from.features
     )
@@ -771,7 +771,7 @@ data class Negotiating(
 ) : ChannelStateWithCommitments() {
     init {
         require(closingTxProposed.isNotEmpty()) { "there must always be a list for the current negotiation" }
-        require(!commitments.localParams.isFunder || !closingTxProposed.any { it.isEmpty() }) { "funder must have at least one closing signature for every negotiation attempt because it initiates the closing" }
+        require(!commitments.localParams.isFunder || !closingTxProposed.any { it.isEmpty() }) { "initiator must have at least one closing signature for every negotiation attempt because it initiates the closing" }
     }
 
     constructor(from: fr.acinq.lightning.channel.Negotiating) : this(

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
@@ -183,7 +183,7 @@ data class LocalParams constructor(
         from.htlcMinimum,
         from.toSelfDelay,
         from.maxAcceptedHtlcs,
-        from.isFunder,
+        from.isInitiator,
         from.defaultFinalScriptPubKey,
         from.features
     )
@@ -787,7 +787,7 @@ data class Negotiating(
 ) : ChannelStateWithCommitments() {
     init {
         require(closingTxProposed.isNotEmpty()) { "there must always be a list for the current negotiation" }
-        require(!commitments.localParams.isFunder || !closingTxProposed.any { it.isEmpty() }) { "funder must have at least one closing signature for every negotiation attempt because it initiates the closing" }
+        require(!commitments.localParams.isFunder || !closingTxProposed.any { it.isEmpty() }) { "initiator must have at least one closing signature for every negotiation attempt because it initiates the closing" }
     }
 
     constructor(from: fr.acinq.lightning.channel.Negotiating) : this(

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
@@ -533,7 +533,7 @@ data class InitFunder(
     val channelConfig: ChannelConfig,
     val channelType: ChannelType
 ) {
-    constructor(from: fr.acinq.lightning.channel.ChannelEvent.InitFunder) : this(
+    constructor(from: fr.acinq.lightning.channel.ChannelEvent.InitInitiator) : this(
         from.temporaryChannelId,
         from.fundingAmount,
         from.pushAmount,
@@ -559,7 +559,7 @@ data class WaitForAcceptChannel(
         StaticParams(from.staticParams),
         from.currentTip,
         OnChainFeerates(from.currentOnChainFeerates),
-        InitFunder(from.initFunder),
+        InitFunder(from.init),
         from.lastSent
     )
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
@@ -361,10 +361,10 @@ class CommitmentsTestsCommon : LightningTestSuite() {
 
     // See https://github.com/lightningnetwork/lightning-rfc/issues/728
     @Test
-    fun `funder keeps additional reserve to avoid channel being stuck`() {
-        val isFunder = true
+    fun `initiator keeps additional reserve to avoid channel being stuck`() {
+        val isInitiator = true
         val currentBlockHeight = 144L
-        val c = makeCommitments(100000000.msat, 50000000.msat, FeeratePerKw(2500.sat), 546.sat, isFunder)
+        val c = makeCommitments(100000000.msat, 50000000.msat, FeeratePerKw(2500.sat), 546.sat, isInitiator)
         val (_, cmdAdd) = TestsHelper.makeCmdAdd(c.availableBalanceForSend(), randomKey().publicKey(), currentBlockHeight)
         val (c1, _) = c.sendAdd(cmdAdd, UUID.randomUUID(), currentBlockHeight).right!!
         assertEquals(c1.availableBalanceForSend(), 0.msat)
@@ -471,10 +471,10 @@ class CommitmentsTestsCommon : LightningTestSuite() {
 
     @OptIn(ExperimentalUnsignedTypes::class)
     companion object {
-        fun makeCommitments(toLocal: MilliSatoshi, toRemote: MilliSatoshi, feeRatePerKw: FeeratePerKw = FeeratePerKw(0.sat), dustLimit: Satoshi = 0.sat, isFunder: Boolean = true, announceChannel: Boolean = true): Commitments {
+        fun makeCommitments(toLocal: MilliSatoshi, toRemote: MilliSatoshi, feeRatePerKw: FeeratePerKw = FeeratePerKw(0.sat), dustLimit: Satoshi = 0.sat, isInitiator: Boolean = true, announceChannel: Boolean = true): Commitments {
             val channelKeys = ChannelKeys(KeyPath("42"), randomKey(), randomKey(), randomKey(), randomKey(), randomKey(), randomBytes32())
             val localParams = LocalParams(
-                randomKey().publicKey(), channelKeys, dustLimit, Long.MAX_VALUE, 0.sat, 1.msat, CltvExpiryDelta(144), 50, isFunder, ByteVector.empty, Features.empty
+                randomKey().publicKey(), channelKeys, dustLimit, Long.MAX_VALUE, 0.sat, 1.msat, CltvExpiryDelta(144), 50, isInitiator, ByteVector.empty, Features.empty
             )
             val remoteParams = RemoteParams(
                 randomKey().publicKey(), dustLimit, Long.MAX_VALUE, 0.sat, 1.msat, CltvExpiryDelta(144), 50,
@@ -509,7 +509,7 @@ class CommitmentsTestsCommon : LightningTestSuite() {
         fun makeCommitments(toLocal: MilliSatoshi, toRemote: MilliSatoshi, localNodeId: PublicKey, remoteNodeId: PublicKey, announceChannel: Boolean): Commitments {
             val channelKeys = ChannelKeys(KeyPath("42"), randomKey(), randomKey(), randomKey(), randomKey(), randomKey(), randomBytes32())
             val localParams = LocalParams(
-                localNodeId, channelKeys, 0.sat, Long.MAX_VALUE, 0.sat, 1.msat, CltvExpiryDelta(144), 50, isFunder = true, ByteVector.empty, Features.empty
+                localNodeId, channelKeys, 0.sat, Long.MAX_VALUE, 0.sat, 1.msat, CltvExpiryDelta(144), 50, isInitiator = true, ByteVector.empty, Features.empty
             )
             val remoteParams = RemoteParams(
                 remoteNodeId, 0.sat, Long.MAX_VALUE, 0.sat, 1.msat, CltvExpiryDelta(144), 50, randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey(), randomKey().publicKey(), Features.empty

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -99,7 +99,7 @@ object TestsHelper {
         val aliceInit = Init(aliceFeatures.toByteArray().toByteVector())
         val bobInit = Init(bobFeatures.toByteArray().toByteVector())
         val ra = alice.process(
-            ChannelEvent.InitFunder(
+            ChannelEvent.InitInitiator(
                 ByteVector32.Zeroes,
                 fundingAmount,
                 pushMsat,
@@ -115,7 +115,7 @@ object TestsHelper {
         )
         alice = ra.first
         assertTrue(alice is WaitForAcceptChannel)
-        val rb = bob.process(ChannelEvent.InitFundee(ByteVector32.Zeroes, bobChannelParams, ChannelConfig.standard, aliceInit))
+        val rb = bob.process(ChannelEvent.InitNonInitiator(ByteVector32.Zeroes, bobChannelParams, ChannelConfig.standard, aliceInit))
         bob = rb.first
         assertTrue(bob is WaitForOpenChannel)
         val open = ra.second.findOutgoingMessage<OpenChannel>()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
@@ -1599,7 +1599,7 @@ class ClosingTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv GetTxResponse (funder, tx found)`() {
+    fun `recv GetTxResponse (initiator, tx found)`() {
         val (alice, _) = initForceClose()
         val fundingTx = alice.fundingTx
         assertNotNull(fundingTx)
@@ -1611,7 +1611,7 @@ class ClosingTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv GetTxResponse (funder, tx not found)`() {
+    fun `recv GetTxResponse (initiator, tx not found)`() {
         val (alice, _) = initForceClose()
         val fundingTx = alice.fundingTx
         assertNotNull(fundingTx)
@@ -1624,7 +1624,7 @@ class ClosingTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv GetTxResponse (fundee, tx found)`() {
+    fun `recv GetTxResponse (non-initiator, tx found)`() {
         val (alice, bob) = initForceClose()
         val fundingTx = alice.fundingTx
         assertNotNull(fundingTx)
@@ -1636,7 +1636,7 @@ class ClosingTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv GetTxResponse (fundee, tx not found)`() {
+    fun `recv GetTxResponse (non-initiator, tx not found)`() {
         val (alice, bob) = initForceClose()
         val fundingTx = alice.fundingTx
         assertNotNull(fundingTx)
@@ -1648,13 +1648,13 @@ class ClosingTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv GetTxResponse (fundee, tx not found, timeout)`() {
+    fun `recv GetTxResponse (non-initiator, tx not found, timeout)`() {
         val (alice, bob) = initForceClose()
         val fundingTx = alice.fundingTx
         assertNotNull(fundingTx)
 
         // test starts here
-        val (bob1, _) = bob.process(ChannelEvent.NewBlock(bob.currentBlockHeight + Channel.FUNDING_TIMEOUT_FUNDEE_BLOCK + 1, BlockHeader(0, ByteVector32.Zeroes, ByteVector32.Zeroes, 0, 0, 0)))
+        val (bob1, _) = bob.process(ChannelEvent.NewBlock(bob.currentBlockHeight + Channel.FUNDING_TIMEOUT_NON_INITIATOR_BLOCK + 1, BlockHeader(0, ByteVector32.Zeroes, ByteVector32.Zeroes, 0, 0, 0)))
         val (bob2, actions2) = bob1.process(ChannelEvent.GetFundingTxResponse(GetTxWithMetaResponse(fundingTx.txid, null, currentTimestampMillis())))
         assertTrue { bob2 is Aborted }
         assertEquals(1, actions2.size)
@@ -1688,7 +1688,7 @@ class ClosingTestsCommon : LightningTestSuite() {
         val (bob2, _) = bob1.process(ChannelEvent.GetFundingTxResponse(GetTxWithMetaResponse(bob.commitments.commitInput.outPoint.txid, null, currentTimestampMillis())))
         assertEquals(bob1, bob2)
         // Fast forward after the funding timeout.
-        val (bob3, _) = bob2.process(ChannelEvent.NewBlock(bob2.currentBlockHeight + Channel.FUNDING_TIMEOUT_FUNDEE_BLOCK + 1, BlockHeader(0, ByteVector32.Zeroes, ByteVector32.Zeroes, 0, 0, 0)))
+        val (bob3, _) = bob2.process(ChannelEvent.NewBlock(bob2.currentBlockHeight + Channel.FUNDING_TIMEOUT_NON_INITIATOR_BLOCK + 1, BlockHeader(0, ByteVector32.Zeroes, ByteVector32.Zeroes, 0, 0, 0)))
         // We give up, Channel is aborted
         val (bob4, actions4) = bob3.process(ChannelEvent.GetFundingTxResponse(GetTxWithMetaResponse(bob.commitments.commitInput.outPoint.txid, null, currentTimestampMillis())))
         assertTrue { bob4 is Aborted }
@@ -1852,7 +1852,7 @@ class ClosingTestsCommon : LightningTestSuite() {
 
         fun initForceClose(): Pair<Closing, Closing> {
             val (alice, bob) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs, TestConstants.fundingAmount, TestConstants.pushMsat)
-            // funder
+            // initiator
             val alice1 = run {
                 val (alice1, actions1) = alice.process(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
                 assertTrue(alice1 is Closing)
@@ -1889,7 +1889,7 @@ class ClosingTestsCommon : LightningTestSuite() {
                 alice1
             }
 
-            // fundee
+            // non-initiator
             val bob1 = run {
                 val (bob1, actions1) = bob.process(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
                 assertTrue(bob1 is Closing)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NegotiatingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NegotiatingTestsCommon.kt
@@ -38,7 +38,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         val bob1 = bob.updateFeerate(FeeratePerKw(7_500.sat))
         val (alice2, bob2, aliceCloseSig1) = if (bobInitiates) mutualCloseBob(alice1, bob1) else mutualCloseAlice(alice1, bob1)
 
-        // alice is funder so she initiates the negotiation
+        // alice is initiator so she initiates the negotiation
         assertEquals(aliceCloseSig1.feeSatoshis, 3370.sat) // matches a feerate of 5000 sat/kw
         val aliceFeeRange = aliceCloseSig1.tlvStream.get<ClosingSignedTlv.FeeRange>()
         assertNotNull(aliceFeeRange)
@@ -116,7 +116,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         val bob1 = bob.updateFeerate(FeeratePerKw(5_000.sat))
         val (alice2, bob2, aliceCloseSig1) = if (bobInitiates) mutualCloseBob(alice1, bob1) else mutualCloseAlice(alice1, bob1)
 
-        // alice is funder so she initiates the negotiation
+        // alice is initiator so she initiates the negotiation
         assertEquals(aliceCloseSig1.feeSatoshis, 3370.sat) // matches a feerate of 5000 sat/kw
         val aliceFeeRange = aliceCloseSig1.tlvStream.get<ClosingSignedTlv.FeeRange>()
         assertNotNull(aliceFeeRange)
@@ -148,7 +148,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `override on-chain fee estimator (funder)`() {
+    fun `override on-chain fee estimator (initiator)`() {
         val (alice, bob) = reachNormal()
         val alice1 = alice.updateFeerate(FeeratePerKw(10_000.sat))
         val bob1 = bob.updateFeerate(FeeratePerKw(10_000.sat))
@@ -176,12 +176,12 @@ class NegotiatingTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `override on-chain fee estimator (fundee)`() {
+    fun `override on-chain fee estimator (non-initiator)`() {
         val (alice, bob) = reachNormal()
         val alice1 = alice.updateFeerate(FeeratePerKw(10_000.sat))
         val bob1 = bob.updateFeerate(FeeratePerKw(10_000.sat))
 
-        // alice is funder, so bob's override will simply be ignored
+        // alice is initiator, so bob's override will simply be ignored
         val (alice2, bob2, aliceCloseSig) = mutualCloseBob(alice1, bob1, feerates = ClosingFeerates(FeeratePerKw(2_500.sat), FeeratePerKw(2_000.sat), FeeratePerKw(3_000.sat)))
         assertEquals(aliceCloseSig.feeSatoshis, 6740.sat) // matches a feerate of 10 000 sat/kw
 
@@ -214,7 +214,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv ClosingSigned (other side ignores our fee range, funder)`() {
+    fun `recv ClosingSigned (other side ignores our fee range, initiator)`() {
         val (alice, bob) = reachNormal()
         val alice1 = alice.updateFeerate(FeeratePerKw(1_000.sat))
         val (alice2, bob2, aliceCloseSig1) = mutualCloseAlice(alice1, bob)
@@ -262,7 +262,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv ClosingSigned (other side ignores our fee range, fundee)`() {
+    fun `recv ClosingSigned (other side ignores our fee range, non-initiator)`() {
         val (alice, bob) = reachNormal()
         val bob1 = bob.updateFeerate(FeeratePerKw(10_000.sat))
         val (alice2, bob2, _) = mutualCloseBob(alice, bob1)
@@ -353,7 +353,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
     @Test
     fun `recv BITCOIN_FUNDING_SPENT (counterparty's mutual close)`() {
-        // NB: we're fundee here, not funder
+        // NB: we're not the initiator here
         val (bob, alice) = reachNormal()
         val priv = randomKey()
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
@@ -168,7 +168,7 @@ class NormalTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv CMD_ADD_HTLC (HTLC dips into remote funder fee reserve)`() {
+    fun `recv CMD_ADD_HTLC (HTLC dips into remote initiator fee reserve)`() {
         val (alice0, bob0) = reachNormal()
         val (alice1, bob1) = addHtlc(764_660_000.msat, alice0, bob0).first
         val (alice2, bob2) = crossSign(alice1, bob1)
@@ -645,7 +645,7 @@ class NormalTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv CMD_SIGN (channel backup, fundee)`() {
+    fun `recv CMD_SIGN (channel backup, non-initiator)`() {
         val (alice, bob) = reachNormal()
         assertTrue(alice.commitments.localParams.features.hasFeature(Feature.ChannelBackupProvider))
         assertTrue(bob.commitments.localParams.features.hasFeature(Feature.ChannelBackupClient))
@@ -881,7 +881,7 @@ class NormalTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv RevokeAndAck (channel backup, fundee)`() {
+    fun `recv RevokeAndAck (channel backup, non-initiator)`() {
         val (alice, bob) = reachNormal()
         assertTrue(alice.commitments.localParams.features.hasFeature(Feature.ChannelBackupProvider))
         assertTrue(bob.commitments.localParams.features.hasFeature(Feature.ChannelBackupClient))

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
@@ -282,7 +282,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
         val (bob3, _) = bob2.processEx(ChannelEvent.GetFundingTxResponse(GetTxWithMetaResponse(bob.commitments.commitInput.outPoint.txid, null, currentTimestampMillis())))
         assertEquals(bob2, bob3)
         // Fast forward after the funding timeout
-        val (bob4, _) = bob3.processEx(ChannelEvent.NewBlock(bob3.currentBlockHeight + Channel.FUNDING_TIMEOUT_FUNDEE_BLOCK + 1, BlockHeader(0, ByteVector32.Zeroes, ByteVector32.Zeroes, 0, 0, 0)))
+        val (bob4, _) = bob3.processEx(ChannelEvent.NewBlock(bob3.currentBlockHeight + Channel.FUNDING_TIMEOUT_NON_INITIATOR_BLOCK + 1, BlockHeader(0, ByteVector32.Zeroes, ByteVector32.Zeroes, 0, 0, 0)))
         // We give up, Channel is aborted
         val (bob5, actions5) = bob4.processEx(ChannelEvent.GetFundingTxResponse(GetTxWithMetaResponse(bob.commitments.commitInput.outPoint.txid, null, currentTimestampMillis())))
         assertTrue { bob5 is Aborted }
@@ -302,7 +302,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
         val (bob2, _) = bob1.processEx(ChannelEvent.GetFundingTxResponse(GetTxWithMetaResponse(bob.commitments.commitInput.outPoint.txid, null, currentTimestampMillis())))
         assertEquals(bob1, bob2)
         // Fast forward after the funding timeout
-        val (bob3, _) = bob2.processEx(ChannelEvent.NewBlock(bob2.currentBlockHeight + Channel.FUNDING_TIMEOUT_FUNDEE_BLOCK + 1, BlockHeader(0, ByteVector32.Zeroes, ByteVector32.Zeroes, 0, 0, 0)))
+        val (bob3, _) = bob2.processEx(ChannelEvent.NewBlock(bob2.currentBlockHeight + Channel.FUNDING_TIMEOUT_NON_INITIATOR_BLOCK + 1, BlockHeader(0, ByteVector32.Zeroes, ByteVector32.Zeroes, 0, 0, 0)))
         // We give up, Channel is aborted
         val (bob4, actions4) = bob3.processEx(ChannelEvent.GetFundingTxResponse(GetTxWithMetaResponse(bob.commitments.commitInput.outPoint.txid, null, currentTimestampMillis())))
         assertTrue { bob4 is Aborted }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreatedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreatedTestsCommon.kt
@@ -44,7 +44,7 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv FundingCreated (funder can't pay fees)`() {
+    fun `recv FundingCreated (initiator can't pay fees)`() {
         val (_, bob, fundingCreated) = init(ChannelType.SupportedChannelType.AnchorOutputs, 1_000_100.sat, 1_000_000.sat.toMilliSatoshi())
         val (bob1, actions1) = bob.process(ChannelEvent.MessageReceived(fundingCreated))
         actions1.hasOutgoingMessage<Error>()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannelTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannelTestsCommon.kt
@@ -33,7 +33,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
         val unsupportedChannelTypes = listOf(ChannelType.SupportedChannelType.Standard, ChannelType.SupportedChannelType.StaticRemoteKey)
         unsupportedChannelTypes.forEach { channelType ->
             val (alice1, actions1) = alice.process(
-                ChannelEvent.InitFunder(
+                ChannelEvent.InitInitiator(
                     ByteVector32.Zeroes,
                     TestConstants.fundingAmount,
                     0.msat,

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
@@ -50,7 +50,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     fun `generate channel keys`() {
         val seed = ByteVector("aeb3e9b5642cd4523e9e09164047f60adb413633549c3c6189192921311894d501")
         val keyManager = LocalKeyManager(seed, Block.TestnetGenesisBlock.hash)
-        val fundingKeyPath = makefundingKeyPath(ByteVector("06535806c1aa73971ec4877a5e2e684fa636136c073810f190b63eefc58ca488"), isFunder = false)
+        val fundingKeyPath = makefundingKeyPath(ByteVector("06535806c1aa73971ec4877a5e2e684fa636136c073810f190b63eefc58ca488"), isInitiator = false)
         val channelKeys = keyManager.channelKeys(fundingKeyPath)
 
         // README !
@@ -89,17 +89,17 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         assertEquals(keyPath.toString(), "m/1909530642'/1080788911/847211985'/1791010671/1303008749'/34154019'/723973395/767609665")
     }
 
-    fun makefundingKeyPath(entropy: ByteVector, isFunder: Boolean): KeyPath {
+    fun makefundingKeyPath(entropy: ByteVector, isInitiator: Boolean): KeyPath {
         val items = (0..7).toList().map { Pack.int32BE(entropy.toByteArray(), it * 4).toLong() and 0xFFFFFFFFL }
-        val last = DeterministicWallet.hardened(if (isFunder) 1L else 0L)
+        val last = DeterministicWallet.hardened(if (isInitiator) 1L else 0L)
         return KeyPath(items + last)
     }
 
     @Test
-    fun `test vectors (testnet, funder)`() {
+    fun `test vectors (testnet, initiator)`() {
         val seed = ByteVector("17b086b228025fa8f4416324b6ba2ec36e68570ae2fc3d392520969f2a9d0c1501")
         val keyManager = LocalKeyManager(seed, Block.TestnetGenesisBlock.hash)
-        val fundingKeyPath = makefundingKeyPath(ByteVector("be4fa97c62b9f88437a3be577b31eb48f2165c7bc252194a15ff92d995778cfb"), isFunder = true)
+        val fundingKeyPath = makefundingKeyPath(ByteVector("be4fa97c62b9f88437a3be577b31eb48f2165c7bc252194a15ff92d995778cfb"), isInitiator = true)
         val fundingPub = keyManager.fundingPublicKey(fundingKeyPath)
 
         val localParams = TestConstants.Alice.channelParams.copy(channelKeys = keyManager.channelKeys(fundingKeyPath))
@@ -114,10 +114,10 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `test vectors (testnet, fundee)`() {
+    fun `test vectors (testnet, non-initiator)`() {
         val seed = ByteVector("aeb3e9b5642cd4523e9e09164047f60adb413633549c3c6189192921311894d501")
         val keyManager = LocalKeyManager(seed, Block.TestnetGenesisBlock.hash)
-        val fundingKeyPath = makefundingKeyPath(ByteVector("06535806c1aa73971ec4877a5e2e684fa636136c073810f190b63eefc58ca488"), isFunder = false)
+        val fundingKeyPath = makefundingKeyPath(ByteVector("06535806c1aa73971ec4877a5e2e684fa636136c073810f190b63eefc58ca488"), isInitiator = false)
         val fundingPub = keyManager.fundingPublicKey(fundingKeyPath)
 
         val localParams = TestConstants.Alice.channelParams.copy(channelKeys = keyManager.channelKeys(fundingKeyPath))
@@ -132,10 +132,10 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `test vectors (mainnet, funder)`() {
+    fun `test vectors (mainnet, initiator)`() {
         val seed = ByteVector("d8d5431487c2b19ee6486aad6c3bdfb99d10b727bade7fa848e2ab7901c15bff01")
         val keyManager = LocalKeyManager(seed, Block.LivenetGenesisBlock.hash)
-        val fundingKeyPath = makefundingKeyPath(ByteVector("ec1c41cd6be2b6e4ef46c1107f6c51fbb2066d7e1f7720bde4715af233ae1322"), isFunder = true)
+        val fundingKeyPath = makefundingKeyPath(ByteVector("ec1c41cd6be2b6e4ef46c1107f6c51fbb2066d7e1f7720bde4715af233ae1322"), isInitiator = true)
         val fundingPub = keyManager.fundingPublicKey(fundingKeyPath)
 
         val localParams = TestConstants.Alice.channelParams.copy(channelKeys = keyManager.channelKeys(fundingKeyPath))
@@ -150,10 +150,10 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `test vectors (mainnet, fundee)`() {
+    fun `test vectors (mainnet, non-initiator)`() {
         val seed = ByteVector("4b809dd593b36131c454d60c2f7bdfd49d12ec455e5b657c47a9ca0f5dfc5eef01")
         val keyManager = LocalKeyManager(seed, Block.LivenetGenesisBlock.hash)
-        val fundingKeyPath = makefundingKeyPath(ByteVector("2b4f045be5303d53f9d3a84a1e70c12251168dc29f300cf9cece0ec85cd8182b"), isFunder = false)
+        val fundingKeyPath = makefundingKeyPath(ByteVector("2b4f045be5303d53f9d3a84a1e70c12251168dc29f300cf9cece0ec85cd8182b"), isInitiator = false)
         val fundingPub = keyManager.fundingPublicKey(fundingKeyPath)
 
         val localParams = TestConstants.Alice.channelParams.copy(channelKeys = keyManager.channelKeys(fundingKeyPath))

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
@@ -104,7 +104,7 @@ object TestConstants {
         val channelParams: LocalParams = PeerChannels.makeChannelParams(
             nodeParams,
             defaultFinalScriptPubkey = ByteVector(closingPubKeyInfo.second),
-            isFunder = true,
+            isInitiator = true,
             fundingAmount
         ).copy(channelReserve = 10_000.sat) // Bob will need to keep that much satoshis as direct payment
     }
@@ -180,7 +180,7 @@ object TestConstants {
         val channelParams: LocalParams = PeerChannels.makeChannelParams(
             nodeParams,
             defaultFinalScriptPubkey = ByteVector(closingPubKeyInfo.second),
-            isFunder = false,
+            isInitiator = false,
             fundingAmount
         ).copy(channelReserve = 20_000.sat) // Alice will need to keep that much satoshis as direct payment
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
@@ -560,20 +560,20 @@ class TransactionsTestsCommon : LightningTestSuite() {
         val remotePubKeyScript = write(pay2wpkh(PrivateKey(randomBytes32()).publicKey()))
 
         run {
-            // Different amounts, both outputs untrimmed, local is funder:
+            // Different amounts, both outputs untrimmed, local is the initiator:
             val spec = CommitmentSpec(setOf(), feerate, 150_000_000.msat, 250_000_000.msat)
-            val closingTx = makeClosingTx(commitInput, localPubKeyScript, remotePubKeyScript, localIsFunder = true, localDustLimit, 1000.sat, spec)
+            val closingTx = makeClosingTx(commitInput, localPubKeyScript, remotePubKeyScript, localIsInitiator = true, localDustLimit, 1000.sat, spec)
             assertEquals(2, closingTx.tx.txOut.size)
             assertNotNull(closingTx.toLocalIndex)
             assertEquals(localPubKeyScript.toByteVector(), closingTx.toLocalOutput!!.publicKeyScript)
-            assertEquals(149_000.sat, closingTx.toLocalOutput!!.amount) // funder pays the fee
+            assertEquals(149_000.sat, closingTx.toLocalOutput!!.amount) // initiator pays the fee
             val toRemoteIndex = (closingTx.toLocalIndex!! + 1) % 2
             assertEquals(250_000.sat, closingTx.tx.txOut[toRemoteIndex].amount)
         }
         run {
-            // Same amounts, both outputs untrimmed, local is fundee:
+            // Same amounts, both outputs untrimmed, local is not the initiator:
             val spec = CommitmentSpec(setOf(), feerate, 150_000_000.msat, 150_000_000.msat)
-            val closingTx = makeClosingTx(commitInput, localPubKeyScript, remotePubKeyScript, localIsFunder = false, localDustLimit, 1000.sat, spec)
+            val closingTx = makeClosingTx(commitInput, localPubKeyScript, remotePubKeyScript, localIsInitiator = false, localDustLimit, 1000.sat, spec)
             assertEquals(2, closingTx.tx.txOut.size)
             assertNotNull(closingTx.toLocalIndex)
             assertEquals(localPubKeyScript.toByteVector(), closingTx.toLocalOutput!!.publicKeyScript)
@@ -584,7 +584,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
         run {
             // Their output is trimmed:
             val spec = CommitmentSpec(setOf(), feerate, 150_000_000.msat, 1_000.msat)
-            val closingTx = makeClosingTx(commitInput, localPubKeyScript, remotePubKeyScript, localIsFunder = false, localDustLimit, 1000.sat, spec)
+            val closingTx = makeClosingTx(commitInput, localPubKeyScript, remotePubKeyScript, localIsInitiator = false, localDustLimit, 1000.sat, spec)
             assertEquals(1, closingTx.tx.txOut.size)
             assertNotNull(closingTx.toLocalOutput)
             assertEquals(localPubKeyScript.toByteVector(), closingTx.toLocalOutput!!.publicKeyScript)
@@ -594,14 +594,14 @@ class TransactionsTestsCommon : LightningTestSuite() {
         run {
             // Our output is trimmed:
             val spec = CommitmentSpec(setOf(), feerate, 50_000.msat, 150_000_000.msat)
-            val closingTx = makeClosingTx(commitInput, localPubKeyScript, remotePubKeyScript, localIsFunder = true, localDustLimit, 1000.sat, spec)
+            val closingTx = makeClosingTx(commitInput, localPubKeyScript, remotePubKeyScript, localIsInitiator = true, localDustLimit, 1000.sat, spec)
             assertEquals(1, closingTx.tx.txOut.size)
             assertNull(closingTx.toLocalOutput)
         }
         run {
             // Both outputs are trimmed:
             val spec = CommitmentSpec(setOf(), feerate, 50_000.msat, 10_000.msat)
-            val closingTx = makeClosingTx(commitInput, localPubKeyScript, remotePubKeyScript, localIsFunder = true, localDustLimit, 1000.sat, spec)
+            val closingTx = makeClosingTx(commitInput, localPubKeyScript, remotePubKeyScript, localIsInitiator = true, localDustLimit, 1000.sat, spec)
             assertTrue(closingTx.tx.txOut.isEmpty())
             assertNull(closingTx.toLocalOutput)
         }

--- a/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
+++ b/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
@@ -167,7 +167,7 @@ object Node {
                 // these values mean that we will basically accept whatever feerate our peer is using.
                 // there is not much else we can do and this is mitigated by the fact that :
                 // - we only use the anchor_outputs format
-                // - we never fund channels (we're always "fundee" in LN parlance)
+                // - we never fund channels (we're always the "non-initiator" in LN parlance)
                 feerateTolerance = FeerateTolerance(ratioLow = 0.05, ratioHigh = 10.0)
             ),
             maxHtlcValueInFlightMsat = 5000000000L,


### PR DESCRIPTION
And fundee to non-initiator. This is a refactoring step for dual funding support. It doesn't contain any logic change, only renaming.

Note that we cannot rename fields/structs that are serialized, otherwise we break backwards-compatibility, that's why we currently keep `InitFunder`/`InitFundee`.