### PR TITLE
Only declare native source sets if used

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,43 +86,46 @@ kotlin {
         }
     }
 
-    val nativeMain by sourceSets.creating { dependsOn(commonMain) }
-    val nativeTest by sourceSets.creating { dependsOn(commonTest) }
+    if (currentOs.isLinux || currentOs.isMacOsX) {
 
-    if (currentOs.isLinux) {
-        linuxX64("linux") {
-            compilations["main"].defaultSourceSet {
-                dependsOn(nativeMain)
-            }
-            compilations["test"].defaultSourceSet {
-                dependsOn(nativeTest)
-                dependencies {
-                    implementation(ktor("client-curl"))
+        val nativeMain by sourceSets.creating { dependsOn(commonMain) }
+        val nativeTest by sourceSets.creating { dependsOn(commonTest) }
+
+        if (currentOs.isLinux) {
+            linuxX64("linux") {
+                compilations["main"].defaultSourceSet {
+                    dependsOn(nativeMain)
+                }
+                compilations["test"].defaultSourceSet {
+                    dependsOn(nativeTest)
+                    dependencies {
+                        implementation(ktor("client-curl"))
+                    }
                 }
             }
         }
-    }
 
-    if (currentOs.isMacOsX) {
-        ios {
-            val platform = when (name) {
-                "iosX64" -> "iphonesimulator"
-                "iosArm64" -> "iphoneos"
-                else -> error("Unsupported target $name")
-            }
+        if (currentOs.isMacOsX) {
+            ios {
+                val platform = when (name) {
+                    "iosX64" -> "iphonesimulator"
+                    "iosArm64" -> "iphoneos"
+                    else -> error("Unsupported target $name")
+                }
 
-            compilations["main"].cinterops.create("PhoenixCrypto") {
-                val interopTask = tasks[interopProcessingTaskName]
-                interopTask.dependsOn(":PhoenixCrypto:buildCrypto${platform.capitalize()}")
-                includeDirs.headerFilterOnly("$rootDir/PhoenixCrypto/build/Release-$platform/include")
-            }
-            compilations["main"].defaultSourceSet {
-                dependsOn(nativeMain)
-            }
-            compilations["test"].defaultSourceSet {
-                dependsOn(nativeTest)
-                dependencies {
-                    implementation(ktor("client-ios"))
+                compilations["main"].cinterops.create("PhoenixCrypto") {
+                    val interopTask = tasks[interopProcessingTaskName]
+                    interopTask.dependsOn(":PhoenixCrypto:buildCrypto${platform.capitalize()}")
+                    includeDirs.headerFilterOnly("$rootDir/PhoenixCrypto/build/Release-$platform/include")
+                }
+                compilations["main"].defaultSourceSet {
+                    dependsOn(nativeMain)
+                }
+                compilations["test"].defaultSourceSet {
+                    dependsOn(nativeTest)
+                    dependencies {
+                        implementation(ktor("client-ios"))
+                    }
                 }
             }
         }


### PR DESCRIPTION
Source sets `nativeMain`/`nativeTest` are only used on Linux and MacOSX, but are defined for all OSes, causing the following gradle warning, and potentially messing with Intellij on Windows:

```
The following Kotlin source sets were configured but not added to any Kotlin compilation:
 * nativeMain
 * nativeTest
You can add a source set to a target's compilation by connecting it with the compilation's default source set using 'dependsOn'.
See https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html#connecting-source-sets

```