### PR TITLE
Fix peer state when disconnecting

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -297,6 +297,7 @@ class Peer(
 
     fun disconnect() {
         if (this::socket.isInitialized) socket.close()
+        _connectionState.value = Connection.CLOSED(null)
         output.close()
     }
 


### PR DESCRIPTION
This PR fixes an issue in the peer connection state. Disconnecting Peer while connecting would not update the state of the connection, which would get stuck in the Connecting state. As such the reconnection logic in Phoenix would not attempt to reconnect to Peer.

You'll notice this is the exact same bugfix we performed in #362 for the ElectrumClient :sweat_smile:

