### PR TITLE
Randomize final expiry

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
@@ -336,8 +336,8 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
             )
         }
 
-        val finalExpiryDelta = request.paymentRequest.minFinalExpiryDelta ?: Channel.MIN_CLTV_EXPIRY_DELTA
-        val finalExpiry = finalExpiryDelta.toCltvExpiry(currentBlockHeight.toLong())
+        val minFinalExpiryDelta = request.paymentRequest.minFinalExpiryDelta ?: Channel.MIN_CLTV_EXPIRY_DELTA
+        val finalExpiry = nodeParams.paymentRecipientExpiryParams.computeFinalExpiry(currentBlockHeight, minFinalExpiryDelta)
         val finalPayload = PaymentOnion.FinalPayload.createSinglePartPayload(request.amount, finalExpiry, request.paymentRequest.paymentSecret, request.paymentRequest.paymentMetadata)
 
         val invoiceFeatures = Features(request.paymentRequest.features)

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
@@ -98,6 +98,7 @@ object TestConstants {
             minFundingSatoshis = 1_000.sat,
             maxFundingSatoshis = 25_000_000.sat,
             maxPaymentAttempts = 5,
+            paymentRecipientExpiryParams = RecipientCltvExpiryParams(CltvExpiryDelta(0), CltvExpiryDelta(0)),
             zeroConfPeers = setOf(),
             enableTrampolinePayment = true
         )
@@ -175,6 +176,7 @@ object TestConstants {
             minFundingSatoshis = 1_000.sat,
             maxFundingSatoshis = 25_000_000.sat,
             maxPaymentAttempts = 5,
+            paymentRecipientExpiryParams = RecipientCltvExpiryParams(CltvExpiryDelta(0), CltvExpiryDelta(0)),
             zeroConfPeers = setOf(),
             enableTrampolinePayment = true
         )


### PR DESCRIPTION
When sending outgoing payments, using an expiry that is very close to the current block height makes it obvious to the next-to-last node who the recipient is.

We add a random expiry to the amount we use to make it plausible that the route contains more hops.

Core Lightning and LDK already do this, LND doesn't.