### PR TITLE
WalletState.balance: clarify confirmed vs unconfirmed balance

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -158,7 +158,7 @@ class ElectrumMiniWallet(
                                     // request new parent txs
                                     newUtxos.forEach { utxo -> client.sendElectrumRequest(GetTransaction(utxo.txid)) }
                                     val walletState = _walletStateFlow.value.copy(addresses = _walletStateFlow.value.addresses + (address to msg.unspents))
-                                    logger.mdcinfo { "${msg.unspents.size} utxo(s) for address=$address balance=${walletState.balance(true)}" }
+                                    logger.mdcinfo { "${msg.unspents.size} utxo(s) for address=$address balance=${walletState.totalBalance}" }
                                     msg.unspents.forEach { logger.debug { "utxo=${it.outPoint.txid}:${it.outPoint.index} amount=${it.value} sat" } }
                                     // publish the updated balance
                                     _walletStateFlow.value = walletState

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -215,10 +215,10 @@ class Peer(
         }
         launch {
             finalWallet.walletStateFlow
-                .distinctUntilChangedBy {
-                    Pair(it.balance(includingUnconfirmed = true), it.unconfirmedBalance())
-                }.collect { wallet ->
-                    logger.info { "${wallet.balance(includingUnconfirmed = true)} available on final wallet (${wallet.unconfirmedBalance()} unconfirmed)" }
+                .distinctUntilChangedBy { Pair(it.unconfirmedBalance, it.confirmedBalance) }
+                .collect { wallet ->
+                    logger.info { "${wallet.totalBalance} available on final wallet (${wallet.unconfirmedBalance} unconfirmed)" }
+                }
                 }
         }
         launch {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -215,25 +215,27 @@ class Peer(
         }
         launch {
             finalWallet.walletStateFlow
-                .distinctUntilChangedBy { it.balance }
-                .collect { wallet ->
-                    logger.info { "${wallet.balance} available on final wallet" }
+                .distinctUntilChangedBy {
+                    Pair(it.balance(includingUnconfirmed = true), it.unconfirmedBalance())
+                }.collect { wallet ->
+                    logger.info { "${wallet.balance(includingUnconfirmed = true)} available on final wallet (${wallet.unconfirmedBalance()} unconfirmed)" }
                 }
         }
         launch {
             swapInWallet.walletStateFlow
                 .filter { it.consistent }
                 .fold(false) { swapAlreadyAttempted, wallet ->
-                    if (wallet.balance > 10_000.sat) {
+                    val balance = wallet.balance(includingUnconfirmed = false)
+                    if (balance > 10_000.sat) {
                         if (swapAlreadyAttempted) {
-                            logger.info { "${wallet.balance} available on swap-in wallet but swap-in already attempted: not doing anything" }
+                            logger.info { "$balance available on swap-in wallet but swap-in already attempted: not doing anything" }
                         } else {
-                            logger.info { "${wallet.balance} available on swap-in wallet: requesting channel" }
+                            logger.info { "$balance available on swap-in wallet: requesting channel" }
                             input.send(RequestChannelOpen(Lightning.randomBytes32(), wallet, maxFeeBasisPoints = 100, maxFeeFloor = 3_000.sat)) // 100 bips = 1 %
                         }
                         true
                     } else {
-                        logger.info { "${wallet.balance} available on swap-in wallet but amount insufficient: waiting for more" }
+                        logger.info { "$balance available on swap-in wallet but amount insufficient: waiting for more" }
                         swapAlreadyAttempted
                     }
                 }
@@ -677,7 +679,7 @@ class Peer(
                                 is RequestChannelOpen -> {
                                     // We have to pay the fees for our inputs, so we deduce them from our funding amount.
                                     val fundingFee = Transactions.weight2fee(msg.fundingFeerate, request.wallet.utxos.size * Transactions.p2wpkhInputWeight)
-                                    val fundingAmount = request.wallet.balance - fundingFee
+                                    val fundingAmount = request.wallet.balance(includingUnconfirmed = false) - fundingFee
                                     nodeParams._nodeEvents.emit(SwapInEvents.Accepted(request.requestId, fundingFee, origin.fee))
                                     Triple(request.wallet, fundingAmount, origin.fee)
                                 }
@@ -837,7 +839,7 @@ class Peer(
             cmd is RequestChannelOpen -> {
                 // We currently only support p2wpkh inputs.
                 val utxos = cmd.wallet.utxos
-                val balance = cmd.wallet.balance
+                val balance = cmd.wallet.balance(includingUnconfirmed = false)
                 val grandParents = utxos.map { utxo -> utxo.previousTx.txIn.map { txIn -> txIn.outPoint } }.flatten()
                 val pleaseOpenChannel = PleaseOpenChannel(
                     nodeParams.chainHash,

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
@@ -28,7 +28,7 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
             .first()
 
         assertEquals(0, walletState.utxos.size)
-        assertEquals(0.sat, walletState.balance(true))
+        assertEquals(0.sat, walletState.totalBalance)
 
         client.stop()
     }
@@ -44,7 +44,7 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
             .first()
 
         assertEquals(6, walletState.utxos.size)
-        assertEquals(30_000_000.sat, walletState.balance(true))
+        assertEquals(30_000_000.sat, walletState.totalBalance)
 
         client.stop()
     }
@@ -63,7 +63,7 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
 
         // this has been checked on the blockchain
         assertEquals(4 + 6 + 1, walletState.utxos.size)
-        assertEquals(72_000_000.sat + 30_000_000.sat + 2_000_000.sat, walletState.balance(true))
+        assertEquals(72_000_000.sat + 30_000_000.sat + 2_000_000.sat, walletState.totalBalance)
         assertEquals(11, walletState.utxos.size)
         // make sure txid is correct has electrum api is confusing
         walletState.parentTxs.forEach { assertEquals(it.key, it.value.txid) }
@@ -111,8 +111,8 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
         val walletState1 = wallet1.walletStateFlow.filter { it.parentTxs.size == 4 }.first()
         val walletState2 = wallet2.walletStateFlow.filter { it.parentTxs.size == 6 }.first()
 
-        assertEquals(7200_0000.sat, walletState1.balance(true))
-        assertEquals(3000_0000.sat, walletState2.balance(true))
+        assertEquals(7200_0000.sat, walletState1.totalBalance)
+        assertEquals(3000_0000.sat, walletState2.totalBalance)
 
         assertEquals(4, walletState1.parentTxs.size)
         assertEquals(6, walletState2.parentTxs.size)

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
@@ -28,7 +28,7 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
             .first()
 
         assertEquals(0, walletState.utxos.size)
-        assertEquals(0.sat, walletState.balance)
+        assertEquals(0.sat, walletState.balance(true))
 
         client.stop()
     }
@@ -44,7 +44,7 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
             .first()
 
         assertEquals(6, walletState.utxos.size)
-        assertEquals(30_000_000.sat, walletState.balance)
+        assertEquals(30_000_000.sat, walletState.balance(true))
 
         client.stop()
     }
@@ -63,7 +63,7 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
 
         // this has been checked on the blockchain
         assertEquals(4 + 6 + 1, walletState.utxos.size)
-        assertEquals(72_000_000.sat + 30_000_000.sat + 2_000_000.sat, walletState.balance)
+        assertEquals(72_000_000.sat + 30_000_000.sat + 2_000_000.sat, walletState.balance(true))
         assertEquals(11, walletState.utxos.size)
         // make sure txid is correct has electrum api is confusing
         walletState.parentTxs.forEach { assertEquals(it.key, it.value.txid) }
@@ -111,8 +111,8 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
         val walletState1 = wallet1.walletStateFlow.filter { it.parentTxs.size == 4 }.first()
         val walletState2 = wallet2.walletStateFlow.filter { it.parentTxs.size == 6 }.first()
 
-        assertEquals(7200_0000.sat, walletState1.balance)
-        assertEquals(3000_0000.sat, walletState2.balance)
+        assertEquals(7200_0000.sat, walletState1.balance(true))
+        assertEquals(3000_0000.sat, walletState2.balance(true))
 
         assertEquals(4, walletState1.parentTxs.size)
         assertEquals(6, walletState2.parentTxs.size)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -308,7 +308,7 @@ object TestsHelper {
         val privKey = keyManager.bip84PrivateKey(account = 1, addressIndex = 0)
         val address = Bitcoin.computeP2WpkhAddress(privKey.publicKey(), Block.RegtestGenesisBlock.hash)
         val parentTx = Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 3), 0)), listOf(TxOut(amount, Script.pay2wpkh(privKey.publicKey()))), 0)
-        return privKey to WalletState(mapOf(address to listOf(UnspentItem(parentTx.txid, 0, amount.toLong(), 0))), mapOf(parentTx.txid to parentTx))
+        return privKey to WalletState(mapOf(address to listOf(UnspentItem(parentTx.txid, 0, amount.toLong(), 654321))), mapOf(parentTx.txid to parentTx))
     }
 
     fun addHtlc(amount: MilliSatoshi, payer: ChannelState, payee: ChannelState): Triple<Pair<ChannelState, ChannelState>, ByteVector32, UpdateAddHtlc> {


### PR DESCRIPTION
Previously, WalletState had a `var balance: Satoshi` property. However this didn't distinguish between confirmed vs unconfirmed UTXOs.

This was troublesome for the dual-funding flow, which is started like this:

```kotlin
if (wallet.balance > 10_000.sat) {
  // Start swap-in if not already started
}
```

Because initiating the Dual-Funding flow with unconfirmed inputs would ultimately fail, with the server sending a `TxAbort` containing the message:

> "the completed interactive tx contains unconfirmed inputs"

This PR modifies the WalletState, allowing for improved inspection of the balance:

```kotlin
fun balance(includingUnconfirmed: Boolean): Satoshi {
  return if (includingUnconfirmed) {
    utxos.map { it.amount }.sum()
  } else {
    utxos.filter { it.blockHeight > 0L }.map { it.amount }.sum()
  }
}

fun unconfirmedBalance(): Satoshi {
  return utxos.filter { it.blockHeight == 0L }.map { it.amount }.sum()
}
```

And the Peer is then updated accordingly:

```kotlin

val balance = wallet.balance(includingUnconfirmed = false)
if (balance > 10_000.sat) {
  // Start swap-in if not already started
}
```