### PR TITLE
Improve invoice features validation

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -50,10 +50,7 @@ interface SendPayment {
     val details: OutgoingPayment.Details
     val trampolineFeesOverride: List<TrampolineFees>?
     val paymentRequest: PaymentRequest
-
-    val paymentHash: ByteVector32
-        get() = details.paymentHash
-
+    val paymentHash: ByteVector32 get() = details.paymentHash
 }
 
 data class SendPaymentNormal(
@@ -763,7 +760,7 @@ class Peer(
             }
             event is SendPayment -> {
                 val currentTip = currentTipFlow.filterNotNull().first()
-                when (val result = outgoingPaymentHandler.sendPayment(event, _channels, currentTip.first)) {
+                when (val result = outgoingPaymentHandler.sendPayment(event, _channels, features, currentTip.first)) {
                     is OutgoingPaymentHandler.Progress -> {
                         _eventsFlow.emit(PaymentProgress(result.request, result.fees))
                         result.actions.forEach { input.send(it) }

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
@@ -15,6 +15,7 @@ sealed class FinalFailure {
     // @formatter:off
     object AlreadyPaid : FinalFailure() { override fun toString(): String = "this invoice has already been paid" }
     object InvalidPaymentAmount : FinalFailure() { override fun toString(): String = "payment amount must be positive" }
+    object FeaturesNotSupported : FinalFailure() { override fun toString(): String = "payment request features not supported" }
     object InvalidPaymentId : FinalFailure() { override fun toString(): String = "payment ID must be unique" }
     object NoAvailableChannels : FinalFailure() { override fun toString(): String = "no channels available to send payment" }
     object InsufficientBalance : FinalFailure() { override fun toString(): String = "not enough funds in wallet to afford payment" }

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
@@ -46,13 +46,13 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
 
     private fun getPaymentAttempt(childId: UUID): PaymentAttempt? = childToParentId[childId]?.let { pending[it] }
 
-    suspend fun sendPayment(request: SendPayment, channels: Map<ByteVector32, ChannelState>, features: Features, currentBlockHeight: Int): SendPaymentResult {
+    suspend fun sendPayment(request: SendPayment, channels: Map<ByteVector32, ChannelState>, nodeFeatures: Features, currentBlockHeight: Int): SendPaymentResult {
         logger.info { "h:${request.paymentHash} p:${request.paymentId} sending ${request.amount} to ${request.recipient}" }
         if (request.amount <= 0.msat) {
             logger.warning { "h:${request.paymentHash} p:${request.paymentId} payment amount must be positive (${request.amount})" }
             return Failure(request, FinalFailure.InvalidPaymentAmount.toPaymentFailure())
         }
-        if (!features.areSupported(Features(request.paymentRequest.features).invoiceFeatures())) {
+        if (!nodeFeatures.areSupported(Features(request.paymentRequest.features).invoiceFeatures())) {
             logger.warning { "h:${request.paymentHash} p:${request.paymentId} invoice contains mandatory features that we don't support" }
             return Failure(request, FinalFailure.FeaturesNotSupported.toPaymentFailure())
         }

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
@@ -46,11 +46,15 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
 
     private fun getPaymentAttempt(childId: UUID): PaymentAttempt? = childToParentId[childId]?.let { pending[it] }
 
-    suspend fun sendPayment(request: SendPayment, channels: Map<ByteVector32, ChannelState>, currentBlockHeight: Int): SendPaymentResult {
+    suspend fun sendPayment(request: SendPayment, channels: Map<ByteVector32, ChannelState>, features: Features, currentBlockHeight: Int): SendPaymentResult {
         logger.info { "h:${request.paymentHash} p:${request.paymentId} sending ${request.amount} to ${request.recipient}" }
         if (request.amount <= 0.msat) {
             logger.warning { "h:${request.paymentHash} p:${request.paymentId} payment amount must be positive (${request.amount})" }
             return Failure(request, FinalFailure.InvalidPaymentAmount.toPaymentFailure())
+        }
+        if (!features.areSupported(Features(request.paymentRequest.features).invoiceFeatures())) {
+            logger.warning { "h:${request.paymentHash} p:${request.paymentId} invoice contains mandatory features that we don't support" }
+            return Failure(request, FinalFailure.FeaturesNotSupported.toPaymentFailure())
         }
         if (pending.containsKey(request.paymentId)) {
             logger.error { "h:${request.paymentHash} p:${request.paymentId} contract violation: caller is recycling uuid's" }

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/PaymentRequest.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/PaymentRequest.kt
@@ -53,7 +53,7 @@ data class PaymentRequest(
     val routingInfo: List<TaggedField.RoutingInfo> = tags.filterIsInstance<TaggedField.RoutingInfo>()
 
     init {
-        val f = Features(features)
+        val f = Features(features).invoiceFeatures()
         require(f.hasFeature(Feature.VariableLengthOnion)) { "${Feature.VariableLengthOnion.rfcName} must be supported" }
         require(f.hasFeature(Feature.PaymentSecret)) { "${Feature.PaymentSecret.rfcName} must be supported" }
         require(Features.validateFeatureGraph(f) == null)

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
@@ -49,12 +49,12 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val (alice, _) = TestsHelper.reachNormal()
         val features = Features(Feature.VariableLengthOnion to FeatureSupport.Mandatory, Feature.PaymentSecret to FeatureSupport.Mandatory, Feature.BasicMultiPartPayment to FeatureSupport.Optional)
         // The following invoice requires payment_metadata.
-        val invoice1 = PaymentRequest.read("lnbc5n1p3jxw4vpp5wx34rq09j23xu7st7c0e3nvgj0fpxqan228p9cn7j844ntg0x76sdp2d4skuerpw3hhy7fqwpshjmt9de6zqmt9w3skgct5vycqpxsp5um9px6qwcptwygnalxst2u6rs6sxh3quxt4yaj5xtk7m4xsjf43q9q2gqqqqqqsgqp08gpettwwak2zhqaj3emaxz8aa35mfmh4t8e8zhjwevvrz30c2x590dx6nm4t79hcydqfkwm6wemkmncdaxy296dpwvysljmqtj2ecqz3el57")
+        val invoice1 = PaymentRequestTestsCommon.createInvoiceUnsafe(features = Features(Feature.VariableLengthOnion to FeatureSupport.Mandatory, Feature.PaymentSecret to FeatureSupport.Mandatory, Feature.PaymentMetadata to FeatureSupport.Mandatory))
         // The following invoice requires unknown feature bit 188.
-        val invoice2 = PaymentRequest.read("lnbc5n1p3jxwhzpp59m50ft09rlcvsyw05n3vpm8a9wmqdqq9v04nhh2dqrs3a24w3jfsdpgd4skuerpw3hhy7fqw4hxkmn0wahzqen9v9682un9cqpxsp5lessxrq3qg88ztrhkhw3unw8kfmw2rxk3pk3ptxxlkqj2gc3dtzs9pxgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsgqmk8mdcragv2pvln3j960m2t7fxv8g8zx3yafhnvs6rz6e3j768ajm2tzcz302ppvc3spukpah2v3d4tynfghnv9lsk3xxq2e9ctrhncqw007ae")
+        val invoice2 = PaymentRequestTestsCommon.createInvoiceUnsafe(features = Features(mapOf(Feature.VariableLengthOnion to FeatureSupport.Mandatory, Feature.PaymentSecret to FeatureSupport.Mandatory), setOf(UnknownFeature(188))))
         for (invoice in listOf(invoice1, invoice2)) {
             val outgoingPaymentHandler = OutgoingPaymentHandler(alice.staticParams.nodeParams.nodeId, defaultWalletParams, InMemoryPaymentsDb())
-            val payment = SendPaymentNormal(UUID.randomUUID(), invoice.amount!!, invoice.nodeId, OutgoingPayment.Details.Normal(invoice))
+            val payment = SendPaymentNormal(UUID.randomUUID(), 15_000.msat, invoice.nodeId, OutgoingPayment.Details.Normal(invoice))
             val result = outgoingPaymentHandler.sendPayment(payment, mapOf(), features, alice.currentBlockHeight)
             assertFailureEquals(result as OutgoingPaymentHandler.Failure, OutgoingPaymentHandler.Failure(payment, FinalFailure.FeaturesNotSupported.toPaymentFailure()))
             assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))


### PR DESCRIPTION
This PR contains two commits that fix two separate bugs related to invoice features.
The first commit ensures that we ignore feature bits that aren't related to invoice features when parsing an invoice.
The second commit ensures that we don't pay an invoice that contains mandatory features we don't support.