### PR TITLE
Rename `Events` to `Commands`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Aborted.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Aborted.kt
@@ -7,11 +7,11 @@ import fr.acinq.lightning.blockchain.fee.OnChainFeerates
  * Channel has been aborted before it was funded (because we did not receive a FundingCreated or FundingSigned message for example)
  */
 data class Aborted(override val staticParams: StaticParams, override val currentTip: Pair<Int, BlockHeader>, override val currentOnChainFeerates: OnChainFeerates) : ChannelState() {
-    override fun processInternal(event: ChannelEvent): Pair<ChannelState, List<ChannelAction>> {
+    override fun processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return Pair(this, listOf())
     }
 
-    override fun handleLocalError(event: ChannelEvent, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
+    override fun handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
         return Pair(this, listOf())
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Closed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Closed.kt
@@ -16,12 +16,12 @@ data class Closed(val state: Closing) : ChannelStateWithCommitments() {
         return this.copy(state = state.updateCommitments(input) as Closing)
     }
 
-    override fun processInternal(event: ChannelEvent): Pair<ChannelState, List<ChannelAction>> {
+    override fun processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return Pair(this, listOf())
     }
 
-    override fun handleLocalError(event: ChannelEvent, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "c:$channelId error on event ${event::class} in state ${this::class}" }
+    override fun handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
+        logger.error(t) { "c:$channelId error on event ${cmd::class} in state ${this::class}" }
         return Pair(this, listOf())
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ErrorInformationLeak.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ErrorInformationLeak.kt
@@ -9,7 +9,7 @@ data class ErrorInformationLeak(
     override val currentOnChainFeerates: OnChainFeerates,
     override val commitments: Commitments
 ) : ChannelStateWithCommitments() {
-    override fun processInternal(event: ChannelEvent): Pair<ChannelState, List<ChannelAction>> {
+    override fun processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return Pair(this, listOf())
     }
 
@@ -17,7 +17,7 @@ data class ErrorInformationLeak(
         return this.copy(commitments = input)
     }
 
-    override fun handleLocalError(event: ChannelEvent, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
+    override fun handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
         return Pair(this, listOf())
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -109,7 +109,7 @@ object Helpers {
     }
 
     /** Called by the initiator. */
-    fun validateParamsInitiator(nodeParams: NodeParams, init: ChannelEvent.InitInitiator, open: OpenDualFundedChannel, accept: AcceptDualFundedChannel): Either<ChannelException, ChannelFeatures> {
+    fun validateParamsInitiator(nodeParams: NodeParams, init: ChannelCommand.InitInitiator, open: OpenDualFundedChannel, accept: AcceptDualFundedChannel): Either<ChannelException, ChannelFeatures> {
         require(open.channelType != null) { "we should have sent a channel type in open_channel" }
         if (accept.channelType == null) {
             // We only open channels to peers who support explicit channel type negotiation.

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingConfirmed.kt
@@ -29,30 +29,30 @@ data class LegacyWaitForFundingConfirmed(
 ) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun processInternal(event: ChannelEvent): Pair<ChannelState, List<ChannelAction>> {
-        return when (event) {
-            is ChannelEvent.MessageReceived -> when (event.message) {
-                is ChannelReady -> Pair(this.copy(deferred = FundingLocked(event.message.channelId, event.message.nextPerCommitmentPoint)), listOf())
-                is Error -> handleRemoteError(event.message)
+    override fun processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+        return when (cmd) {
+            is ChannelCommand.MessageReceived -> when (cmd.message) {
+                is ChannelReady -> Pair(this.copy(deferred = FundingLocked(cmd.message.channelId, cmd.message.nextPerCommitmentPoint)), listOf())
+                is Error -> handleRemoteError(cmd.message)
                 else -> Pair(this, listOf())
             }
-            is ChannelEvent.WatchReceived ->
-                when (event.watch) {
+            is ChannelCommand.WatchReceived ->
+                when (cmd.watch) {
                     is WatchEventConfirmed -> {
                         val result = runTrying {
-                            Transaction.correctlySpends(commitments.localCommit.publishableTxs.commitTx.tx, listOf(event.watch.tx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+                            Transaction.correctlySpends(commitments.localCommit.publishableTxs.commitTx.tx, listOf(cmd.watch.tx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
                         }
                         if (result is Try.Failure) {
                             logger.error { "c:$channelId funding tx verification failed: ${result.error}" }
-                            return handleLocalError(event, InvalidCommitmentSignature(channelId, event.watch.tx.txid))
+                            return handleLocalError(cmd, InvalidCommitmentSignature(channelId, cmd.watch.tx.txid))
                         }
                         val nextPerCommitmentPoint = keyManager.commitmentPoint(commitments.localParams.channelKeys.shaSeed, 1)
                         val channelReady = ChannelReady(commitments.channelId, nextPerCommitmentPoint)
                         // this is the temporary channel id that we will use in our channel_update message, the goal is to be able to use our channel
                         // as soon as it reaches NORMAL state, and before it is announced on the network
                         // (this id might be updated when the funding tx gets deeply buried, if there was a reorg in the meantime)
-                        val blockHeight = event.watch.blockHeight
-                        val txIndex = event.watch.txIndex
+                        val blockHeight = cmd.watch.blockHeight
+                        val txIndex = cmd.watch.txIndex
                         val shortChannelId = ShortChannelId(blockHeight, txIndex, commitments.commitInput.outPoint.index.toInt())
                         val nextState = LegacyWaitForFundingLocked(staticParams, currentTip, currentOnChainFeerates, commitments, shortChannelId, FundingLocked(commitments.channelId, nextPerCommitmentPoint))
                         val actions = listOf(
@@ -61,32 +61,32 @@ data class LegacyWaitForFundingConfirmed(
                         )
                         if (deferred != null) {
                             logger.info { "c:$channelId funding_locked has already been received" }
-                            val resultPair = nextState.process(ChannelEvent.MessageReceived(deferred))
+                            val resultPair = nextState.process(ChannelCommand.MessageReceived(deferred))
                             Pair(resultPair.first, actions + resultPair.second)
                         } else {
                             Pair(nextState, actions)
                         }
                     }
-                    is WatchEventSpent -> when (event.watch.tx.txid) {
-                        commitments.remoteCommit.txid -> handleRemoteSpentCurrent(event.watch.tx)
-                        else -> handleRemoteSpentOther(event.watch.tx)
+                    is WatchEventSpent -> when (cmd.watch.tx.txid) {
+                        commitments.remoteCommit.txid -> handleRemoteSpentCurrent(cmd.watch.tx)
+                        else -> handleRemoteSpentOther(cmd.watch.tx)
                     }
                 }
-            is ChannelEvent.ExecuteCommand -> when (event.command) {
-                is CMD_CLOSE -> Pair(this, listOf(ChannelAction.ProcessCmdRes.NotExecuted(event.command, CommandUnavailableInThisState(channelId, this::class.toString()))))
-                is CMD_FORCECLOSE -> handleLocalError(event, ForcedLocalCommit(channelId))
-                else -> unhandled(event)
+            is ChannelCommand.ExecuteCommand -> when (cmd.command) {
+                is CMD_CLOSE -> Pair(this, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmd.command, CommandUnavailableInThisState(channelId, this::class.toString()))))
+                is CMD_FORCECLOSE -> handleLocalError(cmd, ForcedLocalCommit(channelId))
+                else -> unhandled(cmd)
             }
-            is ChannelEvent.CheckHtlcTimeout -> Pair(this, listOf())
-            is ChannelEvent.NewBlock -> Pair(this.copy(currentTip = Pair(event.height, event.Header)), listOf())
-            is ChannelEvent.SetOnChainFeerates -> Pair(this.copy(currentOnChainFeerates = event.feerates), listOf())
-            is ChannelEvent.Disconnected -> Pair(Offline(this), listOf())
-            else -> unhandled(event)
+            is ChannelCommand.CheckHtlcTimeout -> Pair(this, listOf())
+            is ChannelCommand.NewBlock -> Pair(this.copy(currentTip = Pair(cmd.height, cmd.Header)), listOf())
+            is ChannelCommand.SetOnChainFeerates -> Pair(this.copy(currentOnChainFeerates = cmd.feerates), listOf())
+            is ChannelCommand.Disconnected -> Pair(Offline(this), listOf())
+            else -> unhandled(cmd)
         }
     }
 
-    override fun handleLocalError(event: ChannelEvent, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "c:$channelId error on event ${event::class} in state ${this::class}" }
+    override fun handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
+        logger.error(t) { "c:$channelId error on event ${cmd::class} in state ${this::class}" }
         val error = Error(channelId, t.message)
         return when {
             commitments.nothingAtStake() -> Pair(Aborted(staticParams, currentTip, currentOnChainFeerates), listOf(ChannelAction.Message.Send(error)))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForInit.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForInit.kt
@@ -12,96 +12,96 @@ import fr.acinq.lightning.wire.OpenDualFundedChannel
 import fr.acinq.lightning.wire.TlvStream
 
 data class WaitForInit(override val staticParams: StaticParams, override val currentTip: Pair<Int, BlockHeader>, override val currentOnChainFeerates: OnChainFeerates) : ChannelState() {
-    override fun processInternal(event: ChannelEvent): Pair<ChannelState, List<ChannelAction>> {
+    override fun processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when {
-            event is ChannelEvent.InitNonInitiator -> {
+            cmd is ChannelCommand.InitNonInitiator -> {
                 val nextState = WaitForOpenChannel(
                     staticParams,
                     currentTip,
                     currentOnChainFeerates,
-                    event.temporaryChannelId,
-                    event.fundingAmount,
-                    event.pushAmount,
-                    event.wallet,
-                    event.localParams,
-                    event.channelConfig,
-                    event.remoteInit
+                    cmd.temporaryChannelId,
+                    cmd.fundingAmount,
+                    cmd.pushAmount,
+                    cmd.wallet,
+                    cmd.localParams,
+                    cmd.channelConfig,
+                    cmd.remoteInit
                 )
                 Pair(nextState, listOf())
             }
-            event is ChannelEvent.InitInitiator && isValidChannelType(event.channelType) -> {
+            cmd is ChannelCommand.InitInitiator && isValidChannelType(cmd.channelType) -> {
                 val open = OpenDualFundedChannel(
                     chainHash = staticParams.nodeParams.chainHash,
-                    temporaryChannelId = event.temporaryChannelId,
-                    fundingFeerate = event.fundingTxFeerate,
-                    commitmentFeerate = event.commitTxFeerate,
-                    fundingAmount = event.fundingAmount,
-                    dustLimit = event.localParams.dustLimit,
-                    maxHtlcValueInFlightMsat = event.localParams.maxHtlcValueInFlightMsat,
-                    htlcMinimum = event.localParams.htlcMinimum,
-                    toSelfDelay = event.localParams.toSelfDelay,
-                    maxAcceptedHtlcs = event.localParams.maxAcceptedHtlcs,
+                    temporaryChannelId = cmd.temporaryChannelId,
+                    fundingFeerate = cmd.fundingTxFeerate,
+                    commitmentFeerate = cmd.commitTxFeerate,
+                    fundingAmount = cmd.fundingAmount,
+                    dustLimit = cmd.localParams.dustLimit,
+                    maxHtlcValueInFlightMsat = cmd.localParams.maxHtlcValueInFlightMsat,
+                    htlcMinimum = cmd.localParams.htlcMinimum,
+                    toSelfDelay = cmd.localParams.toSelfDelay,
+                    maxAcceptedHtlcs = cmd.localParams.maxAcceptedHtlcs,
                     lockTime = currentBlockHeight.toLong(),
-                    fundingPubkey = event.localParams.channelKeys.fundingPubKey,
-                    revocationBasepoint = event.localParams.channelKeys.revocationBasepoint,
-                    paymentBasepoint = event.localParams.channelKeys.paymentBasepoint,
-                    delayedPaymentBasepoint = event.localParams.channelKeys.delayedPaymentBasepoint,
-                    htlcBasepoint = event.localParams.channelKeys.htlcBasepoint,
-                    firstPerCommitmentPoint = keyManager.commitmentPoint(event.localParams.channelKeys.shaSeed, 0),
-                    channelFlags = event.channelFlags,
+                    fundingPubkey = cmd.localParams.channelKeys.fundingPubKey,
+                    revocationBasepoint = cmd.localParams.channelKeys.revocationBasepoint,
+                    paymentBasepoint = cmd.localParams.channelKeys.paymentBasepoint,
+                    delayedPaymentBasepoint = cmd.localParams.channelKeys.delayedPaymentBasepoint,
+                    htlcBasepoint = cmd.localParams.channelKeys.htlcBasepoint,
+                    firstPerCommitmentPoint = keyManager.commitmentPoint(cmd.localParams.channelKeys.shaSeed, 0),
+                    channelFlags = cmd.channelFlags,
                     tlvStream = TlvStream(
                         buildList {
-                            add(ChannelTlv.ChannelTypeTlv(event.channelType))
-                            if (event.pushAmount > 0.msat) add(ChannelTlv.PushAmountTlv(event.pushAmount))
-                            if (event.channelOrigin != null) add(ChannelTlv.ChannelOriginTlv(event.channelOrigin))
+                            add(ChannelTlv.ChannelTypeTlv(cmd.channelType))
+                            if (cmd.pushAmount > 0.msat) add(ChannelTlv.PushAmountTlv(cmd.pushAmount))
+                            if (cmd.channelOrigin != null) add(ChannelTlv.ChannelOriginTlv(cmd.channelOrigin))
                         }
                     )
                 )
-                val nextState = WaitForAcceptChannel(staticParams, currentTip, currentOnChainFeerates, event, open)
+                val nextState = WaitForAcceptChannel(staticParams, currentTip, currentOnChainFeerates, cmd, open)
                 Pair(nextState, listOf(ChannelAction.Message.Send(open)))
             }
-            event is ChannelEvent.InitInitiator -> {
-                logger.warning { "c:${event.temporaryChannelId} cannot open channel with invalid channel_type=${event.channelType.name}" }
+            cmd is ChannelCommand.InitInitiator -> {
+                logger.warning { "c:${cmd.temporaryChannelId} cannot open channel with invalid channel_type=${cmd.channelType.name}" }
                 Pair(Aborted(staticParams, currentTip, currentOnChainFeerates), listOf())
             }
-            event is ChannelEvent.Restore && event.state is Closing && event.state.nothingAtStake() -> {
-                logger.info { "c:${event.state.channelId} we have nothing at stake, going straight to CLOSED" }
-                Pair(Closed(event.state), listOf())
+            cmd is ChannelCommand.Restore && cmd.state is Closing && cmd.state.nothingAtStake() -> {
+                logger.info { "c:${cmd.state.channelId} we have nothing at stake, going straight to CLOSED" }
+                Pair(Closed(cmd.state), listOf())
             }
-            event is ChannelEvent.Restore && event.state is Closing -> {
-                val closingType = event.state.closingTypeAlreadyKnown()
-                logger.info { "c:${event.state.channelId} channel is closing (closing type = ${closingType?.let { it::class } ?: "unknown yet"})" }
+            cmd is ChannelCommand.Restore && cmd.state is Closing -> {
+                val closingType = cmd.state.closingTypeAlreadyKnown()
+                logger.info { "c:${cmd.state.channelId} channel is closing (closing type = ${closingType?.let { it::class } ?: "unknown yet"})" }
                 // if the closing type is known:
                 // - there is no need to watch the funding tx because it has already been spent and the spending tx has
                 //   already reached mindepth
                 // - there is no need to attempt to publish transactions for other type of closes
                 when (closingType) {
                     is MutualClose -> {
-                        Pair(event.state, doPublish(closingType.tx, event.state.channelId))
+                        Pair(cmd.state, doPublish(closingType.tx, cmd.state.channelId))
                     }
                     is LocalClose -> {
-                        val actions = closingType.localCommitPublished.run { doPublish(event.state.channelId, event.state.staticParams.nodeParams.minDepthBlocks.toLong()) }
-                        Pair(event.state, actions)
+                        val actions = closingType.localCommitPublished.run { doPublish(cmd.state.channelId, cmd.state.staticParams.nodeParams.minDepthBlocks.toLong()) }
+                        Pair(cmd.state, actions)
                     }
                     is RemoteClose -> {
-                        val actions = closingType.remoteCommitPublished.run { doPublish(event.state.channelId, event.state.staticParams.nodeParams.minDepthBlocks.toLong()) }
-                        Pair(event.state, actions)
+                        val actions = closingType.remoteCommitPublished.run { doPublish(cmd.state.channelId, cmd.state.staticParams.nodeParams.minDepthBlocks.toLong()) }
+                        Pair(cmd.state, actions)
                     }
                     is RevokedClose -> {
-                        val actions = closingType.revokedCommitPublished.run { doPublish(event.state.channelId, event.state.staticParams.nodeParams.minDepthBlocks.toLong()) }
-                        Pair(event.state, actions)
+                        val actions = closingType.revokedCommitPublished.run { doPublish(cmd.state.channelId, cmd.state.staticParams.nodeParams.minDepthBlocks.toLong()) }
+                        Pair(cmd.state, actions)
                     }
                     is RecoveryClose -> {
-                        val actions = closingType.remoteCommitPublished.run { doPublish(event.state.channelId, event.state.staticParams.nodeParams.minDepthBlocks.toLong()) }
-                        Pair(event.state, actions)
+                        val actions = closingType.remoteCommitPublished.run { doPublish(cmd.state.channelId, cmd.state.staticParams.nodeParams.minDepthBlocks.toLong()) }
+                        Pair(cmd.state, actions)
                     }
                     null -> {
                         // in all other cases we need to be ready for any type of closing
-                        val commitments = event.state.commitments
+                        val commitments = cmd.state.commitments
                         val actions = mutableListOf<ChannelAction>(
                             ChannelAction.Blockchain.SendWatch(
                                 WatchSpent(
-                                    event.state.channelId,
+                                    cmd.state.channelId,
                                     commitments.commitInput.outPoint.txid,
                                     commitments.commitInput.outPoint.index.toInt(),
                                     commitments.commitInput.txOut.publicKeyScript,
@@ -109,65 +109,65 @@ data class WaitForInit(override val staticParams: StaticParams, override val cur
                                 )
                             ),
                         )
-                        val minDepth = event.state.staticParams.nodeParams.minDepthBlocks.toLong()
-                        event.state.mutualClosePublished.forEach { actions.addAll(doPublish(it, event.state.channelId)) }
-                        event.state.localCommitPublished?.run { actions.addAll(doPublish(event.state.channelId, minDepth)) }
-                        event.state.remoteCommitPublished?.run { actions.addAll(doPublish(event.state.channelId, minDepth)) }
-                        event.state.nextRemoteCommitPublished?.run { actions.addAll(doPublish(event.state.channelId, minDepth)) }
-                        event.state.revokedCommitPublished.forEach { it.run { actions.addAll(doPublish(event.state.channelId, minDepth)) } }
-                        event.state.futureRemoteCommitPublished?.run { actions.addAll(doPublish(event.state.channelId, minDepth)) }
+                        val minDepth = cmd.state.staticParams.nodeParams.minDepthBlocks.toLong()
+                        cmd.state.mutualClosePublished.forEach { actions.addAll(doPublish(it, cmd.state.channelId)) }
+                        cmd.state.localCommitPublished?.run { actions.addAll(doPublish(cmd.state.channelId, minDepth)) }
+                        cmd.state.remoteCommitPublished?.run { actions.addAll(doPublish(cmd.state.channelId, minDepth)) }
+                        cmd.state.nextRemoteCommitPublished?.run { actions.addAll(doPublish(cmd.state.channelId, minDepth)) }
+                        cmd.state.revokedCommitPublished.forEach { it.run { actions.addAll(doPublish(cmd.state.channelId, minDepth)) } }
+                        cmd.state.futureRemoteCommitPublished?.run { actions.addAll(doPublish(cmd.state.channelId, minDepth)) }
                         // if commitment number is zero, we also need to make sure that the funding tx has been published
                         if (commitments.localCommit.index == 0L && commitments.remoteCommit.index == 0L) {
-                            event.state.fundingTx?.let { actions.add(ChannelAction.Blockchain.PublishTx(it)) }
+                            cmd.state.fundingTx?.let { actions.add(ChannelAction.Blockchain.PublishTx(it)) }
                         }
-                        Pair(event.state, actions)
+                        Pair(cmd.state, actions)
                     }
                 }
             }
-            event is ChannelEvent.Restore && event.state is LegacyWaitForFundingConfirmed -> {
-                val minDepth = Helpers.minDepthForFunding(staticParams.nodeParams, event.state.commitments.fundingAmount)
-                logger.info { "c:${event.state.channelId} restoring legacy unconfirmed channel (waiting for $minDepth confirmations)" }
-                val watch = WatchConfirmed(event.state.channelId, event.state.commitments.fundingTxId, event.state.commitments.commitInput.txOut.publicKeyScript, minDepth.toLong(), BITCOIN_FUNDING_DEPTHOK)
-                Pair(Offline(event.state), listOf(ChannelAction.Blockchain.SendWatch(watch)))
+            cmd is ChannelCommand.Restore && cmd.state is LegacyWaitForFundingConfirmed -> {
+                val minDepth = Helpers.minDepthForFunding(staticParams.nodeParams, cmd.state.commitments.fundingAmount)
+                logger.info { "c:${cmd.state.channelId} restoring legacy unconfirmed channel (waiting for $minDepth confirmations)" }
+                val watch = WatchConfirmed(cmd.state.channelId, cmd.state.commitments.fundingTxId, cmd.state.commitments.commitInput.txOut.publicKeyScript, minDepth.toLong(), BITCOIN_FUNDING_DEPTHOK)
+                Pair(Offline(cmd.state), listOf(ChannelAction.Blockchain.SendWatch(watch)))
             }
-            event is ChannelEvent.Restore && event.state is WaitForFundingConfirmed -> {
-                val minDepth = Helpers.minDepthForFunding(staticParams.nodeParams, event.state.fundingParams.fundingAmount)
-                logger.info { "c:${event.state.channelId} restoring unconfirmed channel (waiting for $minDepth confirmations)" }
-                val allCommitments = listOf(event.state.commitments) + event.state.previousFundingTxs.map { it.second }
+            cmd is ChannelCommand.Restore && cmd.state is WaitForFundingConfirmed -> {
+                val minDepth = Helpers.minDepthForFunding(staticParams.nodeParams, cmd.state.fundingParams.fundingAmount)
+                logger.info { "c:${cmd.state.channelId} restoring unconfirmed channel (waiting for $minDepth confirmations)" }
+                val allCommitments = listOf(cmd.state.commitments) + cmd.state.previousFundingTxs.map { it.second }
                 val watches = allCommitments.map { WatchConfirmed(it.channelId, it.fundingTxId, it.commitInput.txOut.publicKeyScript, minDepth.toLong(), BITCOIN_FUNDING_DEPTHOK) }
                 val actions = buildList {
-                    event.state.fundingTx.signedTx?.let { add(ChannelAction.Blockchain.PublishTx(it)) }
+                    cmd.state.fundingTx.signedTx?.let { add(ChannelAction.Blockchain.PublishTx(it)) }
                     addAll(watches.map { ChannelAction.Blockchain.SendWatch(it) })
                 }
-                Pair(Offline(event.state), actions)
+                Pair(Offline(cmd.state), actions)
             }
-            event is ChannelEvent.Restore && event.state is ChannelStateWithCommitments -> {
-                logger.info { "c:${event.state.channelId} restoring channel" }
+            cmd is ChannelCommand.Restore && cmd.state is ChannelStateWithCommitments -> {
+                logger.info { "c:${cmd.state.channelId} restoring channel" }
                 // We only need to republish the funding transaction when using zero-conf: otherwise, it is already confirmed.
                 val fundingTx = when {
-                    event.state is WaitForChannelReady && event.state.staticParams.useZeroConf -> event.state.fundingTx.signedTx
+                    cmd.state is WaitForChannelReady && cmd.state.staticParams.useZeroConf -> cmd.state.fundingTx.signedTx
                     else -> null
                 }
                 val watchSpent = WatchSpent(
-                    event.state.channelId,
-                    event.state.commitments.fundingTxId,
-                    event.state.commitments.commitInput.outPoint.index.toInt(),
-                    event.state.commitments.commitInput.txOut.publicKeyScript,
+                    cmd.state.channelId,
+                    cmd.state.commitments.fundingTxId,
+                    cmd.state.commitments.commitInput.outPoint.index.toInt(),
+                    cmd.state.commitments.commitInput.txOut.publicKeyScript,
                     BITCOIN_FUNDING_SPENT
                 )
                 val actions = buildList {
                     fundingTx?.let {
-                        logger.info { "c:${event.state.channelId} republishing funding tx (txId=${it.txid})" }
+                        logger.info { "c:${cmd.state.channelId} republishing funding tx (txId=${it.txid})" }
                         add(ChannelAction.Blockchain.PublishTx(it))
                     }
                     add(ChannelAction.Blockchain.SendWatch(watchSpent))
                 }
-                Pair(Offline(event.state), actions)
+                Pair(Offline(cmd.state), actions)
             }
-            event is ChannelEvent.NewBlock -> Pair(this.copy(currentTip = Pair(event.height, event.Header)), listOf())
-            event is ChannelEvent.SetOnChainFeerates -> Pair(this.copy(currentOnChainFeerates = event.feerates), listOf())
-            event is ChannelEvent.ExecuteCommand && event.command is CloseCommand -> Pair(Aborted(staticParams, currentTip, currentOnChainFeerates), listOf())
-            else -> unhandled(event)
+            cmd is ChannelCommand.NewBlock -> Pair(this.copy(currentTip = Pair(cmd.height, cmd.Header)), listOf())
+            cmd is ChannelCommand.SetOnChainFeerates -> Pair(this.copy(currentOnChainFeerates = cmd.feerates), listOf())
+            cmd is ChannelCommand.ExecuteCommand && cmd.command is CloseCommand -> Pair(Aborted(staticParams, currentTip, currentOnChainFeerates), listOf())
+            else -> unhandled(cmd)
         }
     }
 
@@ -179,8 +179,8 @@ data class WaitForInit(override val staticParams: StaticParams, override val cur
         }
     }
 
-    override fun handleLocalError(event: ChannelEvent, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${event::class} in state ${this::class}" }
-        return Pair(this, listOf(ChannelAction.ProcessLocalError(t, event)))
+    override fun handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
+        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        return Pair(this, listOf(ChannelAction.ProcessLocalError(t, cmd)))
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForRemotePublishFutureCommitment.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForRemotePublishFutureCommitment.kt
@@ -18,16 +18,16 @@ data class WaitForRemotePublishFutureCommitment(
 ) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun processInternal(event: ChannelEvent): Pair<ChannelState, List<ChannelAction>> {
+    override fun processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when {
-            event is ChannelEvent.WatchReceived && event.watch is WatchEventSpent && event.watch.event is BITCOIN_FUNDING_SPENT -> handleRemoteSpentFuture(event.watch.tx)
-            event is ChannelEvent.Disconnected -> Pair(Offline(this), listOf())
-            else -> unhandled(event)
+            cmd is ChannelCommand.WatchReceived && cmd.watch is WatchEventSpent && cmd.watch.event is BITCOIN_FUNDING_SPENT -> handleRemoteSpentFuture(cmd.watch.tx)
+            cmd is ChannelCommand.Disconnected -> Pair(Offline(this), listOf())
+            else -> unhandled(cmd)
         }
     }
 
-    override fun handleLocalError(event: ChannelEvent, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "c:${commitments.channelId} error on event ${event::class} in state ${this::class}" }
+    override fun handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
+        logger.error(t) { "c:${commitments.channelId} error on event ${cmd::class} in state ${this::class}" }
         val error = Error(channelId, t.message)
         return Pair(Aborted(staticParams, currentTip, currentOnChainFeerates), listOf(ChannelAction.Message.Send(error)))
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -56,7 +56,7 @@ object Disconnected : PeerCommand()
 
 sealed class PaymentCommand : PeerCommand()
 data class ReceivePayment(val paymentPreimage: ByteVector32, val amount: MilliSatoshi?, val description: String, val expirySeconds: Long? = null, val result: CompletableDeferred<PaymentRequest>) : PaymentCommand()
-object CheckPaymentsTimeout : PaymentCommand()
+private object CheckPaymentsTimeout : PaymentCommand()
 data class PayToOpenResponseCommand(val payToOpenResponse: PayToOpenResponse) : PeerCommand()
 
 interface SendPayment {

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
@@ -569,7 +569,7 @@ data class InitInitiator(
     val channelConfig: ChannelConfig,
     val channelType: ChannelType,
 ) {
-    constructor(from: fr.acinq.lightning.channel.ChannelEvent.InitInitiator) : this(
+    constructor(from: fr.acinq.lightning.channel.ChannelCommand.InitInitiator) : this(
         from.fundingAmount,
         from.pushAmount,
         WalletState(from.wallet),

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientStateTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientStateTest.kt
@@ -24,10 +24,10 @@ class ElectrumClientStateTest : LightningTestSuite() {
 
     @Test
     fun `ClientClosed state`() {
-        ClientClosed.process(Connected, logger).let { (newState, actions) ->
+        ClientClosed.process(ElectrumClientCommand.Connected, logger).let { (newState, actions) ->
             assertEquals(WaitingForVersion, newState)
             assertEquals(1, actions.size)
-            assertTrue(actions[0] is SendRequest)
+            assertTrue(actions[0] is ElectrumClientAction.SendRequest)
         }
     }
 
@@ -36,13 +36,13 @@ class ElectrumClientStateTest : LightningTestSuite() {
         listOf(
             WaitingForVersion, WaitingForTip, ClientRunning(0, testBlockHeader), ClientClosed
         ).forEach { state ->
-            state.process(Disconnected, logger).let { (nextState, actions) ->
+            state.process(ElectrumClientCommand.Disconnected, logger).let { (nextState, actions) ->
                 assertEquals(ClientClosed, nextState)
                 assertTrue(actions.isEmpty())
             }
 
             if (state !is ClientRunning)
-                state.process(AskForHeader, logger).let { (nextState, actions) ->
+                state.process(ElectrumClientCommand.AskForHeader, logger).let { (nextState, actions) ->
                     assertEquals(state, nextState)
                     assertTrue(actions.isEmpty())
                 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/ChannelDataTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/ChannelDataTestsCommon.kt
@@ -271,14 +271,14 @@ class ChannelDataTestsCommon : LightningTestSuite(), LoggingContext {
             val (bob5, alice5) = nodes5
             val (bob6, alice6) = crossSign(bob5, alice5)
             // Alice and Bob both know the preimage for only one of the two HTLCs they received.
-            val (alice7, _) = alice6.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(htlcBob.id, preimageBob)))
-            val (bob7, _) = bob6.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(htlcAlice.id, preimageAlice)))
+            val (alice7, _) = alice6.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlcBob.id, preimageBob)))
+            val (bob7, _) = bob6.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlcAlice.id, preimageAlice)))
             // Alice publishes her commitment.
-            val (aliceClosing, _) = alice7.processEx(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
+            val (aliceClosing, _) = alice7.processEx(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
             assertTrue(aliceClosing is Closing)
             val lcp = aliceClosing.localCommitPublished
             assertNotNull(lcp)
-            val (bobClosing, _) = bob7.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice0.channelId, BITCOIN_FUNDING_SPENT, lcp.commitTx)))
+            val (bobClosing, _) = bob7.processEx(ChannelCommand.WatchReceived(WatchEventSpent(alice0.channelId, BITCOIN_FUNDING_SPENT, lcp.commitTx)))
             assertTrue(bobClosing is Closing)
             val rcp = bobClosing.remoteCommitPublished
             assertNotNull(rcp)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
@@ -427,14 +427,14 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
             val (bob7, alice7) = nodes7
             val (bob8, alice8) = TestsHelper.crossSign(bob7, alice7)
             // Alice and Bob both know the preimage for only one of the two HTLCs they received.
-            val (alice9, _) = alice8.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(htlcBob2.id, preimageBob2)))
-            val (bob9, _) = bob8.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(htlcAlice2.id, preimageAlice2)))
+            val (alice9, _) = alice8.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlcBob2.id, preimageBob2)))
+            val (bob9, _) = bob8.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlcAlice2.id, preimageAlice2)))
             // Alice publishes her commitment.
-            val (aliceClosing, _) = alice9.processEx(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
+            val (aliceClosing, _) = alice9.processEx(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
             assertTrue(aliceClosing is Closing)
             val lcp = aliceClosing.localCommitPublished
             assertNotNull(lcp)
-            val (bobClosing, _) = bob9.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice0.channelId, BITCOIN_FUNDING_SPENT, lcp.commitTx)))
+            val (bobClosing, _) = bob9.processEx(ChannelCommand.WatchReceived(WatchEventSpent(alice0.channelId, BITCOIN_FUNDING_SPENT, lcp.commitTx)))
             assertTrue(bobClosing is Closing)
             val rcp = bobClosing.remoteCommitPublished
             assertNotNull(rcp)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/RecoveryTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/RecoveryTestsCommon.kt
@@ -22,7 +22,7 @@ class RecoveryTestsCommon {
         val (alice1, _) = TestsHelper.addHtlc(MilliSatoshi(50000), alice, bob).first
 
         // Alice force-closes the channel and publishes her commit tx
-        val (_, actions) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
+        val (_, actions) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
         val transactions = actions.findTxs()
         val commitTx = transactions[0]
         val aliceTx = transactions[1]

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
@@ -32,7 +32,7 @@ class LegacyWaitForFundingConfirmedTestsCommon {
         assertIs<LegacyWaitForFundingConfirmed>(state)
         val fundingTx = Transaction.read("020000000100000000000000000000000000000000000000000000000000000000000000000000000000ffffffff0140420f0000000000220020f9aafa9be1212d0d373760c279f3817f9be707d674cae5f38bb31c1fd85c202900000000")
         assertEquals(state.commitments.fundingTxId, fundingTx.txid)
-        val (state1, actions1) = WaitForInit(state.staticParams, state.currentTip, state.currentOnChainFeerates).processEx(ChannelEvent.Restore(state))
+        val (state1, actions1) = WaitForInit(state.staticParams, state.currentTip, state.currentOnChainFeerates).processEx(ChannelCommand.Restore(state))
         assertIs<Offline>(state1)
         assertEquals(actions1.size, 1)
         val watchConfirmed = actions1.findWatch<WatchConfirmed>()
@@ -41,7 +41,7 @@ class LegacyWaitForFundingConfirmedTestsCommon {
         // Reconnect to our peer.
         val localInit = Init(state.commitments.localParams.features.toByteArray().byteVector())
         val remoteInit = Init(state.commitments.remoteParams.features.toByteArray().byteVector())
-        val (state2, actions2) = state1.processEx(ChannelEvent.Connected(localInit, remoteInit))
+        val (state2, actions2) = state1.processEx(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<Syncing>(state2)
         assertTrue(actions2.isEmpty())
         val channelReestablish = ChannelReestablish(
@@ -51,13 +51,13 @@ class LegacyWaitForFundingConfirmedTestsCommon {
             PrivateKey(ByteVector32.Zeroes),
             randomKey().publicKey()
         )
-        val (state3, actions3) = state2.processEx(ChannelEvent.MessageReceived(channelReestablish))
+        val (state3, actions3) = state2.processEx(ChannelCommand.MessageReceived(channelReestablish))
         assertEquals(state, state3)
         assertEquals(actions3.size, 2)
         actions3.hasOutgoingMessage<ChannelReestablish>()
         assertEquals(watchConfirmed, actions3.findWatch())
         // The funding tx confirms.
-        val (state4, actions4) = state3.processEx(ChannelEvent.WatchReceived(WatchEventConfirmed(state.channelId, watchConfirmed.event, 1105, 3, fundingTx)))
+        val (state4, actions4) = state3.processEx(ChannelCommand.WatchReceived(WatchEventConfirmed(state.channelId, watchConfirmed.event, 1105, 3, fundingTx)))
         assertIs<LegacyWaitForFundingLocked>(state4)
         assertEquals(actions4.size, 2)
         actions4.hasOutgoingMessage<ChannelReady>()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NegotiatingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NegotiatingTestsCommon.kt
@@ -26,7 +26,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
     fun `recv CMD_ADD_HTLC`() {
         val (alice, _, _) = init()
         val (_, add) = makeCmdAdd(500_000.msat, alice.staticParams.remoteNodeId, TestConstants.defaultBlockHeight.toLong())
-        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(add))
+        val (alice1, actions1) = alice.processEx(ChannelCommand.ExecuteCommand(add))
         assertTrue(alice1 is Negotiating)
         assertEquals(1, actions1.size)
         actions1.hasCommandError<ChannelUnavailable>()
@@ -49,7 +49,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertNull(alice2.bestUnpublishedClosingTx)
 
         // bob answers with a counter proposition in alice's fee range
-        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig1))
+        val (bob3, bobActions3) = bob2.processEx(ChannelCommand.MessageReceived(aliceCloseSig1))
         assertTrue(bob3 is Negotiating)
         val bobCloseSig1 = bobActions3.findOutgoingMessage<ClosingSigned>()
         assertTrue(aliceFeeRange.min < bobCloseSig1.feeSatoshis)
@@ -59,14 +59,14 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertNotNull(bob3.bestUnpublishedClosingTx)
 
         // alice accepts this proposition
-        val (alice3, aliceActions3) = alice2.processEx(ChannelEvent.MessageReceived(bobCloseSig1))
+        val (alice3, aliceActions3) = alice2.processEx(ChannelCommand.MessageReceived(bobCloseSig1))
         assertTrue(alice3 is Closing)
         val mutualCloseTx = aliceActions3.findTxs().first()
         assertEquals(aliceActions3.findWatch<WatchConfirmed>().txId, mutualCloseTx.txid)
         assertEquals(mutualCloseTx.txOut.size, 2) // NB: anchors are removed from the closing tx
         val aliceCloseSig2 = aliceActions3.findOutgoingMessage<ClosingSigned>()
         assertEquals(aliceCloseSig2.feeSatoshis, bobCloseSig1.feeSatoshis)
-        val (bob4, bobActions4) = bob3.processEx(ChannelEvent.MessageReceived(aliceCloseSig2))
+        val (bob4, bobActions4) = bob3.processEx(ChannelCommand.MessageReceived(aliceCloseSig2))
         assertTrue(bob4 is Closing)
         bobActions4.hasTx(mutualCloseTx)
         assertEquals(bobActions4.findWatch<WatchConfirmed>().txId, mutualCloseTx.txid)
@@ -93,7 +93,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         val bob1 = bob.updateFeerate(FeeratePerKw(2_500.sat))
 
         val (_, bob2, aliceCloseSig) = mutualCloseAlice(alice1, bob1)
-        val (bob3, actions) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
+        val (bob3, actions) = bob2.processEx(ChannelCommand.MessageReceived(aliceCloseSig))
         assertTrue(bob3 is Closing)
         val bobCloseSig = actions.findOutgoingMessage<ClosingSigned>()
         assertEquals(bobCloseSig.feeSatoshis, aliceCloseSig.feeSatoshis)
@@ -106,7 +106,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         val bob1 = bob.updateFeerate(FeeratePerKw(20_000.sat))
 
         val (_, bob2, aliceCloseSig) = mutualCloseAlice(alice1, bob1)
-        val (_, actions) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
+        val (_, actions) = bob2.processEx(ChannelCommand.MessageReceived(aliceCloseSig))
         val bobCloseSig = actions.findOutgoingMessage<ClosingSigned>()
         assertEquals(bobCloseSig.feeSatoshis, aliceCloseSig.tlvStream.get<ClosingSignedTlv.FeeRange>()!!.max)
     }
@@ -122,7 +122,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertNotNull(aliceFeeRange)
 
         // bob agrees with that proposal
-        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig1))
+        val (bob3, bobActions3) = bob2.processEx(ChannelCommand.MessageReceived(aliceCloseSig1))
         assertTrue(bob3 is Closing)
         val bobCloseSig1 = bobActions3.findOutgoingMessage<ClosingSigned>()
         assertNotNull(bobCloseSig1.tlvStream.get<ClosingSignedTlv.FeeRange>())
@@ -130,7 +130,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         val mutualCloseTx = bobActions3.findTxs().first()
         assertEquals(mutualCloseTx.txOut.size, 2) // NB: anchors are removed from the closing tx
 
-        val (alice3, aliceActions3) = alice2.processEx(ChannelEvent.MessageReceived(bobCloseSig1))
+        val (alice3, aliceActions3) = alice2.processEx(ChannelCommand.MessageReceived(bobCloseSig1))
         assertTrue(alice3 is Closing)
         aliceActions3.hasTx(mutualCloseTx)
     }
@@ -159,18 +159,18 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertEquals(aliceCloseSig.tlvStream.get(), ClosingSignedTlv.FeeRange(1348.sat, 2022.sat))
 
         // bob chooses alice's highest fee
-        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
+        val (bob3, bobActions3) = bob2.processEx(ChannelCommand.MessageReceived(aliceCloseSig))
         val bobCloseSig = bobActions3.findOutgoingMessage<ClosingSigned>()
         assertEquals(bobCloseSig.feeSatoshis, 2022.sat)
 
         // alice accepts this proposition
-        val (alice3, aliceActions3) = alice2.processEx(ChannelEvent.MessageReceived(bobCloseSig))
+        val (alice3, aliceActions3) = alice2.processEx(ChannelCommand.MessageReceived(bobCloseSig))
         assertTrue(alice3 is Closing)
         val mutualCloseTx = aliceActions3.findTxs().first()
         val aliceCloseSig2 = aliceActions3.findOutgoingMessage<ClosingSigned>()
         assertEquals(aliceCloseSig2.feeSatoshis, 2022.sat)
 
-        val (bob4, bobActions4) = bob3.processEx(ChannelEvent.MessageReceived(aliceCloseSig2))
+        val (bob4, bobActions4) = bob3.processEx(ChannelCommand.MessageReceived(aliceCloseSig2))
         assertTrue(bob4 is Closing)
         bobActions4.hasTx(mutualCloseTx)
     }
@@ -186,14 +186,14 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertEquals(aliceCloseSig.feeSatoshis, 6740.sat) // matches a feerate of 10 000 sat/kw
 
         // bob directly agrees because their fee estimator matches
-        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
+        val (bob3, bobActions3) = bob2.processEx(ChannelCommand.MessageReceived(aliceCloseSig))
         assertTrue(bob3 is Closing)
         val mutualCloseTx = bobActions3.findTxs().first()
         val bobCloseSig = bobActions3.findOutgoingMessage<ClosingSigned>()
         assertEquals(bobCloseSig.feeSatoshis, aliceCloseSig.feeSatoshis)
 
         // alice accepts this proposition
-        val (alice3, aliceActions3) = alice2.processEx(ChannelEvent.MessageReceived(bobCloseSig))
+        val (alice3, aliceActions3) = alice2.processEx(ChannelCommand.MessageReceived(bobCloseSig))
         assertTrue(alice3 is Closing)
         aliceActions3.hasTx(mutualCloseTx)
     }
@@ -206,7 +206,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         // Bob has nothing at stake
         val (_, bob2, aliceCloseSig) = mutualCloseBob(alice1, bob1)
-        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
+        val (bob3, bobActions3) = bob2.processEx(ChannelCommand.MessageReceived(aliceCloseSig))
         assertTrue(bob3 is Closing)
         val mutualCloseTx = bobActions3.findTxs().first()
         assertEquals(bob3.mutualClosePublished.map { it.tx }, listOf(mutualCloseTx))
@@ -227,7 +227,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         // bob makes a proposal outside our fee range
         val (_, bobCloseSig1) = makeLegacyClosingSigned(alice2, bob2, 2_500.sat)
-        val (alice3, actions3) = alice2.processEx(ChannelEvent.MessageReceived(bobCloseSig1))
+        val (alice3, actions3) = alice2.processEx(ChannelCommand.MessageReceived(bobCloseSig1))
         assertTrue(alice3 is Negotiating)
         val aliceCloseSig2 = actions3.findOutgoingMessage<ClosingSigned>()
         assertTrue(aliceCloseSig1.feeSatoshis < aliceCloseSig2.feeSatoshis)
@@ -236,7 +236,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertNotNull(alice3.bestUnpublishedClosingTx)
 
         val (_, bobCloseSig2) = makeLegacyClosingSigned(alice2, bob2, 2_000.sat)
-        val (alice4, actions4) = alice3.processEx(ChannelEvent.MessageReceived(bobCloseSig2))
+        val (alice4, actions4) = alice3.processEx(ChannelCommand.MessageReceived(bobCloseSig2))
         assertTrue(alice4 is Negotiating)
         val aliceCloseSig3 = actions4.findOutgoingMessage<ClosingSigned>()
         assertTrue(aliceCloseSig2.feeSatoshis < aliceCloseSig3.feeSatoshis)
@@ -245,7 +245,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertNotNull(alice4.bestUnpublishedClosingTx)
 
         val (_, bobCloseSig3) = makeLegacyClosingSigned(alice2, bob2, 1_800.sat)
-        val (alice5, actions5) = alice4.processEx(ChannelEvent.MessageReceived(bobCloseSig3))
+        val (alice5, actions5) = alice4.processEx(ChannelCommand.MessageReceived(bobCloseSig3))
         assertTrue(alice5 is Negotiating)
         val aliceCloseSig4 = actions5.findOutgoingMessage<ClosingSigned>()
         assertTrue(aliceCloseSig3.feeSatoshis < aliceCloseSig4.feeSatoshis)
@@ -254,7 +254,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertNotNull(alice5.bestUnpublishedClosingTx)
 
         val (_, bobCloseSig4) = makeLegacyClosingSigned(alice2, bob2, aliceCloseSig4.feeSatoshis)
-        val (alice6, actions6) = alice5.processEx(ChannelEvent.MessageReceived(bobCloseSig4))
+        val (alice6, actions6) = alice5.processEx(ChannelCommand.MessageReceived(bobCloseSig4))
         assertTrue(alice6 is Closing)
         val mutualCloseTx = actions6.findTxs().first()
         assertEquals(alice6.mutualClosePublished.size, 1)
@@ -269,7 +269,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         // alice starts with a very low proposal
         val (aliceCloseSig1, _) = makeLegacyClosingSigned(alice2, bob2, 500.sat)
-        val (bob3, actions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig1))
+        val (bob3, actions3) = bob2.processEx(ChannelCommand.MessageReceived(aliceCloseSig1))
         assertTrue(bob3 is Negotiating)
         val bobCloseSig1 = actions3.findOutgoingMessage<ClosingSigned>()
         assertTrue(3000.sat < bobCloseSig1.feeSatoshis)
@@ -277,7 +277,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertNotNull(bob3.bestUnpublishedClosingTx)
 
         val (aliceCloseSig2, _) = makeLegacyClosingSigned(alice2, bob2, 750.sat)
-        val (bob4, actions4) = bob3.processEx(ChannelEvent.MessageReceived(aliceCloseSig2))
+        val (bob4, actions4) = bob3.processEx(ChannelCommand.MessageReceived(aliceCloseSig2))
         assertTrue(bob4 is Negotiating)
         val bobCloseSig2 = actions4.findOutgoingMessage<ClosingSigned>()
         assertTrue(2000.sat < bobCloseSig2.feeSatoshis)
@@ -285,7 +285,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertNotNull(bob4.bestUnpublishedClosingTx)
 
         val (aliceCloseSig3, _) = makeLegacyClosingSigned(alice2, bob2, 1000.sat)
-        val (bob5, actions5) = bob4.processEx(ChannelEvent.MessageReceived(aliceCloseSig3))
+        val (bob5, actions5) = bob4.processEx(ChannelCommand.MessageReceived(aliceCloseSig3))
         assertTrue(bob5 is Negotiating)
         val bobCloseSig3 = actions5.findOutgoingMessage<ClosingSigned>()
         assertTrue(1500.sat < bobCloseSig3.feeSatoshis)
@@ -293,7 +293,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertNotNull(bob5.bestUnpublishedClosingTx)
 
         val (aliceCloseSig4, _) = makeLegacyClosingSigned(alice2, bob2, 1300.sat)
-        val (bob6, actions6) = bob5.processEx(ChannelEvent.MessageReceived(aliceCloseSig4))
+        val (bob6, actions6) = bob5.processEx(ChannelCommand.MessageReceived(aliceCloseSig4))
         assertTrue(bob6 is Negotiating)
         val bobCloseSig4 = actions6.findOutgoingMessage<ClosingSigned>()
         assertTrue(1300.sat < bobCloseSig4.feeSatoshis)
@@ -301,7 +301,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertNotNull(bob6.bestUnpublishedClosingTx)
 
         val (aliceCloseSig5, _) = makeLegacyClosingSigned(alice2, bob2, bobCloseSig4.feeSatoshis)
-        val (bob7, actions7) = bob6.processEx(ChannelEvent.MessageReceived(aliceCloseSig5))
+        val (bob7, actions7) = bob6.processEx(ChannelCommand.MessageReceived(aliceCloseSig5))
         assertTrue(bob7 is Closing)
         val mutualCloseTx = actions7.findTxs().first()
         assertEquals(bob7.mutualClosePublished.size, 1)
@@ -321,7 +321,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
             assertNotNull(feeRange)
             val bobNextFee = (aliceCloseSig.feeSatoshis + 500.sat).max(feeRange.max + 1.sat)
             val (_, bobClosing) = makeLegacyClosingSigned(alice2, bob2, bobNextFee)
-            val (aliceNew, actions) = mutableAlice.processEx(ChannelEvent.MessageReceived(bobClosing))
+            val (aliceNew, actions) = mutableAlice.processEx(ChannelCommand.MessageReceived(bobClosing))
             aliceCloseSig = actions.findOutgoingMessage()
             mutableAlice = aliceNew as ChannelStateWithCommitments
         }
@@ -333,7 +333,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
     @Test
     fun `recv ClosingSigned -- invalid signature`() {
         val (_, bob, aliceCloseSig) = init()
-        val (bob1, actions) = bob.processEx(ChannelEvent.MessageReceived(aliceCloseSig.copy(feeSatoshis = 99_000.sat)))
+        val (bob1, actions) = bob.processEx(ChannelCommand.MessageReceived(aliceCloseSig.copy(feeSatoshis = 99_000.sat)))
         assertTrue(bob1 is Closing)
         actions.hasOutgoingMessage<Error>()
         actions.hasWatch<WatchConfirmed>()
@@ -346,7 +346,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertTrue(alice.commitments.localParams.features.hasFeature(Feature.ChannelBackupProvider))
         assertTrue(bob.commitments.localParams.features.hasFeature(Feature.ChannelBackupClient))
         assertTrue(aliceCloseSig.channelData.isEmpty())
-        val (_, actions1) = bob.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
+        val (_, actions1) = bob.processEx(ChannelCommand.MessageReceived(aliceCloseSig))
         val bobCloseSig = actions1.hasOutgoingMessage<ClosingSigned>()
         assertFalse(bobCloseSig.channelData.isEmpty())
     }
@@ -359,17 +359,17 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         // Alice initiates a mutual close with a custom final script
         val finalScript = Script.write(Script.pay2pkh(priv.publicKey())).toByteVector()
-        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(finalScript, null)))
+        val (alice1, actions1) = alice.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(finalScript, null)))
         val shutdownA = actions1.findOutgoingMessage<Shutdown>()
 
         // Bob replies with Shutdown + ClosingSigned
-        val (bob1, actions2) = bob.processEx(ChannelEvent.MessageReceived(shutdownA))
+        val (bob1, actions2) = bob.processEx(ChannelCommand.MessageReceived(shutdownA))
         val shutdownB = actions2.findOutgoingMessage<Shutdown>()
         val closingSignedB = actions2.findOutgoingMessage<ClosingSigned>()
 
         // Alice agrees with Bob's closing fee, publishes her closing tx and replies with her own ClosingSigned
-        val (alice2, _) = alice1.processEx(ChannelEvent.MessageReceived(shutdownB))
-        val (alice3, actions4) = alice2.processEx(ChannelEvent.MessageReceived(closingSignedB))
+        val (alice2, _) = alice1.processEx(ChannelCommand.MessageReceived(shutdownB))
+        val (alice3, actions4) = alice2.processEx(ChannelCommand.MessageReceived(closingSignedB))
         assertTrue(alice3 is Closing)
         val closingTxA = actions4.filterIsInstance<ChannelAction.Blockchain.PublishTx>().first().tx
         val closingSignedA = actions4.findOutgoingMessage<ClosingSigned>()
@@ -381,16 +381,16 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         Transaction.correctlySpends(closingTxA, fundingTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
         // Bob published his closing tx (which should be the same as Alice's)
-        val (bob2, actions5) = bob1.processEx(ChannelEvent.MessageReceived(closingSignedA))
+        val (bob2, actions5) = bob1.processEx(ChannelCommand.MessageReceived(closingSignedA))
         assertTrue(bob2 is Closing)
         val closingTxB = actions5.filterIsInstance<ChannelAction.Blockchain.PublishTx>().first().tx
         assertEquals(closingTxA, closingTxB)
 
         // Alice sees Bob's closing tx (which should be the same as the one she published)
-        val (alice4, _) = alice3.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice3.channelId, BITCOIN_FUNDING_SPENT, closingTxB)))
+        val (alice4, _) = alice3.processEx(ChannelCommand.WatchReceived(WatchEventSpent(alice3.channelId, BITCOIN_FUNDING_SPENT, closingTxB)))
         assertTrue(alice4 is Closing)
 
-        val (alice5, _) = alice4.processEx(ChannelEvent.WatchReceived(WatchEventConfirmed(alice3.channelId, BITCOIN_TX_CONFIRMED(closingTxA), 144, 0, closingTxA)))
+        val (alice5, _) = alice4.processEx(ChannelCommand.WatchReceived(WatchEventConfirmed(alice3.channelId, BITCOIN_TX_CONFIRMED(closingTxA), 144, 0, closingTxA)))
         assertTrue(alice5 is Closed)
     }
 
@@ -401,7 +401,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         val bob1 = bob.updateFeerate(FeeratePerKw(10_000.sat))
         val (alice2, bob2, aliceCloseSig1) = mutualCloseAlice(alice1, bob1)
 
-        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(aliceCloseSig1))
+        val (bob3, bobActions3) = bob2.processEx(ChannelCommand.MessageReceived(aliceCloseSig1))
         assertTrue(bob3 is Negotiating)
         bobActions3.findOutgoingMessage<ClosingSigned>()
         val firstMutualCloseTx = bob3.bestUnpublishedClosingTx
@@ -409,7 +409,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         val (_, bobCloseSig1) = makeLegacyClosingSigned(alice2, bob2, 3_000.sat)
         assertNotEquals(bobCloseSig1.feeSatoshis, aliceCloseSig1.feeSatoshis)
-        val (alice3, aliceActions3) = alice2.processEx(ChannelEvent.MessageReceived(bobCloseSig1))
+        val (alice3, aliceActions3) = alice2.processEx(ChannelCommand.MessageReceived(bobCloseSig1))
         assertTrue(alice3 is Negotiating)
         val aliceCloseSig2 = aliceActions3.findOutgoingMessage<ClosingSigned>()
         assertNotEquals(aliceCloseSig2.feeSatoshis, bobCloseSig1.feeSatoshis)
@@ -418,7 +418,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertNotEquals(firstMutualCloseTx.tx.txid, latestMutualCloseTx.tx.txid)
 
         // at this point bob will receive a new signature, but he decides instead to publish the first mutual close
-        val (alice4, aliceActions4) = alice3.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice3.channelId, BITCOIN_FUNDING_SPENT, firstMutualCloseTx.tx)))
+        val (alice4, aliceActions4) = alice3.processEx(ChannelCommand.WatchReceived(WatchEventSpent(alice3.channelId, BITCOIN_FUNDING_SPENT, firstMutualCloseTx.tx)))
         assertTrue(alice4 is Closing)
         aliceActions4.has<ChannelAction.Storage.StoreState>()
         aliceActions4.hasTx(firstMutualCloseTx.tx)
