### PR TITLE
Remove `@Threadlocal` annotations in tests

### DIFF
--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/bitcoind/BitcoinJsonRPCClient.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/bitcoind/BitcoinJsonRPCClient.kt
@@ -8,10 +8,8 @@ import io.ktor.client.features.auth.providers.*
 import io.ktor.client.features.json.*
 import io.ktor.client.features.json.serializer.*
 import io.ktor.client.request.*
-import kotlin.native.concurrent.ThreadLocal
 
 
-@ThreadLocal
 object BitcoinJsonRPCClient {
     private const val user: String = "foo"
     private const val pwd: String = "bar"

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/bitcoind/BitcoindService.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/bitcoind/BitcoindService.kt
@@ -6,9 +6,7 @@ import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.utils.toByteVector
 import fr.acinq.secp256k1.Hex
 import kotlinx.serialization.json.JsonElement
-import kotlin.native.concurrent.ThreadLocal
 
-@ThreadLocal
 object BitcoindService {
     private val client = BitcoinJsonRPCClient
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/utils/LightningTestSuite.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/utils/LightningTestSuite.kt
@@ -5,16 +5,9 @@ import fr.acinq.lightning.utils.setLightningLoggerFactory
 
 abstract class LightningTestSuite {
 
-    init {
-        setLogger()
-    }
-
     companion object {
-        private var loggerIsSet = false
-        fun setLogger() {
-            if (loggerIsSet) return
+        init {
             setLightningLoggerFactory(testLightningLoggerFactory)
-            loggerIsSet = true
         }
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/utils/LightningTestSuite.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/utils/LightningTestSuite.kt
@@ -1,7 +1,6 @@
 package fr.acinq.lightning.tests.utils
 
 import fr.acinq.lightning.utils.setLightningLoggerFactory
-import kotlin.native.concurrent.ThreadLocal
 
 
 abstract class LightningTestSuite {
@@ -10,7 +9,6 @@ abstract class LightningTestSuite {
         setLogger()
     }
 
-    @ThreadLocal
     companion object {
         private var loggerIsSet = false
         fun setLogger() {


### PR DESCRIPTION
This unlocks building on Windows.

It is a subset of https://github.com/ACINQ/lightning-kmp/pull/348 that is safe to merge, as it only touches test files.