### PR TITLE
Support Electrum requests multiplexing

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumDataTypes.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumDataTypes.kt
@@ -23,9 +23,6 @@ import kotlinx.serialization.json.*
 /**
  * ElectrumMessage
  *       |
- *       |`---- ElectrumSubscription
- *       |             `----- AskForHeaderSubscriptionUpdate
- *       |
  *       |`---- ElectrumRequest
  *       |             |`---- ServerVersion
  *       |             |`---- Ping
@@ -43,8 +40,6 @@ import kotlinx.serialization.json.*
  *                     ...
  */
 sealed interface ElectrumMessage
-sealed interface ElectrumSubscription : ElectrumMessage
-object AskForHeaderSubscriptionUpdate : ElectrumSubscription
 
 /**
  * [ElectrumClient] requests / responses

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumDataTypes.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumDataTypes.kt
@@ -17,17 +17,39 @@ import kotlinx.serialization.json.*
 
 /**
  * Common communication objects between [ElectrumClient] and external ressources (e.g. [ElectrumWatcher])
- * See the documentation for the ElectrumX protocol there: https://github.com/spesmilo/electrumx/
+ * See the documentation for the ElectrumX protocol there: https://electrumx.readthedocs.io
  */
-sealed class ElectrumMessage
-sealed class ElectrumSubscription : ElectrumMessage()
-object AskForHeaderSubscriptionUpdate : ElectrumSubscription()
-data class SendElectrumRequest(val electrumRequest: ElectrumRequest) : ElectrumMessage()
+
+/**
+ * ElectrumMessage
+ *       |
+ *       |`---- ElectrumSubscription
+ *       |             `----- AskForHeaderSubscriptionUpdate
+ *       |
+ *       |`---- ElectrumRequest
+ *       |             |`---- ServerVersion
+ *       |             |`---- Ping
+ *       |             |`---- GetScriptHashHistory
+ *       |             |`---- ScriptHashListUnspent
+ *       |             |`---- ScriptHashSubscription
+ *       |             ...
+ *       |
+ *       `----- ElectrumResponse
+ *                     |`---- ServerVersionResponse
+ *                     |`---- PingResponse
+ *                     |`---- GetScriptHashHistoryResponse
+ *                     |`---- ScriptHashListUnspentResponse
+ *                     |`---- ScriptHashSubscriptionResponse
+ *                     ...
+ */
+sealed interface ElectrumMessage
+sealed interface ElectrumSubscription : ElectrumMessage
+object AskForHeaderSubscriptionUpdate : ElectrumSubscription
 
 /**
  * [ElectrumClient] requests / responses
  */