@@ -428,7 +428,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_CLOSE`() {
         val (alice, _, _) = init()
-        val (alice1, actions) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (alice1, actions) = alice.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         assertEquals(alice1, alice)
         assertEquals(actions, listOf(ChannelAction.ProcessCmdRes.NotExecuted(CMD_CLOSE(null, null), ClosingAlreadyInProgress(alice.channelId))))
     }
@@ -436,7 +436,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
     @Test
     fun `recv Error`() {
         val (alice, _, _) = init()
-        val (alice1, actions) = alice.processEx(ChannelEvent.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
+        val (alice1, actions) = alice.processEx(ChannelCommand.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
         assertTrue(alice1 is Closing)
         actions.hasTx(alice.commitments.localCommit.publishableTxs.commitTx.tx)
         assertTrue(actions.findWatches<WatchConfirmed>().map { it.event }.contains(BITCOIN_TX_CONFIRMED(alice.commitments.localCommit.publishableTxs.commitTx.tx)))
@@ -461,16 +461,16 @@ class NegotiatingTestsCommon : LightningTestSuite() {
                 a !is ChannelStateWithCommitments || b !is ChannelStateWithCommitments -> null
                 a is Closing && b is Closing -> Pair(a, b)
                 aliceCloseSig != null -> {
-                    val (b1, actions) = b.processEx(ChannelEvent.MessageReceived(aliceCloseSig))
+                    val (b1, actions) = b.processEx(ChannelCommand.MessageReceived(aliceCloseSig))
                     val bobCloseSig = actions.findOutgoingMessageOpt<ClosingSigned>()
                     if (bobCloseSig != null) {
-                        val (a1, actions2) = a.processEx(ChannelEvent.MessageReceived(bobCloseSig))
+                        val (a1, actions2) = a.processEx(ChannelCommand.MessageReceived(bobCloseSig))
                         return converge(a1, b1, actions2.findOutgoingMessageOpt())
                     }
                     val bobClosingTx = actions.filterIsInstance<ChannelAction.Blockchain.PublishTx>().map { it.tx }.firstOrNull()
                     if (bobClosingTx != null && bobClosingTx.txIn[0].outPoint == a.commitments.localCommit.publishableTxs.commitTx.input.outPoint && a !is Closing) {
                         // Bob just spent the funding tx
-                        val (a1, actions2) = a.processEx(ChannelEvent.WatchReceived(WatchEventSpent(a.channelId, BITCOIN_FUNDING_SPENT, bobClosingTx)))
+                        val (a1, actions2) = a.processEx(ChannelCommand.WatchReceived(WatchEventSpent(a.channelId, BITCOIN_FUNDING_SPENT, bobClosingTx)))
                         return converge(a1, b1, actions2.findOutgoingMessageOpt())
                     }
                     converge(a, b1, null)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
@@ -45,7 +45,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice0, _) = reachNormal()
         val add = defaultAdd.copy(paymentHash = randomBytes32())
 
-        val (alice1, actions) = alice0.processEx(ChannelEvent.ExecuteCommand(add))
+        val (alice1, actions) = alice0.processEx(ChannelCommand.ExecuteCommand(add))
         assertTrue(alice1 is Normal)
         assertTrue(alice1.commitments.availableBalanceForSend() < alice0.commitments.availableBalanceForSend())
 
@@ -68,7 +68,7 @@ class NormalTestsCommon : LightningTestSuite() {
         assertEquals(bob0.commitments.availableBalanceForSend(), 10_000_000.msat)
         val add = defaultAdd.copy(amount = 10_000_000.msat, paymentHash = randomBytes32())
 
-        val (bob1, actions) = bob0.processEx(ChannelEvent.ExecuteCommand(add))
+        val (bob1, actions) = bob0.processEx(ChannelCommand.ExecuteCommand(add))
         assertIs<Normal>(bob1)
         assertEquals(bob1.commitments.availableBalanceForSend(), 0.msat)
 
@@ -82,7 +82,7 @@ class NormalTestsCommon : LightningTestSuite() {
         assertEquals(bob0.commitments.availableBalanceForSend(), 10_000_000.msat)
         val add = defaultAdd.copy(amount = 10_000_000.msat, paymentHash = randomBytes32())
 
-        val (bob1, actions) = bob0.processEx(ChannelEvent.ExecuteCommand(add))
+        val (bob1, actions) = bob0.processEx(ChannelCommand.ExecuteCommand(add))
         assertIs<Normal>(bob1)
         assertEquals(bob1.commitments.availableBalanceForSend(), 0.msat)
 
@@ -96,7 +96,7 @@ class NormalTestsCommon : LightningTestSuite() {
         var alice = alice0
         for (i in 0 until 10) {
             val add = defaultAdd.copy(paymentHash = randomBytes32())
-            val (tempAlice, actions) = alice.processEx(ChannelEvent.ExecuteCommand(add))
+            val (tempAlice, actions) = alice.processEx(ChannelCommand.ExecuteCommand(add))
             alice = tempAlice as Normal
 
             val htlc = actions.findOutgoingMessage<UpdateAddHtlc>()
@@ -114,7 +114,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val currentBlockHeight = alice0.currentBlockHeight.toLong()
         val expiryTooSmall = CltvExpiry(currentBlockHeight + 3)
         val add = defaultAdd.copy(cltvExpiry = expiryTooSmall)
-        val (_, actions1) = alice0.processEx(ChannelEvent.ExecuteCommand(add))
+        val (_, actions1) = alice0.processEx(ChannelCommand.ExecuteCommand(add))
         actions1.hasOutgoingMessage<UpdateAddHtlc>()
     }
 
@@ -124,7 +124,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val currentBlockHeight = alice0.currentBlockHeight.toLong()
         val expiryTooBig = (Channel.MAX_CLTV_EXPIRY_DELTA + 1).toCltvExpiry(currentBlockHeight)
         val add = defaultAdd.copy(cltvExpiry = expiryTooBig)
-        val (alice1, actions1) = alice0.processEx(ChannelEvent.ExecuteCommand(add))
+        val (alice1, actions1) = alice0.processEx(ChannelCommand.ExecuteCommand(add))
         val actualError = actions1.findCommandError<ExpiryTooBig>()
         val expectedError = ExpiryTooBig(alice0.channelId, Channel.MAX_CLTV_EXPIRY_DELTA.toCltvExpiry(currentBlockHeight), expiryTooBig, currentBlockHeight)
         assertEquals(expectedError, actualError)
@@ -135,7 +135,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv CMD_ADD_HTLC -- value too small`() {
         val (alice0, _) = reachNormal()
         val add = defaultAdd.copy(amount = 50.msat)
-        val (alice1, actions) = alice0.processEx(ChannelEvent.ExecuteCommand(add))
+        val (alice1, actions) = alice0.processEx(ChannelCommand.ExecuteCommand(add))
         val actualError = actions.findCommandError<HtlcValueTooSmall>()
         val expectedError = HtlcValueTooSmall(alice0.channelId, 1000.msat, 50.msat)
         assertEquals(expectedError, actualError)
@@ -148,7 +148,7 @@ class NormalTestsCommon : LightningTestSuite() {
         // Alice has a minimum set to 0 msat (which should be invalid, but may mislead Bob into relaying 0-value HTLCs which is forbidden by the spec).
         assertEquals(0.msat, alice0.commitments.localParams.htlcMinimum)
         val add = defaultAdd.copy(amount = 0.msat)
-        val (bob1, actions) = bob0.processEx(ChannelEvent.ExecuteCommand(add))
+        val (bob1, actions) = bob0.processEx(ChannelCommand.ExecuteCommand(add))
         val actualError = actions.findCommandError<HtlcValueTooSmall>()
         val expectedError = HtlcValueTooSmall(bob0.channelId, 1.msat, 0.msat)
         assertEquals(expectedError, actualError)
@@ -163,11 +163,11 @@ class NormalTestsCommon : LightningTestSuite() {
         assertEquals(0.msat, bob0.commitments.availableBalanceForSend())
 
         val cmdAdd = defaultAdd.copy(amount = 1_500.msat)
-        val (alice1, actionsAlice) = alice0.processEx(ChannelEvent.ExecuteCommand(cmdAdd))
+        val (alice1, actionsAlice) = alice0.processEx(ChannelCommand.ExecuteCommand(cmdAdd))
         assertTrue(alice1 is Normal)
         val add = actionsAlice.hasOutgoingMessage<UpdateAddHtlc>()
 
-        val (bob1, actionsBob) = bob0.processEx(ChannelEvent.MessageReceived(add))
+        val (bob1, actionsBob) = bob0.processEx(ChannelCommand.MessageReceived(add))
         assertTrue(bob1 is Normal)
         assertTrue(actionsBob.isEmpty())
         assertEquals(0.msat, bob1.commitments.availableBalanceForSend())
@@ -177,7 +177,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv CMD_ADD_HTLC -- insufficient funds`() {
         val (alice0, _) = reachNormal()
         val add = defaultAdd.copy(amount = Int.MAX_VALUE.msat)
-        val (alice1, actions) = alice0.processEx(ChannelEvent.ExecuteCommand(add))
+        val (alice1, actions) = alice0.processEx(ChannelCommand.ExecuteCommand(add))
         val actualError = actions.findCommandError<InsufficientFunds>()
         val expectError = InsufficientFunds(alice0.channelId, amount = Int.MAX_VALUE.msat, missing = 1_372_823.sat, reserve = 10_000.sat, fees = 7_140.sat)
         assertEquals(expectError, actualError)
@@ -188,7 +188,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv CMD_ADD_HTLC -- insufficient funds + missing 1 msat`() {
         val (_, bob0) = reachNormal()
         val add = defaultAdd.copy(amount = bob0.commitments.availableBalanceForSend() + 1.sat.toMilliSatoshi())
-        val (bob1, actions) = bob0.processEx(ChannelEvent.ExecuteCommand(add))
+        val (bob1, actions) = bob0.processEx(ChannelCommand.ExecuteCommand(add))
         val actualError = actions.findCommandError<InsufficientFunds>()
         val expectedError = InsufficientFunds(bob0.channelId, amount = add.amount, missing = 1.sat, reserve = 10000.sat, fees = 0.sat)
         assertEquals(expectedError, actualError)
@@ -203,7 +203,7 @@ class NormalTestsCommon : LightningTestSuite() {
         assertEquals(0.msat, (alice2 as ChannelStateWithCommitments).commitments.availableBalanceForSend())
 
         tailrec fun loop(bob: ChannelState, count: Int): ChannelState = if (count == 0) bob else {
-            val (newBob, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 16_000_000.msat)))
+            val (newBob, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 16_000_000.msat)))
             actions1.hasOutgoingMessage<UpdateAddHtlc>()
             loop(newBob, count - 1)
         }
@@ -213,18 +213,18 @@ class NormalTestsCommon : LightningTestSuite() {
         // alice maintains an extra reserve to accommodate for a few more HTLCs, so the first HTLCs should be allowed
         val bob3 = loop(bob2, 9)
         // but this one will dip alice below her reserve: we must wait for the previous HTLCs to settle before sending any more
-        val (_, actionsBob4) = bob3.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 12_500_000.msat)))
+        val (_, actionsBob4) = bob3.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 12_500_000.msat)))
         actionsBob4.findCommandError<RemoteCannotAffordFeesForNewHtlc>()
     }
 
     @Test
     fun `recv CMD_ADD_HTLC -- insufficient funds with pending htlcs`() {
         val (alice0, _) = reachNormal()
-        val (alice1, actionsAlice1) = alice0.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 300_000_000.msat)))
+        val (alice1, actionsAlice1) = alice0.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 300_000_000.msat)))
         actionsAlice1.hasOutgoingMessage<UpdateAddHtlc>()
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 300_000_000.msat)))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 300_000_000.msat)))
         actionsAlice2.hasOutgoingMessage<UpdateAddHtlc>()
