### PR TITLE
Revert "Remove migration prototype (#381)"

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -102,6 +102,8 @@ data class ChannelClosing(val channelId: ByteVector32) : PeerEvent()
 data class SendSwapOutRequest(val amount: Satoshi, val bitcoinAddress: String, val feePerKw: Long) : PeerCommand()
 data class SwapOutResponseEvent(val swapOutResponse: SwapOutResponse) : PeerEvent()
 
+data class PhoenixAndroidLegacyInfoEvent(val info: PhoenixAndroidLegacyInfo) : PeerEvent()
+
 /**
  * The peer we establish a connection to. This object contains the TCP socket, a flow of the channels with that peer, and watches
  * the events on those channels and processes the relevant actions. The dialogue with the peer is done in coroutines.
@@ -794,6 +796,11 @@ class Peer(
                     msg is SwapOutResponse -> {
                         logger.info { "n:$remoteNodeId received ${msg::class} amount=${msg.amount} fee=${msg.fee} invoice=${msg.paymentRequest}" }
                         _eventsFlow.emit(SwapOutResponseEvent(msg))
+                    }
+
+                    msg is PhoenixAndroidLegacyInfo -> {
+                        logger.info { "n:$remoteNodeId received ${msg::class} hasChannels=${msg.hasChannels}" }
+                        _eventsFlow.emit(PhoenixAndroidLegacyInfoEvent(msg))
                     }
 
                     msg is OnionMessage -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -82,6 +82,8 @@ interface LightningMessage {
                 UnsetFCMToken.type -> UnsetFCMToken
                 SwapOutRequest.type -> SwapOutRequest.read(stream)
                 SwapOutResponse.type -> SwapOutResponse.read(stream)
+                PhoenixAndroidLegacyInfo.type -> PhoenixAndroidLegacyInfo.read(stream)
+                PhoenixAndroidLegacyMigrate.type -> PhoenixAndroidLegacyMigrate.read(stream)
                 PleaseOpenChannel.type -> PleaseOpenChannel.read(stream)
                 PleaseOpenChannelRejected.type -> PleaseOpenChannelRejected.read(stream)
                 else -> UnknownMessage(code.toLong())
@@ -1539,6 +1541,42 @@ data class SwapOutResponse(
                 fee = Satoshi(LightningCodecs.u64(input)),
                 paymentRequest = LightningCodecs.bytes(input, LightningCodecs.u16(input)).decodeToString()
             )
+        }
+    }
+}
+
+data class PhoenixAndroidLegacyInfo(
+    val hasChannels: Boolean
+) : LightningMessage {
+    override val type: Long get() = PhoenixAndroidLegacyInfo.type
+
+    override fun write(out: Output) {
+        LightningCodecs.writeByte(if (hasChannels) 0xff else 0, out)
+    }
+
+    companion object : LightningMessageReader<PhoenixAndroidLegacyInfo> {
+        const val type: Long = 35023
+
+        override fun read(input: Input): PhoenixAndroidLegacyInfo {
+            return PhoenixAndroidLegacyInfo(LightningCodecs.byte(input) != 0)
+        }
+    }
+}
+
+data class PhoenixAndroidLegacyMigrate(
+    val newNodeId: PublicKey
+) : LightningMessage {
+    override val type: Long get() = PhoenixAndroidLegacyMigrate.type
+
+    override fun write(out: Output) {
+        LightningCodecs.writeBytes(newNodeId.value, out)
+    }
+
+    companion object : LightningMessageReader<PhoenixAndroidLegacyMigrate> {
+        const val type: Long = 35025
+
+        override fun read(input: Input): PhoenixAndroidLegacyMigrate {
+            return PhoenixAndroidLegacyMigrate(PublicKey(LightningCodecs.bytes(input, 33)))
         }
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -83,7 +83,6 @@ interface LightningMessage {
                 SwapOutRequest.type -> SwapOutRequest.read(stream)
                 SwapOutResponse.type -> SwapOutResponse.read(stream)
                 PhoenixAndroidLegacyInfo.type -> PhoenixAndroidLegacyInfo.read(stream)
-                PhoenixAndroidLegacyMigrate.type -> PhoenixAndroidLegacyMigrate.read(stream)
                 PleaseOpenChannel.type -> PleaseOpenChannel.read(stream)
                 PleaseOpenChannelRejected.type -> PleaseOpenChannelRejected.read(stream)
                 else -> UnknownMessage(code.toLong())
@@ -1559,24 +1558,6 @@ data class PhoenixAndroidLegacyInfo(
 
         override fun read(input: Input): PhoenixAndroidLegacyInfo {
             return PhoenixAndroidLegacyInfo(LightningCodecs.byte(input) != 0)
-        }
-    }
-}
-
-data class PhoenixAndroidLegacyMigrate(
-    val newNodeId: PublicKey
-) : LightningMessage {
-    override val type: Long get() = PhoenixAndroidLegacyMigrate.type
-
-    override fun write(out: Output) {
-        LightningCodecs.writeBytes(newNodeId.value, out)
-    }
-
-    companion object : LightningMessageReader<PhoenixAndroidLegacyMigrate> {
-        const val type: Long = 35025
-
-        override fun read(input: Input): PhoenixAndroidLegacyMigrate {
-            return PhoenixAndroidLegacyMigrate(PublicKey(LightningCodecs.bytes(input, 33)))
         }
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -678,4 +678,34 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
             assertArrayEquals(it.second, encoded)
         }
     }
+
+    @Test
+    fun `encode - decode phoenix-android-legacy-info messages`() {
+        val testCases = listOf(
+            Pair(PhoenixAndroidLegacyInfo(hasChannels = true), Hex.decode("88cfff")),
+            Pair(PhoenixAndroidLegacyInfo(hasChannels = false), Hex.decode("88cf00")),
+        )
+        testCases.forEach {
+            val decoded = LightningMessage.decode(it.second)
+            assertNotNull(decoded)
+            assertEquals(it.first, decoded)
+            val encoded = LightningMessage.encode(decoded)
+            assertArrayEquals(it.second, encoded)
+        }
+    }
+
+    @Test
+    fun `encode - decode phoenix-android-legacy-migrate messages`() {
+        val newNodeId = "033622d7b0326dd18826bc005b956f40ef25a5a55d69f98eb200a7f07179c1ccd9"
+        val testCases = listOf(
+            Pair(PhoenixAndroidLegacyMigrate(newNodeId = PublicKey.fromHex(newNodeId)), Hex.decode("88d1033622d7b0326dd18826bc005b956f40ef25a5a55d69f98eb200a7f07179c1ccd9")),
+        )
+        testCases.forEach {
+            val decoded = LightningMessage.decode(it.second)
+            assertNotNull(decoded)
+            assertEquals(it.first, decoded)
+            val encoded = LightningMessage.encode(decoded)
+            assertArrayEquals(it.second, encoded)
+        }
+    }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -693,19 +693,4 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
             assertArrayEquals(it.second, encoded)
         }
     }
-
-    @Test
-    fun `encode - decode phoenix-android-legacy-migrate messages`() {
-        val newNodeId = "033622d7b0326dd18826bc005b956f40ef25a5a55d69f98eb200a7f07179c1ccd9"
-        val testCases = listOf(
-            Pair(PhoenixAndroidLegacyMigrate(newNodeId = PublicKey.fromHex(newNodeId)), Hex.decode("88d1033622d7b0326dd18826bc005b956f40ef25a5a55d69f98eb200a7f07179c1ccd9")),
-        )
-        testCases.forEach {
-            val decoded = LightningMessage.decode(it.second)
-            assertNotNull(decoded)
-            assertEquals(it.first, decoded)
-            val encoded = LightningMessage.encode(decoded)
-            assertArrayEquals(it.second, encoded)
-        }
-    }
 }


### PR DESCRIPTION
This reverts commit 659f22cd9b5207697fba7c1fcbebbde0b3ca3d9e.

I jumped the gun: independently of the migration method, we still need a way for Legacy Phoenix to tell if they have channels. So we need to keep those messages.