### PR TITLE
Skip JVM tests on macOS GitHub CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,5 +63,5 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: ./gradlew build -PintegrationTests=include
       - name: Check without integration
-        if: matrix.os != 'ubuntu-latest'
-        run: ./gradlew build
+        if: matrix.os == 'macOS-latest'
+        run: ./gradlew build -x jvmTest

--- a/PhoenixCrypto/build.gradle.kts
+++ b/PhoenixCrypto/build.gradle.kts
@@ -4,6 +4,7 @@ listOf("iphoneos", "iphonesimulator").forEach { sdk ->
 
         commandLine(
             "xcodebuild",
+            "-quiet",
             "-project", "PhoenixCrypto.xcodeproj",
             "-target", "PhoenixCrypto",
             "-sdk", sdk


### PR DESCRIPTION
The `check` GitHub action on MacOS is slow. We try to improve that marginally by skipping the JVM tests which are already ran on Ubuntu.

Note that the macOS build is slow mostly because the `iosX64Test` task is slow. This PR does not improve that.

We also remove all nominal outputs from the `PhoenixCrypto` build. Only warning and errors will be printed.