-        val (_, actionsAlice3) = alice2.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 500_000_000.msat)))
+        val (_, actionsAlice3) = alice2.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 500_000_000.msat)))
         val actualError = actionsAlice3.findCommandError<InsufficientFunds>()
         val expectError = InsufficientFunds(alice0.channelId, amount = 500_000_000.msat, missing = 328_780.sat, reserve = 10_000.sat, fees = 8_860.sat)
         assertEquals(expectError, actualError)
@@ -233,13 +233,13 @@ class NormalTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_ADD_HTLC -- insufficient funds with pending htlcs and 0 balance`() {
         val (alice0, _) = reachNormal()
-        val (alice1, actionsAlice1) = alice0.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 500_000_000.msat)))
+        val (alice1, actionsAlice1) = alice0.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 500_000_000.msat)))
         actionsAlice1.hasOutgoingMessage<UpdateAddHtlc>()
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 200_000_000.msat)))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 200_000_000.msat)))
         actionsAlice2.hasOutgoingMessage<UpdateAddHtlc>()
-        val (alice3, actionsAlice3) = alice2.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 71_120_000.msat)))
+        val (alice3, actionsAlice3) = alice2.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 71_120_000.msat)))
         actionsAlice3.hasOutgoingMessage<UpdateAddHtlc>()
-        val (_, actionsAlice4) = alice3.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 1_000_000.msat)))
+        val (_, actionsAlice4) = alice3.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 1_000_000.msat)))
         val actualError = actionsAlice4.findCommandError<InsufficientFunds>()
         val expectedError = InsufficientFunds(alice0.channelId, amount = 1_000_000.msat, missing = 900.sat, reserve = 10_000.sat, fees = 8_860.sat)
         assertEquals(expectedError, actualError)
@@ -251,7 +251,7 @@ class NormalTestsCommon : LightningTestSuite() {
             val (_, bob) = reachNormal()
             bob.copy(commitments = bob.commitments.copy(remoteParams = bob.commitments.remoteParams.copy(maxHtlcValueInFlightMsat = 150_000_000)))
         }
-        val (_, actions) = bob0.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 151_000_000.msat)))
+        val (_, actions) = bob0.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 151_000_000.msat)))
         val actualError = actions.findCommandError<HtlcValueTooHighInFlight>()
         val expectedError = HtlcValueTooHighInFlight(bob0.channelId, maximum = 150_000_000UL, actual = 151_000_000.msat)
         assertEquals(expectedError, actualError)
@@ -263,7 +263,7 @@ class NormalTestsCommon : LightningTestSuite() {
             val (_, bob) = reachNormal()
             bob.copy(commitments = bob.commitments.copy(localParams = bob.commitments.localParams.copy(maxHtlcValueInFlightMsat = 100_000_000)))
         }
-        val (_, actions) = bob0.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 101_000_000.msat)))
+        val (_, actions) = bob0.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 101_000_000.msat)))
         val actualError = actions.findCommandError<HtlcValueTooHighInFlight>()
         val expectedError = HtlcValueTooHighInFlight(bob0.channelId, maximum = 100_000_000UL, actual = 101_000_000.msat)
         assertEquals(expectedError, actualError)
@@ -275,9 +275,9 @@ class NormalTestsCommon : LightningTestSuite() {
             val (_, bob) = reachNormal()
             bob.copy(commitments = bob.commitments.copy(remoteParams = bob.commitments.remoteParams.copy(maxHtlcValueInFlightMsat = 150_000_000)))
         }
-        val (bob1, actionsBob1) = bob0.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 75_500_000.msat)))
+        val (bob1, actionsBob1) = bob0.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 75_500_000.msat)))
         actionsBob1.hasOutgoingMessage<UpdateAddHtlc>()
-        val (_, actionsBob2) = bob1.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 75_500_000.msat)))
+        val (_, actionsBob2) = bob1.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 75_500_000.msat)))
         val actualError = actionsBob2.findCommandError<HtlcValueTooHighInFlight>()
         val expectedError = HtlcValueTooHighInFlight(bob0.channelId, maximum = 150_000_000UL, actual = 151_000_000.msat)
         assertEquals(expectedError, actualError)
@@ -291,14 +291,14 @@ class NormalTestsCommon : LightningTestSuite() {
         val alice1 = run {
             var alice = alice0
             for (i in 0 until bob0.staticParams.nodeParams.maxAcceptedHtlcs) {
-                val (tempAlice, actions) = alice.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 1_000_000.msat)))
+                val (tempAlice, actions) = alice.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 1_000_000.msat)))
                 actions.hasOutgoingMessage<UpdateAddHtlc>()
                 alice = tempAlice as Normal
             }
             alice
         }
 
-        val (_, actions) = alice1.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 1_000_000.msat)))
+        val (_, actions) = alice1.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 1_000_000.msat)))
         val actualError = actions.findCommandError<TooManyAcceptedHtlcs>()
         val expectedError = TooManyAcceptedHtlcs(alice0.channelId, maximum = 100)
         assertEquals(expectedError, actualError)
@@ -313,14 +313,14 @@ class NormalTestsCommon : LightningTestSuite() {
         val alice2 = run {
             var alice = alice1
             for (i in 0 until 5) {
-                val (tempAlice, actions) = alice.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 1_000_000.msat)))
+                val (tempAlice, actions) = alice.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 1_000_000.msat)))
                 actions.hasOutgoingMessage<UpdateAddHtlc>()
                 alice = tempAlice as Normal
             }
             alice
         }
 
-        val (_, actions) = alice2.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = 1_000_000.msat)))
+        val (_, actions) = alice2.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = 1_000_000.msat)))
         val actualError = actions.findCommandError<TooManyOfferedHtlcs>()
         val expectedError = TooManyOfferedHtlcs(alice0.channelId, maximum = 5)
         assertEquals(expectedError, actualError)
@@ -329,13 +329,13 @@ class NormalTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_ADD_HTLC -- over capacity`() {
         val (alice0, _) = reachNormal()
-        val (alice1, actionsAlice1) = alice0.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(amount = alice0.commitments.fundingAmount.toMilliSatoshi() * 2 / 3)))
+        val (alice1, actionsAlice1) = alice0.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(amount = alice0.commitments.fundingAmount.toMilliSatoshi() * 2 / 3)))
         actionsAlice1.hasOutgoingMessage<UpdateAddHtlc>()
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         actionsAlice2.hasOutgoingMessage<CommitSig>()
         // this is over channel-capacity
         val failAdd = defaultAdd.copy(amount = alice0.commitments.fundingAmount.toMilliSatoshi() * 2 / 3)
-        val (_, actionsAlice3) = alice2.processEx(ChannelEvent.ExecuteCommand(failAdd))
+        val (_, actionsAlice3) = alice2.processEx(ChannelCommand.ExecuteCommand(failAdd))
         val actualError = actionsAlice3.findCommandError<InsufficientFunds>()
         val expectedError = InsufficientFunds(alice0.channelId, failAdd.amount, 560_393.sat, 10_000.sat, 8_000.sat)
         assertEquals(expectedError, actualError)
@@ -344,12 +344,12 @@ class NormalTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_ADD_HTLC -- after having sent Shutdown`() {
         val (alice0, _) = reachNormal()
-        val (alice1, actionsAlice1) = alice0.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (alice1, actionsAlice1) = alice0.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         actionsAlice1.findOutgoingMessage<Shutdown>()
         assertTrue(alice1 is Normal && alice1.localShutdown != null && alice1.remoteShutdown == null)
 
         val (_, cmdAdd) = makeCmdAdd(500_000_000.msat, alice0.staticParams.nodeParams.nodeId, TestConstants.defaultBlockHeight.toLong(), randomBytes32())
-        val (_, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(cmdAdd))
+        val (_, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(cmdAdd))
         assertNotNull(actionsAlice2.findCommandError<NoMoreHtlcsClosingInProgress>())
     }
 
@@ -359,16 +359,16 @@ class NormalTestsCommon : LightningTestSuite() {
 
         // let's make alice send an htlc
         val (_, cmdAdd1) = makeCmdAdd(500_000_000.msat, alice0.staticParams.nodeParams.nodeId, TestConstants.defaultBlockHeight.toLong(), randomBytes32())
-        val (alice1, actionsAlice1) = alice0.processEx(ChannelEvent.ExecuteCommand(cmdAdd1))
+        val (alice1, actionsAlice1) = alice0.processEx(ChannelCommand.ExecuteCommand(cmdAdd1))
         actionsAlice1.findOutgoingMessage<UpdateAddHtlc>()
 
         // at the same time bob initiates a closing
-        val (_, actionsBob1) = bob0.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (_, actionsBob1) = bob0.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         val shutdown = actionsBob1.findOutgoingMessage<Shutdown>()
 
-        val (alice2, _) = alice1.processEx(ChannelEvent.MessageReceived(shutdown))
+        val (alice2, _) = alice1.processEx(ChannelCommand.MessageReceived(shutdown))
         val (_, cmdAdd2) = makeCmdAdd(100_000_000.msat, alice0.staticParams.nodeParams.nodeId, TestConstants.defaultBlockHeight.toLong(), randomBytes32())
-        val (_, actionsAlice3) = alice2.processEx(ChannelEvent.ExecuteCommand(cmdAdd2))
+        val (_, actionsAlice3) = alice2.processEx(ChannelCommand.ExecuteCommand(cmdAdd2))
         assertNotNull(actionsAlice3.findCommandError<NoMoreHtlcsClosingInProgress>())
     }
 
@@ -376,7 +376,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv UpdateAddHtlc`() {
         val (_, bob0) = reachNormal()
         val add = UpdateAddHtlc(bob0.channelId, 0, 15_000.msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(bob0.currentBlockHeight.toLong()), TestConstants.emptyOnionPacket)
-        val (bob1, actions1) = bob0.processEx(ChannelEvent.MessageReceived(add))
+        val (bob1, actions1) = bob0.processEx(ChannelCommand.MessageReceived(add))
         assertTrue(actions1.isEmpty())
         val expected = bob0.copy(commitments = bob0.commitments.copy(remoteNextHtlcId = 1, remoteChanges = bob0.commitments.remoteChanges.copy(proposed = listOf(add))))
         assertEquals(expected, bob1)
@@ -387,7 +387,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice0, _) = reachNormal(ChannelType.SupportedChannelType.AnchorOutputsZeroReserve, bobFundingAmount = 10_000.sat, alicePushAmount = 0.msat)
         assertEquals(alice0.commitments.availableBalanceForReceive(), 10_000_000.msat)
         val add = UpdateAddHtlc(alice0.channelId, 0, 10_000_000.msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(alice0.currentBlockHeight.toLong()), TestConstants.emptyOnionPacket)
-        val (alice1, actions1) = alice0.processEx(ChannelEvent.MessageReceived(add))
+        val (alice1, actions1) = alice0.processEx(ChannelCommand.MessageReceived(add))
         assertIs<Normal>(alice1)
         assertTrue(actions1.isEmpty())
         assertEquals(alice1.commitments.remoteChanges.proposed, listOf(add))
@@ -398,7 +398,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice0, _) = reachNormal(ChannelType.SupportedChannelType.AnchorOutputsZeroReserve, bobFundingAmount = 10_000.sat, alicePushAmount = 0.msat, zeroConf = true)
         assertEquals(alice0.commitments.availableBalanceForReceive(), 10_000_000.msat)
         val add = UpdateAddHtlc(alice0.channelId, 0, 10_000_000.msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(alice0.currentBlockHeight.toLong()), TestConstants.emptyOnionPacket)
-        val (alice1, actions1) = alice0.processEx(ChannelEvent.MessageReceived(add))
+        val (alice1, actions1) = alice0.processEx(ChannelCommand.MessageReceived(add))
         assertIs<Normal>(alice1)
         assertTrue(actions1.isEmpty())
         assertEquals(alice1.commitments.remoteChanges.proposed, listOf(add))
@@ -408,13 +408,13 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv UpdateAddHtlc -- unexpected id`() {
         val (_, bob0) = reachNormal()
         val add = UpdateAddHtlc(bob0.channelId, 0, 15_000.msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(bob0.currentBlockHeight.toLong()), TestConstants.emptyOnionPacket)
-        val (bob1, actions1) = bob0.processEx(ChannelEvent.MessageReceived(add))
+        val (bob1, actions1) = bob0.processEx(ChannelCommand.MessageReceived(add))
         assertTrue(actions1.isEmpty())
-        val (bob2, actions2) = bob1.processEx(ChannelEvent.MessageReceived(add.copy(id = 1)))
+        val (bob2, actions2) = bob1.processEx(ChannelCommand.MessageReceived(add.copy(id = 1)))
         assertTrue(actions2.isEmpty())
-        val (bob3, actions3) = bob2.processEx(ChannelEvent.MessageReceived(add.copy(id = 2)))
+        val (bob3, actions3) = bob2.processEx(ChannelCommand.MessageReceived(add.copy(id = 2)))
         assertTrue(actions3.isEmpty())
-        val (bob4, actions4) = bob3.processEx(ChannelEvent.MessageReceived(add.copy(id = 4)))
+        val (bob4, actions4) = bob3.processEx(ChannelCommand.MessageReceived(add.copy(id = 4)))
         assertTrue(bob4 is Closing)
         val error = actions4.hasOutgoingMessage<Error>()
         assertEquals(error.toAscii(), UnexpectedHtlcId(bob0.channelId, 3, 4).message)
@@ -424,7 +424,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv UpdateAddHtlc -- value too small`() {
         val (_, bob0) = reachNormal()
         val add = UpdateAddHtlc(bob0.channelId, 0, 150.msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(bob0.currentBlockHeight.toLong()), TestConstants.emptyOnionPacket)
-        val (bob1, actions1) = bob0.processEx(ChannelEvent.MessageReceived(add))
+        val (bob1, actions1) = bob0.processEx(ChannelCommand.MessageReceived(add))
         assertTrue(bob1 is Closing)
         val error = actions1.hasOutgoingMessage<Error>()
         assertEquals(error.toAscii(), HtlcValueTooSmall(bob0.channelId, 1_000.msat, add.amountMsat).message)
@@ -434,7 +434,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv UpdateAddHtlc -- insufficient funds`() {
         val (_, bob0) = reachNormal()
         val add = UpdateAddHtlc(bob0.channelId, 0, 800_000_000.msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(bob0.currentBlockHeight.toLong()), TestConstants.emptyOnionPacket)
-        val (bob1, actions1) = bob0.processEx(ChannelEvent.MessageReceived(add))
+        val (bob1, actions1) = bob0.processEx(ChannelCommand.MessageReceived(add))
         assertTrue(bob1 is Closing)
         val error = actions1.hasOutgoingMessage<Error>()
         assertEquals(error.toAscii(), InsufficientFunds(bob0.channelId, 800_000_000.msat, 17_140.sat, 10_000.sat, 7_140.sat).message)
@@ -444,13 +444,13 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv UpdateAddHtlc -- insufficient funds with pending htlcs`() {
         val (_, bob0) = reachNormal()
         val add = UpdateAddHtlc(bob0.channelId, 0, 15_000_000.msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(bob0.currentBlockHeight.toLong()), TestConstants.emptyOnionPacket)
-        val (bob1, actions1) = bob0.processEx(ChannelEvent.MessageReceived(add))
+        val (bob1, actions1) = bob0.processEx(ChannelCommand.MessageReceived(add))
         assertTrue(actions1.isEmpty())
-        val (bob2, actions2) = bob1.processEx(ChannelEvent.MessageReceived(add.copy(id = 1)))
+        val (bob2, actions2) = bob1.processEx(ChannelCommand.MessageReceived(add.copy(id = 1)))
         assertTrue(actions2.isEmpty())
-        val (bob3, actions3) = bob2.processEx(ChannelEvent.MessageReceived(add.copy(id = 2)))
+        val (bob3, actions3) = bob2.processEx(ChannelCommand.MessageReceived(add.copy(id = 2)))
         assertTrue(actions3.isEmpty())
-        val (bob4, actions4) = bob3.processEx(ChannelEvent.MessageReceived(add.copy(id = 3, amountMsat = 800_000_000.msat)))
+        val (bob4, actions4) = bob3.processEx(ChannelCommand.MessageReceived(add.copy(id = 3, amountMsat = 800_000_000.msat)))
         assertTrue(bob4 is Closing)
         val error = actions4.hasOutgoingMessage<Error>()
         assertEquals(error.toAscii(), InsufficientFunds(bob0.channelId, 800_000_000.msat, 64_720.sat, 10_000.sat, 9_720.sat).message)
@@ -463,7 +463,7 @@ class NormalTestsCommon : LightningTestSuite() {
             alice.copy(commitments = alice.commitments.copy(localParams = alice.commitments.localParams.copy(maxHtlcValueInFlightMsat = 150_000_000)))
         }
         val add = UpdateAddHtlc(alice0.channelId, 0, 151_000_000.msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(alice0.currentBlockHeight.toLong()), TestConstants.emptyOnionPacket)
-        val (alice1, actions1) = alice0.processEx(ChannelEvent.MessageReceived(add))
+        val (alice1, actions1) = alice0.processEx(ChannelCommand.MessageReceived(add))
         assertTrue(alice1 is Closing)
         val error = actions1.hasOutgoingMessage<Error>()
         assertEquals(error.toAscii(), HtlcValueTooHighInFlight(alice0.channelId, 150_000_000UL, 151_000_000.msat).message)
@@ -478,7 +478,7 @@ class NormalTestsCommon : LightningTestSuite() {
             var bob = bob0
             for (i in 0 until bob0.staticParams.nodeParams.maxAcceptedHtlcs) {
                 val add = UpdateAddHtlc(bob0.channelId, i.toLong(), 2_500_000.msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(bob0.currentBlockHeight.toLong()), TestConstants.emptyOnionPacket)
-                val (tempBob, actions) = bob.processEx(ChannelEvent.MessageReceived(add))
+                val (tempBob, actions) = bob.processEx(ChannelCommand.MessageReceived(add))
                 assertTrue(actions.isEmpty())
                 bob = tempBob as Normal
             }
@@ -487,7 +487,7 @@ class NormalTestsCommon : LightningTestSuite() {
 
         val nextHtlcId = bob1.commitments.remoteNextHtlcId
         val add = UpdateAddHtlc(bob0.channelId, nextHtlcId, 2_000_000.msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(bob0.currentBlockHeight.toLong()), TestConstants.emptyOnionPacket)
-        val (bob2, actions2) = bob1.processEx(ChannelEvent.MessageReceived(add))
+        val (bob2, actions2) = bob1.processEx(ChannelCommand.MessageReceived(add))
         assertTrue(bob2 is Closing)
         val error = actions2.hasOutgoingMessage<Error>()
         assertEquals(error.toAscii(), TooManyAcceptedHtlcs(bob0.channelId, bob0.staticParams.nodeParams.maxAcceptedHtlcs.toLong()).message)
@@ -497,7 +497,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv CMD_SIGN`() {
         val (alice0, bob0) = reachNormal()
         val (alice1, _) = addHtlc(50_000_000.msat, payer = alice0, payee = bob0).first
-        val (alice2, actions) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice2, actions) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actions.findOutgoingMessage<CommitSig>()
         assertEquals(1, commitSig.htlcSignatures.size)
         assertTrue(alice2 is ChannelStateWithCommitments)
@@ -509,23 +509,23 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice0, bob0) = reachNormal()
         val add = defaultAdd.copy(amount = 10_000_000.msat, paymentHash = randomBytes32())
 
-        val (alice1, actionsAlice1) = alice0.processEx(ChannelEvent.ExecuteCommand(add))
+        val (alice1, actionsAlice1) = alice0.processEx(ChannelCommand.ExecuteCommand(add))
         val htlc1 = actionsAlice1.findOutgoingMessage<UpdateAddHtlc>()
-        val (bob1, _) = bob0.processEx(ChannelEvent.MessageReceived(htlc1))
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(add))
+        val (bob1, _) = bob0.processEx(ChannelCommand.MessageReceived(htlc1))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(add))
         val htlc2 = actionsAlice2.findOutgoingMessage<UpdateAddHtlc>()
-        val (bob2, _) = bob1.processEx(ChannelEvent.MessageReceived(htlc2))
+        val (bob2, _) = bob1.processEx(ChannelCommand.MessageReceived(htlc2))
 
         val (alice3, bob3) = crossSign(alice2, bob2)
 
-        val (bob4, actionsBob4) = bob3.processEx(ChannelEvent.ExecuteCommand(add))
+        val (bob4, actionsBob4) = bob3.processEx(ChannelCommand.ExecuteCommand(add))
         val htlc3 = actionsBob4.findOutgoingMessage<UpdateAddHtlc>()
-        val (alice4, _) = alice3.processEx(ChannelEvent.MessageReceived(htlc3))
-        val (bob5, actionsBob5) = bob4.processEx(ChannelEvent.ExecuteCommand(add))
+        val (alice4, _) = alice3.processEx(ChannelCommand.MessageReceived(htlc3))
+        val (bob5, actionsBob5) = bob4.processEx(ChannelCommand.ExecuteCommand(add))
         val htlc4 = actionsBob5.findOutgoingMessage<UpdateAddHtlc>()
-        alice4.processEx(ChannelEvent.MessageReceived(htlc4))
+        alice4.processEx(ChannelCommand.MessageReceived(htlc4))
 
-        val (_, actionsBob6) = bob5.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (_, actionsBob6) = bob5.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actionsBob6.findOutgoingMessage<CommitSig>()
         assertEquals(4, commitSig.htlcSignatures.size)
     }
@@ -555,28 +555,28 @@ class NormalTestsCommon : LightningTestSuite() {
         val (bob3, alice3) = addHtlc(addBob1.toMilliSatoshi(), bob2, alice2).first
         val (bob4, alice4) = addHtlc(addBob2.toMilliSatoshi(), bob3, alice3).first
 
-        val (alice5, aActions5) = alice4.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice5, aActions5) = alice4.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig0 = aActions5.findOutgoingMessage<CommitSig>()
 
-        val (bob5, bActions5) = bob4.processEx(ChannelEvent.MessageReceived(commitSig0))
+        val (bob5, bActions5) = bob4.processEx(ChannelCommand.MessageReceived(commitSig0))
         val revokeAndAck0 = bActions5.findOutgoingMessage<RevokeAndAck>()
         val commandSign0 = bActions5.findCommand<CMD_SIGN>()
 
-        val (alice6, _) = alice5.processEx(ChannelEvent.MessageReceived(revokeAndAck0))
-        val (bob6, bActions6) = bob5.processEx(ChannelEvent.ExecuteCommand(commandSign0))
+        val (alice6, _) = alice5.processEx(ChannelCommand.MessageReceived(revokeAndAck0))
+        val (bob6, bActions6) = bob5.processEx(ChannelCommand.ExecuteCommand(commandSign0))
         val commitSig1 = bActions6.findOutgoingMessage<CommitSig>()
 
-        val (alice7, aActions7) = alice6.processEx(ChannelEvent.MessageReceived(commitSig1))
+        val (alice7, aActions7) = alice6.processEx(ChannelCommand.MessageReceived(commitSig1))
         val revokeAndAck1 = aActions7.findOutgoingMessage<RevokeAndAck>()
-        val (bob7, _) = bob6.processEx(ChannelEvent.MessageReceived(revokeAndAck1))
+        val (bob7, _) = bob6.processEx(ChannelCommand.MessageReceived(revokeAndAck1))
 
         val commandSign1 = aActions7.findCommand<CMD_SIGN>()
-        val (alice8, aActions8) = alice7.processEx(ChannelEvent.ExecuteCommand(commandSign1))
+        val (alice8, aActions8) = alice7.processEx(ChannelCommand.ExecuteCommand(commandSign1))
         val commitSig2 = aActions8.findOutgoingMessage<CommitSig>()
 
-        val (_, bActions8) = bob7.processEx(ChannelEvent.MessageReceived(commitSig2))
+        val (_, bActions8) = bob7.processEx(ChannelCommand.MessageReceived(commitSig2))
         val revokeAndAck2 = bActions8.findOutgoingMessage<RevokeAndAck>()
-        val (_, _) = alice8.processEx(ChannelEvent.MessageReceived(revokeAndAck2))
+        val (_, _) = alice8.processEx(ChannelCommand.MessageReceived(revokeAndAck2))
 
         val aliceHtlcInfos = buildList {
             addAll(aActions5.filterIsInstance<ChannelAction.Storage.StoreHtlcInfos>())
@@ -602,19 +602,19 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice1, bob1) = run {
             var (alice1, bob1) = alice0 to bob0
             for (i in epsilons) {
-                val (stateA, actionsA) = alice1.processEx(ChannelEvent.ExecuteCommand(add.copy(amount = add.amount + (i * 1000).msat)))
+                val (stateA, actionsA) = alice1.processEx(ChannelCommand.ExecuteCommand(add.copy(amount = add.amount + (i * 1000).msat)))
                 alice1 = stateA as Normal
                 val updateAddHtlc = actionsA.findOutgoingMessage<UpdateAddHtlc>()
-                val (stateB, _) = bob1.processEx(ChannelEvent.MessageReceived(updateAddHtlc))
+                val (stateB, _) = bob1.processEx(ChannelCommand.MessageReceived(updateAddHtlc))
                 bob1 = stateB as Normal
             }
             alice1 to bob1
         }
 
-        val (_, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (_, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actionsAlice2.findOutgoingMessage<CommitSig>()
         assertEquals(htlcCount, commitSig.htlcSignatures.size)
-        val (bob2, _) = bob1.processEx(ChannelEvent.MessageReceived(commitSig))
+        val (bob2, _) = bob1.processEx(ChannelCommand.MessageReceived(commitSig))
         bob2 as ChannelStateWithCommitments
         val htlcTxs = bob2.commitments.localCommit.publishableTxs.htlcTxsAndSigs
         assertEquals(htlcCount, htlcTxs.size)
@@ -625,7 +625,7 @@ class NormalTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_SIGN -- no changes`() {
         val (alice0, _) = reachNormal()
-        val (_, actions) = alice0.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (_, actions) = alice0.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(actions.isEmpty())
     }
 
@@ -636,14 +636,14 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(alice1 is Normal)
         assertTrue(alice1.commitments.remoteNextCommitInfo.isRight)
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         actionsAlice2.hasOutgoingMessage<CommitSig>()
         assertTrue(alice2 is Normal)
         assertNotNull(alice2.commitments.remoteNextCommitInfo.left)
         val waitForRevocation = alice2.commitments.remoteNextCommitInfo.left!!
         assertFalse(waitForRevocation.reSignAsap)
 
-        val (alice3, actionsAlice3) = alice2.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice3, actionsAlice3) = alice2.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(alice3 is Normal)
         assertEquals(Either.Left(waitForRevocation), alice3.commitments.remoteNextCommitInfo)
         assertNull(actionsAlice3.findOutgoingMessageOpt<CommitSig>())
@@ -656,7 +656,7 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(alice1 is Normal)
         assertTrue(alice1.commitments.remoteNextCommitInfo.isRight)
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         actionsAlice2.hasOutgoingMessage<CommitSig>()
         assertTrue(alice2 is Normal)
         assertNotNull(alice2.commitments.remoteNextCommitInfo.left)
@@ -664,7 +664,7 @@ class NormalTestsCommon : LightningTestSuite() {
         assertFalse(waitForRevocation.reSignAsap)
 
         val (alice3, _) = addHtlc(50_000_000.msat, alice2, bob1).first
-        val (alice4, actionsAlice4) = alice3.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice4, actionsAlice4) = alice3.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(alice4 is Normal)
         assertEquals(Either.Left(waitForRevocation.copy(reSignAsap = true)), alice4.commitments.remoteNextCommitInfo)
         assertTrue(actionsAlice4.isEmpty())
@@ -677,9 +677,9 @@ class NormalTestsCommon : LightningTestSuite() {
         val (nodes1, preimage, htlc) = addHtlc(50_000_000.msat, alice0, bob0)
         val (alice1, bob1) = nodes1
         val (_, bob2) = crossSign(alice1, bob1)
-        val (bob3, actions3) = bob2.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, preimage)))
+        val (bob3, actions3) = bob2.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, preimage)))
         actions3.hasOutgoingMessage<UpdateFulfillHtlc>()
-        val (bob4, actions4) = bob3.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob4, actions4) = bob3.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(bob4 is Normal)
         actions4.hasOutgoingMessage<CommitSig>()
         assertTrue(bob4.commitments.availableBalanceForSend() > 0.msat)
