### PR TITLE
Fix electrum state when disconnecting

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ kotlin.code.style=official
 kotlin.incremental.multiplatform=true
 kotlin.mpp.stability.nowarn=true
 # https://youtrack.jetbrains.com/issue/KT-36086
-#kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
+kotlin.mpp.enableCInteropCommonization=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,6 @@ kotlin.code.style=official
 kotlin.incremental.multiplatform=true
 kotlin.mpp.stability.nowarn=true
 # https://youtrack.jetbrains.com/issue/KT-36086
-kotlin.mpp.enableGranularSourceSetsMetadata=true
+#kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
-kotlin.mpp.enableCInteropCommonization=true
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
@@ -251,6 +251,7 @@ class ElectrumClient(
 
     fun disconnect() {
         if (this::socket.isInitialized) socket.close()
+        _connectionState.value = Connection.CLOSED(null)
         output.close()
     }
 


### PR DESCRIPTION
This PR fixes an issue in the electrum connection `state`. Disconnecting Electrum while connecting would not update the state of the connection, which would get stuck in the `Connecting` state. As such the reconnection logic in Phoenix would not attempt to reconnect to Electrum.

We also enable hierarchical multiplatform and cinterop commonization in gradle properties. This fixes a few issues in the IDE. See https://youtrack.jetbrains.com/issue/KT-40975