### PR TITLE
Use `typealias` to factor chachapoly implementation

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/noise/Chacha20Poly1305CipherFunctions.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/noise/Chacha20Poly1305CipherFunctions.kt
@@ -1,3 +1,30 @@
 package fr.acinq.lightning.crypto.noise
 
+import fr.acinq.lightning.crypto.ChaCha20Poly1305
+
 expect object Chacha20Poly1305CipherFunctions : CipherFunctions
+
+/**
+ * Default implementation for [[Chacha20Poly1305CipherFunctions]]. Can be used by modules by
+ * defining a type alias.
+ */
+object Chacha20Poly1305CipherFunctionsDefault : CipherFunctions {
+    override fun name() = "ChaChaPoly"
+
+    // as specified in BOLT #8
+    fun nonce(n: Long): ByteArray = ByteArray(4) + ChaCha20Poly1305.write64(n)
+
+    // Encrypts plaintext using the cipher key k of 32 bytes and an 8-byte unsigned integer nonce n which must be unique.
+    override fun encrypt(k: ByteArray, n: Long, ad: ByteArray, plaintext: ByteArray): ByteArray {
+        val (ciphertext, mac) = ChaCha20Poly1305.encrypt(k, nonce(n), plaintext, ad)
+        return ciphertext + mac
+    }
+
+    // Decrypts ciphertext using a cipher key k of 32 bytes, an 8-byte unsigned integer nonce n, and associated data ad.
+    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+    override fun decrypt(k: ByteArray, n: Long, ad: ByteArray, ciphertextAndMac: ByteArray): ByteArray {
+        val ciphertext = ciphertextAndMac.dropLast(16).toByteArray()
+        val mac = ciphertextAndMac.takeLast(16).toByteArray()
+        return ChaCha20Poly1305.decrypt(k, nonce(n), ciphertext, ad, mac)
+    }
+}

--- a/src/jvmMain/kotlin/fr/acinq/lightning/crypto/noise/Chacha20Poly1305CipherFunctions.kt
+++ b/src/jvmMain/kotlin/fr/acinq/lightning/crypto/noise/Chacha20Poly1305CipherFunctions.kt
@@ -1,24 +1,3 @@
 package fr.acinq.lightning.crypto.noise
 
-import fr.acinq.lightning.crypto.ChaCha20Poly1305
-
-actual object Chacha20Poly1305CipherFunctions : CipherFunctions {
-    override fun name() = "ChaChaPoly"
-
-    // as specified in BOLT #8
-    fun nonce(n: Long): ByteArray = ByteArray(4) + ChaCha20Poly1305.write64(n)
-
-    // Encrypts plaintext using the cipher key k of 32 bytes and an 8-byte unsigned integer nonce n which must be unique.
-    override fun encrypt(k: ByteArray, n: Long, ad: ByteArray, plaintext: ByteArray): ByteArray {
-        val (ciphertext, mac) = ChaCha20Poly1305.encrypt(k, nonce(n), plaintext, ad)
-        return ciphertext + mac
-    }
-
-    // Decrypts ciphertext using a cipher key k of 32 bytes, an 8-byte unsigned integer nonce n, and associated data ad.
-    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
-    override fun decrypt(k: ByteArray, n: Long, ad: ByteArray, ciphertextAndMac: ByteArray): ByteArray {
-        val ciphertext = ciphertextAndMac.dropLast(16).toByteArray()
-        val mac = ciphertextAndMac.takeLast(16).toByteArray()
-        return ChaCha20Poly1305.decrypt(k, nonce(n), ciphertext, ad, mac)
-    }
-}
+actual typealias Chacha20Poly1305CipherFunctions = Chacha20Poly1305CipherFunctionsDefault

--- a/src/linuxMain/kotlin/fr/acinq/lightning/crypto/noise/Chacha20Poly1305CipherFunctions.kt
+++ b/src/linuxMain/kotlin/fr/acinq/lightning/crypto/noise/Chacha20Poly1305CipherFunctions.kt
@@ -1,24 +1,3 @@
 package fr.acinq.lightning.crypto.noise
 
-import fr.acinq.lightning.crypto.ChaCha20Poly1305
-
-actual object Chacha20Poly1305CipherFunctions : CipherFunctions {
-    override fun name() = "ChaChaPoly"
-
-    // as specified in BOLT #8
-    fun nonce(n: Long): ByteArray = ByteArray(4) + ChaCha20Poly1305.write64(n)
-
-    // Encrypts plaintext using the cipher key k of 32 bytes and an 8-byte unsigned integer nonce n which must be unique.
-    override fun encrypt(k: ByteArray, n: Long, ad: ByteArray, plaintext: ByteArray): ByteArray {
-        val (ciphertext, mac) = ChaCha20Poly1305.encrypt(k, nonce(n), plaintext, ad)
-        return ciphertext + mac
-    }
-
-    // Decrypts ciphertext using a cipher key k of 32 bytes, an 8-byte unsigned integer nonce n, and associated data ad.
-    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
-    override fun decrypt(k: ByteArray, n: Long, ad: ByteArray, ciphertextAndMac: ByteArray): ByteArray {
-        val ciphertext = ciphertextAndMac.dropLast(16).toByteArray()
-        val mac = ciphertextAndMac.takeLast(16).toByteArray()
-        return ChaCha20Poly1305.decrypt(k, nonce(n), ciphertext, ad, mac)
-    }
-}
+actual typealias Chacha20Poly1305CipherFunctions = Chacha20Poly1305CipherFunctionsDefault


### PR DESCRIPTION
This has been extracted from #348 and was successfully tested by @dpad85 (https://github.com/ACINQ/lightning-kmp/pull/348#pullrequestreview-1085859557).

See https://kotlinlang.org/docs/multiplatform-connect-to-apis.html#rules-for-expected-and-actual-declarations