@@ -688,9 +688,9 @@ class NormalTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_SIGN -- after CMD_UPDATE_FEE`() {
         val (alice, _) = reachNormal()
-        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_UPDATE_FEE(FeeratePerKw.CommitmentFeerate + FeeratePerKw(1_000.sat))))
+        val (alice1, actions1) = alice.processEx(ChannelCommand.ExecuteCommand(CMD_UPDATE_FEE(FeeratePerKw.CommitmentFeerate + FeeratePerKw(1_000.sat))))
         actions1.hasOutgoingMessage<UpdateFee>()
-        val (_, actions2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (_, actions2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         actions2.hasOutgoingMessage<CommitSig>()
     }
 
@@ -700,11 +700,11 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(alice.commitments.localParams.features.hasFeature(Feature.ChannelBackupProvider))
         assertTrue(bob.commitments.localParams.features.hasFeature(Feature.ChannelBackupClient))
         val (_, cmdAdd) = makeCmdAdd(50_000_000.msat, alice.staticParams.nodeParams.nodeId, alice.currentBlockHeight.toLong())
-        val (bob1, actions) = bob.processEx(ChannelEvent.ExecuteCommand(cmdAdd))
+        val (bob1, actions) = bob.processEx(ChannelCommand.ExecuteCommand(cmdAdd))
         val add = actions.findOutgoingMessage<UpdateAddHtlc>()
-        val (alice1, _) = alice.processEx(ChannelEvent.MessageReceived(add))
+        val (alice1, _) = alice.processEx(ChannelCommand.MessageReceived(add))
         assertTrue { (alice1 as Normal).commitments.remoteChanges.proposed.contains(add) }
-        val (bob2, actions2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob2, actions2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actions2.findOutgoingMessage<CommitSig>()
         val blob = Serialization.encrypt(bob.staticParams.nodeParams.nodePrivateKey.value, bob2 as Normal)
         assertEquals(blob, commitSig.channelData)
@@ -718,7 +718,7 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(bob1 is Normal)
 
         val (_, bob2) = signAndRevack(alice1, bob1)
-        val (bob3, actions3) = bob2.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob3, actions3) = bob2.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actions3.findOutgoingMessage<CommitSig>()
         assertTrue(commitSig.channelData.isEmpty())
         assertTrue(bob3 is Normal)
@@ -737,10 +737,10 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(bob1 is Normal)
 
         val (alice2, bob2) = signAndRevack(alice1, bob1)
-        val (bob3, actionsBob3) = bob2.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob3, actionsBob3) = bob2.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(bob3 is Normal)
         val commitSig = actionsBob3.findOutgoingMessage<CommitSig>()
-        val (alice3, _) = alice2.processEx(ChannelEvent.MessageReceived(commitSig))
+        val (alice3, _) = alice2.processEx(ChannelCommand.MessageReceived(commitSig))
         assertTrue(alice3 is Normal)
         assertTrue(alice3.commitments.localCommit.spec.htlcs.outgoings().any { it.id == htlc.id })
         assertEquals(1, alice3.commitments.localCommit.publishableTxs.htlcTxsAndSigs.size)
@@ -767,9 +767,9 @@ class NormalTestsCommon : LightningTestSuite() {
         val (bob7, alice7) = nodes7
 
         val (alice8, bob8) = signAndRevack(alice7, bob7)
-        val (_, actionsBob9) = bob8.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (_, actionsBob9) = bob8.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actionsBob9.findOutgoingMessage<CommitSig>()
-        val (alice9, _) = alice8.processEx(ChannelEvent.MessageReceived(commitSig))
+        val (alice9, _) = alice8.processEx(ChannelCommand.MessageReceived(commitSig))
         assertTrue(alice9 is Normal)
         assertEquals(1, alice9.commitments.localCommit.index)
         assertEquals(3, alice9.commitments.localCommit.publishableTxs.htlcTxsAndSigs.size)
@@ -778,15 +778,15 @@ class NormalTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CommitSig -- only fee update`() {
         val (alice0, bob0) = reachNormal()
-        val (alice1, actions1) = alice0.processEx(ChannelEvent.ExecuteCommand(CMD_UPDATE_FEE(FeeratePerKw.CommitmentFeerate + FeeratePerKw(1_000.sat), false)))
+        val (alice1, actions1) = alice0.processEx(ChannelCommand.ExecuteCommand(CMD_UPDATE_FEE(FeeratePerKw.CommitmentFeerate + FeeratePerKw(1_000.sat), false)))
         val updateFee = actions1.findOutgoingMessage<UpdateFee>()
         assertEquals(FeeratePerKw.CommitmentFeerate + FeeratePerKw(1_000.sat), updateFee.feeratePerKw)
-        val (bob1, _) = bob0.processEx(ChannelEvent.MessageReceived(updateFee))
-        val (alice2, actions2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob1, _) = bob0.processEx(ChannelCommand.MessageReceived(updateFee))
+        val (alice2, actions2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actions2.findOutgoingMessage<CommitSig>()
-        val (_, actions3) = bob1.processEx(ChannelEvent.MessageReceived(commitSig))
+        val (_, actions3) = bob1.processEx(ChannelCommand.MessageReceived(commitSig))
         val revokeAndAck = actions3.findOutgoingMessage<RevokeAndAck>()
-        val (alice3, _) = alice2.processEx(ChannelEvent.MessageReceived(revokeAndAck))
+        val (alice3, _) = alice2.processEx(ChannelCommand.MessageReceived(revokeAndAck))
         assertTrue(alice3 is Normal)
     }
 
@@ -796,13 +796,13 @@ class NormalTestsCommon : LightningTestSuite() {
         val r = randomBytes32()
         val h = Crypto.sha256(r).toByteVector32()
 
-        val (alice1, actionsAlice1) = alice0.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(paymentHash = h)))
+        val (alice1, actionsAlice1) = alice0.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(paymentHash = h)))
         val htlc1 = actionsAlice1.findOutgoingMessage<UpdateAddHtlc>()
-        val (bob1, _) = bob0.processEx(ChannelEvent.MessageReceived(htlc1))
+        val (bob1, _) = bob0.processEx(ChannelCommand.MessageReceived(htlc1))
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(defaultAdd.copy(paymentHash = h)))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(defaultAdd.copy(paymentHash = h)))
         val htlc2 = actionsAlice2.findOutgoingMessage<UpdateAddHtlc>()
-        val (bob2, _) = bob1.processEx(ChannelEvent.MessageReceived(htlc2))
+        val (bob2, _) = bob1.processEx(ChannelCommand.MessageReceived(htlc2))
         assertEquals(listOf(htlc1, htlc2), (bob2 as ChannelStateWithCommitments).commitments.remoteChanges.proposed)
 
         val (_, bob3) = crossSign(alice2, bob2)
@@ -820,7 +820,7 @@ class NormalTestsCommon : LightningTestSuite() {
 
         // signature is invalid but it doesn't matter
         val sig = CommitSig(ByteVector32.Zeroes, ByteVector64.Zeroes, emptyList())
-        val (bob1, actionsBob1) = bob0.processEx(ChannelEvent.MessageReceived(sig))
+        val (bob1, actionsBob1) = bob0.processEx(ChannelCommand.MessageReceived(sig))
         assertTrue(bob1 is Closing)
         actionsBob1.hasOutgoingMessage<Error>()
 
@@ -848,7 +848,7 @@ class NormalTestsCommon : LightningTestSuite() {
 
         // signature is invalid but it doesn't matter
         val sig = CommitSig(ByteVector32.Zeroes, ByteVector64.Zeroes, emptyList())
-        val (bob1, actionsBob1) = bob0.processEx(ChannelEvent.MessageReceived(sig))
+        val (bob1, actionsBob1) = bob0.processEx(ChannelCommand.MessageReceived(sig))
         assertTrue(bob1 is Closing)
         actionsBob1.hasOutgoingMessage<Error>()
 
@@ -876,11 +876,11 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(bob1 is Normal)
         val tx = bob1.commitments.localCommit.publishableTxs.commitTx.tx
 
-        val (_, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (_, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actionsAlice2.findOutgoingMessage<CommitSig>()
         val badCommitSig = commitSig.copy(htlcSignatures = commitSig.htlcSignatures + commitSig.htlcSignatures)
 
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.MessageReceived(badCommitSig))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.MessageReceived(badCommitSig))
         assertTrue(bob2 is Closing)
         actionsBob2.hasOutgoingMessage<Error>()
         assertEquals(2, actionsBob2.filterIsInstance<ChannelAction.Blockchain.PublishTx>().count())
@@ -907,10 +907,10 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(bob1 is Normal)
         val tx = bob1.commitments.localCommit.publishableTxs.commitTx.tx
 
-        val (_, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (_, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actionsAlice2.findOutgoingMessage<CommitSig>()
         val badCommitSig = commitSig.copy(htlcSignatures = listOf(commitSig.signature))
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.MessageReceived(badCommitSig))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.MessageReceived(badCommitSig))
         assertTrue(bob2 is Closing)
         actionsBob2.hasOutgoingMessage<Error>()
         assertEquals(2, actionsBob2.filterIsInstance<ChannelAction.Blockchain.PublishTx>().count())
@@ -936,19 +936,19 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(alice.commitments.localParams.features.hasFeature(Feature.ChannelBackupProvider))
         assertTrue(bob.commitments.localParams.features.hasFeature(Feature.ChannelBackupClient))
         val (_, cmdAdd) = makeCmdAdd(50_000_000.msat, alice.staticParams.nodeParams.nodeId, alice.currentBlockHeight.toLong())
-        val (bob1, actions) = bob.processEx(ChannelEvent.ExecuteCommand(cmdAdd))
+        val (bob1, actions) = bob.processEx(ChannelCommand.ExecuteCommand(cmdAdd))
         val add = actions.findOutgoingMessage<UpdateAddHtlc>()
-        val (alice1, _) = alice.processEx(ChannelEvent.MessageReceived(add))
+        val (alice1, _) = alice.processEx(ChannelCommand.MessageReceived(add))
         assertTrue(alice1 is Normal)
         assertTrue(alice1.commitments.remoteChanges.proposed.contains(add))
-        val (bob2, actions2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob2, actions2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actions2.findOutgoingMessage<CommitSig>()
-        val (alice2, actions3) = alice1.processEx(ChannelEvent.MessageReceived(commitSig))
+        val (alice2, actions3) = alice1.processEx(ChannelCommand.MessageReceived(commitSig))
         val revack = actions3.findOutgoingMessage<RevokeAndAck>()
-        val (bob3, _) = bob2.processEx(ChannelEvent.MessageReceived(revack))
-        val (_, actions4) = alice2.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob3, _) = bob2.processEx(ChannelCommand.MessageReceived(revack))
+        val (_, actions4) = alice2.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig1 = actions4.findOutgoingMessage<CommitSig>()
-        val (bob4, actions5) = bob3.processEx(ChannelEvent.MessageReceived(commitSig1))
+        val (bob4, actions5) = bob3.processEx(ChannelCommand.MessageReceived(commitSig1))
         val revack1 = actions5.findOutgoingMessage<RevokeAndAck>()
         val blob = Serialization.encrypt(bob4.staticParams.nodeParams.nodePrivateKey.value, bob4 as Normal)
         assertEquals(blob, revack1.channelData)
@@ -959,15 +959,15 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice0, bob0) = reachNormal(bobFeatures = TestConstants.Bob.nodeParams.features.remove(Feature.ChannelBackupClient))
         val (alice1, bob1) = addHtlc(50_000_000.msat, alice0, bob0).first
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(alice2 is Normal)
         assertTrue(alice2.commitments.remoteNextCommitInfo.isLeft)
         val commitSig = actionsAlice2.findOutgoingMessage<CommitSig>()
-        val (_, actionsBob2) = bob1.processEx(ChannelEvent.MessageReceived(commitSig))
+        val (_, actionsBob2) = bob1.processEx(ChannelCommand.MessageReceived(commitSig))
         val revokeAndAck = actionsBob2.findOutgoingMessage<RevokeAndAck>()
         assertTrue(revokeAndAck.channelData.isEmpty())
 
-        val (alice3, _) = alice2.processEx(ChannelEvent.MessageReceived(revokeAndAck))
+        val (alice3, _) = alice2.processEx(ChannelCommand.MessageReceived(revokeAndAck))
         assertTrue(alice3 is Normal)
         assertTrue(alice3.commitments.remoteNextCommitInfo.isRight)
         assertEquals(1, alice3.commitments.localChanges.acked.size)
@@ -979,20 +979,20 @@ class NormalTestsCommon : LightningTestSuite() {
         val (nodes, _, add) = addHtlc(50_000_000.msat, alice0, bob0)
         val (alice1, bob1) = nodes
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig0 = actionsAlice2.findOutgoingMessage<CommitSig>()
 
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.MessageReceived(commitSig0))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.MessageReceived(commitSig0))
         val revokeAndAck0 = actionsBob2.findOutgoingMessage<RevokeAndAck>()
         val cmd = actionsBob2.findCommand<CMD_SIGN>()
-        val (bob3, actionsBob3) = bob2.processEx(ChannelEvent.ExecuteCommand(cmd))
-        val (alice3, _) = alice2.processEx(ChannelEvent.MessageReceived(revokeAndAck0))
+        val (bob3, actionsBob3) = bob2.processEx(ChannelCommand.ExecuteCommand(cmd))
+        val (alice3, _) = alice2.processEx(ChannelCommand.MessageReceived(revokeAndAck0))
         assertTrue(alice3 is Normal)
         assertTrue(alice3.commitments.remoteNextCommitInfo.isRight)
         val commitSig1 = actionsBob3.findOutgoingMessage<CommitSig>()
-        val (_, actionsAlice4) = alice3.processEx(ChannelEvent.MessageReceived(commitSig1))
+        val (_, actionsAlice4) = alice3.processEx(ChannelCommand.MessageReceived(commitSig1))
         val revokeAndAck1 = actionsAlice4.findOutgoingMessage<RevokeAndAck>()
-        val (bob4, actionsBob4) = bob3.processEx(ChannelEvent.MessageReceived(revokeAndAck1))
+        val (bob4, actionsBob4) = bob3.processEx(ChannelCommand.MessageReceived(revokeAndAck1))
         assertTrue(bob4 is Normal)
         assertTrue(bob4.commitments.remoteNextCommitInfo.isRight)
         actionsBob4.has<ChannelAction.Storage.StoreState>()
@@ -1017,20 +1017,20 @@ class NormalTestsCommon : LightningTestSuite() {
         val (nodes7, _, _) = addHtlc(4_000_000.msat, bob6, alice6) //  b->a (regular)
         val (bob7, alice7) = nodes7
 
-        val (alice8, actionsAlice8) = alice7.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice8, actionsAlice8) = alice7.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig0 = actionsAlice8.findOutgoingMessage<CommitSig>()
-        val (bob8, actionsBob8) = bob7.processEx(ChannelEvent.MessageReceived(commitSig0))
+        val (bob8, actionsBob8) = bob7.processEx(ChannelCommand.MessageReceived(commitSig0))
         val revokeAndAck0 = actionsBob8.findOutgoingMessage<RevokeAndAck>()
         val cmd = actionsBob8.findCommand<CMD_SIGN>()
-        val (bob9, actionsBob9) = bob8.processEx(ChannelEvent.ExecuteCommand(cmd))
-        val (alice9, _) = alice8.processEx(ChannelEvent.MessageReceived(revokeAndAck0))
+        val (bob9, actionsBob9) = bob8.processEx(ChannelCommand.ExecuteCommand(cmd))
+        val (alice9, _) = alice8.processEx(ChannelCommand.MessageReceived(revokeAndAck0))
         assertTrue(alice9 is Normal)
         assertTrue(alice9.commitments.remoteNextCommitInfo.isRight)
 
         val commitSig1 = actionsBob9.findOutgoingMessage<CommitSig>()
-        val (_, actionsAlice10) = alice9.processEx(ChannelEvent.MessageReceived(commitSig1))
+        val (_, actionsAlice10) = alice9.processEx(ChannelCommand.MessageReceived(commitSig1))
         val revokeAndAck1 = actionsAlice10.findOutgoingMessage<RevokeAndAck>()
-        val (bob10, actionsBob10) = bob9.processEx(ChannelEvent.MessageReceived(revokeAndAck1))
+        val (bob10, actionsBob10) = bob9.processEx(ChannelCommand.MessageReceived(revokeAndAck1))
         assertTrue(bob10 is Normal)
         assertTrue(bob10.commitments.remoteNextCommitInfo.isRight)
         assertEquals(1, bob10.commitments.remoteCommit.index)
@@ -1045,19 +1045,19 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(alice1 is Normal)
         assertTrue(alice1.commitments.remoteNextCommitInfo.isRight)
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig0 = actionsAlice2.findOutgoingMessage<CommitSig>()
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.MessageReceived(commitSig0))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.MessageReceived(commitSig0))
 
         val (alice3, _) = addHtlc(50_000_000.msat, alice2, bob2).first
-        val (alice4, _) = alice3.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice4, _) = alice3.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(alice4 is Normal)
         assertTrue(alice4.commitments.remoteNextCommitInfo.left?.reSignAsap == true)
 
         val revokeAndAck0 = actionsBob2.findOutgoingMessage<RevokeAndAck>()
-        val (alice5, actionsAlice5) = alice4.processEx(ChannelEvent.MessageReceived(revokeAndAck0))
+        val (alice5, actionsAlice5) = alice4.processEx(ChannelCommand.MessageReceived(revokeAndAck0))
         val cmd = actionsAlice5.findCommand<CMD_SIGN>()
-        val (_, actionsAlice6) = alice5.processEx(ChannelEvent.ExecuteCommand(cmd))
+        val (_, actionsAlice6) = alice5.processEx(ChannelCommand.ExecuteCommand(cmd))
         actionsAlice6.hasOutgoingMessage<CommitSig>()
     }
 
@@ -1068,12 +1068,12 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(alice1 is Normal)
         val tx = alice1.commitments.localCommit.publishableTxs.commitTx.tx
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig0 = actionsAlice2.findOutgoingMessage<CommitSig>()
-        val (_, actionsBob2) = bob1.processEx(ChannelEvent.MessageReceived(commitSig0))
+        val (_, actionsBob2) = bob1.processEx(ChannelCommand.MessageReceived(commitSig0))
         actionsBob2.hasOutgoingMessage<RevokeAndAck>()
 
-        val (alice3, actionsAlice3) = alice2.processEx(ChannelEvent.MessageReceived(RevokeAndAck(ByteVector32.Zeroes, PrivateKey(randomBytes32()), PrivateKey(randomBytes32()).publicKey())))
+        val (alice3, actionsAlice3) = alice2.processEx(ChannelCommand.MessageReceived(RevokeAndAck(ByteVector32.Zeroes, PrivateKey(randomBytes32()), PrivateKey(randomBytes32()).publicKey())))
         assertTrue(alice3 is Closing)
         actionsAlice3.hasOutgoingMessage<Error>()
         assertEquals(2, actionsAlice3.filterIsInstance<ChannelAction.Blockchain.PublishTx>().count())
@@ -1089,7 +1089,7 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(alice1.commitments.remoteNextCommitInfo.isRight)
         val tx = alice1.commitments.localCommit.publishableTxs.commitTx.tx
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.MessageReceived(RevokeAndAck(ByteVector32.Zeroes, PrivateKey(randomBytes32()), PrivateKey(randomBytes32()).publicKey())))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.MessageReceived(RevokeAndAck(ByteVector32.Zeroes, PrivateKey(randomBytes32()), PrivateKey(randomBytes32()).publicKey())))
         assertTrue(alice2 is Closing)
         actionsAlice2.hasOutgoingMessage<Error>()
         assertEquals(2, actionsAlice2.filterIsInstance<ChannelAction.Blockchain.PublishTx>().count())
@@ -1104,7 +1104,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val (_, bob1) = crossSign(nodes.first, nodes.second)
         assertTrue(bob1 is Normal)
 
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, r)))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, r)))
         val fulfillHtlc = actionsBob2.findOutgoingMessage<UpdateFulfillHtlc>()
         assertEquals(bob1.copy(commitments = bob1.commitments.copy(localChanges = bob1.commitments.localChanges.copy(bob1.commitments.localChanges.proposed + fulfillHtlc))), bob2)
     }
@@ -1114,7 +1114,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val (_, bob0) = reachNormal()
         val cmd = CMD_FULFILL_HTLC(42, randomBytes32())
 
-        val (_, actions) = bob0.processEx(ChannelEvent.ExecuteCommand(cmd))
+        val (_, actions) = bob0.processEx(ChannelCommand.ExecuteCommand(cmd))
         val actualError = actions.findCommandError<UnknownHtlcId>()
         val expectedError = UnknownHtlcId(bob0.channelId, 42)
         assertEquals(expectedError, actualError)
@@ -1128,7 +1128,7 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(bob1 is Normal)
 
         val cmd = CMD_FULFILL_HTLC(htlc.id, ByteVector32.Zeroes)
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.ExecuteCommand(cmd))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.ExecuteCommand(cmd))
         actionsBob2.hasCommandError<InvalidHtlcPreimage>()
         assertEquals(bob1, bob2)
     }
@@ -1138,11 +1138,11 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice0, bob0) = reachNormal()
         val (nodes, r, htlc) = addHtlc(50_000_000.msat, alice0, bob0)
         val (alice1, bob1) = crossSign(nodes.first, nodes.second)
-        val (_, actionsBob2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, r)))
+        val (_, actionsBob2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, r)))
         val fulfill = actionsBob2.findOutgoingMessage<UpdateFulfillHtlc>()
         assertTrue(alice1 is Normal)
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.MessageReceived(fulfill))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.MessageReceived(fulfill))
         assertEquals(alice1.copy(commitments = alice1.commitments.copy(remoteChanges = alice1.commitments.remoteChanges.copy(alice1.commitments.remoteChanges.proposed + fulfill))), alice2)
         val addSettled = actionsAlice2.filterIsInstance<ChannelAction.ProcessCmdRes.AddSettledFulfill>().first()
         assertEquals(htlc, addSettled.htlc)
@@ -1153,7 +1153,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv UpdateFulfillHtlc -- unknown htlc id`() {
         val (alice0, _) = reachNormal()
         val commitTx = alice0.commitments.localCommit.publishableTxs.commitTx.tx
-        val (alice1, actions1) = alice0.processEx(ChannelEvent.MessageReceived(UpdateFulfillHtlc(alice0.channelId, 42, randomBytes32())))
+        val (alice1, actions1) = alice0.processEx(ChannelCommand.MessageReceived(UpdateFulfillHtlc(alice0.channelId, 42, randomBytes32())))
         assertTrue(alice1 is Closing)
         assertTrue(actions1.contains(ChannelAction.Storage.StoreState(alice1)))
         assertTrue(actions1.contains(ChannelAction.Blockchain.PublishTx(commitTx)))
@@ -1167,11 +1167,11 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv UpdateFulfillHtlc -- sender has not signed htlc`() {
         val (alice0, bob0) = reachNormal()
         val (nodes, r, htlc) = addHtlc(50_000_000.msat, alice0, bob0)
-        val (alice1, actions1) = nodes.first.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice1, actions1) = nodes.first.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(alice1 is Normal)
         actions1.findOutgoingMessage<CommitSig>()
         val commitTx = alice1.commitments.localCommit.publishableTxs.commitTx.tx
-        val (alice2, actions2) = alice1.processEx(ChannelEvent.MessageReceived(UpdateFulfillHtlc(alice1.channelId, htlc.id, r)))
+        val (alice2, actions2) = alice1.processEx(ChannelCommand.MessageReceived(UpdateFulfillHtlc(alice1.channelId, htlc.id, r)))
         assertTrue(alice2 is Closing)
         assertTrue(actions2.contains(ChannelAction.Storage.StoreState(alice2)))
         assertTrue(actions2.contains(ChannelAction.Blockchain.PublishTx(commitTx)))
@@ -1188,7 +1188,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice1, _) = crossSign(nodes.first, nodes.second)
         assertTrue(alice1 is Normal)
         val commitTx = alice1.commitments.localCommit.publishableTxs.commitTx.tx
-        val (alice2, actions2) = alice1.processEx(ChannelEvent.MessageReceived(UpdateFulfillHtlc(alice0.channelId, htlc.id, ByteVector32.Zeroes)))
+        val (alice2, actions2) = alice1.processEx(ChannelCommand.MessageReceived(UpdateFulfillHtlc(alice0.channelId, htlc.id, ByteVector32.Zeroes)))
         assertTrue(alice2 is Closing)
         assertTrue(actions2.contains(ChannelAction.Storage.StoreState(alice2)))
         assertTrue(actions2.contains(ChannelAction.Blockchain.PublishTx(commitTx)))
@@ -1206,7 +1206,7 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(bob1 is Normal)
 
         val cmd = CMD_FAIL_HTLC(htlc.id, CMD_FAIL_HTLC.Reason.Failure(PermanentChannelFailure))
-        val (bob2, actions2) = bob1.processEx(ChannelEvent.ExecuteCommand(cmd))
+        val (bob2, actions2) = bob1.processEx(ChannelCommand.ExecuteCommand(cmd))
         val fail = actions2.findOutgoingMessage<UpdateFailHtlc>()
         assertEquals(bob1.copy(commitments = bob1.commitments.copy(localChanges = bob1.commitments.localChanges.copy(bob1.commitments.localChanges.proposed + fail))), bob2)
     }
@@ -1215,7 +1215,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv CMD_FAIL_HTLC -- unknown htlc id`() {
         val (_, bob0) = reachNormal()
         val cmdFail = CMD_FAIL_HTLC(42, CMD_FAIL_HTLC.Reason.Failure(PermanentChannelFailure))
-        val (bob1, actions1) = bob0.processEx(ChannelEvent.ExecuteCommand(cmdFail))
+        val (bob1, actions1) = bob0.processEx(ChannelCommand.ExecuteCommand(cmdFail))
         assertEquals(actions1, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmdFail, UnknownHtlcId(bob0.channelId, 42))))
         assertEquals(bob0, bob1)
     }
@@ -1228,7 +1228,7 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(bob1 is Normal)
 
         val cmdFail = CMD_FAIL_MALFORMED_HTLC(htlc.id, Sphinx.hash(htlc.onionRoutingPacket), FailureMessage.BADONION)
-        val (bob2, actions2) = bob1.processEx(ChannelEvent.ExecuteCommand(cmdFail))
+        val (bob2, actions2) = bob1.processEx(ChannelCommand.ExecuteCommand(cmdFail))
         val fail = actions2.findOutgoingMessage<UpdateFailMalformedHtlc>()
         assertEquals(bob1.copy(commitments = bob1.commitments.copy(localChanges = bob1.commitments.localChanges.copy(bob1.commitments.localChanges.proposed + fail))), bob2)
     }
@@ -1237,7 +1237,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv CMD_FAIL_HTLC_MALFORMED -- unknown htlc id`() {
         val (_, bob0) = reachNormal()
         val cmdFail = CMD_FAIL_MALFORMED_HTLC(42, ByteVector32.Zeroes, FailureMessage.BADONION)
-        val (bob1, actions1) = bob0.processEx(ChannelEvent.ExecuteCommand(cmdFail))
+        val (bob1, actions1) = bob0.processEx(ChannelCommand.ExecuteCommand(cmdFail))
         assertEquals(actions1, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmdFail, UnknownHtlcId(bob0.channelId, 42))))
         assertEquals(bob0, bob1)
     }
@@ -1249,7 +1249,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val (_, bob1) = crossSign(nodes.first, nodes.second)
 
         val cmdFail = CMD_FAIL_MALFORMED_HTLC(htlc.id, Sphinx.hash(htlc.onionRoutingPacket), 42)
-        val (bob2, actions2) = bob1.processEx(ChannelEvent.ExecuteCommand(cmdFail))
+        val (bob2, actions2) = bob1.processEx(ChannelCommand.ExecuteCommand(cmdFail))
         assertEquals(actions2, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmdFail, InvalidFailureCode(bob0.channelId))))
         assertEquals(bob1, bob2)
     }
@@ -1259,11 +1259,11 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice0, bob0) = reachNormal()
         val (nodes, _, htlc) = addHtlc(50_000_000.msat, alice0, bob0)
         val (alice1, bob1) = crossSign(nodes.first, nodes.second)
-        val (_, actionsBob2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_FAIL_HTLC(htlc.id, CMD_FAIL_HTLC.Reason.Failure(PermanentChannelFailure))))
+        val (_, actionsBob2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_FAIL_HTLC(htlc.id, CMD_FAIL_HTLC.Reason.Failure(PermanentChannelFailure))))
         val fail = actionsBob2.findOutgoingMessage<UpdateFailHtlc>()
         assertTrue(alice1 is Normal)
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.MessageReceived(fail))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.MessageReceived(fail))
         assertTrue(alice2 is Normal)
         assertTrue(actionsAlice2.isEmpty())
         assertEquals(alice1.copy(commitments = alice1.commitments.copy(remoteChanges = alice1.commitments.remoteChanges.copy(alice1.commitments.remoteChanges.proposed + fail))), alice2)
@@ -1273,7 +1273,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv UpdateFailHtlc -- unknown htlc id`() {
         val (alice0, _) = reachNormal()
         val commitTx = alice0.commitments.localCommit.publishableTxs.commitTx.tx
-        val (alice1, actions1) = alice0.processEx(ChannelEvent.MessageReceived(UpdateFailHtlc(alice0.channelId, 42, ByteVector.empty)))
+        val (alice1, actions1) = alice0.processEx(ChannelCommand.MessageReceived(UpdateFailHtlc(alice0.channelId, 42, ByteVector.empty)))
         assertTrue(alice1 is Closing)
         assertTrue(actions1.contains(ChannelAction.Storage.StoreState(alice1)))
         assertTrue(actions1.contains(ChannelAction.Blockchain.PublishTx(commitTx)))
@@ -1287,11 +1287,11 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv UpdateFailHtlc -- sender has not signed htlc`() {
         val (alice0, bob0) = reachNormal()
         val (nodes, _, htlc) = addHtlc(50_000_000.msat, alice0, bob0)
-        val (alice1, actions1) = nodes.first.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice1, actions1) = nodes.first.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(alice1 is Normal)
         actions1.findOutgoingMessage<CommitSig>()
         val commitTx = alice1.commitments.localCommit.publishableTxs.commitTx.tx
-        val (alice2, actions2) = alice1.processEx(ChannelEvent.MessageReceived(UpdateFailHtlc(alice1.channelId, htlc.id, ByteVector.empty)))
+        val (alice2, actions2) = alice1.processEx(ChannelCommand.MessageReceived(UpdateFailHtlc(alice1.channelId, htlc.id, ByteVector.empty)))
         assertTrue(alice2 is Closing)
         assertTrue(actions2.contains(ChannelAction.Storage.StoreState(alice2)))
         assertTrue(actions2.contains(ChannelAction.Blockchain.PublishTx(commitTx)))
@@ -1306,11 +1306,11 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice0, bob0) = reachNormal()
         val (nodes, _, htlc) = addHtlc(50_000_000.msat, alice0, bob0)
         val (alice1, bob1) = crossSign(nodes.first, nodes.second)
-        val (_, actionsBob2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_FAIL_MALFORMED_HTLC(htlc.id, Sphinx.hash(htlc.onionRoutingPacket), FailureMessage.BADONION)))
+        val (_, actionsBob2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_FAIL_MALFORMED_HTLC(htlc.id, Sphinx.hash(htlc.onionRoutingPacket), FailureMessage.BADONION)))
         val fail = actionsBob2.findOutgoingMessage<UpdateFailMalformedHtlc>()
         assertTrue(alice1 is Normal)
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.MessageReceived(fail))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.MessageReceived(fail))
         assertTrue(alice2 is Normal)
         assertTrue(actionsAlice2.isEmpty())
         assertEquals(alice1.copy(commitments = alice1.commitments.copy(remoteChanges = alice1.commitments.remoteChanges.copy(alice1.commitments.remoteChanges.proposed + fail))), alice2)
@@ -1320,7 +1320,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv UpdateFailMalformedHtlc -- unknown htlc id`() {
         val (alice0, _) = reachNormal()
         val commitTx = alice0.commitments.localCommit.publishableTxs.commitTx.tx
-        val (alice1, actions1) = alice0.processEx(ChannelEvent.MessageReceived(UpdateFailMalformedHtlc(alice0.channelId, 42, ByteVector32.Zeroes, FailureMessage.BADONION)))
+        val (alice1, actions1) = alice0.processEx(ChannelCommand.MessageReceived(UpdateFailMalformedHtlc(alice0.channelId, 42, ByteVector32.Zeroes, FailureMessage.BADONION)))
         assertTrue(alice1 is Closing)
         assertTrue(actions1.contains(ChannelAction.Storage.StoreState(alice1)))
         assertTrue(actions1.contains(ChannelAction.Blockchain.PublishTx(commitTx)))
@@ -1338,7 +1338,7 @@ class NormalTestsCommon : LightningTestSuite() {
         assertTrue(alice1 is Normal)
         val commitTx = alice1.commitments.localCommit.publishableTxs.commitTx.tx
 
-        val (alice2, actions2) = alice1.processEx(ChannelEvent.MessageReceived(UpdateFailMalformedHtlc(alice0.channelId, htlc.id, Sphinx.hash(htlc.onionRoutingPacket), 42)))
+        val (alice2, actions2) = alice1.processEx(ChannelCommand.MessageReceived(UpdateFailMalformedHtlc(alice0.channelId, htlc.id, Sphinx.hash(htlc.onionRoutingPacket), 42)))
         assertTrue(alice2 is Closing)
         assertTrue(actions2.contains(ChannelAction.Storage.StoreState(alice2)))
         assertTrue(actions2.contains(ChannelAction.Blockchain.PublishTx(commitTx)))
@@ -1352,7 +1352,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv UpdateFee`() {
         val (_, bob) = reachNormal()
         val fee = UpdateFee(ByteVector32.Zeroes, FeeratePerKw(7_500.sat))
-        val (bob1, _) = bob.processEx(ChannelEvent.MessageReceived(fee))
+        val (bob1, _) = bob.processEx(ChannelCommand.MessageReceived(fee))
         bob1 as Normal
         assertEquals(bob.commitments.copy(remoteChanges = bob.commitments.remoteChanges.copy(proposed = bob.commitments.remoteChanges.proposed + fee)), bob1.commitments)
     }
