### PR TITLE
Upgrade to Kotlin 1.7.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,6 @@ kotlin {
             api(ktor("network"))
             api(ktor("network-tls"))
             implementation("org.slf4j:slf4j-api:$slf4jVersion")
-            api("org.xerial:sqlite-jdbc:3.32.3.2")
         }
         compilations["test"].defaultSourceSet.dependencies {
             val target = when {
@@ -88,6 +87,7 @@ kotlin {
             implementation(ktor("server-content-negotiation"))
             implementation(ktor("serialization-kotlinx-json"))
             implementation("com.typesafe:config:1.4.1")
+            api("org.xerial:sqlite-jdbc:3.32.3.2")
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,9 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
 
 plugins {
-    kotlin("multiplatform") version "1.6.21"
-    kotlin("plugin.serialization") version "1.6.21"
-    id("org.jetbrains.dokka") version "1.6.21"
+    kotlin("multiplatform") version "1.7.20"
+    kotlin("plugin.serialization") version "1.7.20"
+    id("org.jetbrains.dokka") version "1.7.10"
     `maven-publish`
 }
 
@@ -24,22 +24,30 @@ allprojects {
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
 kotlin {
-    val ktorVersion: String by extra { "2.0.3" }
-    fun ktor(module: String) = "io.ktor:ktor-$module:$ktorVersion"
+    // -- acinq
+    val bitcoinKmpVersion = "0.9.0"
     val secp256k1Version = "0.7.0"
-    val serializationVersion = "1.3.3"
-    val coroutineVersion = "1.6.3"
+    // -- ktor
+    val ktorVersion: String by extra { "2.1.2" }
+    fun ktor(module: String) = "io.ktor:ktor-$module:$ktorVersion"
+    // -- kotlinx
+    val serializationVersion = "1.4.0"
+    val coroutineVersion = "1.6.4"
+    val datetimeVersion = "0.4.0"
+    // -- logging
+    val kodeinLogVersion = "0.13.0"
+    val slf4jVersion = "1.7.36"
 
     val commonMain by sourceSets.getting {
         dependencies {
-            api("fr.acinq.bitcoin:bitcoin-kmp:0.9.0")
+            api("fr.acinq.bitcoin:bitcoin-kmp:$bitcoinKmpVersion")
             api("fr.acinq.secp256k1:secp256k1-kmp:$secp256k1Version")
-            api("org.kodein.log:kodein-log:0.13.0")
             api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion")
             api("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
             api("org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion")
             api("org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion")
-            api("org.jetbrains.kotlinx:kotlinx-datetime:0.3.2")
+            api("org.jetbrains.kotlinx:kotlinx-datetime:$datetimeVersion")
+            api("org.kodein.log:kodein-log:$kodeinLogVersion")
         }
     }
     val commonTest by sourceSets.getting {
@@ -56,14 +64,11 @@ kotlin {
     }
 
     jvm {
-        compilations.all {
-            kotlinOptions.jvmTarget = "1.8"
-        }
         compilations["main"].defaultSourceSet.dependencies {
             api(ktor("client-okhttp"))
             api(ktor("network"))
             api(ktor("network-tls"))
-            implementation("org.slf4j:slf4j-api:1.7.36")
+            implementation("org.slf4j:slf4j-api:$slf4jVersion")
             api("org.xerial:sqlite-jdbc:3.32.3.2")
         }
         compilations["test"].defaultSourceSet.dependencies {
@@ -76,7 +81,7 @@ kotlin {
             implementation("fr.acinq.secp256k1:secp256k1-kmp-jni-jvm-$target:$secp256k1Version")
             implementation(kotlin("test-junit"))
             implementation("org.bouncycastle:bcprov-jdk15on:1.64")
-            implementation("ch.qos.logback:logback-classic:1.2.3")
+            implementation("ch.qos.logback:logback-classic:1.4.1")
             implementation(ktor("server-netty"))
             implementation(ktor("serialization"))
             implementation(ktor("server-status-pages"))
@@ -132,7 +137,6 @@ kotlin {
     }
 
     sourceSets.all {
-        languageSettings.optIn("kotlin.RequiresOptIn")
         languageSettings.optIn("kotlin.ExperimentalStdlibApi")
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,3 @@ kotlin.code.style=official
 kotlin.incremental.multiplatform=true
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableCInteropCommonization=true
-kotlin.native.binary.memoryModel=experimental

--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/freeze.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/freeze.kt
@@ -1,4 +1,0 @@
-package fr.acinq.lightning.utils
-
-
-expect fun <T : Any> T.ensureNeverFrozen()

--- a/src/jvmMain/kotlin/fr/acinq/lightning/utils/freezeJvm.kt
+++ b/src/jvmMain/kotlin/fr/acinq/lightning/utils/freezeJvm.kt
@@ -1,4 +1,0 @@
-package fr.acinq.lightning.utils
-
-
-actual fun <T : Any> T.ensureNeverFrozen() {}

--- a/src/nativeMain/kotlin/fr/acinq/lightning/utils/freezeNative.kt
+++ b/src/nativeMain/kotlin/fr/acinq/lightning/utils/freezeNative.kt
@@ -1,6 +1,0 @@
-package fr.acinq.lightning.utils
-
-import kotlin.native.concurrent.ensureNeverFrozen as nativeEnsureNeverFrozen
-
-
-actual fun <T : Any> T.ensureNeverFrozen() = nativeEnsureNeverFrozen()


### PR DESCRIPTION
This PR upgrade kotlin to 1.7.20, along with several dependencies:

- ktor to 2.1.2
- kotlinx.coroutine to 1.6.4
- kotlinx.serialization to 1.4.0
- kotlinx.datetime to 0.4.0

With kotlin 1.7.20, the memory model is enabled by default and performances should be better. There are also some options (e.g. [call suspend from swift](https://kotlinlang.org/docs/whatsnew1720.html#calling-kotlin-suspending-functions-from-swift-objective-c)) that could be interesting on iOS.