### PR TITLE
Use IO dispatcher when connecting to a pinned electrum server on the JVM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ allprojects {
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
 kotlin {
-    val ktorVersion: String by extra { "1.6.3" }
+    val ktorVersion: String by extra { "1.6.5" }
     fun ktor(module: String) = "io.ktor:ktor-$module:$ktorVersion"
     val secp256k1Version = "0.6.4"
     val serializationVersion = "1.2.2"


### PR DESCRIPTION
This PR fixes an issue where connections to an electrum server using a pinned certificate would change dispatcher.

We also update ktor to 1.6.5 which is the latest ktor version supporting kotlin 1.5.31.