@@ -1361,9 +1361,9 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv UpdateFee -- 2 in a row`() {
         val (_, bob) = reachNormal()
         val fee1 = UpdateFee(ByteVector32.Zeroes, FeeratePerKw(7_500.sat))
-        val (bob1, _) = bob.processEx(ChannelEvent.MessageReceived(fee1))
+        val (bob1, _) = bob.processEx(ChannelCommand.MessageReceived(fee1))
         val fee2 = UpdateFee(ByteVector32.Zeroes, FeeratePerKw(9_000.sat))
-        val (bob2, _) = bob1.processEx(ChannelEvent.MessageReceived(fee2))
+        val (bob2, _) = bob1.processEx(ChannelCommand.MessageReceived(fee2))
         assertTrue(bob2 is Normal)
         assertEquals(bob.commitments.copy(remoteChanges = bob.commitments.remoteChanges.copy(proposed = bob.commitments.remoteChanges.proposed + fee2)), bob2.commitments)
     }
@@ -1378,7 +1378,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val commitTx = bob1.commitments.localCommit.publishableTxs.commitTx.tx
 
         val fee = UpdateFee(ByteVector32.Zeroes, FeeratePerKw.CommitmentFeerate * 4)
-        val (bob2, actions) = bob1.processEx(ChannelEvent.MessageReceived(fee))
+        val (bob2, actions) = bob1.processEx(ChannelCommand.MessageReceived(fee))
         assertTrue(bob2 is Closing)
         actions.hasTx(commitTx)
         actions.hasWatch<WatchConfirmed>()
@@ -1390,7 +1390,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv UpdateFee -- remote feerate is too small`() {
         val (_, bob) = reachNormal()
         assertEquals(FeeratePerKw.CommitmentFeerate, bob.commitments.localCommit.spec.feerate)
-        val (bob1, actions) = bob.processEx(ChannelEvent.MessageReceived(UpdateFee(bob.channelId, FeeratePerKw(252.sat))))
+        val (bob1, actions) = bob.processEx(ChannelCommand.MessageReceived(UpdateFee(bob.channelId, FeeratePerKw(252.sat))))
         assertTrue(bob1 is Closing)
         actions.hasTx(bob.commitments.localCommit.publishableTxs.commitTx.tx)
         actions.hasWatch<WatchConfirmed>()
@@ -1404,18 +1404,18 @@ class NormalTestsCommon : LightningTestSuite() {
         assertNull(alice.remoteChannelUpdate)
         assertNull(bob.remoteChannelUpdate)
         val aliceUpdate = Announcements.makeChannelUpdate(alice.staticParams.nodeParams.chainHash, alice.privateKey, alice.staticParams.remoteNodeId, alice.shortChannelId, CltvExpiryDelta(36), 5.msat, 15.msat, 150, 150_000.msat)
-        val (bob1, actions1) = bob.processEx(ChannelEvent.MessageReceived(aliceUpdate))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.MessageReceived(aliceUpdate))
         assertTrue(bob1 is Normal)
         assertEquals(bob1.remoteChannelUpdate, aliceUpdate)
         actions1.has<ChannelAction.Storage.StoreState>()
 
         val aliceUpdateOtherChannel = Announcements.makeChannelUpdate(alice.staticParams.nodeParams.chainHash, alice.privateKey, alice.staticParams.remoteNodeId, ShortChannelId(7), CltvExpiryDelta(12), 1.msat, 10.msat, 50, 15_000.msat)
-        val (bob2, actions2) = bob1.processEx(ChannelEvent.MessageReceived(aliceUpdateOtherChannel))
+        val (bob2, actions2) = bob1.processEx(ChannelCommand.MessageReceived(aliceUpdateOtherChannel))
         assertEquals(bob1, bob2)
         assertTrue(actions2.isEmpty())
 
         val bobUpdate = Announcements.makeChannelUpdate(bob.staticParams.nodeParams.chainHash, bob.privateKey, bob.staticParams.remoteNodeId, bob.shortChannelId, CltvExpiryDelta(24), 1.msat, 5.msat, 10, 125_000.msat)
-        val (bob3, actions3) = bob2.processEx(ChannelEvent.MessageReceived(bobUpdate))
+        val (bob3, actions3) = bob2.processEx(ChannelCommand.MessageReceived(bobUpdate))
         assertEquals(bob1, bob3)
         assertTrue(actions3.isEmpty())
     }
@@ -1424,7 +1424,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv CMD_CLOSE -- no pending htlcs`() {
         val (alice, _) = reachNormal()
         assertNull(alice.localShutdown)
-        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (alice1, actions1) = alice.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         assertTrue(alice1 is Normal)
         actions1.hasOutgoingMessage<Shutdown>()
         assertNotNull(alice1.localShutdown)
@@ -1435,7 +1435,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice, bob) = reachNormal()
         val (nodes, _, _) = addHtlc(1000.msat, payer = alice, payee = bob)
         val (alice1, _) = nodes
-        val (alice2, actions1) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (alice2, actions1) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         assertTrue(alice2 is Normal)
         actions1.hasCommandError<CannotCloseWithUnsignedOutgoingHtlcs>()
     }
@@ -1445,7 +1445,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice, bob) = reachNormal()
         val (nodes, _, _) = addHtlc(1000.msat, payer = alice, payee = bob)
         val (_, bob1) = nodes
-        val (bob2, actions1) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (bob2, actions1) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         assertTrue(bob2 is Normal)
         actions1.hasOutgoingMessage<Shutdown>()
         assertNotNull(bob2.localShutdown)
@@ -1455,7 +1455,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv CMD_CLOSE -- with invalid final script`() {
         val (alice, _) = reachNormal()
         assertNull(alice.localShutdown)
-        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(ByteVector("00112233445566778899"), null)))
+        val (alice1, actions1) = alice.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(ByteVector("00112233445566778899"), null)))
         assertTrue(alice1 is Normal)
         actions1.hasCommandError<InvalidFinalScript>()
     }