-sealed class ElectrumRequest(vararg params: Any) {
+sealed class ElectrumRequest(vararg params: Any) : ElectrumMessage {
     abstract val method: String
     private val parameters = params.toList()
 
@@ -48,7 +70,7 @@ sealed class ElectrumRequest(vararg params: Any) {
     }
 }
 
-sealed class ElectrumResponse : ElectrumMessage()
+sealed interface ElectrumResponse : ElectrumMessage
 
 data class ServerVersion(
     private val clientName: String = ElectrumClient.ELECTRUM_CLIENT_NAME,
@@ -57,20 +79,20 @@ data class ServerVersion(
     override val method: String = "server.version"
 }
 
-data class ServerVersionResponse(val clientName: String, val protocolVersion: String) : ElectrumResponse()
+data class ServerVersionResponse(val clientName: String, val protocolVersion: String) : ElectrumResponse
 
 object Ping : ElectrumRequest() {
     override val method: String = "server.ping"
 }
 
-object PingResponse : ElectrumResponse()
+object PingResponse : ElectrumResponse
 
 data class GetScriptHashHistory(val scriptHash: ByteVector32) : ElectrumRequest(scriptHash) {
     override val method: String = "blockchain.scripthash.get_history"
 }
 
 data class TransactionHistoryItem(val blockHeight: Int, val txid: ByteVector32)
-data class GetScriptHashHistoryResponse(val scriptHash: ByteVector32, val history: List<TransactionHistoryItem>) : ElectrumResponse()
+data class GetScriptHashHistoryResponse(val scriptHash: ByteVector32, val history: List<TransactionHistoryItem>) : ElectrumResponse
 
 data class ScriptHashListUnspent(val scriptHash: ByteVector32) : ElectrumRequest(scriptHash) {
     override val method: String = "blockchain.scripthash.listunspent"
@@ -80,37 +102,37 @@ data class UnspentItem(val txid: ByteVector32, val outputIndex: Int, val value: 
     val outPoint by lazy { OutPoint(txid.reversed(), outputIndex.toLong()) }
 }
 
-data class ScriptHashListUnspentResponse(val scriptHash: ByteVector32, val unspents: List<UnspentItem>) : ElectrumResponse()
+data class ScriptHashListUnspentResponse(val scriptHash: ByteVector32, val unspents: List<UnspentItem>) : ElectrumResponse
 
 data class BroadcastTransaction(val tx: Transaction) : ElectrumRequest(tx) {
     override val method: String = "blockchain.transaction.broadcast"
 }
 
-data class BroadcastTransactionResponse(val tx: Transaction, val error: JsonRPCError? = null) : ElectrumResponse()
+data class BroadcastTransactionResponse(val tx: Transaction, val error: JsonRPCError? = null) : ElectrumResponse
 
 data class GetTransactionIdFromPosition(val blockHeight: Int, val txIndex: Int, val merkle: Boolean = false) : ElectrumRequest(blockHeight, txIndex, merkle) {
     override val method: String = "blockchain.transaction.id_from_pos"
 }
 
-data class GetTransactionIdFromPositionResponse(val txid: ByteVector32, val blockHeight: Int, val txIndex: Int, val merkle: List<ByteVector32> = emptyList()) : ElectrumResponse()
+data class GetTransactionIdFromPositionResponse(val txid: ByteVector32, val blockHeight: Int, val txIndex: Int, val merkle: List<ByteVector32> = emptyList()) : ElectrumResponse
 
 data class GetTransaction(val txid: ByteVector32, val contextOpt: Any? = null) : ElectrumRequest(txid) {
     override val method: String = "blockchain.transaction.get"
 }
 
-data class GetTransactionResponse(val tx: Transaction, val contextOpt: Any? = null) : ElectrumResponse()
+data class GetTransactionResponse(val tx: Transaction, val contextOpt: Any? = null) : ElectrumResponse
 
 data class GetHeader(val blockHeight: Int) : ElectrumRequest(blockHeight) {
     override val method: String = "blockchain.block.header"
 }
 
-data class GetHeaderResponse(val blockHeight: Int, val header: BlockHeader) : ElectrumResponse()
+data class GetHeaderResponse(val blockHeight: Int, val header: BlockHeader) : ElectrumResponse
 
 data class GetHeaders(val start_height: Int, val count: Int, val cp_height: Int = 0) : ElectrumRequest(start_height, count, cp_height) {
     override val method: String = "blockchain.block.headers"
 }
 
-data class GetHeadersResponse(val start_height: Int, val headers: List<BlockHeader>, val max: Int) : ElectrumResponse() {
+data class GetHeadersResponse(val start_height: Int, val headers: List<BlockHeader>, val max: Int) : ElectrumResponse {
     override fun toString(): String = "GetHeadersResponse($start_height, ${headers.size}, ${headers.first()}, ${headers.last()}, $max)"
 }
 
@@ -118,7 +140,7 @@ data class GetMerkle(val txid: ByteVector32, val blockHeight: Int, val contextOp
     override val method: String = "blockchain.transaction.get_merkle"
 }
 
-data class GetMerkleResponse(val txid: ByteVector32, val merkle: List<ByteVector32>, val block_height: Int, val pos: Int, val contextOpt: Transaction? = null) : ElectrumResponse() {
+data class GetMerkleResponse(val txid: ByteVector32, val merkle: List<ByteVector32>, val block_height: Int, val pos: Int, val contextOpt: Transaction? = null) : ElectrumResponse {
     val root: ByteVector32 by lazy {
         tailrec fun loop(pos: Int, hashes: List<ByteVector32>): ByteVector32 {
             return if (hashes.size == 1) hashes[0]
@@ -137,30 +159,35 @@ data class EstimateFees(val confirmations: Int) : ElectrumRequest(confirmations)
     override val method: String = "blockchain.estimatefee"
 }
 
-data class EstimateFeeResponse(val confirmations: Int, val feerate: FeeratePerKw?) : ElectrumResponse()
+data class EstimateFeeResponse(val confirmations: Int, val feerate: FeeratePerKw?) : ElectrumResponse
 
 
 data class ScriptHashSubscription(val scriptHash: ByteVector32) : ElectrumRequest(scriptHash) {
     override val method: String = "blockchain.scripthash.subscribe"
 }
 
-data class ScriptHashSubscriptionResponse(val scriptHash: ByteVector32, val status: String = "") : ElectrumResponse()
+data class ScriptHashSubscriptionResponse(val scriptHash: ByteVector32, val status: String = "") : ElectrumResponse
 
 object HeaderSubscription : ElectrumRequest() {
     override val method: String = "blockchain.headers.subscribe"
 }
 
-data class HeaderSubscriptionResponse(val blockHeight: Int, val header: BlockHeader) : ElectrumResponse()
+data class HeaderSubscriptionResponse(val blockHeight: Int, val header: BlockHeader) : ElectrumResponse
 
 /**
  * Other Electrum responses
  */
-data class TransactionHistory(val history: List<TransactionHistoryItem>) : ElectrumResponse()
-data class AddressStatus(val address: String, val status: String?) : ElectrumResponse()
-data class ServerError(val request: ElectrumRequest, val error: JsonRPCError) : ElectrumResponse()
+data class TransactionHistory(val history: List<TransactionHistoryItem>) : ElectrumResponse
+data class AddressStatus(val address: String, val status: String?) : ElectrumResponse
+data class ServerError(val request: ElectrumRequest, val error: JsonRPCError) : ElectrumResponse
 
 /**
- * ElectrumResponse deserializer
+ * The Electrum server sends two types of messages:
+ *   - JSON RPC responses (in reply to requests such as [GetTransaction])
+ *   - Notifications (following subscriptions such as [ScriptHashSubscriptionResponse]
+ *
+ * The former are correlated 1:1 with JSON RPC requests, based on request id. The latter are not: one
+ * subscription can yield an indefinite number of notifications.
  */
 object ElectrumResponseDeserializer : KSerializer<Either<ElectrumResponse, JsonRPCResponse>> {
     private val json = Json { ignoreUnknownKeys = true }
@@ -184,14 +211,17 @@ object ElectrumResponseDeserializer : KSerializer<Either<ElectrumResponse, JsonR
                         val hex = header.getValue("hex").jsonPrimitive.content
                         Either.Left(HeaderSubscriptionResponse(height, BlockHeader.read(hex)))
                     }
+
                     "blockchain.scripthash.subscribe" -> {
                         val scriptHash = params[0].jsonPrimitive.content
                         val status = params[1].jsonPrimitive.contentOrNull
                         Either.Left(ScriptHashSubscriptionResponse(ByteVector32.fromValidHex(scriptHash), status ?: ""))
                     }
+
                     else -> throw SerializationException("JSON-RPC Method ${method.content} is not supported")
                 }
             }
+
             else -> Either.Right(json.decodeFromJsonElement(JsonRPCResponseDeserializer(json), jsonObject))
         }
     }
@@ -237,6 +267,7 @@ internal fun parseJsonResponse(request: ElectrumRequest, rpcResponse: JsonRPCRes
             val resultArray = rpcResponse.result.jsonArray
             ServerVersionResponse(resultArray[0].toString(), resultArray[1].toString())
         }
+
         Ping -> PingResponse
         is GetScriptHashHistory -> {
             val jsonArray = rpcResponse.result.jsonArray
@@ -247,6 +278,7 @@ internal fun parseJsonResponse(request: ElectrumRequest, rpcResponse: JsonRPCRes
             }
             GetScriptHashHistoryResponse(request.scriptHash, items)
         }
+
         is ScriptHashListUnspent -> {
             val jsonArray = rpcResponse.result.jsonArray
             val items = jsonArray.map {
@@ -258,6 +290,7 @@ internal fun parseJsonResponse(request: ElectrumRequest, rpcResponse: JsonRPCRes
             }
             ScriptHashListUnspentResponse(request.scriptHash, items)
         }
+
         is GetTransactionIdFromPosition -> {
             val (txHash, leaves) = if (rpcResponse.result is JsonPrimitive) {
                 rpcResponse.result.content to emptyList()
@@ -269,10 +302,12 @@ internal fun parseJsonResponse(request: ElectrumRequest, rpcResponse: JsonRPCRes
 
             GetTransactionIdFromPositionResponse(ByteVector32.fromValidHex(txHash), request.blockHeight, request.txIndex, leaves)
         }
+
         is GetTransaction -> {
             val hex = rpcResponse.result.jsonPrimitive.content
             GetTransactionResponse(Transaction.read(hex), request.contextOpt)
         }
+
         is ScriptHashSubscription -> {
             val status = when (rpcResponse.result) {
                 is JsonPrimitive -> rpcResponse.result.jsonPrimitive.content
@@ -280,6 +315,7 @@ internal fun parseJsonResponse(request: ElectrumRequest, rpcResponse: JsonRPCRes
             }
             ScriptHashSubscriptionResponse(request.scriptHash, status)
         }
+
         is BroadcastTransaction -> {
             val message = rpcResponse.result.jsonPrimitive.content
             // if we got here, it means that the server's response does not contain an error and message should be our
@@ -293,15 +329,18 @@ internal fun parseJsonResponse(request: ElectrumRequest, rpcResponse: JsonRPCRes
                     if (result.result == request.tx.txid) BroadcastTransactionResponse(request.tx)
                     else BroadcastTransactionResponse(request.tx, JsonRPCError(1, "response txid $result does not match request txid ${request.tx.txid}"))
                 }
+
                 is Try.Failure -> {
                     BroadcastTransactionResponse(request.tx, JsonRPCError(1, message))
                 }
             }
         }
+
         is GetHeader -> {
             val hex = rpcResponse.result.jsonPrimitive.content
             GetHeaderResponse(request.blockHeight, BlockHeader.read(hex))
         }
+
         is GetHeaders -> {
             val jsonObject = rpcResponse.result.jsonObject
             val max = jsonObject.getValue("max").jsonPrimitive.int
@@ -323,6 +362,7 @@ internal fun parseJsonResponse(request: ElectrumRequest, rpcResponse: JsonRPCRes
 
             GetHeadersResponse(request.start_height, blockHeaders, max)
         }
+
         is GetMerkle -> {
             val jsonObject = rpcResponse.result.jsonObject
             val leaves = jsonObject.getValue("merkle").jsonArray.map { ByteVector32.fromValidHex(it.jsonPrimitive.content) }
@@ -330,12 +370,14 @@ internal fun parseJsonResponse(request: ElectrumRequest, rpcResponse: JsonRPCRes
             val pos = jsonObject.getValue("pos").jsonPrimitive.int
             GetMerkleResponse(request.txid, leaves, blockHeight, pos, request.contextOpt)
         }
+
         is EstimateFees -> {
             val btcperkb: Double? = if (rpcResponse.result.jsonPrimitive.intOrNull == -1) null else rpcResponse.result.jsonPrimitive.double
             val feeratePerKb = btcperkb?.let { FeeratePerKB(Satoshi((it * 100_000_000).toLong())) }
             val feeratePerKw = feeratePerKb?.let { FeeratePerKw(it) }
             EstimateFeeResponse(request.confirmations, feeratePerKw)
         }
+
         HeaderSubscription -> {
             val jsonObject = rpcResponse.result.jsonObject
             val height = jsonObject.getValue("height").jsonPrimitive.int

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -158,13 +158,9 @@ class ElectrumMiniWallet(
 
                             is GetTransactionResponse -> {
                                 // electrum broadcast responses to all clients, is this for us?
-                                if (_walletStateFlow.value.utxos.map { it.txid }.contains(msg.tx.txid)) {
-                                    val walletState = _walletStateFlow.value.copy(parentTxs = _walletStateFlow.value.parentTxs + (msg.tx.txid to msg.tx))
-                                    logger.mdcinfo { "received parent transaction with txid=${msg.tx.txid}" }
-                                    _walletStateFlow.value = walletState
-                                } else {
-                                    logger.mdcinfo { "ignoring unrelated transaction with txid=${msg.tx.txid}" }
-                                }
+                                val walletState = _walletStateFlow.value.copy(parentTxs = _walletStateFlow.value.parentTxs + (msg.tx.txid to msg.tx))
+                                logger.mdcinfo { "received parent transaction with txid=${msg.tx.txid}" }
+                                _walletStateFlow.value = walletState
 
                             }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -156,7 +156,6 @@ class ElectrumMiniWallet(
                             }
 
                             is GetTransactionResponse -> {
-                                // electrum broadcast responses to all clients, is this for us?
                                 val walletState = _walletStateFlow.value.copy(parentTxs = _walletStateFlow.value.parentTxs + (msg.tx.txid to msg.tx))
                                 logger.mdcinfo { "received parent transaction with txid=${msg.tx.txid}" }
                                 _walletStateFlow.value = walletState

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -132,7 +132,7 @@ class ElectrumMiniWallet(
                                 scriptHashes[msg.scriptHash]?.let { bitcoinAddress ->
                                     if (msg.status.isNotEmpty()) {
                                         logger.mdcinfo { "non-empty status for address=$bitcoinAddress, requesting utxos" }
-                                        client.sendElectrumRequest(ScriptHashListUnspent(msg.scriptHash))
+                                        client.sendElectrumMessage(ScriptHashListUnspent(msg.scriptHash))
                                     }
                                 }
                             }
@@ -140,7 +140,7 @@ class ElectrumMiniWallet(
                                 scriptHashes[msg.scriptHash]?.let { address ->
                                     val newUtxos = msg.unspents.minus((_walletStateFlow.value.addresses[address] ?: emptyList()).toSet())
                                     // request new parent txs
-                                    newUtxos.forEach { utxo -> client.sendElectrumRequest(GetTransaction(utxo.txid)) }
+                                    newUtxos.forEach { utxo -> client.sendElectrumMessage(GetTransaction(utxo.txid)) }
                                     val walletState = _walletStateFlow.value.copy(addresses = _walletStateFlow.value.addresses + (address to msg.unspents))
                                     logger.mdcinfo { "${msg.unspents.size} utxo(s) for address=$address balance=${walletState.balance}" }
                                     msg.unspents.forEach { logger.debug { "utxo=${it.outPoint.txid}:${it.outPoint.index} amount=${it.value} sat" } }
@@ -175,7 +175,7 @@ class ElectrumMiniWallet(
         val pubkeyScript = ByteVector(Script.write(Bitcoin.addressToPublicKeyScript(chainHash, bitcoinAddress)))
         val scriptHash = ElectrumClient.computeScriptHash(pubkeyScript)
         logger.info { "subscribing to address=$bitcoinAddress pubkeyScript=$pubkeyScript scriptHash=$scriptHash" }
-        client.sendElectrumRequest(ScriptHashSubscription(scriptHash))
+        client.sendElectrumMessage(ScriptHashSubscription(scriptHash))
         return scriptHash to bitcoinAddress
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
@@ -9,6 +9,7 @@ import fr.acinq.lightning.blockchain.electrum.ElectrumClient.Companion.computeSc
 import fr.acinq.lightning.blockchain.electrum.ElectrumWatcher.Companion.registerToScriptHash
 import fr.acinq.lightning.transactions.Scripts
 import fr.acinq.lightning.utils.Connection
+import fr.acinq.lightning.utils.UUID
 import fr.acinq.lightning.utils.currentTimestampMillis
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
@@ -435,6 +436,8 @@ class ElectrumWatcher(
 
     private val eventChannel = Channel<WatcherEvent>(Channel.BUFFERED)
 
+    val electrumClientCallerId = UUID.randomUUID()
+
     private val input = produce(capacity = Channel.BUFFERED) {
         launch {
             eventChannel.consumeEach { send(it) }
@@ -445,9 +448,12 @@ class ElectrumWatcher(
             }
         }
         launch {
-            client.notifications.collect {
-                eventChannel.send(ReceivedMessage(it))
-            }
+            client.notifications
+                .filter { it.ids.isEmpty() || it.ids.contains(electrumClientCallerId) }
+                .map { it.msg }
+                .collect {
+                    eventChannel.send(ReceivedMessage(it))
+                }
         }
     }
 
@@ -478,27 +484,24 @@ class ElectrumWatcher(
             actions.forEach { action ->
                 yield()
                 when (action) {
-                    is AskForHeaderUpdate -> client.askCurrentHeader()
+                    is AskForHeaderUpdate -> client.askCurrentHeader(electrumClientCallerId)
                     is RegisterToScriptHashNotification -> client.sendElectrumRequest(
+                        electrumClientCallerId,
                         ScriptHashSubscription(action.scriptHash)
                     )
+
                     is PublishAsapAction -> eventChannel.send(PublishAsapEvent(action.tx))
-                    is BroadcastTxAction -> client.sendElectrumRequest(BroadcastTransaction(action.tx))
-                    is AskForScriptHashHistory -> client.sendElectrumRequest(
-                        GetScriptHashHistory(action.scriptHash)
-                    )
-                    is AskForTransaction -> client.sendElectrumRequest(
-                        GetTransaction(action.txid, action.contextOpt)
-                    )
-                    is AskForMerkle -> client.sendElectrumRequest(
-                        GetMerkle(action.txId, action.txheight, action.tx)
-                    )
+                    is BroadcastTxAction -> client.sendElectrumRequest(electrumClientCallerId, BroadcastTransaction(action.tx))
+                    is AskForScriptHashHistory -> client.sendElectrumRequest(electrumClientCallerId, GetScriptHashHistory(action.scriptHash))
+                    is AskForTransaction -> client.sendElectrumRequest(electrumClientCallerId, GetTransaction(action.txid, action.contextOpt))
+                    is AskForMerkle -> client.sendElectrumRequest(electrumClientCallerId, GetMerkle(action.txId, action.txheight, action.tx))
                     is NotifyWatch -> {
                         if (action.broadcastNotification)
                             _notificationsFlow.emit(NotifyWatchEvent(action.watchEvent))
                         else
                             eventChannel.send(ReceiveWatchEvent(action.watchEvent))
                     }
+
                     is NotifyTxWithMeta -> {
                         _notificationsFlow.emit(NotifyTxEvent(action.channelId, action.txWithMeta))
                     }
@@ -609,6 +612,7 @@ class ElectrumWatcher(
                 logger.info { "added watch-spent on output=$txid:$outputIndex scriptHash=$scriptHash" }
                 RegisterToScriptHashNotification(scriptHash)
             }
+
             is WatchConfirmed -> {
                 val (_, txid, publicKeyScript, _, _) = watch
                 val scriptHash = computeScriptHash(publicKeyScript)

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
@@ -78,6 +78,7 @@ private data class WatcherDisconnected(
                 if (event.connection == Connection.ESTABLISHED) returnState(AskForHeaderUpdate)
                 else returnState()
             }
+
             is ReceivedMessage -> when (val message = event.message) {
                 is HeaderSubscriptionResponse -> {
                     newState {
@@ -95,15 +96,19 @@ private data class WatcherDisconnected(
                         )
                     }
                 }
+
                 else -> returnState()
             }
+
             is ReceiveWatch -> newState(copy(watches = watches + event.watch))
             is PublishAsapEvent -> {
                 newState(copy(publishQueue = publishQueue + PublishAsap(event.tx)))
             }
+
             is GetTxWithMetaEvent -> {
                 newState(copy(getTxQueue = getTxQueue + (event.request)))
             }
+
             else -> unhandled(event)
         }
 }
@@ -144,6 +149,7 @@ internal data class WatcherRunning(
                             actions = scriptHashesActions + broadcastTxActions
                         }
                     }
+
                     message is ScriptHashSubscriptionResponse -> {
                         if (scriptHashSubscriptions.contains(message.scriptHash)) {
                             val (scriptHash, status) = message
@@ -168,6 +174,7 @@ internal data class WatcherRunning(
                             returnState()
                         }
                     }
+
                     message is GetScriptHashHistoryResponse -> {
                         // we retrieve the transaction before checking watches
                         // NB: height=-1 means that the tx is unconfirmed and at least one of its inputs is also unconfirmed.
@@ -177,6 +184,7 @@ internal data class WatcherRunning(
                         }
                         returnState(actions = getTransactionList)
                     }
+
                     message is GetTransactionResponse -> {
                         when (message.contextOpt) {
                             is TransactionHistoryItem -> {
@@ -219,13 +227,16 @@ internal data class WatcherRunning(
                                     actions = notifyWatchSpentList + notifyWatchConfirmedList + getMerkleList
                                 }
                             }
+
                             is GetTxWithMeta -> {
                                 val getTxWithMeta = GetTxWithMetaResponse(message.tx.txid, message.tx, tip.time)
                                 returnState(action = NotifyTxWithMeta(message.contextOpt.channelId, getTxWithMeta))
                             }
+
                             else -> returnState()
                         }
                     }
+
                     message is BroadcastTransactionResponse -> {
                         val (tx, errorOpt) = message
                         when {
@@ -235,10 +246,12 @@ internal data class WatcherRunning(
                         }
                         newState(copy(sent = sent - tx))
                     }
+
                     message is ServerError && message.request is GetTransaction && message.request.contextOpt is GetTxWithMeta -> {
                         val getTxWithMeta = GetTxWithMetaResponse(message.request.txid, null, tip.time)
                         returnState(action = NotifyTxWithMeta(message.request.contextOpt.channelId, getTxWithMeta))
                     }
+
                     message is GetMerkleResponse -> {
                         val (txid, _, txheight, pos, tx) = message
                         val confirmations = height - txheight + 1
@@ -261,9 +274,11 @@ internal data class WatcherRunning(
                             actions = notifyWatchConfirmedList
                         }
                     }
+
                     else -> returnState()
                 }
             }
+
             is GetTxWithMetaEvent -> returnState(AskForTransaction(event.request.txid, event.request))
             is PublishAsapEvent -> {
                 val tx = event.tx
@@ -286,12 +301,14 @@ internal data class WatcherRunning(
                             logger = logger
                         )
                     }
+
                     cltvTimeout > blockCount -> {
                         logger.info { "delaying publication of txid=${tx.txid} until block=$cltvTimeout (curblock=$blockCount)" }
                         val updatedBlock2tx = block2tx.toMutableMap()
                         updatedBlock2tx[cltvTimeout] = block2tx.getOrElse(cltvTimeout) { emptyList() } + tx
                         newState(copy(block2tx = updatedBlock2tx))
                     }
+
                     else -> {
                         logger.info { "publishing tx=[${tx.txid} / $tx]" }
                         newState {
@@ -301,6 +318,7 @@ internal data class WatcherRunning(
                     }
                 }
             }
+
             is ReceiveWatch -> setupWatch(event.watch, logger)
             is ReceiveWatchEvent -> when (val watchEvent = event.watchEvent) {
                 is WatchEventConfirmed -> {
@@ -328,8 +346,10 @@ internal data class WatcherRunning(
                         }
                     }
                 }
+
                 else -> unhandled(event)
             }
+
             is ClientStateUpdate -> {
                 if (event.connection is Connection.CLOSED) newState(
                     WatcherDisconnected(
@@ -458,19 +478,19 @@ class ElectrumWatcher(
             actions.forEach { action ->
                 yield()
                 when (action) {
-                    is AskForHeaderUpdate -> client.sendElectrumMessage(AskForHeaderSubscriptionUpdate)
-                    is RegisterToScriptHashNotification -> client.sendElectrumMessage(
+                    is AskForHeaderUpdate -> client.askCurrentHeader()
+                    is RegisterToScriptHashNotification -> client.sendElectrumRequest(
                         ScriptHashSubscription(action.scriptHash)
                     )
                     is PublishAsapAction -> eventChannel.send(PublishAsapEvent(action.tx))
-                    is BroadcastTxAction -> client.sendElectrumMessage(BroadcastTransaction(action.tx))
-                    is AskForScriptHashHistory -> client.sendElectrumMessage(
+                    is BroadcastTxAction -> client.sendElectrumRequest(BroadcastTransaction(action.tx))
+                    is AskForScriptHashHistory -> client.sendElectrumRequest(
                         GetScriptHashHistory(action.scriptHash)
                     )
-                    is AskForTransaction -> client.sendElectrumMessage(
+                    is AskForTransaction -> client.sendElectrumRequest(
                         GetTransaction(action.txid, action.contextOpt)
                     )
-                    is AskForMerkle -> client.sendElectrumMessage(
+                    is AskForMerkle -> client.sendElectrumRequest(
                         GetMerkle(action.txId, action.txheight, action.tx)
                     )
                     is NotifyWatch -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
@@ -458,19 +458,19 @@ class ElectrumWatcher(
             actions.forEach { action ->
                 yield()
                 when (action) {
-                    is AskForHeaderUpdate -> client.sendMessage(AskForHeaderSubscriptionUpdate)
-                    is RegisterToScriptHashNotification -> client.sendElectrumRequest(
+                    is AskForHeaderUpdate -> client.sendElectrumMessage(AskForHeaderSubscriptionUpdate)
+                    is RegisterToScriptHashNotification -> client.sendElectrumMessage(
                         ScriptHashSubscription(action.scriptHash)
                     )
                     is PublishAsapAction -> eventChannel.send(PublishAsapEvent(action.tx))
-                    is BroadcastTxAction -> client.sendElectrumRequest(BroadcastTransaction(action.tx))
-                    is AskForScriptHashHistory -> client.sendElectrumRequest(
+                    is BroadcastTxAction -> client.sendElectrumMessage(BroadcastTransaction(action.tx))
+                    is AskForScriptHashHistory -> client.sendElectrumMessage(
                         GetScriptHashHistory(action.scriptHash)
                     )
-                    is AskForTransaction -> client.sendElectrumRequest(
+                    is AskForTransaction -> client.sendElectrumMessage(
                         GetTransaction(action.txid, action.contextOpt)
                     )
-                    is AskForMerkle -> client.sendElectrumRequest(
+                    is AskForMerkle -> client.sendElectrumMessage(
                         GetMerkle(action.txId, action.txheight, action.tx)
                     )
                     is NotifyWatch -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -197,7 +197,7 @@ class Peer(
         }
         launch {
             watcher.client.connectionState.filter { it == Connection.ESTABLISHED }.collect {
-                watcher.client.sendElectrumMessage(AskForHeaderSubscriptionUpdate)
+                watcher.client.askCurrentHeader()
                 // onchain fees are retrieved punctually, when electrum status moves to Connection.ESTABLISHED
                 // since the application is not running most of the time, and when it is, it will be only for a few minutes, this is good enough.
                 // (for a node that is online most of the time things would be different and we would need to re-evaluate onchain fee estimates on a regular basis)
@@ -277,9 +277,9 @@ class Peer(
             .produceIn(this) // creates a ad-hoc receive channel to collect values
             .consumeAsFlow() // once
         watcher.client.connectionState.filter { it == Connection.ESTABLISHED }.first()
-        watcher.client.sendElectrumMessage(EstimateFees(2))
-        watcher.client.sendElectrumMessage(EstimateFees(6))
-        watcher.client.sendElectrumMessage(EstimateFees(10))
+        watcher.client.sendElectrumRequest(EstimateFees(2))
+        watcher.client.sendElectrumRequest(EstimateFees(6))
+        watcher.client.sendElectrumRequest(EstimateFees(10))
         val sortedFees = flow.toList().sortedBy { it.confirmations }
         logger.info { "on-chain fees: $sortedFees" }
         // TODO: If some feerates are null, we may implement a retry

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -197,7 +197,7 @@ class Peer(
         }
         launch {
             watcher.client.connectionState.filter { it == Connection.ESTABLISHED }.collect {
-                watcher.client.sendMessage(AskForHeaderSubscriptionUpdate)
+                watcher.client.sendElectrumMessage(AskForHeaderSubscriptionUpdate)
                 // onchain fees are retrieved punctually, when electrum status moves to Connection.ESTABLISHED
                 // since the application is not running most of the time, and when it is, it will be only for a few minutes, this is good enough.
                 // (for a node that is online most of the time things would be different and we would need to re-evaluate onchain fee estimates on a regular basis)
@@ -277,9 +277,9 @@ class Peer(
             .produceIn(this) // creates a ad-hoc receive channel to collect values
             .consumeAsFlow() // once
         watcher.client.connectionState.filter { it == Connection.ESTABLISHED }.first()
-        watcher.client.sendElectrumRequest(EstimateFees(2))
-        watcher.client.sendElectrumRequest(EstimateFees(6))
-        watcher.client.sendElectrumRequest(EstimateFees(10))
+        watcher.client.sendElectrumMessage(EstimateFees(2))
+        watcher.client.sendElectrumMessage(EstimateFees(6))
+        watcher.client.sendElectrumMessage(EstimateFees(10))
         val sortedFees = flow.toList().sortedBy { it.confirmations }
         logger.info { "on-chain fees: $sortedFees" }
         // TODO: If some feerates are null, we may implement a retry

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -181,11 +181,11 @@ class Peer(
     val currentTipFlow = MutableStateFlow<Pair<Int, BlockHeader>?>(null)
     val onChainFeeratesFlow = MutableStateFlow<OnChainFeerates?>(null)
 
-    val finalWallet = ElectrumMiniWallet(nodeParams.chainHash, watcher.client, scope, nodeParams.loggerFactory)
+    val finalWallet = ElectrumMiniWallet(nodeParams.chainHash, watcher.client, scope, nodeParams.loggerFactory, name = "final")
     val finalAddress: String = nodeParams.keyManager.bip84Address(account = 0L, addressIndex = 0L).also { finalWallet.addAddress(it) }
 
-    val swapInWallet = ElectrumMiniWallet(nodeParams.chainHash, watcher.client, scope, nodeParams.loggerFactory)
-    val swapInAddress: String = nodeParams.keyManager.bip84Address(account = 1L, addressIndex = 0L).also { finalWallet.addAddress(it) }
+    val swapInWallet = ElectrumMiniWallet(nodeParams.chainHash, watcher.client, scope, nodeParams.loggerFactory, name = "swap-in")
+    val swapInAddress: String = nodeParams.keyManager.bip84Address(account = 1L, addressIndex = 0L).also { swapInWallet.addAddress(it) }
 
     init {
         launch {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -187,8 +187,6 @@ class Peer(
     val swapInWallet = ElectrumMiniWallet(nodeParams.chainHash, watcher.client, scope, nodeParams.loggerFactory, name = "swap-in")
     val swapInAddress: String = nodeParams.keyManager.bip84Address(account = 1L, addressIndex = 0L).also { swapInWallet.addAddress(it) }
 
-    val electrumClientCallerId = UUID.randomUUID()
-
     init {
         launch {
             watcher.client.notifications.filterIsInstance<HeaderSubscriptionResponse>()
@@ -199,7 +197,7 @@ class Peer(
         }
         launch {
             watcher.client.connectionState.filter { it == Connection.ESTABLISHED }.collect {
-                watcher.client.askCurrentHeader(UUID.randomUUID())
+                watcher.client.askCurrentHeader()
                 // onchain fees are retrieved punctually, when electrum status moves to Connection.ESTABLISHED
                 // since the application is not running most of the time, and when it is, it will be only for a few minutes, this is good enough.
                 // (for a node that is online most of the time things would be different and we would need to re-evaluate onchain fee estimates on a regular basis)
@@ -279,9 +277,9 @@ class Peer(
             .produceIn(this) // creates a ad-hoc receive channel to collect values
             .consumeAsFlow() // once
         watcher.client.connectionState.filter { it == Connection.ESTABLISHED }.first()
-        watcher.client.sendElectrumRequest(electrumClientCallerId, EstimateFees(2))
-        watcher.client.sendElectrumRequest(electrumClientCallerId, EstimateFees(6))
-        watcher.client.sendElectrumRequest(electrumClientCallerId, EstimateFees(10))
+        watcher.client.sendElectrumRequest(EstimateFees(2))
+        watcher.client.sendElectrumRequest(EstimateFees(6))
+        watcher.client.sendElectrumRequest(EstimateFees(10))
         val sortedFees = flow.toList().sortedBy { it.confirmations }
         logger.info { "on-chain fees: $sortedFees" }
         // TODO: If some feerates are null, we may implement a retry

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -187,6 +187,8 @@ class Peer(
     val swapInWallet = ElectrumMiniWallet(nodeParams.chainHash, watcher.client, scope, nodeParams.loggerFactory, name = "swap-in")
     val swapInAddress: String = nodeParams.keyManager.bip84Address(account = 1L, addressIndex = 0L).also { swapInWallet.addAddress(it) }
 
+    val electrumClientCallerId = UUID.randomUUID()
+
     init {
         launch {
             watcher.client.notifications.filterIsInstance<HeaderSubscriptionResponse>()
@@ -197,7 +199,7 @@ class Peer(
         }
         launch {
             watcher.client.connectionState.filter { it == Connection.ESTABLISHED }.collect {
-                watcher.client.askCurrentHeader()
+                watcher.client.askCurrentHeader(UUID.randomUUID())
                 // onchain fees are retrieved punctually, when electrum status moves to Connection.ESTABLISHED
                 // since the application is not running most of the time, and when it is, it will be only for a few minutes, this is good enough.
                 // (for a node that is online most of the time things would be different and we would need to re-evaluate onchain fee estimates on a regular basis)
@@ -277,9 +279,9 @@ class Peer(
             .produceIn(this) // creates a ad-hoc receive channel to collect values
             .consumeAsFlow() // once
         watcher.client.connectionState.filter { it == Connection.ESTABLISHED }.first()
-        watcher.client.sendElectrumRequest(EstimateFees(2))
-        watcher.client.sendElectrumRequest(EstimateFees(6))
-        watcher.client.sendElectrumRequest(EstimateFees(10))
+        watcher.client.sendElectrumRequest(electrumClientCallerId, EstimateFees(2))
+        watcher.client.sendElectrumRequest(electrumClientCallerId, EstimateFees(6))
+        watcher.client.sendElectrumRequest(electrumClientCallerId, EstimateFees(10))
         val sortedFees = flow.toList().sortedBy { it.confirmations }
         logger.info { "on-chain fees: $sortedFees" }
         // TODO: If some feerates are null, we may implement a retry

--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/jsonrpc.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/jsonrpc.kt
@@ -3,7 +3,6 @@ package fr.acinq.lightning.utils
 import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.Transaction
 import fr.acinq.secp256k1.Hex
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -33,6 +32,7 @@ fun List<Any>.asJsonRPCParameters(): List<JsonRPCParam> = map {
             it -> 1
             else -> 0
         }.asParam()
+
         is ByteVector -> it.toHex().asParam()
         is Transaction -> Hex.encode(Transaction.write(it)).asParam()
         else -> error("Unsupported type ${it::class} as JSON-RPC parameter")

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientStateTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientStateTest.kt
@@ -43,7 +43,7 @@ class ElectrumClientStateTest : LightningTestSuite() {
             }
 
             if (state !is ClientRunning)
-                state.process(ElectrumClientCommand.AskForHeader(42), logger).let { (nextState, actions) ->
+                state.process(ElectrumClientCommand.AskForHeader(UUID.randomUUID()), logger).let { (nextState, actions) ->
                     assertEquals(state, nextState)
                     assertTrue(actions.isEmpty())
                 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientStateTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientStateTest.kt
@@ -43,7 +43,7 @@ class ElectrumClientStateTest : LightningTestSuite() {
             }
 
             if (state !is ClientRunning)
-                state.process(ElectrumClientCommand.AskForHeader(UUID.randomUUID()), logger).let { (nextState, actions) ->
+                state.process(ElectrumClientCommand.AskForHeader(42), logger).let { (nextState, actions) ->
                     assertEquals(state, nextState)
                     assertTrue(actions.isEmpty())
                 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientStateTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientStateTest.kt
@@ -2,6 +2,7 @@ package fr.acinq.lightning.blockchain.electrum
 
 import fr.acinq.bitcoin.BlockHeader
 import fr.acinq.lightning.tests.utils.LightningTestSuite
+import fr.acinq.lightning.utils.UUID
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 import kotlin.test.Test
@@ -42,7 +43,7 @@ class ElectrumClientStateTest : LightningTestSuite() {
             }
 
             if (state !is ClientRunning)
-                state.process(ElectrumClientCommand.AskForHeader, logger).let { (nextState, actions) ->
+                state.process(ElectrumClientCommand.AskForHeader(UUID.randomUUID()), logger).let { (nextState, actions) ->
                     assertEquals(state, nextState)
                     assertTrue(actions.isEmpty())
                 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
@@ -63,7 +63,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumRequest(EstimateFees(3))
+        client.sendElectrumMessage(EstimateFees(3))
 
         notifications.consumerCheck<EstimateFeeResponse> { message ->
             assertTrue { message.feerate!! >= FeeratePerKw.MinimumFeeratePerKw }
@@ -77,7 +77,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendMessage(SendElectrumRequest(GetTransactionIdFromPosition(height, position)))
+        client.sendElectrumMessage(GetTransactionIdFromPosition(height, position))
 
         notifications.consumerCheck<GetTransactionIdFromPositionResponse> { message ->
             assertEquals(GetTransactionIdFromPositionResponse(referenceTx.txid, height, position), message)
@@ -91,7 +91,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendMessage(SendElectrumRequest(GetTransactionIdFromPosition(height, position, true)))
+        client.sendElectrumMessage(GetTransactionIdFromPosition(height, position, true))
 
         notifications.consumerCheck<GetTransactionIdFromPositionResponse> { message ->
             assertEquals(GetTransactionIdFromPositionResponse(referenceTx.txid, height, position, merkleProof), message)
@@ -105,7 +105,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendMessage(SendElectrumRequest(GetTransaction(referenceTx.txid)))
+        client.sendElectrumMessage(GetTransaction(referenceTx.txid))
 
         notifications.consumerCheck<GetTransactionResponse> { message ->
             assertEquals(referenceTx, message.tx)
@@ -119,7 +119,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendMessage(SendElectrumRequest(GetHeader(100000)))
+        client.sendElectrumMessage(GetHeader(100000))
 
         notifications.consumerCheck<GetHeaderResponse> { message ->
             assertEquals(
@@ -137,7 +137,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val notifications = client.notifications.produceIn(this)
 
         val start = (500000 / 2016) * 2016
-        client.sendElectrumRequest(GetHeaders(start, 2016))
+        client.sendElectrumMessage(GetHeaders(start, 2016))
 
         notifications.consumerCheck<GetHeadersResponse> { message ->
             assertEquals(start, message.start_height)
@@ -152,7 +152,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumRequest(GetMerkle(referenceTx.txid, 500000))
+        client.sendElectrumMessage(GetMerkle(referenceTx.txid, 500000))
 
         notifications.consumerCheck<GetMerkleResponse> { message ->
             assertEquals(referenceTx.txid, message.txid)
@@ -172,7 +172,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendMessage(AskForHeaderSubscriptionUpdate)
+        client.sendElectrumMessage(AskForHeaderSubscriptionUpdate)
 
         notifications.consumerCheck<HeaderSubscriptionResponse>()
 
@@ -184,7 +184,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumRequest(ScriptHashSubscription(scriptHash))
+        client.sendElectrumMessage(ScriptHashSubscription(scriptHash))
 
         notifications.consumerCheck<ScriptHashSubscriptionResponse> { message ->
             assertNotEquals("", message.status)
@@ -198,7 +198,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumRequest(GetScriptHashHistory(scriptHash))
+        client.sendElectrumMessage(GetScriptHashHistory(scriptHash))
 
         notifications.consumerCheck<GetScriptHashHistoryResponse> { message ->
             assertTrue { message.history.contains(TransactionHistoryItem(500000, referenceTx.txid)) }
@@ -212,7 +212,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumRequest(ScriptHashListUnspent(scriptHash))
+        client.sendElectrumMessage(ScriptHashListUnspent(scriptHash))
 
         notifications.consumerCheck<ScriptHashListUnspentResponse> { message ->
             assertTrue { message.unspents.isEmpty() }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
@@ -63,7 +63,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumMessage(EstimateFees(3))
+        client.sendElectrumRequest(EstimateFees(3))
 
         notifications.consumerCheck<EstimateFeeResponse> { message ->
             assertTrue { message.feerate!! >= FeeratePerKw.MinimumFeeratePerKw }
@@ -77,7 +77,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumMessage(GetTransactionIdFromPosition(height, position))
+        client.sendElectrumRequest(GetTransactionIdFromPosition(height, position))
 
         notifications.consumerCheck<GetTransactionIdFromPositionResponse> { message ->
             assertEquals(GetTransactionIdFromPositionResponse(referenceTx.txid, height, position), message)
@@ -91,7 +91,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumMessage(GetTransactionIdFromPosition(height, position, true))
+        client.sendElectrumRequest(GetTransactionIdFromPosition(height, position, true))
 
         notifications.consumerCheck<GetTransactionIdFromPositionResponse> { message ->
             assertEquals(GetTransactionIdFromPositionResponse(referenceTx.txid, height, position, merkleProof), message)
@@ -105,7 +105,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumMessage(GetTransaction(referenceTx.txid))
+        client.sendElectrumRequest(GetTransaction(referenceTx.txid))
 
         notifications.consumerCheck<GetTransactionResponse> { message ->
             assertEquals(referenceTx, message.tx)
@@ -119,7 +119,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumMessage(GetHeader(100000))
+        client.sendElectrumRequest(GetHeader(100000))
 
         notifications.consumerCheck<GetHeaderResponse> { message ->
             assertEquals(
@@ -137,7 +137,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val notifications = client.notifications.produceIn(this)
 
         val start = (500000 / 2016) * 2016
-        client.sendElectrumMessage(GetHeaders(start, 2016))
+        client.sendElectrumRequest(GetHeaders(start, 2016))
 
         notifications.consumerCheck<GetHeadersResponse> { message ->
             assertEquals(start, message.start_height)
@@ -152,7 +152,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumMessage(GetMerkle(referenceTx.txid, 500000))
+        client.sendElectrumRequest(GetMerkle(referenceTx.txid, 500000))
 
         notifications.consumerCheck<GetMerkleResponse> { message ->
             assertEquals(referenceTx.txid, message.txid)
@@ -172,7 +172,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumMessage(AskForHeaderSubscriptionUpdate)
+        client.askCurrentHeader()
 
         notifications.consumerCheck<HeaderSubscriptionResponse>()
 
@@ -184,7 +184,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumMessage(ScriptHashSubscription(scriptHash))
+        client.sendElectrumRequest(ScriptHashSubscription(scriptHash))
 
         notifications.consumerCheck<ScriptHashSubscriptionResponse> { message ->
             assertNotEquals("", message.status)
@@ -198,7 +198,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumMessage(GetScriptHashHistory(scriptHash))
+        client.sendElectrumRequest(GetScriptHashHistory(scriptHash))
 
         notifications.consumerCheck<GetScriptHashHistoryResponse> { message ->
             assertTrue { message.history.contains(TransactionHistoryItem(500000, referenceTx.txid)) }
@@ -212,7 +212,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val client = connectToMainnetServer()
         val notifications = client.notifications.produceIn(this)
 
-        client.sendElectrumMessage(ScriptHashListUnspent(scriptHash))
+        client.sendElectrumRequest(ScriptHashListUnspent(scriptHash))
 
         notifications.consumerCheck<ScriptHashListUnspentResponse> { message ->
             assertTrue { message.unspents.isEmpty() }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
@@ -140,5 +140,8 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
         assertEquals(7200_0000.sat, walletState1.spendableBalance)
         assertEquals(3000_0000.sat, walletState2.spendableBalance)
 
+        assertEquals(4, walletState1.parentTxs.size)
+        assertEquals(6, walletState2.parentTxs.size)
+
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumUtils.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumUtils.kt
@@ -1,0 +1,24 @@
+package fr.acinq.lightning.blockchain.electrum
+
+import fr.acinq.lightning.io.TcpSocket
+import fr.acinq.lightning.utils.Connection
+import fr.acinq.lightning.utils.ServerAddress
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import org.kodein.log.LoggerFactory
+
+suspend fun connectToElectrumServer(scope: CoroutineScope, addr: ServerAddress): ElectrumClient {
+    val client = ElectrumClient(TcpSocket.Builder(), scope, LoggerFactory.default).apply { connect(addr) }
+
+    client.connectionState.first { it is Connection.CLOSED }
+    client.connectionState.first { it is Connection.ESTABLISHING }
+    client.connectionState.first { it is Connection.ESTABLISHED }
+
+    return client
+}
+
+suspend fun CoroutineScope.connectToTestnetServer(): ElectrumClient =
+    connectToElectrumServer(this, ServerAddress("testnet1.electrum.acinq.co", 51002, TcpSocket.TLS.UNSAFE_CERTIFICATES))
+
+suspend fun CoroutineScope.connectToMainnetServer(): ElectrumClient =
+    connectToElectrumServer(this, ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES))

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
@@ -166,7 +166,7 @@ public fun buildPeer(
     databases: InMemoryDatabases = InMemoryDatabases()
 ): Peer {
     val electrum = ElectrumClient(TcpSocket.Builder(), scope, LoggerFactory.default)
-    val watcher = ElectrumWatcher(electrum, scope, LoggerFactory.default)
+    val watcher = ElectrumWatcher(electrum.Caller(), scope, LoggerFactory.default)
     val peer = Peer(nodeParams, walletParams, watcher, databases, TcpSocket.Builder(), scope)
     peer.currentTipFlow.value = 0 to Block.RegtestGenesisBlock.header
     peer.onChainFeeratesFlow.value = OnChainFeerates(

--- a/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
+++ b/src/jvmTest/kotlin/fr/acinq/lightning/Node.kt
@@ -219,7 +219,7 @@ object Node {
 
         runBlocking {
             val electrum = ElectrumClient(TcpSocket.Builder(), this, nodeParams.loggerFactory).apply { connect(electrumServerAddress) }
-            val watcher = ElectrumWatcher(electrum, this, nodeParams.loggerFactory)
+            val watcher = ElectrumWatcher(electrum.Caller(), this, nodeParams.loggerFactory)
             val peer = Peer(nodeParams, walletParams, watcher, db, TcpSocket.Builder(), this)
 
             launch { connectLoop(peer) }


### PR DESCRIPTION
This is the minimum change to make `ElectrumClient` support multiple independent "callers" (watcher, wallets).

Requests made by independent callers are identified with a unique id and multiplexed on the same connection. Each caller then listens to the `notifications` flow and only keeps responses for his identifiers. For convenience, this is encapsulated in an inner class `ElectrumClient.Caller` which presents the same interface as before multiplexing.

Note that subscribtion responses are currently _not_ multiplexed. They don't have an associated id and are sent to all callers.

