### PR TITLE
Remove lightning test factory

### DIFF
--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/utils/LightningTestSuite.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/utils/LightningTestSuite.kt
@@ -1,14 +1,3 @@
 package fr.acinq.lightning.tests.utils
 
-import fr.acinq.lightning.utils.setLightningLoggerFactory
-
-
-abstract class LightningTestSuite {
-
-    companion object {
-        init {
-            setLightningLoggerFactory(testLightningLoggerFactory)
-        }
-    }
-
-}
+abstract class LightningTestSuite

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/utils/testLogger.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/utils/testLogger.kt
@@ -1,6 +1,0 @@
-package fr.acinq.lightning.tests.utils
-
-import org.kodein.log.LoggerFactory
-
-
-expect val testLightningLoggerFactory: LoggerFactory

--- a/src/iosTest/kotlin/fr/acinq/lightning/tests/utils/testLoggerIos.kt
+++ b/src/iosTest/kotlin/fr/acinq/lightning/tests/utils/testLoggerIos.kt
@@ -1,7 +1,0 @@
-package fr.acinq.lightning.tests.utils
-
-import org.kodein.log.LoggerFactory
-import org.kodein.log.frontend.simplePrintFrontend
-
-
-actual val testLightningLoggerFactory: LoggerFactory = LoggerFactory(simplePrintFrontend)

--- a/src/jvmTest/kotlin/fr/acinq/lightning/tests/util/testLoggerJvm.kt
+++ b/src/jvmTest/kotlin/fr/acinq/lightning/tests/util/testLoggerJvm.kt
@@ -1,6 +1,0 @@
-package fr.acinq.lightning.tests.utils
-
-import org.kodein.log.LoggerFactory
-
-
-actual val testLightningLoggerFactory: LoggerFactory = LoggerFactory.default

--- a/src/linuxTest/kotlin/fr/acinq/lightning/tests/utils/testLoggerLinux.kt
+++ b/src/linuxTest/kotlin/fr/acinq/lightning/tests/utils/testLoggerLinux.kt
@@ -1,6 +1,0 @@
-package fr.acinq.lightning.tests.utils
-
-import org.kodein.log.LoggerFactory
-
-
-actual val testLightningLoggerFactory: LoggerFactory = LoggerFactory.default


### PR DESCRIPTION
So I was wondering why we needed a global variable `LightningLoggerFactory: LoggerFactory`, which needed to be set in a thread-safe manner in tests, which required a `@ThreadLocal` in `commonTests`, which prevented building on Windows.

Turns out we are setting this variable to `LoggerFactory.default = LoggerFactory(defaultLogFrontend)` everywhere, except in the module `iosTest`, where we set it to `LoggerFactory(simplePrintFrontend)`:
```
commonMain:
  (via LightningLoggerDelegateProvider)
  setLightningLoggerFactory(LoggerFactory.default)

commonTest:
  (via LightningTestSuite)
  setLightningLoggerFactory(testLightningLoggerFactory)
  expect val testLightningLoggerFactory: LoggerFactory
  
  jvmTest:
    actual val testLightningLoggerFactory: LoggerFactory = LoggerFactory.default

  linuxTest:
    actual val testLightningLoggerFactory: LoggerFactory = LoggerFactory.default

  iosTest:
    actual val testLightningLoggerFactory: LoggerFactory = LoggerFactory(simplePrintFrontend)
```

What's the difference between `defaultLogFrontend` and `simplePrintFrontend`? Looking at kodein logs:
```
commonMain:
    public expect val defaultLogFrontend: LogFrontend

jvmMain:
    public actual val defaultLogFrontend: LogFrontend by lazy {
    when {
        isSlf4jAvailable() -> slf4jFrontend
        isAndroidAvailable() -> androidFrontend
        else -> printFrontend
    }
  }
  
defaultNativeMain:
    public actual val defaultLogFrontend: LogFrontend = printFrontend
```

So it seems we went through all this simply to be able to use `simplePrintFrontend` instead of `printFrontend` on iOS. What's the difference between the two you ask?
```kotlin
public val printFrontend: LogFrontend = printerFrontend {
    if (it.level.severity >= Logger.Level.WARNING.severity) ::errPrintln else ::println
}

public val simplePrintFrontend: LogFrontend = printerFrontend { ::println }
```

Is there a reason why we don't want to send error logs to `stderr` on iOS?