@@ -1464,7 +1464,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv CMD_CLOSE -- with unsupported native segwit script`() {
         val (alice, _) = reachNormal()
         assertNull(alice.localShutdown)
-        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(ByteVector("51050102030405"), null)))
+        val (alice1, actions1) = alice.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(ByteVector("51050102030405"), null)))
         assertTrue(alice1 is Normal)
         actions1.hasCommandError<InvalidFinalScript>()
     }
@@ -1476,7 +1476,7 @@ class NormalTestsCommon : LightningTestSuite() {
             bobFeatures = TestConstants.Bob.nodeParams.features.copy(TestConstants.Bob.nodeParams.features.activated + (Feature.ShutdownAnySegwit to FeatureSupport.Optional)),
         )
         assertNull(alice.localShutdown)
-        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(ByteVector("51050102030405"), null)))
+        val (alice1, actions1) = alice.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(ByteVector("51050102030405"), null)))
         actions1.hasOutgoingMessage<Shutdown>()
         assertTrue(alice1 is Normal)
         assertNotNull(alice1.localShutdown)
@@ -1487,7 +1487,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice, bob) = reachNormal()
         val (nodes, _, _) = addHtlc(1000.msat, payer = alice, payee = bob)
         val (alice1, _) = crossSign(nodes.first, nodes.second)
-        val (alice2, actions1) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (alice2, actions1) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         actions1.hasOutgoingMessage<Shutdown>()
         assertTrue(alice2 is Normal)
         assertNotNull(alice2.localShutdown)
@@ -1497,11 +1497,11 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv CMD_CLOSE -- two in a row`() {
         val (alice, _) = reachNormal()
         assertNull(alice.localShutdown)
-        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (alice1, actions1) = alice.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         assertTrue(alice1 is Normal)
         actions1.hasOutgoingMessage<Shutdown>()
         assertNotNull(alice1.localShutdown)
-        val (alice2, actions2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (alice2, actions2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         assertTrue(alice2 is Normal)
         actions2.hasCommandError<ClosingAlreadyInProgress>()
     }
@@ -1510,10 +1510,10 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv CMD_CLOSE -- while waiting for a RevokeAndAck`() {
         val (alice, bob) = reachNormal()
         val (nodes, _, _) = addHtlc(1000.msat, payer = alice, payee = bob)
-        val (alice1, actions1) = nodes.first.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice1, actions1) = nodes.first.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(alice1 is Normal)
         actions1.hasOutgoingMessage<CommitSig>()
-        val (alice2, actions2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (alice2, actions2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         assertTrue(alice2 is Normal)
         actions2.hasOutgoingMessage<Shutdown>()
     }
@@ -1521,12 +1521,12 @@ class NormalTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_CLOSE -- with unsigned fee update`() {
         val (alice, _) = reachNormal()
-        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_UPDATE_FEE(FeeratePerKw(20_000.sat), false)))
+        val (alice1, actions1) = alice.processEx(ChannelCommand.ExecuteCommand(CMD_UPDATE_FEE(FeeratePerKw(20_000.sat), false)))
         actions1.hasOutgoingMessage<UpdateFee>()
-        val (alice2, actions2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (alice2, actions2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         actions2.hasCommandError<CannotCloseWithUnsignedOutgoingUpdateFee>()
-        val (alice3, _) = alice2.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
-        val (alice4, actions4) = alice3.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (alice3, _) = alice2.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
+        val (alice4, actions4) = alice3.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         assertTrue(alice4 is Normal)
         actions4.hasOutgoingMessage<Shutdown>()
     }
@@ -1534,7 +1534,7 @@ class NormalTestsCommon : LightningTestSuite() {
     @Test
     fun `recv Shutdown -- no pending htlcs`() {
         val (alice, bob) = reachNormal()
-        val (alice1, actions1) = alice.processEx(ChannelEvent.MessageReceived(Shutdown(alice.channelId, bob.commitments.localParams.defaultFinalScriptPubKey)))
+        val (alice1, actions1) = alice.processEx(ChannelCommand.MessageReceived(Shutdown(alice.channelId, bob.commitments.localParams.defaultFinalScriptPubKey)))
         assertTrue(alice1 is Negotiating)
         actions1.hasOutgoingMessage<Shutdown>()
         actions1.hasOutgoingMessage<ClosingSigned>()
@@ -1544,21 +1544,21 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv Shutdown -- with unacked sent htlcs`() {
         val (alice, bob) = reachNormal()
         val (nodes, _, _) = addHtlc(50000000.msat, payer = alice, payee = bob)
-        val (bob1, actions1) = nodes.second.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (bob1, actions1) = nodes.second.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
 
         val shutdown = actions1.findOutgoingMessage<Shutdown>()
-        val (alice1, actions2) = nodes.first.processEx(ChannelEvent.MessageReceived(shutdown))
+        val (alice1, actions2) = nodes.first.processEx(ChannelCommand.MessageReceived(shutdown))
         // Alice sends a new sig
         assertEquals(actions2, listOf(ChannelAction.Message.SendToSelf(CMD_SIGN)))
-        val (alice2, actions3) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice2, actions3) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actions3.findOutgoingMessage<CommitSig>()
 
         // Bob replies with a revocation
-        val (_, actions4) = bob1.processEx(ChannelEvent.MessageReceived(commitSig))
+        val (_, actions4) = bob1.processEx(ChannelCommand.MessageReceived(commitSig))
         val revack = actions4.findOutgoingMessage<RevokeAndAck>()
 
         // as soon as alice has received the revocation, she will send her shutdown message
-        val (alice3, actions5) = alice2.processEx(ChannelEvent.MessageReceived(revack))
+        val (alice3, actions5) = alice2.processEx(ChannelCommand.MessageReceived(revack))
         assertTrue(alice3 is ShuttingDown)
         actions5.hasOutgoingMessage<Shutdown>()
     }
@@ -1567,7 +1567,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv Shutdown -- with unacked received htlcs`() {
         val (alice, bob) = reachNormal()
         val (nodes, _, _) = addHtlc(50000000.msat, payer = alice, payee = bob)
-        val (bob1, actions1) = nodes.second.processEx(ChannelEvent.MessageReceived(Shutdown(alice.channelId, alice.commitments.localParams.defaultFinalScriptPubKey)))
+        val (bob1, actions1) = nodes.second.processEx(ChannelCommand.MessageReceived(Shutdown(alice.channelId, alice.commitments.localParams.defaultFinalScriptPubKey)))
         assertTrue(bob1 is Closing)
         actions1.hasOutgoingMessage<Error>()
         assertEquals(2, actions1.filterIsInstance<ChannelAction.Blockchain.PublishTx>().count())
@@ -1577,43 +1577,43 @@ class NormalTestsCommon : LightningTestSuite() {
     @Test
     fun `recv Shutdown -- with unsigned fee update`() {
         val (alice, bob) = reachNormal()
-        val (alice1, aliceActions1) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_UPDATE_FEE(FeeratePerKw(20_000.sat), true)))
+        val (alice1, aliceActions1) = alice.processEx(ChannelCommand.ExecuteCommand(CMD_UPDATE_FEE(FeeratePerKw(20_000.sat), true)))
         val updateFee = aliceActions1.hasOutgoingMessage<UpdateFee>()
-        val (alice2, aliceActions2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice2, aliceActions2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val sigAlice = aliceActions2.hasOutgoingMessage<CommitSig>()
 
         // Bob initiates a close before receiving the signature.
-        val (bob1, _) = bob.processEx(ChannelEvent.MessageReceived(updateFee))
-        val (bob2, bobActions2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (bob1, _) = bob.processEx(ChannelCommand.MessageReceived(updateFee))
+        val (bob2, bobActions2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         val shutdownBob = bobActions2.hasOutgoingMessage<Shutdown>()
 
-        val (bob3, bobActions3) = bob2.processEx(ChannelEvent.MessageReceived(sigAlice))
+        val (bob3, bobActions3) = bob2.processEx(ChannelCommand.MessageReceived(sigAlice))
         val revBob = bobActions3.hasOutgoingMessage<RevokeAndAck>()
         bobActions3.hasCommand<CMD_SIGN>()
-        val (bob4, bobActions4) = bob3.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob4, bobActions4) = bob3.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val sigBob = bobActions4.hasOutgoingMessage<CommitSig>()
 
-        val (alice3, aliceActions3) = alice2.processEx(ChannelEvent.MessageReceived(shutdownBob))
+        val (alice3, aliceActions3) = alice2.processEx(ChannelCommand.MessageReceived(shutdownBob))
         val shutdownAlice = aliceActions3.hasOutgoingMessage<Shutdown>()
-        val (alice4, _) = alice3.processEx(ChannelEvent.MessageReceived(revBob))
-        val (alice5, aliceActions5) = alice4.processEx(ChannelEvent.MessageReceived(sigBob))
+        val (alice4, _) = alice3.processEx(ChannelCommand.MessageReceived(revBob))
+        val (alice5, aliceActions5) = alice4.processEx(ChannelCommand.MessageReceived(sigBob))
         assertTrue(alice5 is Negotiating)
         val revAlice = aliceActions5.hasOutgoingMessage<RevokeAndAck>()
         val closingAlice = aliceActions5.hasOutgoingMessage<ClosingSigned>()
 
-        val (bob5, _) = bob4.processEx(ChannelEvent.MessageReceived(shutdownAlice))
-        val (bob6, _) = bob5.processEx(ChannelEvent.MessageReceived(revAlice))
-        val (bob7, bobActions7) = bob6.processEx(ChannelEvent.MessageReceived(closingAlice))
+        val (bob5, _) = bob4.processEx(ChannelCommand.MessageReceived(shutdownAlice))
+        val (bob6, _) = bob5.processEx(ChannelCommand.MessageReceived(revAlice))
+        val (bob7, bobActions7) = bob6.processEx(ChannelCommand.MessageReceived(closingAlice))
         assertTrue(bob7 is Closing)
         val closingBob = bobActions7.hasOutgoingMessage<ClosingSigned>()
-        val (alice6, _) = alice5.processEx(ChannelEvent.MessageReceived(closingBob))
+        val (alice6, _) = alice5.processEx(ChannelCommand.MessageReceived(closingBob))
         assertTrue(alice6 is Closing)
     }
 
     @Test
     fun `recv Shutdown -- with invalid script`() {
         val (_, bob) = reachNormal()
-        val (bob1, actions1) = bob.processEx(ChannelEvent.MessageReceived(Shutdown(bob.channelId, ByteVector("00112233445566778899"))))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.MessageReceived(Shutdown(bob.channelId, ByteVector("00112233445566778899"))))
         assertTrue(bob1 is Closing)
         actions1.hasOutgoingMessage<Error>()
         assertEquals(2, actions1.filterIsInstance<ChannelAction.Blockchain.PublishTx>().count())
@@ -1623,7 +1623,7 @@ class NormalTestsCommon : LightningTestSuite() {
     @Test
     fun `recv Shutdown -- with unsupported native segwit script`() {
         val (_, bob) = reachNormal()
-        val (bob1, actions1) = bob.processEx(ChannelEvent.MessageReceived(Shutdown(bob.channelId, ByteVector("51050102030405"))))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.MessageReceived(Shutdown(bob.channelId, ByteVector("51050102030405"))))
         assertTrue(bob1 is Closing)
         actions1.hasOutgoingMessage<Error>()
         assertEquals(2, actions1.filterIsInstance<ChannelAction.Blockchain.PublishTx>().count())
@@ -1636,7 +1636,7 @@ class NormalTestsCommon : LightningTestSuite() {
             aliceFeatures = TestConstants.Alice.nodeParams.features.copy(TestConstants.Alice.nodeParams.features.activated + (Feature.ShutdownAnySegwit to FeatureSupport.Optional)),
             bobFeatures = TestConstants.Bob.nodeParams.features.copy(TestConstants.Bob.nodeParams.features.activated + (Feature.ShutdownAnySegwit to FeatureSupport.Optional)),
         )
-        val (bob1, actions1) = bob.processEx(ChannelEvent.MessageReceived(Shutdown(bob.channelId, ByteVector("51050102030405"))))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.MessageReceived(Shutdown(bob.channelId, ByteVector("51050102030405"))))
         assertTrue(bob1 is Negotiating)
         actions1.hasOutgoingMessage<Shutdown>()
     }
@@ -1646,11 +1646,11 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice, bob) = reachNormal()
         val (nodes, _, _) = addHtlc(50000000.msat, payer = alice, payee = bob)
         val (_, bob1) = crossSign(nodes.first, nodes.second)
-        val (bob2, actions1) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (bob2, actions1) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         actions1.hasOutgoingMessage<Shutdown>()
 
         // actual test begins
-        val (bob3, actions2) = bob2.processEx(ChannelEvent.MessageReceived(Shutdown(bob.channelId, ByteVector("00112233445566778899"))))
+        val (bob3, actions2) = bob2.processEx(ChannelCommand.MessageReceived(Shutdown(bob.channelId, ByteVector("00112233445566778899"))))
         assertTrue(bob3 is Closing)
         actions2.hasOutgoingMessage<Error>()
         assertEquals(2, actions2.filterIsInstance<ChannelAction.Blockchain.PublishTx>().count())
@@ -1664,7 +1664,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val (_, bob1) = crossSign(nodes.first, nodes.second)
 
         // actual test begins
-        val (bob2, actions1) = bob1.processEx(ChannelEvent.MessageReceived(Shutdown(bob.channelId, alice.commitments.localParams.defaultFinalScriptPubKey)))
+        val (bob2, actions1) = bob1.processEx(ChannelCommand.MessageReceived(Shutdown(bob.channelId, alice.commitments.localParams.defaultFinalScriptPubKey)))
         assertTrue(bob2 is ShuttingDown)
         actions1.hasOutgoingMessage<Shutdown>()
     }
@@ -1673,13 +1673,13 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv Shutdown -- while waiting for a RevokeAndAck`() {
         val (alice, bob) = reachNormal()
         val (nodes, _, _) = addHtlc(50000000.msat, payer = alice, payee = bob)
-        val (alice1, actions1) = nodes.first.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice1, actions1) = nodes.first.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         actions1.hasOutgoingMessage<CommitSig>()
-        val (_, actions2) = bob.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (_, actions2) = bob.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         val shutdown = actions2.findOutgoingMessage<Shutdown>()
 
         // actual test begins
-        val (alice2, actions3) = alice1.processEx(ChannelEvent.MessageReceived(shutdown))
+        val (alice2, actions3) = alice1.processEx(ChannelCommand.MessageReceived(shutdown))
         assertTrue(alice2 is ShuttingDown)
         actions3.hasOutgoingMessage<Shutdown>()
     }
@@ -1688,14 +1688,14 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `recv Shutdown -- while waiting for a RevokeAndAck with pending outgoing htlc`() {
         val (alice, bob) = reachNormal()
         // let's make bob send a Shutdown message
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         val shutdown = actions1.findOutgoingMessage<Shutdown>()
 
         // this is just so we have something to sign
         val (nodes, _, _) = addHtlc(50000000.msat, payer = alice, payee = bob1)
-        val (alice1, actions2) = nodes.first.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice1, actions2) = nodes.first.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actions2.findOutgoingMessage<CommitSig>()
-        val (bob2, actions3) = nodes.second.processEx(ChannelEvent.MessageReceived(commitSig))
+        val (bob2, actions3) = nodes.second.processEx(ChannelCommand.MessageReceived(commitSig))
         val revack = actions3.findOutgoingMessage<RevokeAndAck>()
 
         // adding an outgoing pending htlc
@@ -1703,23 +1703,23 @@ class NormalTestsCommon : LightningTestSuite() {
 
         // actual test begins
         // alice eventually gets bob's shutdown
-        val (alice3, actions4) = nodes1.first.processEx(ChannelEvent.MessageReceived(shutdown))
+        val (alice3, actions4) = nodes1.first.processEx(ChannelCommand.MessageReceived(shutdown))
         // alice can't do anything for now other than waiting for bob to send the revocation
         assertTrue(actions4.isEmpty())
         // bob sends the revocation
-        val (alice4, actions5) = alice3.processEx(ChannelEvent.MessageReceived(revack))
+        val (alice4, actions5) = alice3.processEx(ChannelCommand.MessageReceived(revack))
         assertTrue(actions5.contains(ChannelAction.Message.SendToSelf(CMD_SIGN)))
         // bob will also sign back
-        val (bob3, actions6) = nodes1.second.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
-        val (alice5, actions7) = alice4.processEx(ChannelEvent.MessageReceived(actions6.findOutgoingMessage<CommitSig>()))
+        val (bob3, actions6) = nodes1.second.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
+        val (alice5, actions7) = alice4.processEx(ChannelCommand.MessageReceived(actions6.findOutgoingMessage<CommitSig>()))
 
         // then alice can sign the 2nd htlc
         assertTrue(actions7.contains(ChannelAction.Message.SendToSelf(CMD_SIGN)))
-        val (alice6, actions8) = alice5.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice6, actions8) = alice5.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(alice6 is Normal)
-        val (_, actions9) = bob3.processEx(ChannelEvent.MessageReceived(actions8.findOutgoingMessage<CommitSig>()))
+        val (_, actions9) = bob3.processEx(ChannelCommand.MessageReceived(actions8.findOutgoingMessage<CommitSig>()))
         // bob replies with the 2nd revocation
-        val (alice7, actions11) = alice6.processEx(ChannelEvent.MessageReceived(actions9.findOutgoingMessage<RevokeAndAck>()))
+        val (alice7, actions11) = alice6.processEx(ChannelCommand.MessageReceived(actions9.findOutgoingMessage<RevokeAndAck>()))
         // then alice sends her shutdown
         assertTrue(alice7 is ShuttingDown)
         actions11.hasOutgoingMessage<Shutdown>()
@@ -1759,7 +1759,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val bobCommitTx = bob8.commitments.localCommit.publishableTxs.commitTx.tx
         assertEquals(8, bobCommitTx.txOut.size) // 2 main outputs, 4 pending htlcs and 2 anchors
 
-        val (aliceClosing, actions) = alice8.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice8.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)))
+        val (aliceClosing, actions) = alice8.processEx(ChannelCommand.WatchReceived(WatchEventSpent(alice8.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)))
         assertTrue(aliceClosing is Closing)
         assertTrue(actions.isNotEmpty())
 
@@ -1806,9 +1806,9 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice7, bob7) = fulfillHtlc(1, preimage_alice2bob_2, payer = alice6, payee = bob6)
         val (bob8, alice8) = fulfillHtlc(0, preimage_bob2alice_1, payer = bob7, payee = alice7)
         // alice sign but we intercept bob's revocation
-        val (alice9, actions8) = alice8.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice9, actions8) = alice8.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actions8.findOutgoingMessage<CommitSig>()
-        val (bob9, _) = bob8.processEx(ChannelEvent.MessageReceived(commitSig))
+        val (bob9, _) = bob8.processEx(ChannelCommand.MessageReceived(commitSig))
         assertTrue(alice9 is Normal)
         assertTrue(bob9 is Normal)
 
@@ -1829,7 +1829,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val bobCommitTx = bob9.commitments.localCommit.publishableTxs.commitTx.tx
         assertEquals(7, bobCommitTx.txOut.size) // 2 main outputs, 3 pending htlcs and 2 anchors
 
-        val (aliceClosing, actions9) = alice9.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice9.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)))
+        val (aliceClosing, actions9) = alice9.processEx(ChannelCommand.WatchReceived(WatchEventSpent(alice9.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)))
         assertTrue(aliceClosing is Closing)
         assertTrue(actions9.isNotEmpty())
 
@@ -1901,13 +1901,13 @@ class NormalTestsCommon : LightningTestSuite() {
         //  a->b =  10 000 sat
         assertEquals(8, revokedTx.txOut.size) // 2 anchor outputs + 2 main outputs + 4 htlc
 
-        val (aliceClosing1, actions1) = alice.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, revokedTx)))
+        val (aliceClosing1, actions1) = alice.processEx(ChannelCommand.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, revokedTx)))
         assertTrue(aliceClosing1 is Closing)
         assertEquals(1, aliceClosing1.revokedCommitPublished.size)
         actions1.hasOutgoingMessage<Error>()
         assertEquals(ChannelAction.Storage.GetHtlcInfos(revokedTx.txid, 4), actions1.find())
 
-        val (aliceClosing2, actions2) = aliceClosing1.processEx(ChannelEvent.GetHtlcInfosResponse(revokedTx.txid, adds.take(4).map { ChannelAction.Storage.HtlcInfo(alice.channelId, 4, it.paymentHash, it.cltvExpiry) }))
+        val (aliceClosing2, actions2) = aliceClosing1.processEx(ChannelCommand.GetHtlcInfosResponse(revokedTx.txid, adds.take(4).map { ChannelAction.Storage.HtlcInfo(alice.channelId, 4, it.paymentHash, it.cltvExpiry) }))
         assertTrue(aliceClosing2 is Closing)
         assertEquals(1, aliceClosing2.revokedCommitPublished.size)
         assertNull(actions2.findOutgoingMessageOpt<Error>())
@@ -1944,11 +1944,11 @@ class NormalTestsCommon : LightningTestSuite() {
         val (alice1, _) = crossSign(nodes.first, nodes.second)
         assertTrue(alice1 is Normal)
 
-        val (alice2, actions2) = alice1.processEx(ChannelEvent.NewBlock(alice1.currentBlockHeight + 1, alice1.currentTip.second))
+        val (alice2, actions2) = alice1.processEx(ChannelCommand.NewBlock(alice1.currentBlockHeight + 1, alice1.currentTip.second))
         assertEquals(alice1.copy(currentTip = alice2.currentTip), alice2)
         assertTrue(actions2.isEmpty())
 
-        val (alice3, actions3) = alice2.processEx(ChannelEvent.CheckHtlcTimeout)
+        val (alice3, actions3) = alice2.processEx(ChannelCommand.CheckHtlcTimeout)
         assertEquals(alice2, alice3)
         assertTrue(actions3.isEmpty())
     }
@@ -1962,7 +1962,7 @@ class NormalTestsCommon : LightningTestSuite() {
 
         // alice restarted after the htlc timed out
         val alice2 = alice1.copy(currentTip = alice1.currentTip.copy(first = htlc.cltvExpiry.toLong().toInt()))
-        val (alice3, actions) = alice2.processEx(ChannelEvent.CheckHtlcTimeout)
+        val (alice3, actions) = alice2.processEx(ChannelCommand.CheckHtlcTimeout)
         assertTrue(alice3 is Closing)
         assertNotNull(alice3.localCommitPublished)
         actions.hasOutgoingMessage<Error>()
@@ -2003,15 +2003,15 @@ class NormalTestsCommon : LightningTestSuite() {
         val (nodes, preimage, htlc) = addHtlc(50_000_000.msat, alice0, bob0)
         val (_, bob1) = crossSign(nodes.first, nodes.second)
 
-        val (bob2, actions2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, preimage)))
+        val (bob2, actions2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, preimage)))
         actions2.hasOutgoingMessage<UpdateFulfillHtlc>()
-        val (bob3, actions3) = bob2.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob3, actions3) = bob2.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         actions3.hasOutgoingMessage<CommitSig>()
 
         // fulfilled htlc is close to timing out and alice still hasn't signed, so bob closes the channel
         val (bob4, actions4) = run {
-            val (tmp, _) = bob3.processEx(ChannelEvent.NewBlock(htlc.cltvExpiry.toLong().toInt() - 3, bob3.currentTip.second))
-            tmp.processEx(ChannelEvent.CheckHtlcTimeout)
+            val (tmp, _) = bob3.processEx(ChannelCommand.NewBlock(htlc.cltvExpiry.toLong().toInt() - 3, bob3.currentTip.second))
+            tmp.processEx(ChannelCommand.CheckHtlcTimeout)
         }
         checkFulfillTimeout(bob4, actions4)
     }
@@ -2022,13 +2022,13 @@ class NormalTestsCommon : LightningTestSuite() {
         val (nodes, preimage, htlc) = addHtlc(50_000_000.msat, alice0, bob0)
         val (_, bob1) = crossSign(nodes.first, nodes.second)
 
-        val (bob2, actions2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, preimage)))
+        val (bob2, actions2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, preimage)))
         actions2.hasOutgoingMessage<UpdateFulfillHtlc>()
 
         // bob restarts when the fulfilled htlc is close to timing out
         val bob3 = (bob2 as Normal).copy(currentTip = bob2.currentTip.copy(first = htlc.cltvExpiry.toLong().toInt() - 3))
         // alice still hasn't signed, so bob closes the channel
-        val (bob4, actions4) = bob3.processEx(ChannelEvent.CheckHtlcTimeout)
+        val (bob4, actions4) = bob3.processEx(ChannelCommand.CheckHtlcTimeout)
         checkFulfillTimeout(bob4, actions4)
     }
 
@@ -2038,19 +2038,19 @@ class NormalTestsCommon : LightningTestSuite() {
         val (nodes, preimage, htlc) = addHtlc(50_000_000.msat, alice0, bob0)
         val (alice1, bob1) = crossSign(nodes.first, nodes.second)
 
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, preimage)))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, preimage)))
         val fulfill = actionsBob2.hasOutgoingMessage<UpdateFulfillHtlc>()
-        val (bob3, actionsBob3) = bob2.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob3, actionsBob3) = bob2.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val commitSig = actionsBob3.hasOutgoingMessage<CommitSig>()
-        val (alice2, _) = alice1.processEx(ChannelEvent.MessageReceived(fulfill))
-        val (_, actionsAlice3) = alice2.processEx(ChannelEvent.MessageReceived(commitSig))
+        val (alice2, _) = alice1.processEx(ChannelCommand.MessageReceived(fulfill))
+        val (_, actionsAlice3) = alice2.processEx(ChannelCommand.MessageReceived(commitSig))
         val ack = actionsAlice3.hasOutgoingMessage<RevokeAndAck>()
-        val (bob4, _) = bob3.processEx(ChannelEvent.MessageReceived(ack))
+        val (bob4, _) = bob3.processEx(ChannelCommand.MessageReceived(ack))
 
         // fulfilled htlc is close to timing out and alice has revoked her previous commitment but not signed the new one, so bob closes the channel
         val (bob5, actions5) = run {
-            val (tmp, _) = bob4.processEx(ChannelEvent.NewBlock(htlc.cltvExpiry.toLong().toInt() - 3, bob3.currentTip.second))
-            tmp.processEx(ChannelEvent.CheckHtlcTimeout)
+            val (tmp, _) = bob4.processEx(ChannelCommand.NewBlock(htlc.cltvExpiry.toLong().toInt() - 3, bob3.currentTip.second))
+            tmp.processEx(ChannelCommand.CheckHtlcTimeout)
         }
         checkFulfillTimeout(bob5, actions5)
     }
@@ -2058,7 +2058,7 @@ class NormalTestsCommon : LightningTestSuite() {
     @Test
     fun `recv Disconnected`() {
         val (alice0, _) = reachNormal()
-        val (alice1, _) = alice0.processEx(ChannelEvent.Disconnected)
+        val (alice1, _) = alice0.processEx(ChannelCommand.Disconnected)
         assertTrue(alice1 is Offline)
         val previousState = alice1.state
         assertTrue(previousState is Normal)
@@ -2073,7 +2073,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val (nodes1, _, htlc2) = addHtlc(250_000_000.msat, payer = alice1, payee = bob1)
         val (alice2, _) = nodes1
 
-        val (alice3, actions) = alice2.processEx(ChannelEvent.Disconnected)
+        val (alice3, actions) = alice2.processEx(ChannelCommand.Disconnected)
         assertTrue(alice3 is Offline)
 
         val addSettledFailList = actions.filterIsInstance<ChannelAction.ProcessCmdRes.AddSettledFail>()
@@ -2110,7 +2110,7 @@ class NormalTestsCommon : LightningTestSuite() {
         // an error occurs and alice publishes her commit tx
         assertTrue(alice3 is Normal)
         val aliceCommitTx = alice3.commitments.localCommit.publishableTxs.commitTx
-        val (alice4, actions) = alice3.processEx(ChannelEvent.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
+        val (alice4, actions) = alice3.processEx(ChannelCommand.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
         assertTrue(alice4 is Closing)
         assertNotNull(alice4.localCommitPublished)
         assertEquals(alice4.localCommitPublished!!.commitTx, aliceCommitTx.tx)
@@ -2160,7 +2160,7 @@ class NormalTestsCommon : LightningTestSuite() {
     fun `receive Error -- nothing at stake`() {
         val (_, bob0) = reachNormal(bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
         val bobCommitTx = bob0.commitments.localCommit.publishableTxs.commitTx.tx
-        val (bob1, actions) = bob0.processEx(ChannelEvent.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
+        val (bob1, actions) = bob0.processEx(ChannelCommand.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
         val txs = actions.filterIsInstance<ChannelAction.Blockchain.PublishTx>().map { it.tx }
         assertEquals(txs, listOf(bobCommitTx))
         assertTrue(bob1 is Closing)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
@@ -26,10 +26,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val localInit = Init(ByteVector(alice.commitments.localParams.features.toByteArray()))
         val remoteInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
 
-        val (alice2, actions) = alice1.processEx(ChannelEvent.Connected(localInit, remoteInit))
+        val (alice2, actions) = alice1.processEx(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<Syncing>(alice2)
         val channelReestablishA = actions.findOutgoingMessage<ChannelReestablish>()
-        val (bob2, actions1) = bob1.processEx(ChannelEvent.Connected(remoteInit, localInit))
+        val (bob2, actions1) = bob1.processEx(ChannelCommand.Connected(remoteInit, localInit))
         assertIs<Syncing>(bob2)
         val channelReestablishB = actions1.findOutgoingMessage<ChannelReestablish>()
 
@@ -54,13 +54,13 @@ class OfflineTestsCommon : LightningTestSuite() {
             channelReestablishB
         )
 
-        val (alice3, actions2) = alice2.processEx(ChannelEvent.MessageReceived(channelReestablishB))
+        val (alice3, actions2) = alice2.processEx(ChannelCommand.MessageReceived(channelReestablishB))
         assertEquals(alice, alice3)
         assertEquals(2, actions2.size)
         actions2.hasOutgoingMessage<ChannelReady>()
         actions2.hasWatch<WatchConfirmed>()
 
-        val (bob3, actions3) = bob2.processEx(ChannelEvent.MessageReceived(channelReestablishA))
+        val (bob3, actions3) = bob2.processEx(ChannelCommand.MessageReceived(channelReestablishA))
         assertEquals(bob, bob3)
         assertEquals(2, actions3.size)
         actions3.hasOutgoingMessage<ChannelReady>()
@@ -72,12 +72,12 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice0, bob0) = run {
             val (alice0, bob0) = TestsHelper.reachNormal(bobFeatures = TestConstants.Bob.nodeParams.features.remove(Feature.ChannelBackupClient))
             val cmdAdd = CMD_ADD_HTLC(1_000_000.msat, ByteVector32.Zeroes, CltvExpiryDelta(144).toCltvExpiry(alice0.currentBlockHeight.toLong()), TestConstants.emptyOnionPacket, UUID.randomUUID())
-            val (alice1, actions1) = alice0.processEx(ChannelEvent.ExecuteCommand(cmdAdd))
+            val (alice1, actions1) = alice0.processEx(ChannelCommand.ExecuteCommand(cmdAdd))
             val add = actions1.hasOutgoingMessage<UpdateAddHtlc>()
-            val (alice2, actions2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+            val (alice2, actions2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
             assertIs<Normal>(alice2)
             actions2.hasOutgoingMessage<CommitSig>()
-            val (bob1, _) = bob0.processEx(ChannelEvent.MessageReceived(add))
+            val (bob1, _) = bob0.processEx(ChannelCommand.MessageReceived(add))
             assertIs<Normal>(bob1)
             // bob doesn't receive the sig
             Pair(alice2, bob1)
@@ -87,10 +87,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val localInit = Init(ByteVector(alice0.commitments.localParams.features.toByteArray()))
         val remoteInit = Init(ByteVector(bob0.commitments.localParams.features.toByteArray()))
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.Connected(localInit, remoteInit))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<Syncing>(alice2)
         val channelReestablishA = actionsAlice2.findOutgoingMessage<ChannelReestablish>()
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.Connected(remoteInit, localInit))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.Connected(remoteInit, localInit))
         assertIs<Syncing>(bob2)
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>()
 
@@ -110,31 +110,31 @@ class OfflineTestsCommon : LightningTestSuite() {
         // bob did not receive alice's sig
         assertEquals(channelReestablishB, ChannelReestablish(bob0.channelId, 1, 0, PrivateKey(ByteVector32.Zeroes), bobCurrentPerCommitmentPoint))
 
-        val (alice3, actionsAlice3) = alice2.processEx(ChannelEvent.MessageReceived(channelReestablishB))
+        val (alice3, actionsAlice3) = alice2.processEx(ChannelCommand.MessageReceived(channelReestablishB))
         // alice sends ChannelReady again
         actionsAlice3.hasOutgoingMessage<ChannelReady>()
         // alice re-sends the update and the sig
         val add = actionsAlice3.hasOutgoingMessage<UpdateAddHtlc>()
         val sig = actionsAlice3.hasOutgoingMessage<CommitSig>()
 
-        val (bob3, actionsBob3) = bob2.processEx(ChannelEvent.MessageReceived(channelReestablishA))
+        val (bob3, actionsBob3) = bob2.processEx(ChannelCommand.MessageReceived(channelReestablishA))
         actionsBob3.hasOutgoingMessage<ChannelReady>() // bob sends ChannelReady again
         assertNull(actionsBob3.findOutgoingMessageOpt<RevokeAndAck>()) // bob didn't receive the sig, so he cannot send a rev
 
-        val (bob4, _) = bob3.processEx(ChannelEvent.MessageReceived(add))
-        val (bob5, actionsBob5) = bob4.processEx(ChannelEvent.MessageReceived(sig))
+        val (bob4, _) = bob3.processEx(ChannelCommand.MessageReceived(add))
+        val (bob5, actionsBob5) = bob4.processEx(ChannelCommand.MessageReceived(sig))
         // bob sends back a revocation and a sig
         val revB = actionsBob5.hasOutgoingMessage<RevokeAndAck>()
         actionsBob5.hasCommand<CMD_SIGN>()
-        val (bob6, actionsBob6) = bob5.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob6, actionsBob6) = bob5.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val sigB = actionsBob6.hasOutgoingMessage<CommitSig>()
 
-        val (alice4, _) = alice3.processEx(ChannelEvent.MessageReceived(revB))
-        val (alice5, actionsAlice5) = alice4.processEx(ChannelEvent.MessageReceived(sigB))
+        val (alice4, _) = alice3.processEx(ChannelCommand.MessageReceived(revB))
+        val (alice5, actionsAlice5) = alice4.processEx(ChannelCommand.MessageReceived(sigB))
         assertIs<Normal>(alice5)
         val revA = actionsAlice5.hasOutgoingMessage<RevokeAndAck>()
 
-        val (bob7, _) = bob6.processEx(ChannelEvent.MessageReceived(revA))
+        val (bob7, _) = bob6.processEx(ChannelCommand.MessageReceived(revA))
         assertIs<Normal>(bob7)
 
         assertEquals(1, alice5.commitments.localNextHtlcId)
@@ -146,16 +146,16 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice0, bob0) = run {
             val (alice0, bob0) = TestsHelper.reachNormal(bobFeatures = TestConstants.Bob.nodeParams.features.remove(Feature.ChannelBackupClient))
             val cmdAdd = CMD_ADD_HTLC(1_000_000.msat, ByteVector32.Zeroes, CltvExpiryDelta(144).toCltvExpiry(alice0.currentBlockHeight.toLong()), TestConstants.emptyOnionPacket, UUID.randomUUID())
-            val (alice1, actionsAlice1) = alice0.processEx(ChannelEvent.ExecuteCommand(cmdAdd))
+            val (alice1, actionsAlice1) = alice0.processEx(ChannelCommand.ExecuteCommand(cmdAdd))
             val add = actionsAlice1.hasOutgoingMessage<UpdateAddHtlc>()
-            val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+            val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
             assertIs<Normal>(alice2)
             val sig = actionsAlice2.hasOutgoingMessage<CommitSig>()
-            val (bob1, _) = bob0.processEx(ChannelEvent.MessageReceived(add))
-            val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.MessageReceived(sig))
+            val (bob1, _) = bob0.processEx(ChannelCommand.MessageReceived(add))
+            val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.MessageReceived(sig))
             actionsBob2.hasOutgoingMessage<RevokeAndAck>()
             actionsBob2.hasCommand<CMD_SIGN>()
-            val (bob3, actionsBob3) = bob2.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+            val (bob3, actionsBob3) = bob2.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
             assertIs<Normal>(bob3)
             actionsBob3.hasOutgoingMessage<CommitSig>()
             // bob received the sig, but alice didn't receive the revocation
@@ -166,10 +166,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val localInit = Init(ByteVector(alice0.commitments.localParams.features.toByteArray()))
         val remoteInit = Init(ByteVector(bob0.commitments.localParams.features.toByteArray()))
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.Connected(localInit, remoteInit))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<Syncing>(alice2)
         val channelReestablishA = actionsAlice2.findOutgoingMessage<ChannelReestablish>()
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.Connected(remoteInit, localInit))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.Connected(remoteInit, localInit))
         assertIs<Syncing>(bob2)
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>()
 
@@ -189,22 +189,22 @@ class OfflineTestsCommon : LightningTestSuite() {
         // bob did receive alice's sig
         assertEquals(channelReestablishB, ChannelReestablish(bob0.channelId, 2, 0, PrivateKey(ByteVector32.Zeroes), bobCurrentPerCommitmentPoint))
 
-        val (alice3, actionsAlice3) = alice2.processEx(ChannelEvent.MessageReceived(channelReestablishB))
+        val (alice3, actionsAlice3) = alice2.processEx(ChannelCommand.MessageReceived(channelReestablishB))
         // alice does not re-send messages bob already received
         assertNull(actionsAlice3.findOutgoingMessageOpt<ChannelReady>())
         assertNull(actionsAlice3.findOutgoingMessageOpt<UpdateAddHtlc>())
         assertNull(actionsAlice3.findOutgoingMessageOpt<CommitSig>())
 
-        val (bob3, actionsBob3) = bob2.processEx(ChannelEvent.MessageReceived(channelReestablishA))
+        val (bob3, actionsBob3) = bob2.processEx(ChannelCommand.MessageReceived(channelReestablishA))
         val revB = actionsBob3.hasOutgoingMessage<RevokeAndAck>() // bob re-sends his revocation
         val sigB = actionsBob3.hasOutgoingMessage<CommitSig>() // bob re-sends his signature
 
-        val (alice4, _) = alice3.processEx(ChannelEvent.MessageReceived(revB))
-        val (alice5, actionsAlice5) = alice4.processEx(ChannelEvent.MessageReceived(sigB))
+        val (alice4, _) = alice3.processEx(ChannelCommand.MessageReceived(revB))
+        val (alice5, actionsAlice5) = alice4.processEx(ChannelCommand.MessageReceived(sigB))
         assertIs<Normal>(alice5)
         val revA = actionsAlice5.hasOutgoingMessage<RevokeAndAck>()
 
-        val (bob4, _) = bob3.processEx(ChannelEvent.MessageReceived(revA))
+        val (bob4, _) = bob3.processEx(ChannelCommand.MessageReceived(revA))
         assertIs<Normal>(bob4)
 
         assertEquals(1, alice5.commitments.localNextHtlcId)
@@ -222,9 +222,9 @@ class OfflineTestsCommon : LightningTestSuite() {
             val (nodes2, r2, htlc2) = TestsHelper.addHtlc(25_000_000.msat, bob3, alice3)
             val (bob4, alice4) = TestsHelper.crossSign(nodes2.first, nodes2.second)
             val (bob5, alice5) = TestsHelper.fulfillHtlc(htlc2.id, r2, bob4, alice4)
-            val (alice6, actionsAlice) = alice5.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+            val (alice6, actionsAlice) = alice5.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
             val commitSig = actionsAlice.findOutgoingMessage<CommitSig>()
-            val (bob6, actionsBob) = bob5.processEx(ChannelEvent.MessageReceived(commitSig))
+            val (bob6, actionsBob) = bob5.processEx(ChannelCommand.MessageReceived(commitSig))
             val revokeAndAck = actionsBob.findOutgoingMessage<RevokeAndAck>()
             assertIs<Normal>(alice6)
             assertIs<Normal>(bob6)
@@ -234,10 +234,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice1, bob1) = disconnect(alice0, bob0)
         val initA = Init(ByteVector(alice0.commitments.localParams.features.toByteArray()))
         val initB = Init(ByteVector(bob0.commitments.localParams.features.toByteArray()))
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.Connected(initA, initB))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.Connected(initA, initB))
         assertIs<Syncing>(alice2)
         val channelReestablishA = actionsAlice2.findOutgoingMessage<ChannelReestablish>()
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.Connected(initB, initA))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.Connected(initB, initA))
         assertIs<Syncing>(bob2)
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>()
         assertEquals(channelReestablishA.nextLocalCommitmentNumber, 4)
@@ -245,23 +245,23 @@ class OfflineTestsCommon : LightningTestSuite() {
         assertEquals(channelReestablishB.nextLocalCommitmentNumber, 5)
         assertEquals(channelReestablishB.nextRemoteRevocationNumber, 3)
 
-        val (alice3, actionsAlice3) = alice2.processEx(ChannelEvent.MessageReceived(channelReestablishB))
+        val (alice3, actionsAlice3) = alice2.processEx(ChannelCommand.MessageReceived(channelReestablishB))
         // alice does not re-send messages bob already received
         assertTrue(actionsAlice3.filterIsInstance<ChannelAction.Message.Send>().isEmpty())
 
-        val (bob3, actionsBob3) = bob2.processEx(ChannelEvent.MessageReceived(channelReestablishA))
+        val (bob3, actionsBob3) = bob2.processEx(ChannelCommand.MessageReceived(channelReestablishA))
         assertEquals(1, actionsBob3.filterIsInstance<ChannelAction.Message.Send>().size)
         assertEquals(revB, actionsBob3.findOutgoingMessage())
         actionsBob3.hasCommand<CMD_SIGN>()
-        val (bob4, actionsBob4) = bob3.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob4, actionsBob4) = bob3.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val sigB = actionsBob4.findOutgoingMessage<CommitSig>()
 
-        val (alice4, actionsAlice4) = alice3.processEx(ChannelEvent.MessageReceived(revB))
+        val (alice4, actionsAlice4) = alice3.processEx(ChannelCommand.MessageReceived(revB))
         assertTrue(actionsAlice4.filterIsInstance<ChannelAction.Message.Send>().isEmpty())
-        val (alice5, actionsAlice5) = alice4.processEx(ChannelEvent.MessageReceived(sigB))
+        val (alice5, actionsAlice5) = alice4.processEx(ChannelCommand.MessageReceived(sigB))
         val revA = actionsAlice5.findOutgoingMessage<RevokeAndAck>()
 
-        val (bob5, actionsBob5) = bob4.processEx(ChannelEvent.MessageReceived(revA))
+        val (bob5, actionsBob5) = bob4.processEx(ChannelCommand.MessageReceived(revA))
         assertTrue(actionsBob5.filterIsInstance<ChannelAction.Message.Send>().isEmpty())
 
         assertIs<Normal>(alice5)
@@ -300,29 +300,29 @@ class OfflineTestsCommon : LightningTestSuite() {
         val localInit = Init(ByteVector(alice.commitments.localParams.features.toByteArray()))
         val remoteInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.Connected(localInit, remoteInit))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<Syncing>(alice2)
         val channelReestablishA = actionsAlice2.findOutgoingMessage<ChannelReestablish>()
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.Connected(remoteInit, localInit))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.Connected(remoteInit, localInit))
         assertIs<Syncing>(bob2)
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>()
 
         // alice realizes she has an old state...
-        val (alice3, actionsAlice3) = alice2.processEx(ChannelEvent.MessageReceived(channelReestablishB))
+        val (alice3, actionsAlice3) = alice2.processEx(ChannelCommand.MessageReceived(channelReestablishB))
         // ...and asks bob to publish its current commitment
         val error = actionsAlice3.findOutgoingMessage<Error>()
         assertEquals(error.toAscii(), PleasePublishYourCommitment(aliceOld.channelId).message)
         assertIs<WaitForRemotePublishFutureCommitment>(alice3)
 
         // bob is nice and publishes its commitment as soon as it detects that alice has an outdated commitment
-        val (bob3, actionsBob3) = bob2.processEx(ChannelEvent.MessageReceived(channelReestablishA))
+        val (bob3, actionsBob3) = bob2.processEx(ChannelCommand.MessageReceived(channelReestablishA))
         assertIs<Closing>(bob3)
         assertNotNull(bob3.localCommitPublished)
         val bobCommitTx = bob3.localCommitPublished!!.commitTx
         actionsBob3.hasTx(bobCommitTx)
 
         // alice is able to claim her main output
-        val (alice4, actionsAlice4) = alice3.processEx(ChannelEvent.WatchReceived(WatchEventSpent(aliceOld.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)))
+        val (alice4, actionsAlice4) = alice3.processEx(ChannelCommand.WatchReceived(WatchEventSpent(aliceOld.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)))
         assertIs<Closing>(alice4)
         assertNotNull(alice4.futureRemoteCommitPublished)
         assertEquals(bobCommitTx, alice4.futureRemoteCommitPublished!!.commitTx)
@@ -340,16 +340,16 @@ class OfflineTestsCommon : LightningTestSuite() {
         val localInit = Init(ByteVector(alice0.commitments.localParams.features.toByteArray()))
         val remoteInit = Init(ByteVector(bob0.commitments.localParams.features.toByteArray()))
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.Connected(localInit, remoteInit))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<Syncing>(alice2)
         actionsAlice2.findOutgoingMessage<ChannelReestablish>()
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.Connected(remoteInit, localInit))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.Connected(remoteInit, localInit))
         assertIs<Syncing>(bob2)
         // let's forge a dishonest channel_reestablish
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>().copy(nextRemoteRevocationNumber = 42)
 
         // alice finds out bob is lying
-        val (alice3, actionsAlice3) = alice2.processEx(ChannelEvent.MessageReceived(channelReestablishB))
+        val (alice3, actionsAlice3) = alice2.processEx(ChannelCommand.MessageReceived(channelReestablishB))
         assertIs<Closing>(alice3)
         assertNotNull(alice3.localCommitPublished)
         actionsAlice3.hasTx(alice3.localCommitPublished!!.commitTx)
@@ -381,12 +381,12 @@ class OfflineTestsCommon : LightningTestSuite() {
         }
 
         // Bob's wallet disconnects, but doesn't restart.
-        val (bob1, _) = bob.processEx(ChannelEvent.Disconnected)
+        val (bob1, _) = bob.processEx(ChannelCommand.Disconnected)
         assertIs<Offline>(bob1)
 
         // Alice's wallet restarts.
         val initState = WaitForInit(alice.staticParams, alice.currentTip, alice.currentOnChainFeerates)
-        val (alice1, actions1) = initState.processEx(ChannelEvent.Restore(alice))
+        val (alice1, actions1) = initState.processEx(ChannelCommand.Restore(alice))
         assertEquals(1, actions1.size)
         actions1.hasWatch<WatchSpent>()
         assertIs<Offline>(alice1)
@@ -394,23 +394,23 @@ class OfflineTestsCommon : LightningTestSuite() {
         val localInit = Init(ByteVector(alice.commitments.localParams.features.toByteArray()))
         val remoteInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
 
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.Connected(localInit, remoteInit))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<Syncing>(alice2)
         assertTrue(actionsAlice2.filterIsInstance<ChannelAction.ProcessIncomingHtlc>().isEmpty())
         val channelReestablishAlice = actionsAlice2.hasOutgoingMessage<ChannelReestablish>()
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.Connected(localInit, remoteInit))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.Connected(localInit, remoteInit))
         assertTrue(actionsBob2.filterIsInstance<ChannelAction.ProcessIncomingHtlc>().isEmpty())
         val channelReestablishBob = actionsBob2.hasOutgoingMessage<ChannelReestablish>()
 
         // Alice reprocesses the htlcs received from Bob.
-        val (_, actionsAlice3) = alice2.processEx(ChannelEvent.MessageReceived(channelReestablishBob))
+        val (_, actionsAlice3) = alice2.processEx(ChannelCommand.MessageReceived(channelReestablishBob))
         assertEquals(3, actionsAlice3.size)
         val expectedHtlcsAlice = htlcs.drop(3).take(2).map { ChannelAction.ProcessIncomingHtlc(it) }
         assertEquals(expectedHtlcsAlice, actionsAlice3.filterIsInstance<ChannelAction.ProcessIncomingHtlc>())
         actionsAlice3.hasWatch<WatchConfirmed>()
 
         // Bob reprocesses the htlcs received from Alice.
-        val (_, actionsBob3) = bob2.processEx(ChannelEvent.MessageReceived(channelReestablishAlice))
+        val (_, actionsBob3) = bob2.processEx(ChannelCommand.MessageReceived(channelReestablishAlice))
         assertEquals(4, actionsBob3.size)
         val expectedHtlcsBob = htlcs.take(3).map { ChannelAction.ProcessIncomingHtlc(it) }
         assertEquals(expectedHtlcsBob, actionsBob3.filterIsInstance<ChannelAction.ProcessIncomingHtlc>())
@@ -433,9 +433,9 @@ class OfflineTestsCommon : LightningTestSuite() {
             val (bob5, alice5, htlc5) = TestsHelper.addHtlc(TestsHelper.makeCmdAdd(55_000.msat, aliceId, currentBlockHeight, randomBytes32()).second, bob4, alice4)
             val (alice6, bob6) = TestsHelper.crossSign(alice5, bob5)
             // Bob settles the first two htlcs and sends his signature, but Alice doesn't receive these messages.
-            val (bob7, _) = bob6.processEx(ChannelEvent.ExecuteCommand(CMD_FAIL_HTLC(htlc1.id, CMD_FAIL_HTLC.Reason.Failure(PaymentTimeout), commit = false)))
-            val (bob8, _) = bob7.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(htlc2.id, preimage, commit = false)))
-            val (bob9, _) = bob8.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+            val (bob7, _) = bob6.processEx(ChannelCommand.ExecuteCommand(CMD_FAIL_HTLC(htlc1.id, CMD_FAIL_HTLC.Reason.Failure(PaymentTimeout), commit = false)))
+            val (bob8, _) = bob7.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlc2.id, preimage, commit = false)))
+            val (bob9, _) = bob8.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
             Triple(alice6 as Normal, bob9 as Normal, listOf(htlc1, htlc2, htlc3, htlc4, htlc5))
         }
 
@@ -444,14 +444,14 @@ class OfflineTestsCommon : LightningTestSuite() {
         val aliceInit = Init(ByteVector(alice.commitments.localParams.features.toByteArray()))
         val bobInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
 
-        val (alice2, actionsAlice) = alice1.processEx(ChannelEvent.Connected(aliceInit, bobInit))
-        val (bob2, _) = bob1.processEx(ChannelEvent.Connected(bobInit, aliceInit))
+        val (alice2, actionsAlice) = alice1.processEx(ChannelCommand.Connected(aliceInit, bobInit))
+        val (bob2, _) = bob1.processEx(ChannelCommand.Connected(bobInit, aliceInit))
         assertIs<Syncing>(alice2)
         assertIs<Syncing>(bob2)
         val channelReestablishAlice = actionsAlice.hasOutgoingMessage<ChannelReestablish>()
 
         // Bob resends htlc settlement messages to Alice and reprocesses unsettled htlcs.
-        val (_, actionsBob) = bob2.processEx(ChannelEvent.MessageReceived(channelReestablishAlice))
+        val (_, actionsBob) = bob2.processEx(ChannelCommand.MessageReceived(channelReestablishAlice))
         assertEquals(5, actionsBob.size)
         val fail = actionsBob.hasOutgoingMessage<UpdateFailHtlc>()
         assertEquals(fail.id, htlcs[0].id)
@@ -470,10 +470,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val localInit = Init(ByteVector(alice.commitments.localParams.features.toByteArray()))
         val remoteInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
 
-        val (alice2, actions) = alice1.processEx(ChannelEvent.Connected(localInit, remoteInit))
+        val (alice2, actions) = alice1.processEx(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<Syncing>(alice2)
         actions.findOutgoingMessage<ChannelReestablish>()
-        val (bob2, actions1) = bob1.processEx(ChannelEvent.Connected(remoteInit, localInit))
+        val (bob2, actions1) = bob1.processEx(ChannelCommand.Connected(remoteInit, localInit))
         assertIs<Syncing>(bob2)
         // Bob waits to receive Alice's channel reestablish before sending his own.
         assertTrue(actions1.isEmpty())
@@ -482,20 +482,20 @@ class OfflineTestsCommon : LightningTestSuite() {
     @Test
     fun `republish unconfirmed funding tx after restart`() {
         val (alice, bob, txSigsBob) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs, alicePushAmount = 0.msat)
-        val (alice1, actionsAlice1) = alice.processEx(ChannelEvent.MessageReceived(txSigsBob), minVersion = 3)
+        val (alice1, actionsAlice1) = alice.processEx(ChannelCommand.MessageReceived(txSigsBob), minVersion = 3)
         assertIs<WaitForFundingConfirmed>(alice1)
         val txSigsAlice = actionsAlice1.findOutgoingMessage<TxSignatures>()
         val fundingTx = actionsAlice1.find<ChannelAction.Blockchain.PublishTx>().tx
-        val (bob1, _) = bob.processEx(ChannelEvent.MessageReceived(txSigsAlice), minVersion = 3)
+        val (bob1, _) = bob.processEx(ChannelCommand.MessageReceived(txSigsAlice), minVersion = 3)
         assertIs<WaitForFundingConfirmed>(bob1)
         // Alice restarts:
-        val (alice2, actionsAlice2) = WaitForInit(alice1.staticParams, alice1.currentTip, alice1.currentOnChainFeerates).processEx(ChannelEvent.Restore(alice1), minVersion = 3)
+        val (alice2, actionsAlice2) = WaitForInit(alice1.staticParams, alice1.currentTip, alice1.currentOnChainFeerates).processEx(ChannelCommand.Restore(alice1), minVersion = 3)
         assertEquals(alice2, Offline(alice1))
         assertEquals(actionsAlice2.size, 2)
         actionsAlice2.hasTx(fundingTx)
         assertEquals(actionsAlice2.findWatch<WatchConfirmed>().txId, fundingTx.txid)
         // Bob restarts:
-        val (bob2, actionsBob2) = WaitForInit(bob1.staticParams, bob1.currentTip, bob1.currentOnChainFeerates).processEx(ChannelEvent.Restore(bob1), minVersion = 3)
+        val (bob2, actionsBob2) = WaitForInit(bob1.staticParams, bob1.currentTip, bob1.currentOnChainFeerates).processEx(ChannelCommand.Restore(bob1), minVersion = 3)
         assertEquals(bob2, Offline(bob1))
         assertEquals(actionsBob2.size, 2)
         actionsBob2.hasTx(fundingTx)
@@ -507,11 +507,11 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice, bob, _) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs, alicePushAmount = 0.msat)
         val fundingTx = alice.fundingTx.tx.buildUnsignedTx()
         val (alice1, bob1) = disconnect(alice, bob)
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.WatchReceived(WatchEventConfirmed(alice.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.WatchReceived(WatchEventConfirmed(alice.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)))
         assertEquals(alice1, alice2)
         assertEquals(actionsAlice2.size, 1)
         assertEquals(actionsAlice2.hasWatch<WatchSpent>().txId, fundingTx.txid)
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.WatchReceived(WatchEventConfirmed(bob.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.WatchReceived(WatchEventConfirmed(bob.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)))
         assertEquals(bob1, bob2)
         assertEquals(actionsBob2.size, 1)
         assertEquals(actionsBob2.hasWatch<WatchSpent>().txId, fundingTx.txid)
@@ -523,7 +523,7 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice1, bob1) = WaitForFundingConfirmedTestsCommon.rbf(alice, bob, txSigsBob, walletAlice)
         val previousFundingTx = alice1.previousFundingTxs.first().first.signedTx!!
         val (alice2, bob2) = disconnect(alice1, bob1)
-        val (alice3, actionsAlice3) = alice2.processEx(ChannelEvent.WatchReceived(WatchEventConfirmed(alice.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, previousFundingTx)))
+        val (alice3, actionsAlice3) = alice2.processEx(ChannelCommand.WatchReceived(WatchEventConfirmed(alice.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, previousFundingTx)))
         assertIs<Offline>(alice3)
         val aliceState3 = alice3.state
         assertIs<WaitForFundingConfirmed>(aliceState3)
@@ -531,7 +531,7 @@ class OfflineTestsCommon : LightningTestSuite() {
         assertTrue(aliceState3.previousFundingTxs.isEmpty())
         assertEquals(actionsAlice3.size, 1)
         assertEquals(actionsAlice3.hasWatch<WatchSpent>().txId, previousFundingTx.txid)
-        val (bob3, actionsBob3) = bob2.processEx(ChannelEvent.WatchReceived(WatchEventConfirmed(bob.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, previousFundingTx)))
+        val (bob3, actionsBob3) = bob2.processEx(ChannelCommand.WatchReceived(WatchEventConfirmed(bob.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, previousFundingTx)))
         assertIs<Offline>(bob3)
         val bobState3 = bob3.state
         assertIs<WaitForFundingConfirmed>(bobState3)
@@ -546,15 +546,15 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice0, bob0) = TestsHelper.reachNormal()
         val (nodes, _, _) = TestsHelper.addHtlc(50_000_000.msat, alice0, bob0)
         val (alice1, _) = TestsHelper.crossSign(nodes.first, nodes.second)
-        val (alice2, _) = alice1.processEx(ChannelEvent.Disconnected)
+        val (alice2, _) = alice1.processEx(ChannelCommand.Disconnected)
         assertIs<Offline>(alice2)
 
-        val (alice3, actions3) = alice2.processEx(ChannelEvent.NewBlock(alice2.currentBlockHeight + 1, alice2.currentTip.second))
+        val (alice3, actions3) = alice2.processEx(ChannelCommand.NewBlock(alice2.currentBlockHeight + 1, alice2.currentTip.second))
         assertIs<Offline>(alice3)
         assertEquals((alice2.state as Normal).copy(currentTip = alice3.currentTip), alice3.state)
         assertTrue(actions3.isEmpty())
 
-        val (alice4, actions4) = alice3.processEx(ChannelEvent.CheckHtlcTimeout)
+        val (alice4, actions4) = alice3.processEx(ChannelCommand.CheckHtlcTimeout)
         assertIs<Offline>(alice4)
         assertEquals(alice3, alice4)
         assertTrue(actions4.isEmpty())
@@ -565,12 +565,12 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice0, bob0) = TestsHelper.reachNormal()
         val (nodes, _, htlc) = TestsHelper.addHtlc(50_000_000.msat, alice0, bob0)
         val (alice1, _) = TestsHelper.crossSign(nodes.first, nodes.second)
-        val (alice2, _) = alice1.processEx(ChannelEvent.Disconnected)
+        val (alice2, _) = alice1.processEx(ChannelCommand.Disconnected)
         assertIs<Offline>(alice2)
 
         // alice restarted after the htlc timed out
         val alice3 = alice2.copy(state = (alice2.state as Normal).copy(currentTip = alice2.currentTip.copy(first = htlc.cltvExpiry.toLong().toInt())))
-        val (alice4, actions) = alice3.processEx(ChannelEvent.CheckHtlcTimeout)
+        val (alice4, actions) = alice3.processEx(ChannelCommand.CheckHtlcTimeout)
         assertIs<Closing>(alice4)
         assertNotNull(alice4.localCommitPublished)
         actions.hasOutgoingMessage<Error>()
@@ -589,15 +589,15 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice0, bob0) = TestsHelper.reachNormal()
         val (nodes, preimage, htlc) = TestsHelper.addHtlc(50_000_000.msat, alice0, bob0)
         val (_, bob1) = TestsHelper.crossSign(nodes.first, nodes.second)
-        val (bob2, actions2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, preimage)))
+        val (bob2, actions2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, preimage)))
         actions2.hasOutgoingMessage<UpdateFulfillHtlc>()
-        val (bob3, _) = bob2.processEx(ChannelEvent.Disconnected)
+        val (bob3, _) = bob2.processEx(ChannelCommand.Disconnected)
         assertIs<Offline>(bob3)
 
         // bob restarts when the fulfilled htlc is close to timing out: alice hasn't signed, so bob closes the channel
         val (bob4, actions4) = run {
-            val (tmp, _) = bob3.processEx(ChannelEvent.NewBlock(htlc.cltvExpiry.toLong().toInt(), bob3.state.currentTip.second))
-            tmp.processEx(ChannelEvent.CheckHtlcTimeout)
+            val (tmp, _) = bob3.processEx(ChannelCommand.NewBlock(htlc.cltvExpiry.toLong().toInt(), bob3.state.currentTip.second))
+            tmp.processEx(ChannelCommand.CheckHtlcTimeout)
         }
         assertIs<Closing>(bob4)
         assertNotNull(bob4.localCommitPublished)
@@ -621,10 +621,10 @@ class OfflineTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_FORCECLOSE`() {
         val (alice, _) = TestsHelper.reachNormal()
-        val (alice1, _) = alice.processEx(ChannelEvent.Disconnected)
+        val (alice1, _) = alice.processEx(ChannelCommand.Disconnected)
         assertIs<Offline>(alice1)
         val commitTx = alice1.state.commitments.localCommit.publishableTxs.commitTx.tx
-        val (alice2, actions2) = alice1.process(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
+        val (alice2, actions2) = alice1.process(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
         assertIs<Closing>(alice2)
         actions2.hasTx(commitTx)
         assertNull(actions2.findOutgoingMessageOpt<Error>()) // we're offline so we shouldn't try to send messages
@@ -635,14 +635,14 @@ class OfflineTestsCommon : LightningTestSuite() {
         val bob = run {
             val (alice, bob) = TestsHelper.reachNormal()
             // alice publishes her commitment tx
-            val (bob1, _) = bob.processEx(ChannelEvent.WatchReceived(WatchEventSpent(bob.channelId, BITCOIN_FUNDING_SPENT, alice.commitments.localCommit.publishableTxs.commitTx.tx)))
+            val (bob1, _) = bob.processEx(ChannelCommand.WatchReceived(WatchEventSpent(bob.channelId, BITCOIN_FUNDING_SPENT, alice.commitments.localCommit.publishableTxs.commitTx.tx)))
             assertIs<Closing>(bob1)
             assertNull(bob1.closingTypeAlreadyKnown())
             bob1
         }
 
         val state = WaitForInit(bob.staticParams, bob.currentTip, bob.currentOnChainFeerates)
-        val (state1, actions) = state.processEx(ChannelEvent.Restore(bob))
+        val (state1, actions) = state.processEx(ChannelCommand.Restore(bob))
         assertIs<Closing>(state1)
         assertEquals(4, actions.size)
         val watchSpent = actions.hasWatch<WatchSpent>()
@@ -660,8 +660,8 @@ class OfflineTestsCommon : LightningTestSuite() {
 
     companion object {
         fun disconnect(alice: ChannelStateWithCommitments, bob: ChannelStateWithCommitments): Pair<Offline, Offline> {
-            val (alice1, actionsAlice1) = alice.processEx(ChannelEvent.Disconnected)
-            val (bob1, actionsBob1) = bob.processEx(ChannelEvent.Disconnected)
+            val (alice1, actionsAlice1) = alice.processEx(ChannelCommand.Disconnected)
+            val (bob1, actionsBob1) = bob.processEx(ChannelCommand.Disconnected)
             assertIs<Offline>(alice1)
             assertTrue(actionsAlice1.isEmpty())
             assertIs<Offline>(bob1)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ShutdownTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ShutdownTestsCommon.kt
@@ -35,7 +35,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     fun `recv CMD_ADD_HTLC`() {
         val (_, bob) = init()
         val add = CMD_ADD_HTLC(500000000.msat, r1, cltvExpiry = CltvExpiry(300000), TestConstants.emptyOnionPacket, UUID.randomUUID())
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(add))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(add))
         assertTrue(bob1 is ShuttingDown)
         assertTrue(actions1.any { it is ChannelAction.ProcessCmdRes.AddFailed && it.error == ChannelUnavailable(bob.channelId) })
         assertEquals(bob1.commitments.channelFeatures, ChannelFeatures(setOf(Feature.StaticRemoteKey, Feature.AnchorOutputs)))
@@ -45,7 +45,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     fun `recv CMD_ADD_HTLC -- zero-reserve`() {
         val (_, bob) = init(channelType = ChannelType.SupportedChannelType.AnchorOutputsZeroReserve)
         val add = CMD_ADD_HTLC(500000000.msat, r1, cltvExpiry = CltvExpiry(300000), TestConstants.emptyOnionPacket, UUID.randomUUID())
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(add))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(add))
         assertTrue(bob1 is ShuttingDown)
         assertTrue(actions1.any { it is ChannelAction.ProcessCmdRes.AddFailed && it.error == ChannelUnavailable(bob.channelId) })
         assertEquals(bob1.commitments.channelFeatures, ChannelFeatures(setOf(Feature.StaticRemoteKey, Feature.AnchorOutputs, Feature.ZeroReserveChannels)))
@@ -54,7 +54,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_FULFILL_HTLC`() {
         val (_, bob) = init()
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
         val fulfill = actions1.findOutgoingMessage<UpdateFulfillHtlc>()
         assertTrue { bob1 is ShuttingDown && bob1.commitments.localChanges.proposed.contains(fulfill) }
     }
@@ -63,7 +63,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     fun `recv CMD_FULFILL_HTLC -- unknown htlc id`() {
         val (_, bob) = init()
         val cmd = CMD_FULFILL_HTLC(42, randomBytes32())
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(cmd))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(cmd))
         assertEquals(actions1, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmd, UnknownHtlcId(bob.channelId, 42))))
         assertEquals(bob1, bob)
     }
@@ -72,7 +72,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     fun `recv CMD_FULFILL_HTLC -- invalid preimage`() {
         val (_, bob) = init()
         val cmd = CMD_FULFILL_HTLC(0, randomBytes32())
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(cmd))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(cmd))
         assertEquals(actions1, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmd, InvalidHtlcPreimage(bob.channelId, 0))))
         assertEquals(bob1, bob)
     }
@@ -80,16 +80,16 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv UpdateFulfillHtlc`() {
         val (alice, bob) = init()
-        val (_, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
+        val (_, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
         val fulfill = actions1.findOutgoingMessage<UpdateFulfillHtlc>()
-        val (alice1, _) = alice.processEx(ChannelEvent.MessageReceived(fulfill))
+        val (alice1, _) = alice.processEx(ChannelCommand.MessageReceived(fulfill))
         assertTrue { alice1 is ShuttingDown && alice1.commitments.remoteChanges.proposed.contains(fulfill) }
     }
 
     @Test
     fun `recv UpdateFulfillHtlc -- unknown htlc id`() {
         val (alice, _) = init()
-        val (alice1, actions) = alice.processEx(ChannelEvent.MessageReceived(UpdateFulfillHtlc(alice.channelId, 42, r1)))
+        val (alice1, actions) = alice.processEx(ChannelCommand.MessageReceived(UpdateFulfillHtlc(alice.channelId, 42, r1)))
         actions.hasOutgoingMessage<Error>()
         // Alice should publish: commit tx + main delayed tx + 2 * htlc timeout txs + 2 * htlc delayed txs
         assertEquals(6, actions.findTxs().size)
@@ -99,7 +99,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv UpdateFulfillHtlc -- invalid preimage`() {
         val (alice, _) = init()
-        val (alice1, actions) = alice.processEx(ChannelEvent.MessageReceived(UpdateFulfillHtlc(alice.channelId, 0, randomBytes32())))
+        val (alice1, actions) = alice.processEx(ChannelCommand.MessageReceived(UpdateFulfillHtlc(alice.channelId, 0, randomBytes32())))
         actions.hasOutgoingMessage<Error>()
         // Alice should publish: commit tx + main delayed tx + 2 * htlc timeout txs + 2 * htlc delayed txs
         assertEquals(6, actions.filterIsInstance<ChannelAction.Blockchain.PublishTx>().size)
@@ -109,7 +109,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_FAIL_HTLC`() {
         val (_, bob) = init()
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(CMD_FAIL_HTLC(0, CMD_FAIL_HTLC.Reason.Failure(PermanentChannelFailure))))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(CMD_FAIL_HTLC(0, CMD_FAIL_HTLC.Reason.Failure(PermanentChannelFailure))))
         val fail = actions1.findOutgoingMessage<UpdateFailHtlc>()
         assertTrue { bob1 is ShuttingDown && bob1.commitments.localChanges.proposed.contains(fail) }
     }
@@ -118,7 +118,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     fun `recv CMD_FAIL_HTLC -- unknown htlc id`() {
         val (_, bob) = init()
         val cmdFail = CMD_FAIL_HTLC(42, CMD_FAIL_HTLC.Reason.Failure(PermanentChannelFailure))
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(cmdFail))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(cmdFail))
         assertEquals(actions1, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmdFail, UnknownHtlcId(bob.channelId, 42))))
         assertEquals(bob, bob1)
     }
@@ -126,7 +126,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_FAIL_MALFORMED_HTLC`() {
         val (_, bob) = init()
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(CMD_FAIL_MALFORMED_HTLC(1, ByteVector32(Crypto.sha256(ByteVector.empty)), FailureMessage.BADONION)))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(CMD_FAIL_MALFORMED_HTLC(1, ByteVector32(Crypto.sha256(ByteVector.empty)), FailureMessage.BADONION)))
         val fail = actions1.findOutgoingMessage<UpdateFailMalformedHtlc>()
         assertTrue { bob1 is ShuttingDown && bob1.commitments.localChanges.proposed.contains(fail) }
     }
@@ -135,7 +135,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     fun `recv CMD_FAIL_MALFORMED_HTLC -- unknown htlc id`() {
         val (_, bob) = init()
         val cmdFail = CMD_FAIL_MALFORMED_HTLC(42, ByteVector32(Crypto.sha256(ByteVector.empty)), FailureMessage.BADONION)
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(cmdFail))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(cmdFail))
         assertEquals(actions1, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmdFail, UnknownHtlcId(bob.channelId, 42))))
         assertEquals(bob, bob1)
     }
@@ -144,7 +144,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     fun `recv CMD_FAIL_MALFORMED_HTLC -- invalid failure_code`() {
         val (_, bob) = init()
         val cmdFail = CMD_FAIL_MALFORMED_HTLC(42, randomBytes32(), 42)
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(cmdFail))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(cmdFail))
         assertEquals(actions1, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmdFail, InvalidFailureCode(bob.channelId))))
         assertEquals(bob, bob1)
     }
@@ -152,9 +152,9 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv UpdateFailHtlc`() {
         val (alice, bob) = init()
-        val (_, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(CMD_FAIL_HTLC(0, CMD_FAIL_HTLC.Reason.Failure(PermanentChannelFailure))))
+        val (_, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(CMD_FAIL_HTLC(0, CMD_FAIL_HTLC.Reason.Failure(PermanentChannelFailure))))
         val fail = actions1.findOutgoingMessage<UpdateFailHtlc>()
-        val (alice1, _) = alice.processEx(ChannelEvent.MessageReceived(fail))
+        val (alice1, _) = alice.processEx(ChannelCommand.MessageReceived(fail))
         assertTrue { alice1 is ShuttingDown && alice1.commitments.remoteChanges.proposed.contains(fail) }
     }
 
@@ -162,7 +162,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     fun `recv UpdateFailHtlc -- unknown htlc id`() {
         val (alice, _) = init()
         val commitTx = alice.commitments.localCommit.publishableTxs.commitTx.tx
-        val (alice1, actions1) = alice.processEx(ChannelEvent.MessageReceived(UpdateFailHtlc(alice.channelId, 42, ByteVector.empty)))
+        val (alice1, actions1) = alice.processEx(ChannelCommand.MessageReceived(UpdateFailHtlc(alice.channelId, 42, ByteVector.empty)))
         assertTrue(alice1 is Closing)
         assertTrue(actions1.contains(ChannelAction.Storage.StoreState(alice1)))
         assertTrue(actions1.contains(ChannelAction.Blockchain.PublishTx(commitTx)))
@@ -175,9 +175,9 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv UpdateFailMalformedHtlc`() {
         val (alice, bob) = init()
-        val (_, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(CMD_FAIL_MALFORMED_HTLC(1, ByteVector32(Crypto.sha256(ByteVector.empty)), FailureMessage.BADONION)))
+        val (_, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(CMD_FAIL_MALFORMED_HTLC(1, ByteVector32(Crypto.sha256(ByteVector.empty)), FailureMessage.BADONION)))
         val fail = actions1.findOutgoingMessage<UpdateFailMalformedHtlc>()
-        val (alice1, _) = alice.processEx(ChannelEvent.MessageReceived(fail))
+        val (alice1, _) = alice.processEx(ChannelCommand.MessageReceived(fail))
         assertTrue { alice1 is ShuttingDown && alice1.commitments.remoteChanges.proposed.contains(fail) }
     }
 
@@ -185,7 +185,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     fun `recv UpdateFailMalformedHtlc -- invalid failure_code`() {
         val (alice, _) = init()
         val fail = UpdateFailMalformedHtlc(ByteVector32.Zeroes, 1, ByteVector.empty.sha256(), 42)
-        val (alice1, actions) = alice.processEx(ChannelEvent.MessageReceived(fail))
+        val (alice1, actions) = alice.processEx(ChannelCommand.MessageReceived(fail))
         assertTrue(alice1 is Closing)
         assertTrue(actions.contains(ChannelAction.Storage.StoreState(alice1)))
         assertTrue(actions.contains(ChannelAction.Blockchain.PublishTx(alice.commitments.localCommit.publishableTxs.commitTx.tx)))
@@ -198,11 +198,11 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_SIGN`() {
         val (alice, bob) = init()
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
         val fulfill = actions1.findOutgoingMessage<UpdateFulfillHtlc>()
-        val (alice1, _) = alice.processEx(ChannelEvent.MessageReceived(fulfill))
+        val (alice1, _) = alice.processEx(ChannelCommand.MessageReceived(fulfill))
         val (_, alice2) = signAndRevack(bob1, alice1)
-        val (alice3, actions3) = alice2.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (alice3, actions3) = alice2.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(alice3 is ShuttingDown)
         assertTrue(alice3.commitments.remoteNextCommitInfo.isLeft)
         actions3.hasOutgoingMessage<CommitSig>()
@@ -216,7 +216,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_SIGN -- no changes`() {
         val (_, bob) = init()
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertEquals(bob, bob1)
         assertTrue { actions1.isEmpty() }
     }
@@ -224,15 +224,15 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_SIGN -- while waiting for RevokeAndAck`() {
         val (_, bob) = init()
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
         actions1.hasOutgoingMessage<UpdateFulfillHtlc>()
-        val (bob2, actions2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob2, actions2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(bob2 is ShuttingDown)
         actions2.hasOutgoingMessage<CommitSig>()
         assertNotNull(bob2.commitments.remoteNextCommitInfo.left)
         val waitForRevocation = bob2.commitments.remoteNextCommitInfo.left!!
         assertFalse(waitForRevocation.reSignAsap)
-        val (bob3, actions3) = bob2.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob3, actions3) = bob2.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(bob3 is ShuttingDown)
         assertTrue(actions3.isEmpty())
         assertEquals(Either.Left(waitForRevocation), bob3.commitments.remoteNextCommitInfo)
@@ -241,12 +241,12 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CommitSig`() {
         val (alice0, bob0) = init()
-        val (bob1, actionsBob1) = bob0.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
+        val (bob1, actionsBob1) = bob0.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
         val fulfill = actionsBob1.hasOutgoingMessage<UpdateFulfillHtlc>()
-        val (_, actionsBob2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (_, actionsBob2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val sig = actionsBob2.hasOutgoingMessage<CommitSig>()
-        val (alice1, _) = alice0.processEx(ChannelEvent.MessageReceived(fulfill))
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.MessageReceived(sig))
+        val (alice1, _) = alice0.processEx(ChannelCommand.MessageReceived(fulfill))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.MessageReceived(sig))
         assertTrue(alice2 is ShuttingDown)
         actionsAlice2.hasOutgoingMessage<RevokeAndAck>()
     }
@@ -254,15 +254,15 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CommitSig -- no changes`() {
         val (alice0, bob0) = init()
-        val (bob1, actionsBob1) = bob0.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
+        val (bob1, actionsBob1) = bob0.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
         val fulfill = actionsBob1.hasOutgoingMessage<UpdateFulfillHtlc>()
-        val (_, actionsBob2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (_, actionsBob2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val sig = actionsBob2.hasOutgoingMessage<CommitSig>()
-        val (alice1, _) = alice0.processEx(ChannelEvent.MessageReceived(fulfill))
-        val (alice2, _) = alice1.processEx(ChannelEvent.MessageReceived(sig))
+        val (alice1, _) = alice0.processEx(ChannelCommand.MessageReceived(fulfill))
+        val (alice2, _) = alice1.processEx(ChannelCommand.MessageReceived(sig))
         assertTrue(alice2 is ShuttingDown)
         // alice receives another commit signature
-        val (alice3, actionsAlice3) = alice2.processEx(ChannelEvent.MessageReceived(sig))
+        val (alice3, actionsAlice3) = alice2.processEx(ChannelCommand.MessageReceived(sig))
         assertTrue(alice3 is Closing)
         actionsAlice3.hasOutgoingMessage<Error>()
         assertNotNull(alice3.localCommitPublished)
@@ -272,13 +272,13 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CommitSig -- invalid signature`() {
         val (alice0, bob0) = init()
-        val (bob1, actionsBob1) = bob0.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
+        val (bob1, actionsBob1) = bob0.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
         val fulfill = actionsBob1.hasOutgoingMessage<UpdateFulfillHtlc>()
-        val (_, actionsBob2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (_, actionsBob2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val sig = actionsBob2.hasOutgoingMessage<CommitSig>()
-        val (alice1, _) = alice0.processEx(ChannelEvent.MessageReceived(fulfill))
+        val (alice1, _) = alice0.processEx(ChannelCommand.MessageReceived(fulfill))
         assertTrue(alice1 is ShuttingDown)
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.MessageReceived(sig.copy(signature = ByteVector64.Zeroes)))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.MessageReceived(sig.copy(signature = ByteVector64.Zeroes)))
         assertTrue(alice2 is Closing)
         actionsAlice2.hasOutgoingMessage<Error>()
         assertNotNull(alice2.localCommitPublished)
@@ -303,12 +303,12 @@ class ShutdownTestsCommon : LightningTestSuite() {
         val (alice0, bob0) = init()
         val (alice1, bob1) = fulfillHtlc(0, r1, alice0, bob0)
         val (alice2, bob2) = fulfillHtlc(1, r2, alice1, bob1)
-        val (bob3, actionsBob3) = bob2.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob3, actionsBob3) = bob2.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         val sig = actionsBob3.hasOutgoingMessage<CommitSig>()
-        val (alice3, actionsAlice3) = alice2.processEx(ChannelEvent.MessageReceived(sig))
+        val (alice3, actionsAlice3) = alice2.processEx(ChannelCommand.MessageReceived(sig))
         assertTrue(alice3 is ShuttingDown)
         val revack = actionsAlice3.hasOutgoingMessage<RevokeAndAck>()
-        val (bob4, _) = bob3.processEx(ChannelEvent.MessageReceived(revack))
+        val (bob4, _) = bob3.processEx(ChannelCommand.MessageReceived(revack))
         assertTrue(bob4 is ShuttingDown)
         assertEquals(2, bob4.commitments.localCommit.spec.htlcs.size)
         assertTrue(bob4.commitments.remoteCommit.spec.htlcs.isEmpty())
@@ -330,15 +330,15 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv RevokeAndAck -- invalid preimage`() {
         val (alice0, bob0) = init()
-        val (bob1, actionsBob1) = bob0.processEx(ChannelEvent.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
+        val (bob1, actionsBob1) = bob0.processEx(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(0, r1)))
         val fulfill = actionsBob1.hasOutgoingMessage<UpdateFulfillHtlc>()
-        val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+        val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
         assertTrue(bob2 is ShuttingDown)
         val sig = actionsBob2.hasOutgoingMessage<CommitSig>()
-        val (alice1, _) = alice0.processEx(ChannelEvent.MessageReceived(fulfill))
-        val (_, actionsAlice2) = alice1.processEx(ChannelEvent.MessageReceived(sig))
+        val (alice1, _) = alice0.processEx(ChannelCommand.MessageReceived(fulfill))
+        val (_, actionsAlice2) = alice1.processEx(ChannelCommand.MessageReceived(sig))
         val revack = actionsAlice2.hasOutgoingMessage<RevokeAndAck>()
-        val (bob3, actionsBob3) = bob2.processEx(ChannelEvent.MessageReceived(revack.copy(perCommitmentSecret = randomKey())))
+        val (bob3, actionsBob3) = bob2.processEx(ChannelCommand.MessageReceived(revack.copy(perCommitmentSecret = randomKey())))
         assertTrue(bob3 is Closing)
         assertNotNull(bob3.localCommitPublished)
         actionsBob3.hasTx(bob2.commitments.localCommit.publishableTxs.commitTx.tx)
@@ -348,7 +348,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv RevokeAndAck -- unexpectedly`() {
         val (alice0, _) = init()
-        val (alice1, actions1) = alice0.processEx(ChannelEvent.MessageReceived(RevokeAndAck(alice0.channelId, randomKey(), randomKey().publicKey())))
+        val (alice1, actions1) = alice0.processEx(ChannelCommand.MessageReceived(RevokeAndAck(alice0.channelId, randomKey(), randomKey().publicKey())))
         assertTrue(alice1 is Closing)
         assertNotNull(alice1.localCommitPublished)
         actions1.hasTx(alice0.commitments.localCommit.publishableTxs.commitTx.tx)
@@ -360,7 +360,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
         val (_, bob0) = reachNormal()
         assertTrue(bob0.commitments.localParams.features.hasFeature(Feature.ChannelBackupClient))
         assertFalse(bob0.commitments.channelFeatures.hasFeature(Feature.ChannelBackupClient)) // this isn't a permanent channel feature
-        val (bob1, actions1) = bob0.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (bob1, actions1) = bob0.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         assertTrue(bob1 is Normal)
         val blob = Serialization.encrypt(bob1.staticParams.nodeParams.nodePrivateKey.value, bob1)
         val shutdown = actions1.findOutgoingMessage<Shutdown>()
@@ -372,13 +372,13 @@ class ShutdownTestsCommon : LightningTestSuite() {
         val (alice, _) = init()
 
         run {
-            val (alice1, actions1) = alice.processEx(ChannelEvent.NewBlock(alice.currentBlockHeight + 1, alice.currentTip.second))
+            val (alice1, actions1) = alice.processEx(ChannelCommand.NewBlock(alice.currentBlockHeight + 1, alice.currentTip.second))
             assertEquals(alice.copy(currentTip = alice1.currentTip), alice1)
             assertTrue(actions1.isEmpty())
         }
 
         run {
-            val (alice1, actions1) = alice.processEx(ChannelEvent.CheckHtlcTimeout)
+            val (alice1, actions1) = alice.processEx(ChannelCommand.CheckHtlcTimeout)
             assertEquals(alice, alice1)
             assertTrue(actions1.isEmpty())
         }
@@ -390,8 +390,8 @@ class ShutdownTestsCommon : LightningTestSuite() {
         val commitTx = alice.commitments.localCommit.publishableTxs.commitTx.tx
         val htlcExpiry = alice.commitments.localCommit.spec.htlcs.map { it.add.cltvExpiry }.first()
         val (alice1, actions1) = run {
-            val (tmp, _) = alice.processEx(ChannelEvent.NewBlock(htlcExpiry.toLong().toInt(), alice.currentTip.second))
-            tmp.processEx(ChannelEvent.CheckHtlcTimeout)
+            val (tmp, _) = alice.processEx(ChannelCommand.NewBlock(htlcExpiry.toLong().toInt(), alice.currentTip.second))
+            tmp.processEx(ChannelCommand.CheckHtlcTimeout)
         }
         assertTrue(alice1 is Closing)
         assertNotNull(alice1.localCommitPublished)
@@ -422,16 +422,16 @@ class ShutdownTestsCommon : LightningTestSuite() {
             val (nodes3, _, _) = addHtlc(35_000_000.msat, alice2, bob2)
             val (alice3, bob3) = nodes3
             // alice signs the next commitment, but bob doesn't
-            val (alice4, actionsAlice) = alice3.processEx(ChannelEvent.ExecuteCommand(CMD_SIGN))
+            val (alice4, actionsAlice) = alice3.processEx(ChannelCommand.ExecuteCommand(CMD_SIGN))
             val commitSig = actionsAlice.hasOutgoingMessage<CommitSig>()
-            val (bob4, actionsBob) = bob3.processEx(ChannelEvent.MessageReceived(commitSig))
+            val (bob4, actionsBob) = bob3.processEx(ChannelCommand.MessageReceived(commitSig))
             actionsBob.hasOutgoingMessage<RevokeAndAck>() // not forwarded to Alice (malicious Bob)
             shutdown(alice4, bob4)
         }
 
         val bobCommitTx = bob.commitments.localCommit.publishableTxs.commitTx.tx
         assertEquals(6, bobCommitTx.txOut.size) // 2 main outputs + 2 anchors + 2 pending htlc
-        val (alice1, aliceActions1) = alice.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)))
+        val (alice1, aliceActions1) = alice.processEx(ChannelCommand.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)))
         assertTrue(alice1 is Closing)
         assertNotNull(alice1.nextRemoteCommitPublished)
         aliceActions1.has<ChannelAction.Storage.StoreState>()
@@ -457,7 +457,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
         }
 
         assertEquals(5, revokedTx.txOut.size) // 2 main outputs + 2 anchors + 1 pending htlc
-        val (alice1, aliceActions1) = alice.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, revokedTx)))
+        val (alice1, aliceActions1) = alice.processEx(ChannelCommand.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, revokedTx)))
         assertTrue(alice1 is Closing)
         assertEquals(1, alice1.revokedCommitPublished.size)
         aliceActions1.hasOutgoingMessage<Error>()
@@ -471,14 +471,14 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv Disconnected`() {
         val (alice, _) = init()
-        val (alice1, _) = alice.processEx(ChannelEvent.Disconnected)
+        val (alice1, _) = alice.processEx(ChannelCommand.Disconnected)
         assertTrue { alice1 is Offline }
     }
 
     @Test
     fun `recv CMD_CLOSE`() {
         val (alice, _) = init()
-        val (alice1, actions) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (alice1, actions) = alice.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         assertEquals(alice1, alice)
         assertEquals(actions, listOf(ChannelAction.ProcessCmdRes.NotExecuted(CMD_CLOSE(null, null), ClosingAlreadyInProgress(alice.channelId))))
     }
@@ -523,14 +523,14 @@ class ShutdownTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_FORCECLOSE`() {
         val (alice, _) = init()
-        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
+        val (alice1, actions1) = alice.processEx(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
         testLocalForceClose(alice1, actions1)
     }
 
     @Test
     fun `recv Error`() {
         val (alice, _) = init()
-        val (alice1, actions1) = alice.processEx(ChannelEvent.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
+        val (alice1, actions1) = alice.processEx(ChannelCommand.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
         testLocalForceClose(alice1, actions1)
     }
 
@@ -546,14 +546,14 @@ class ShutdownTestsCommon : LightningTestSuite() {
         ): Pair<ShuttingDown, ShuttingDown> {
             val (alice, bob) = reachNormal(channelType, aliceFeatures, bobFeatures, currentBlockHeight)
             val (_, cmdAdd1) = makeCmdAdd(300_000_000.msat, bob.staticParams.nodeParams.nodeId, currentBlockHeight.toLong(), r1)
-            val (alice1, actions) = alice.processEx(ChannelEvent.ExecuteCommand(cmdAdd1))
+            val (alice1, actions) = alice.processEx(ChannelCommand.ExecuteCommand(cmdAdd1))
             val htlc1 = actions.findOutgoingMessage<UpdateAddHtlc>()
-            val (bob1, _) = bob.processEx(ChannelEvent.MessageReceived(htlc1))
+            val (bob1, _) = bob.processEx(ChannelCommand.MessageReceived(htlc1))
 
             val (_, cmdAdd2) = makeCmdAdd(200_000_000.msat, bob.staticParams.nodeParams.nodeId, currentBlockHeight.toLong(), r2)
-            val (alice2, actions3) = alice1.processEx(ChannelEvent.ExecuteCommand(cmdAdd2))
+            val (alice2, actions3) = alice1.processEx(ChannelCommand.ExecuteCommand(cmdAdd2))
             val htlc2 = actions3.findOutgoingMessage<UpdateAddHtlc>()
-            val (bob2, _) = bob1.processEx(ChannelEvent.MessageReceived(htlc2))
+            val (bob2, _) = bob1.processEx(ChannelCommand.MessageReceived(htlc2))
 
             // Alice signs
             val (alice3, bob3) = signAndRevack(alice2, bob2)
@@ -565,11 +565,11 @@ class ShutdownTestsCommon : LightningTestSuite() {
 
         fun shutdown(alice: ChannelState, bob: ChannelState): Pair<ShuttingDown, ShuttingDown> {
             // Alice initiates a closing
-            val (alice1, actionsAlice) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+            val (alice1, actionsAlice) = alice.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
             val shutdown = actionsAlice.findOutgoingMessage<Shutdown>()
-            val (bob1, actionsBob) = bob.processEx(ChannelEvent.MessageReceived(shutdown))
+            val (bob1, actionsBob) = bob.processEx(ChannelCommand.MessageReceived(shutdown))
             val shutdown1 = actionsBob.findOutgoingMessage<Shutdown>()
-            val (alice2, _) = alice1.processEx(ChannelEvent.MessageReceived(shutdown1))
+            val (alice2, _) = alice1.processEx(ChannelCommand.MessageReceived(shutdown1))
             assertTrue(alice2 is ShuttingDown)
             assertTrue(bob1 is ShuttingDown)
             if (alice2.commitments.channelFeatures.hasFeature(Feature.ChannelBackupClient)) assertFalse(shutdown.channelData.isEmpty())

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
@@ -23,14 +23,14 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
     @Test
     fun `recv TxSignatures -- zero conf`() {
         val (alice, _, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputsZeroReserve, zeroConf = true)
-        val (alice1, actionsAlice1) = alice.processEx(ChannelEvent.MessageReceived(bob.fundingTx.localSigs), minVersion = 3)
+        val (alice1, actionsAlice1) = alice.processEx(ChannelCommand.MessageReceived(bob.fundingTx.localSigs), minVersion = 3)
         assertIs<WaitForChannelReady>(alice1)
         assertEquals(actionsAlice1.size, 3)
         val fundingTx = actionsAlice1.find<ChannelAction.Blockchain.PublishTx>().tx
         assertEquals(alice.commitments.fundingTxId, fundingTx.txid)
         assertEquals(alice.fundingTx.localSigs, actionsAlice1.findOutgoingMessage())
         actionsAlice1.has<ChannelAction.Storage.StoreState>()
-        val (bob1, actionsBob1) = bob.processEx(ChannelEvent.MessageReceived(alice.fundingTx.localSigs), minVersion = 3)
+        val (bob1, actionsBob1) = bob.processEx(ChannelCommand.MessageReceived(alice.fundingTx.localSigs), minVersion = 3)
         assertIs<WaitForChannelReady>(bob1)
         assertEquals(actionsBob1.size, 2)
         assertEquals(actionsBob1.find<ChannelAction.Blockchain.PublishTx>().tx, fundingTx)
@@ -40,9 +40,9 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
     @Test
     fun `recv TxSignatures and restart -- zero conf`() {
         val (alice, _, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputsZeroReserve, zeroConf = true)
-        val (alice1, actionsAlice1) = alice.processEx(ChannelEvent.MessageReceived(bob.fundingTx.localSigs), minVersion = 3)
+        val (alice1, actionsAlice1) = alice.processEx(ChannelCommand.MessageReceived(bob.fundingTx.localSigs), minVersion = 3)
         val fundingTx = actionsAlice1.find<ChannelAction.Blockchain.PublishTx>().tx
-        val (alice2, actionsAlice2) = WaitForInit(alice1.staticParams, alice1.currentTip, alice1.currentOnChainFeerates).processEx(ChannelEvent.Restore(alice1), minVersion = 3)
+        val (alice2, actionsAlice2) = WaitForInit(alice1.staticParams, alice1.currentTip, alice1.currentOnChainFeerates).processEx(ChannelCommand.Restore(alice1), minVersion = 3)
         assertIs<Offline>(alice2)
         assertEquals(actionsAlice2.size, 2)
         assertEquals(actionsAlice2.find<ChannelAction.Blockchain.PublishTx>().tx, fundingTx)
@@ -52,7 +52,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
     @Test
     fun `recv TxSignatures -- duplicate`() {
         val (alice, _, bob, _) = init()
-        val (alice1, actions1) = alice.processEx(ChannelEvent.MessageReceived(bob.fundingTx.localSigs), minVersion = 3)
+        val (alice1, actions1) = alice.processEx(ChannelCommand.MessageReceived(bob.fundingTx.localSigs), minVersion = 3)
         assertEquals(alice1, alice)
         assertTrue(actions1.isEmpty())
     }
@@ -60,7 +60,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
     @Test
     fun `recv TxSignatures -- invalid`() {
         val (alice, _, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputsZeroReserve, zeroConf = true)
-        val (alice1, actionsAlice1) = alice.processEx(ChannelEvent.MessageReceived(bob.fundingTx.localSigs.copy(witnesses = listOf())), minVersion = 3)
+        val (alice1, actionsAlice1) = alice.processEx(ChannelCommand.MessageReceived(bob.fundingTx.localSigs.copy(witnesses = listOf())), minVersion = 3)
         assertEquals(alice, alice1)
         assertEquals(actionsAlice1.size, 1)
         actionsAlice1.hasOutgoingMessage<Warning>()
@@ -69,12 +69,12 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
     @Test
     fun `recv ChannelReady`() {
         val (alice, channelReadyAlice, bob, channelReadyBob) = init()
-        val (alice1, actionsAlice1) = alice.processEx(ChannelEvent.MessageReceived(channelReadyBob), minVersion = 3)
+        val (alice1, actionsAlice1) = alice.processEx(ChannelCommand.MessageReceived(channelReadyBob), minVersion = 3)
         assertIs<Normal>(alice1)
         assertEquals(2, actionsAlice1.size)
         actionsAlice1.has<ChannelAction.Storage.StoreState>()
         assertEquals(actionsAlice1.findWatch<WatchConfirmed>().event, BITCOIN_FUNDING_DEEPLYBURIED)
-        val (bob1, actionsBob1) = bob.processEx(ChannelEvent.MessageReceived(channelReadyAlice), minVersion = 3)
+        val (bob1, actionsBob1) = bob.processEx(ChannelCommand.MessageReceived(channelReadyAlice), minVersion = 3)
         assertIs<Normal>(bob1)
         assertEquals(2, actionsBob1.size)
         actionsBob1.has<ChannelAction.Storage.StoreState>()
@@ -88,11 +88,11 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         assertEquals(aliceBalance, 825_000_000.msat)
         val bobBalance = TestConstants.bobFundingAmount.toMilliSatoshi() - 25_000_000.msat + TestConstants.alicePushAmount
         assertEquals(bobBalance, 175_000_000.msat)
-        val (alice1, _) = alice.processEx(ChannelEvent.MessageReceived(fundingLockedBob), minVersion = 3)
+        val (alice1, _) = alice.processEx(ChannelCommand.MessageReceived(fundingLockedBob), minVersion = 3)
         assertIs<Normal>(alice1)
         assertEquals(alice1.commitments.localCommit.spec.toLocal, aliceBalance)
         assertEquals(alice1.commitments.localCommit.spec.toRemote, bobBalance)
-        val (bob1, _) = bob.processEx(ChannelEvent.MessageReceived(fundingLockedAlice), minVersion = 3)
+        val (bob1, _) = bob.processEx(ChannelCommand.MessageReceived(fundingLockedAlice), minVersion = 3)
         assertIs<Normal>(bob1)
         assertEquals(bob1.commitments.localCommit.spec.toLocal, bobBalance)
         assertEquals(bob1.commitments.localCommit.spec.toRemote, aliceBalance)
@@ -105,11 +105,11 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         assertEquals(aliceBalance, 825_000_000.msat)
         val bobBalance = TestConstants.bobFundingAmount.toMilliSatoshi() - 25_000_000.msat + TestConstants.alicePushAmount
         assertEquals(bobBalance, 175_000_000.msat)
-        val (alice1, _) = alice.processEx(ChannelEvent.MessageReceived(fundingLockedBob), minVersion = 3)
+        val (alice1, _) = alice.processEx(ChannelCommand.MessageReceived(fundingLockedBob), minVersion = 3)
         assertIs<Normal>(alice1)
         assertEquals(alice1.commitments.localCommit.spec.toLocal, aliceBalance)
         assertEquals(alice1.commitments.localCommit.spec.toRemote, bobBalance)
-        val (bob1, _) = bob.processEx(ChannelEvent.MessageReceived(fundingLockedAlice), minVersion = 3)
+        val (bob1, _) = bob.processEx(ChannelCommand.MessageReceived(fundingLockedAlice), minVersion = 3)
         assertIs<Normal>(bob1)
         assertEquals(bob1.commitments.localCommit.spec.toLocal, bobBalance)
         assertEquals(bob1.commitments.localCommit.spec.toRemote, aliceBalance)
@@ -121,7 +121,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         // bob publishes his commitment tx
         run {
             val bobCommitTx = bob.commitments.localCommit.publishableTxs.commitTx.tx
-            val (alice1, actions1) = alice.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)), minVersion = 3)
+            val (alice1, actions1) = alice.processEx(ChannelCommand.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)), minVersion = 3)
             assertIs<Closing>(alice1)
             assertNotNull(alice1.remoteCommitPublished)
             assertEquals(1, actions1.findTxs().size)
@@ -130,7 +130,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         // alice publishes her commitment tx
         run {
             val aliceCommitTx = alice.commitments.localCommit.publishableTxs.commitTx.tx
-            val (bob1, actions1) = bob.processEx(ChannelEvent.WatchReceived(WatchEventSpent(bob.channelId, BITCOIN_FUNDING_SPENT, aliceCommitTx)), minVersion = 3)
+            val (bob1, actions1) = bob.processEx(ChannelCommand.WatchReceived(WatchEventSpent(bob.channelId, BITCOIN_FUNDING_SPENT, aliceCommitTx)), minVersion = 3)
             assertIs<Closing>(bob1)
             assertNotNull(bob1.remoteCommitPublished)
             assertEquals(1, actions1.findTxs().size)
@@ -143,7 +143,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         val (alice, _, _) = init()
         val aliceCommitTx = alice.commitments.localCommit.publishableTxs.commitTx.tx
         val unknownTx = Transaction(2, aliceCommitTx.txIn, listOf(), 0)
-        val (alice1, actions1) = alice.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, unknownTx)), minVersion = 3)
+        val (alice1, actions1) = alice.processEx(ChannelCommand.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, unknownTx)), minVersion = 3)
         assertIs<ErrorInformationLeak>(alice1)
         assertTrue(actions1.isEmpty())
     }
@@ -153,7 +153,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         val (alice, _, bob, _) = init()
         listOf(alice, bob).forEach { state ->
             val commitTx = state.commitments.localCommit.publishableTxs.commitTx.tx
-            val (state1, actions1) = state.processEx(ChannelEvent.MessageReceived(Error(state.channelId, "no lightning for you sir")), minVersion = 3)
+            val (state1, actions1) = state.processEx(ChannelCommand.MessageReceived(Error(state.channelId, "no lightning for you sir")), minVersion = 3)
             assertIs<Closing>(state1)
             assertNotNull(state1.localCommitPublished)
             assertNull(actions1.findOutgoingMessageOpt<Error>())
@@ -166,7 +166,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
     fun `recv CMD_CLOSE`() {
         val (alice, _, bob, _) = init()
         listOf(alice, bob).forEach { state ->
-            val (state1, actions1) = state.processEx(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)), minVersion = 3)
+            val (state1, actions1) = state.processEx(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)), minVersion = 3)
             assertEquals(state, state1)
             assertEquals(1, actions1.size)
             actions1.hasCommandError<CommandUnavailableInThisState>()
@@ -178,7 +178,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         val (alice, _, bob, _) = init()
         listOf(alice, bob).forEach { state ->
             val commitTx = state.commitments.localCommit.publishableTxs.commitTx.tx
-            val (state1, actions1) = state.processEx(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE), minVersion = 3)
+            val (state1, actions1) = state.processEx(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE), minVersion = 3)
             assertIs<Closing>(state1)
             assertNotNull(state1.localCommitPublished)
             val error = actions1.hasOutgoingMessage<Error>()
@@ -191,7 +191,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_FORCECLOSE -- nothing at stake`() {
         val (_, _, bob, _) = init(bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
-        val (bob1, actions1) = bob.processEx(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE), minVersion = 3)
+        val (bob1, actions1) = bob.processEx(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE), minVersion = 3)
         assertIs<Aborted>(bob1)
         assertEquals(1, actions1.size)
         val error = actions1.hasOutgoingMessage<Error>()
@@ -214,25 +214,25 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         ): Fixture {
             return if (zeroConf) {
                 val (alice, commitAlice, bob, commitBob) = WaitForFundingSignedTestsCommon.init(channelType, aliceFeatures, bobFeatures, currentHeight, aliceFundingAmount, bobFundingAmount, alicePushAmount, bobPushAmount, zeroConf)
-                val (alice1, actionsAlice1) = alice.processEx(ChannelEvent.MessageReceived(commitBob), minVersion = 3)
+                val (alice1, actionsAlice1) = alice.processEx(ChannelCommand.MessageReceived(commitBob), minVersion = 3)
                 assertIs<WaitForChannelReady>(alice1)
                 assertEquals(actionsAlice1.findWatch<WatchSpent>().event, BITCOIN_FUNDING_SPENT)
                 val channelReadyAlice = actionsAlice1.findOutgoingMessage<ChannelReady>()
-                val (bob1, actionsBob1) = bob.processEx(ChannelEvent.MessageReceived(commitAlice), minVersion = 3)
+                val (bob1, actionsBob1) = bob.processEx(ChannelCommand.MessageReceived(commitAlice), minVersion = 3)
                 assertIs<WaitForChannelReady>(bob1)
                 assertEquals(actionsBob1.findWatch<WatchSpent>().event, BITCOIN_FUNDING_SPENT)
                 val channelReadyBob = actionsBob1.findOutgoingMessage<ChannelReady>()
                 Fixture(alice1, channelReadyAlice, bob1, channelReadyBob)
             } else {
                 val (alice, bob, txSigsBob) = WaitForFundingConfirmedTestsCommon.init(channelType, aliceFeatures, bobFeatures, currentHeight, aliceFundingAmount, bobFundingAmount, alicePushAmount, bobPushAmount)
-                val (alice1, actionsAlice1) = alice.processEx(ChannelEvent.MessageReceived(txSigsBob), minVersion = 3)
+                val (alice1, actionsAlice1) = alice.processEx(ChannelCommand.MessageReceived(txSigsBob), minVersion = 3)
                 val txSigsAlice = actionsAlice1.hasOutgoingMessage<TxSignatures>()
                 val fundingTx = actionsAlice1.find<ChannelAction.Blockchain.PublishTx>().tx
-                val (bob1, _) = bob.processEx(ChannelEvent.MessageReceived(txSigsAlice), minVersion = 3)
-                val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.WatchReceived(WatchEventConfirmed(alice.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)), minVersion = 3)
+                val (bob1, _) = bob.processEx(ChannelCommand.MessageReceived(txSigsAlice), minVersion = 3)
+                val (alice2, actionsAlice2) = alice1.processEx(ChannelCommand.WatchReceived(WatchEventConfirmed(alice.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)), minVersion = 3)
                 assertIs<WaitForChannelReady>(alice2)
                 val channelReadyAlice = actionsAlice2.findOutgoingMessage<ChannelReady>()
-                val (bob2, actionsBob2) = bob1.processEx(ChannelEvent.WatchReceived(WatchEventConfirmed(bob.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)), minVersion = 3)
+                val (bob2, actionsBob2) = bob1.processEx(ChannelCommand.WatchReceived(WatchEventConfirmed(bob.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)), minVersion = 3)
                 assertIs<WaitForChannelReady>(bob2)
                 val channelReadyBob = actionsBob2.findOutgoingMessage<ChannelReady>()
                 Fixture(alice2, channelReadyAlice, bob2, channelReadyBob)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreatedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreatedTestsCommon.kt
@@ -40,15 +40,15 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     fun `complete interactive-tx protocol`() {
         val (alice, bob, inputAlice) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat)
         // Alice ---- tx_add_input ----> Bob
-        val (bob1, actionsBob1) = bob.process(ChannelEvent.MessageReceived(inputAlice))
+        val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(inputAlice))
         // Alice <--- tx_complete ----- Bob
-        val (alice1, actionsAlice1) = alice.process(ChannelEvent.MessageReceived(actionsBob1.findOutgoingMessage<TxComplete>()))
+        val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(actionsBob1.findOutgoingMessage<TxComplete>()))
         // Alice ---- tx_add_output ----> Bob
-        val (bob2, actionsBob2) = bob1.process(ChannelEvent.MessageReceived(actionsAlice1.findOutgoingMessage<TxAddOutput>()))
+        val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(actionsAlice1.findOutgoingMessage<TxAddOutput>()))
         // Alice <--- tx_complete ----- Bob
-        val (alice2, actionsAlice2) = alice1.process(ChannelEvent.MessageReceived(actionsBob2.findOutgoingMessage<TxComplete>()))
+        val (alice2, actionsAlice2) = alice1.process(ChannelCommand.MessageReceived(actionsBob2.findOutgoingMessage<TxComplete>()))
         // Alice ---- tx_complete ----> Bob
-        val (bob3, actionsBob3) = bob2.process(ChannelEvent.MessageReceived(actionsAlice2.findOutgoingMessage<TxComplete>()))
+        val (bob3, actionsBob3) = bob2.process(ChannelCommand.MessageReceived(actionsAlice2.findOutgoingMessage<TxComplete>()))
         val commitSigAlice = actionsAlice2.findOutgoingMessage<CommitSig>()
         val commitSigBob = actionsBob3.findOutgoingMessage<CommitSig>()
         assertEquals(commitSigAlice.channelId, commitSigBob.channelId)
@@ -67,15 +67,15 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     fun `complete interactive-tx protocol -- with non-initiator contributions`() {
         val (alice, bob, inputAlice) = init(ChannelType.SupportedChannelType.AnchorOutputs)
         // Alice ---- tx_add_input ----> Bob
-        val (bob1, actionsBob1) = bob.process(ChannelEvent.MessageReceived(inputAlice))
+        val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(inputAlice))
         // Alice <--- tx_add_input ----- Bob
-        val (alice1, actionsAlice1) = alice.process(ChannelEvent.MessageReceived(actionsBob1.findOutgoingMessage<TxAddInput>()))
+        val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(actionsBob1.findOutgoingMessage<TxAddInput>()))
         // Alice ---- tx_add_output ----> Bob
-        val (bob2, actionsBob2) = bob1.process(ChannelEvent.MessageReceived(actionsAlice1.findOutgoingMessage<TxAddOutput>()))
+        val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(actionsAlice1.findOutgoingMessage<TxAddOutput>()))
         // Alice <--- tx_complete ----- Bob
-        val (alice2, actionsAlice2) = alice1.process(ChannelEvent.MessageReceived(actionsBob2.findOutgoingMessage<TxComplete>()))
+        val (alice2, actionsAlice2) = alice1.process(ChannelCommand.MessageReceived(actionsBob2.findOutgoingMessage<TxComplete>()))
         // Alice ---- tx_complete ----> Bob
-        val (bob3, actionsBob3) = bob2.process(ChannelEvent.MessageReceived(actionsAlice2.findOutgoingMessage<TxComplete>()))
+        val (bob3, actionsBob3) = bob2.process(ChannelCommand.MessageReceived(actionsAlice2.findOutgoingMessage<TxComplete>()))
         val commitSigAlice = actionsAlice2.findOutgoingMessage<CommitSig>()
         val commitSigBob = actionsBob3.findOutgoingMessage<CommitSig>()
         assertEquals(commitSigAlice.channelId, commitSigBob.channelId)
@@ -90,15 +90,15 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     fun `complete interactive-tx protocol -- zero conf -- zero reserve`() {
         val (alice, bob, inputAlice) = init(ChannelType.SupportedChannelType.AnchorOutputsZeroReserve, alicePushAmount = 0.msat, zeroConf = true)
         // Alice ---- tx_add_input ----> Bob
-        val (bob1, actionsBob1) = bob.process(ChannelEvent.MessageReceived(inputAlice))
+        val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(inputAlice))
         // Alice <--- tx_add_input ----- Bob
-        val (alice1, actionsAlice1) = alice.process(ChannelEvent.MessageReceived(actionsBob1.findOutgoingMessage<TxAddInput>()))
+        val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(actionsBob1.findOutgoingMessage<TxAddInput>()))
         // Alice ---- tx_add_output ----> Bob
-        val (bob2, actionsBob2) = bob1.process(ChannelEvent.MessageReceived(actionsAlice1.findOutgoingMessage<TxAddOutput>()))
+        val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(actionsAlice1.findOutgoingMessage<TxAddOutput>()))
         // Alice <--- tx_complete ----- Bob
-        val (alice2, actionsAlice2) = alice1.process(ChannelEvent.MessageReceived(actionsBob2.findOutgoingMessage<TxComplete>()))
+        val (alice2, actionsAlice2) = alice1.process(ChannelCommand.MessageReceived(actionsBob2.findOutgoingMessage<TxComplete>()))
         // Alice ---- tx_complete ----> Bob
-        val (bob3, actionsBob3) = bob2.process(ChannelEvent.MessageReceived(actionsAlice2.findOutgoingMessage<TxComplete>()))
+        val (bob3, actionsBob3) = bob2.process(ChannelCommand.MessageReceived(actionsAlice2.findOutgoingMessage<TxComplete>()))
         val commitSigAlice = actionsAlice2.findOutgoingMessage<CommitSig>()
         val commitSigBob = actionsBob3.findOutgoingMessage<CommitSig>()
         assertEquals(commitSigAlice.channelId, commitSigBob.channelId)
@@ -113,16 +113,16 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     fun `complete interactive-tx protocol -- initiator can't pay fees`() {
         val (alice, bob, inputAlice) = init(ChannelType.SupportedChannelType.AnchorOutputs, aliceFundingAmount = 1_000_100.sat, bobFundingAmount = 0.sat, alicePushAmount = 1_000_000.sat.toMilliSatoshi())
         // Alice ---- tx_add_input ----> Bob
-        val (bob1, actionsBob1) = bob.process(ChannelEvent.MessageReceived(inputAlice))
+        val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(inputAlice))
         // Alice <--- tx_complete ----- Bob
-        val (alice1, actionsAlice1) = alice.process(ChannelEvent.MessageReceived(actionsBob1.findOutgoingMessage<TxComplete>()))
+        val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(actionsBob1.findOutgoingMessage<TxComplete>()))
         // Alice ---- tx_add_output ----> Bob
-        val (bob2, actionsBob2) = bob1.process(ChannelEvent.MessageReceived(actionsAlice1.findOutgoingMessage<TxAddOutput>()))
+        val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(actionsAlice1.findOutgoingMessage<TxAddOutput>()))
         // Alice <--- tx_complete ----- Bob
-        val (alice2, actionsAlice2) = alice1.process(ChannelEvent.MessageReceived(actionsBob2.findOutgoingMessage<TxComplete>()))
+        val (alice2, actionsAlice2) = alice1.process(ChannelCommand.MessageReceived(actionsBob2.findOutgoingMessage<TxComplete>()))
         assertIs<WaitForFundingSigned>(alice2)
         // Alice ---- tx_complete ----> Bob
-        val (bob3, actionsBob3) = bob2.process(ChannelEvent.MessageReceived(actionsAlice2.findOutgoingMessage<TxComplete>()))
+        val (bob3, actionsBob3) = bob2.process(ChannelCommand.MessageReceived(actionsAlice2.findOutgoingMessage<TxComplete>()))
         actionsBob3.hasOutgoingMessage<Error>()
         assertIs<Aborted>(bob3)
     }
@@ -132,14 +132,14 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
         val (_, bob, inputAlice) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
         run {
             // Invalid serial_id.
-            val (bob1, actionsBob1) = bob.process(ChannelEvent.MessageReceived(inputAlice.copy(serialId = 1)))
+            val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(inputAlice.copy(serialId = 1)))
             actionsBob1.hasOutgoingMessage<Error>()
             assertIs<Aborted>(bob1)
         }
         run {
             // Below dust.
             val txAddOutput = TxAddOutput(inputAlice.channelId, 2, 100.sat, Script.write(Script.pay2wpkh(randomKey().publicKey())).toByteVector())
-            val (bob1, actionsBob1) = bob.process(ChannelEvent.MessageReceived(txAddOutput))
+            val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(txAddOutput))
             actionsBob1.hasOutgoingMessage<Error>()
             assertIs<Aborted>(bob1)
         }
@@ -149,12 +149,12 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     fun `recv CommitSig`() {
         val (alice, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
         run {
-            val (alice1, actionsAlice1) = alice.process(ChannelEvent.MessageReceived(CommitSig(alice.channelId, ByteVector64.Zeroes, listOf())))
+            val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(CommitSig(alice.channelId, ByteVector64.Zeroes, listOf())))
             assertEquals(actionsAlice1.findOutgoingMessage<Error>().toAscii(), UnexpectedCommitSig(alice.channelId).message)
             assertIs<Aborted>(alice1)
         }
         run {
-            val (bob1, actionsBob1) = bob.process(ChannelEvent.MessageReceived(CommitSig(bob.channelId, ByteVector64.Zeroes, listOf())))
+            val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(CommitSig(bob.channelId, ByteVector64.Zeroes, listOf())))
             assertEquals(actionsBob1.findOutgoingMessage<Error>().toAscii(), UnexpectedCommitSig(bob.channelId).message)
             assertIs<Aborted>(bob1)
         }
@@ -164,12 +164,12 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     fun `recv TxSignatures`() {
         val (alice, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
         run {
-            val (alice1, actionsAlice1) = alice.process(ChannelEvent.MessageReceived(TxSignatures(alice.channelId, randomBytes32(), listOf())))
+            val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(TxSignatures(alice.channelId, randomBytes32(), listOf())))
             assertEquals(actionsAlice1.findOutgoingMessage<Error>().toAscii(), UnexpectedFundingSignatures(alice.channelId).message)
             assertIs<Aborted>(alice1)
         }
         run {
-            val (bob1, actionsBob1) = bob.process(ChannelEvent.MessageReceived(TxSignatures(bob.channelId, randomBytes32(), listOf())))
+            val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(TxSignatures(bob.channelId, randomBytes32(), listOf())))
             assertEquals(actionsBob1.findOutgoingMessage<Error>().toAscii(), UnexpectedFundingSignatures(bob.channelId).message)
             assertIs<Aborted>(bob1)
         }
@@ -179,12 +179,12 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     fun `recv TxAbort`() {
         val (alice, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
         run {
-            val (alice1, actionsAlice1) = alice.process(ChannelEvent.MessageReceived(TxAbort(alice.channelId, "changed my mind")))
+            val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(TxAbort(alice.channelId, "changed my mind")))
             assertTrue(actionsAlice1.isEmpty())
             assertIs<Aborted>(alice1)
         }
         run {
-            val (bob1, actionsBob1) = bob.process(ChannelEvent.MessageReceived(TxAbort(bob.channelId, "changed my mind")))
+            val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(TxAbort(bob.channelId, "changed my mind")))
             assertTrue(actionsBob1.isEmpty())
             assertIs<Aborted>(bob1)
         }
@@ -194,13 +194,13 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     fun `recv TxInitRbf`() {
         val (alice, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
         run {
-            val (alice1, actionsAlice1) = alice.process(ChannelEvent.MessageReceived(TxInitRbf(alice.channelId, 0, FeeratePerKw(7500.sat))))
+            val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(TxInitRbf(alice.channelId, 0, FeeratePerKw(7500.sat))))
             assertEquals(actionsAlice1.size, 1)
             assertEquals(actionsAlice1.findOutgoingMessage<Warning>().toAscii(), InvalidRbfAttempt(alice.channelId).message)
             assertEquals(alice, alice1)
         }
         run {
-            val (bob1, actionsBob1) = bob.process(ChannelEvent.MessageReceived(TxInitRbf(bob.channelId, 0, FeeratePerKw(7500.sat))))
+            val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(TxInitRbf(bob.channelId, 0, FeeratePerKw(7500.sat))))
             assertEquals(actionsBob1.size, 1)
             assertEquals(actionsBob1.findOutgoingMessage<Warning>().toAscii(), InvalidRbfAttempt(bob.channelId).message)
             assertEquals(bob, bob1)
@@ -211,13 +211,13 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     fun `recv TxAckRbf`() {
         val (alice, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
         run {
-            val (alice1, actionsAlice1) = alice.process(ChannelEvent.MessageReceived(TxAckRbf(alice.channelId)))
+            val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(TxAckRbf(alice.channelId)))
             assertEquals(actionsAlice1.size, 1)
             assertEquals(actionsAlice1.findOutgoingMessage<Warning>().toAscii(), InvalidRbfAttempt(alice.channelId).message)
             assertEquals(alice, alice1)
         }
         run {
-            val (bob1, actionsBob1) = bob.process(ChannelEvent.MessageReceived(TxAckRbf(bob.channelId)))
+            val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(TxAckRbf(bob.channelId)))
             assertEquals(actionsBob1.size, 1)
             assertEquals(actionsBob1.findOutgoingMessage<Warning>().toAscii(), InvalidRbfAttempt(bob.channelId).message)
             assertEquals(bob, bob1)
@@ -227,7 +227,7 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     @Test
     fun `recv Error`() {
         val (_, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat)
-        val (bob1, actions1) = bob.process(ChannelEvent.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
+        val (bob1, actions1) = bob.process(ChannelCommand.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
         assertIs<Aborted>(bob1)
         assertTrue(actions1.isEmpty())
     }
@@ -235,7 +235,7 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_CLOSE`() {
         val (_, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat)
-        val (bob1, actions1) = bob.process(ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null)))
+        val (bob1, actions1) = bob.process(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         assertEquals(actions1.findOutgoingMessage<Error>().toAscii(), ChannelFundingError(bob.channelId).message)
         assertIs<Aborted>(bob1)
     }
@@ -243,7 +243,7 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     @Test
     fun `recv CMD_FORCECLOSE`() {
         val (_, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat)
-        val (bob1, actions1) = bob.process(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
+        val (bob1, actions1) = bob.process(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
         assertEquals(actions1.findOutgoingMessage<Error>().toAscii(), ChannelFundingError(bob.channelId).message)
         assertIs<Aborted>(bob1)
     }
@@ -251,9 +251,9 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     @Test
     fun `recv Disconnected`() {
         val (_, bob, txAddInput) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat)
-        val (bob1, _) = bob.process(ChannelEvent.MessageReceived(txAddInput))
+        val (bob1, _) = bob.process(ChannelCommand.MessageReceived(txAddInput))
         assertIs<WaitForFundingCreated>(bob1)
-        val (bob2, actions2) = bob1.process(ChannelEvent.Disconnected)
+        val (bob2, actions2) = bob1.process(ChannelCommand.Disconnected)
         assertIs<Aborted>(bob2)
         assertTrue(actions2.isEmpty())
     }
@@ -272,10 +272,10 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
             channelOrigin: ChannelOrigin? = null
         ): Triple<WaitForFundingCreated, WaitForFundingCreated, TxAddInput> {
             val (a, b, open) = TestsHelper.init(channelType, aliceFeatures, bobFeatures, currentHeight, aliceFundingAmount, bobFundingAmount, alicePushAmount, bobPushAmount, zeroConf, channelOrigin)
-            val (b1, actions) = b.process(ChannelEvent.MessageReceived(open))
+            val (b1, actions) = b.process(ChannelCommand.MessageReceived(open))
             val accept = actions.findOutgoingMessage<AcceptDualFundedChannel>()
             assertIs<WaitForFundingCreated>(b1)
-            val (a1, actions2) = a.process(ChannelEvent.MessageReceived(accept))
+            val (a1, actions2) = a.process(ChannelCommand.MessageReceived(accept))
             val aliceInput = actions2.findOutgoingMessage<TxAddInput>()
             assertIs<WaitForFundingCreated>(a1)
             return Triple(a1, b1, aliceInput)

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
@@ -17,7 +17,7 @@ import fr.acinq.lightning.db.OutgoingPaymentsDb
 import fr.acinq.lightning.io.SendPayment
 import fr.acinq.lightning.io.SendPaymentNormal
 import fr.acinq.lightning.io.SendPaymentSwapOut
-import fr.acinq.lightning.io.WrappedChannelEvent
+import fr.acinq.lightning.io.WrappedChannelCommand
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.tests.utils.runSuspendTest
@@ -134,7 +134,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
 
             val progress = result as OutgoingPaymentHandler.Progress
             assertEquals(1, result.actions.size)
-            val processResult = alice.process(progress.actions.first().channelEvent)
+            val processResult = alice.process(progress.actions.first().channelCommand)
             assertTrue { processResult.first is Normal }
             assertTrue { processResult.second.filterIsInstance<ChannelAction.ProcessCmdRes>().isEmpty() }
             alice = processResult.first as Normal
@@ -155,7 +155,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
 
             val progress = result1 as OutgoingPaymentHandler.Progress
             assertEquals(1, result1.actions.size)
-            val cmdAdd = progress.actions.first().channelEvent
+            val cmdAdd = progress.actions.first().channelCommand
             val processResult = alice.process(cmdAdd)
             assertTrue { processResult.first is Normal }
             alice = processResult.first as Normal
@@ -188,7 +188,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
 
             val progress = result as OutgoingPaymentHandler.Progress
             assertEquals(1, result.actions.size)
-            val processResult = alice.process(progress.actions.first().channelEvent)
+            val processResult = alice.process(progress.actions.first().channelCommand)
             assertTrue { processResult.first is Normal }
             assertTrue { processResult.second.filterIsInstance<ChannelAction.ProcessCmdRes>().isEmpty() }
             alice = processResult.first as Normal
@@ -209,7 +209,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
 
             val progress = result1 as OutgoingPaymentHandler.Progress
             assertEquals(1, result1.actions.size)
-            val cmdAdd = progress.actions.first().channelEvent
+            val cmdAdd = progress.actions.first().channelCommand
             val processResult = alice.process(cmdAdd)
             assertTrue { processResult.first is Normal }
             alice = processResult.first as Normal
@@ -489,7 +489,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertTrue(process1 is IncomingPaymentHandler.ProcessAddResult.Pending)
         val process2 = incomingPaymentHandler.process(makeUpdateAddHtlc(adds[1].first, adds[1].second, 5), TestConstants.defaultBlockHeight)
         assertTrue(process2 is IncomingPaymentHandler.ProcessAddResult.Accepted)
-        val fulfills = process2.actions.filterIsInstance<WrappedChannelEvent>().mapNotNull { (it.channelEvent as? ChannelEvent.ExecuteCommand)?.command as? CMD_FULFILL_HTLC }
+        val fulfills = process2.actions.filterIsInstance<WrappedChannelCommand>().mapNotNull { (it.channelCommand as? ChannelCommand.ExecuteCommand)?.command as? CMD_FULFILL_HTLC }
         assertEquals(2, fulfills.size)
 
         // Alice receives the fulfill for these 2 HTLCs.
@@ -967,7 +967,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
     private fun filterAddHtlcCommands(progress: OutgoingPaymentHandler.Progress): List<Pair<ByteVector32, CMD_ADD_HTLC>> {
         val addCommands = mutableListOf<Pair<ByteVector32, CMD_ADD_HTLC>>()
         for (action in progress.actions) {
-            val addCommand = (action.channelEvent as? ChannelEvent.ExecuteCommand)?.command as? CMD_ADD_HTLC
+            val addCommand = (action.channelCommand as? ChannelCommand.ExecuteCommand)?.command as? CMD_ADD_HTLC
             if (addCommand != null) {
                 addCommands.add(Pair(action.channelId, addCommand))
             }

--- a/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationTestsCommon.kt
@@ -83,13 +83,13 @@ class StateSerializationTestsCommon : LightningTestSuite() {
         fun commitSigSize(maxIncoming: Int, maxOutgoing: Int): Int {
             val (alice1, bob1) = addHtlcs(alice, bob, MilliSatoshi(6000_000), maxOutgoing)
             val (bob2, alice2) = addHtlcs(bob1, alice1, MilliSatoshi(6000_000), maxIncoming)
-            val (_, actions) = alice2.process(ChannelEvent.ExecuteCommand(CMD_SIGN))
+            val (_, actions) = alice2.process(ChannelCommand.ExecuteCommand(CMD_SIGN))
             val commitSig0 = actions.findOutgoingMessage<CommitSig>()
 
-            val (bob3, actions1) = bob2.process(ChannelEvent.MessageReceived(commitSig0))
+            val (bob3, actions1) = bob2.process(ChannelCommand.MessageReceived(commitSig0))
             val commandSign0 = actions1.findCommand<CMD_SIGN>()
 
-            val (_, actions2) = bob3.process(ChannelEvent.ExecuteCommand(commandSign0))
+            val (_, actions2) = bob3.process(ChannelCommand.ExecuteCommand(commandSign0))
             val commitSig1 = actions2.findOutgoingMessage<CommitSig>()
 
             val bina = LightningMessage.encode(commitSig0)

--- a/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
+++ b/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
@@ -8,7 +8,7 @@ import fr.acinq.lightning.blockchain.electrum.ElectrumWatcher
 import fr.acinq.lightning.blockchain.fee.FeerateTolerance
 import fr.acinq.lightning.blockchain.fee.OnChainFeeConf
 import fr.acinq.lightning.channel.CMD_CLOSE
-import fr.acinq.lightning.channel.ChannelEvent
+import fr.acinq.lightning.channel.ChannelCommand
 import fr.acinq.lightning.crypto.LocalKeyManager
 import fr.acinq.lightning.db.Databases
 import fr.acinq.lightning.db.InMemoryPaymentsDb
@@ -270,7 +270,7 @@ object Node {
                     }
                     post("/channels/{channelId}/close") {
                         val channelId = ByteVector32(call.parameters["channelId"] ?: error("channelId not provided"))
-                        peer.send(WrappedChannelEvent(channelId, ChannelEvent.ExecuteCommand(CMD_CLOSE(null, null))))
+                        peer.send(WrappedChannelCommand(channelId, ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null))))
                         call.respond(CloseChannelResponse("pending"))
                     }
                 }


### PR DESCRIPTION
Follow _akka typed_ semantics and clear up confusion between in/out messages for "actors":
- `Commands` are input messages, processed by actors
- `Events` are emitted by actors, typically to a `Flow`.