### PR TITLE
Peer only allowed 1 swap-in per app launch

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -31,7 +31,7 @@ data class WalletState(val addresses: Map<String, List<UnspentItem>>, val parent
     val unconfirmedBalance = unconfirmedUtxos.map { it.amount }.sum()
     val totalBalance = confirmedBalance + unconfirmedBalance
 
-    fun drop(reserved: Set<Utxo>): WalletState {
+    fun minus(reserved: Set<Utxo>): WalletState {
         val reservedIds = reserved.map {
             UnspentItemId(it.previousTx.txid, it.outputIndex)
         }.toSet()

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForAcceptChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForAcceptChannel.kt
@@ -59,7 +59,7 @@ data class WaitForAcceptChannel(
                         val fundingPubkeyScript = ByteVector(Script.write(Script.pay2wsh(Scripts.multiSig2of2(localFundingPubkey, remoteParams.fundingPubKey))))
                         val dustLimit = accept.dustLimit.max(init.localParams.dustLimit)
                         val fundingParams = InteractiveTxParams(channelId, true, init.fundingAmount, accept.fundingAmount, fundingPubkeyScript, lastSent.lockTime, dustLimit, lastSent.fundingFeerate)
-                        when (val fundingContributions = FundingContributions.create(fundingParams, init.wallet.utxos)) {
+                        when (val fundingContributions = FundingContributions.create(fundingParams, init.wallet.confirmedUtxos)) {
                             is Either.Left -> {
                                 logger.error { "c:$channelId could not fund channel: ${fundingContributions.value}" }
                                 Pair(Aborted(staticParams, currentTip, currentOnChainFeerates), listOf(ChannelAction.Message.Send(Error(channelId, ChannelFundingError(channelId).message))))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingConfirmed.kt
@@ -115,7 +115,7 @@ data class WaitForFundingConfirmed(
                         fundingParams.dustLimit,
                         rbfStatus.command.targetFeerate
                     )
-                    when (val contributions = FundingContributions.create(fundingParams, rbfStatus.command.wallet.utxos)) {
+                    when (val contributions = FundingContributions.create(fundingParams, rbfStatus.command.wallet.confirmedUtxos)) {
                         is Either.Left -> {
                             logger.warning { "c:$channelId error creating funding contributions: ${contributions.value}" }
                             Pair(this.copy(rbfStatus = RbfStatus.None), listOf(ChannelAction.Message.Send(TxAbort(channelId, ChannelFundingError(channelId).message))))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForOpenChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForOpenChannel.kt
@@ -85,7 +85,7 @@ data class WaitForOpenChannel(
                                 val fundingPubkeyScript = ByteVector(Script.write(Script.pay2wsh(Scripts.multiSig2of2(localFundingPubkey, remoteParams.fundingPubKey))))
                                 val dustLimit = open.dustLimit.max(localParams.dustLimit)
                                 val fundingParams = InteractiveTxParams(channelId, false, fundingAmount, open.fundingAmount, fundingPubkeyScript, open.lockTime, dustLimit, open.fundingFeerate)
-                                when (val fundingContributions = FundingContributions.create(fundingParams, wallet.utxos)) {
+                                when (val fundingContributions = FundingContributions.create(fundingParams, wallet.confirmedUtxos)) {
                                     is Either.Left -> {
                                         logger.error { "c:$temporaryChannelId could not fund channel: ${fundingContributions.value}" }
                                         Pair(Aborted(staticParams, currentTip, currentOnChainFeerates), listOf(ChannelAction.Message.Send(Error(temporaryChannelId, ChannelFundingError(temporaryChannelId).message))))

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -223,19 +223,17 @@ class Peer(
         launch {
             swapInWallet.walletStateFlow
                 .filter { it.consistent }
-                .fold(false) { swapAlreadyAttempted, wallet ->
-                    val balance = wallet.confirmedBalance
+                .fold(setOf<WalletState.Utxo>()) { reservedUtxos, wallet ->
+                    // reservedUtxos are part of a previously issued RequestChannelOpen command
+                    val availableWallet = wallet.drop(reservedUtxos)
+                    val balance = availableWallet.confirmedBalance
                     if (balance > 10_000.sat) {
-                        if (swapAlreadyAttempted) {
-                            logger.info { "$balance available on swap-in wallet but swap-in already attempted: not doing anything" }
-                        } else {
-                            logger.info { "$balance available on swap-in wallet: requesting channel" }
-                            input.send(RequestChannelOpen(Lightning.randomBytes32(), wallet, maxFeeBasisPoints = 100, maxFeeFloor = 3_000.sat)) // 100 bips = 1 %
-                        }
-                        true
+                        logger.info { "$balance available on swap-in wallet: requesting channel" }
+                        input.send(RequestChannelOpen(Lightning.randomBytes32(), availableWallet, maxFeeBasisPoints = 100, maxFeeFloor = 3_000.sat)) // 100 bips = 1 %
+                        reservedUtxos + availableWallet.confirmedUtxos
                     } else {
                         logger.info { "$balance available on swap-in wallet but amount insufficient: waiting for more" }
-                        swapAlreadyAttempted
+                        reservedUtxos.intersect(wallet.utxos) // drop items from reservedUtxos that are no longer in wallet
                     }
                 }
         }
@@ -837,7 +835,7 @@ class Peer(
 
             cmd is RequestChannelOpen -> {
                 // We currently only support p2wpkh inputs.
-                val utxos = cmd.wallet.utxos
+                val utxos = cmd.wallet.confirmedUtxos
                 val balance = cmd.wallet.confirmedBalance
                 val grandParents = utxos.map { utxo -> utxo.previousTx.txIn.map { txIn -> txIn.outPoint } }.flatten()
                 val pleaseOpenChannel = PleaseOpenChannel(

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -230,11 +230,11 @@ class Peer(
                     if (balance > 10_000.sat) {
                         logger.info { "$balance available on swap-in wallet: requesting channel" }
                         input.send(RequestChannelOpen(Lightning.randomBytes32(), availableWallet, maxFeeBasisPoints = 100, maxFeeFloor = 3_000.sat)) // 100 bips = 1 %
-                        reservedUtxos + availableWallet.confirmedUtxos
+                        reservedUtxos.union(availableWallet.confirmedUtxos)
                     } else {
                         logger.info { "$balance available on swap-in wallet but amount insufficient: waiting for more" }
-                        reservedUtxos.intersect(wallet.utxos) // drop items from reservedUtxos that are no longer in wallet
-                    }
+                        reservedUtxos
+                    }.intersect(wallet.utxos) // drop utxos no longer in wallet
                 }
         }
         launch {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -227,12 +227,12 @@ class Peer(
                     // reservedUtxos are part of a previously issued RequestChannelOpen command
                     val availableWallet = wallet.minus(reservedUtxos)
                     val balance = availableWallet.confirmedBalance
+                    logger.info { "swap-in wallet balance: $balance, ${availableWallet.unconfirmedBalance} unconfirmed" }
                     if (balance > 10_000.sat) {
-                        logger.info { "$balance available on swap-in wallet: requesting channel" }
+                        logger.info { "swap-in wallet: requesting channel using confirmed balance: $balance" }
                         input.send(RequestChannelOpen(Lightning.randomBytes32(), availableWallet, maxFeeBasisPoints = 100, maxFeeFloor = 3_000.sat)) // 100 bips = 1 %
                         reservedUtxos.union(availableWallet.confirmedUtxos)
                     } else {
-                        logger.info { "insufficient balance on swap-in wallet ($balance, ${availableWallet.unconfirmedBalance} unconfirmed): waiting for more" }
                         reservedUtxos
                     }.intersect(wallet.utxos) // drop utxos no longer in wallet
                 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -223,7 +223,7 @@ class Peer(
         launch {
             swapInWallet.walletStateFlow
                 .filter { it.consistent }
-                .fold(setOf<WalletState.Utxo>()) { reservedUtxos, wallet ->
+                .fold(emptySet<WalletState.Utxo>()) { reservedUtxos, wallet ->
                     // reservedUtxos are part of a previously issued RequestChannelOpen command
                     val availableWallet = wallet.drop(reservedUtxos)
                     val balance = availableWallet.confirmedBalance

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -225,7 +225,7 @@ class Peer(
                 .filter { it.consistent }
                 .fold(emptySet<WalletState.Utxo>()) { reservedUtxos, wallet ->
                     // reservedUtxos are part of a previously issued RequestChannelOpen command
-                    val availableWallet = wallet.drop(reservedUtxos)
+                    val availableWallet = wallet.minus(reservedUtxos)
                     val balance = availableWallet.confirmedBalance
                     if (balance > 10_000.sat) {
                         logger.info { "$balance available on swap-in wallet: requesting channel" }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -232,7 +232,7 @@ class Peer(
                         input.send(RequestChannelOpen(Lightning.randomBytes32(), availableWallet, maxFeeBasisPoints = 100, maxFeeFloor = 3_000.sat)) // 100 bips = 1 %
                         reservedUtxos.union(availableWallet.confirmedUtxos)
                     } else {
-                        logger.info { "$balance available on swap-in wallet but amount insufficient: waiting for more" }
+                        logger.info { "insufficient balance on swap-in wallet ($balance, ${availableWallet.unconfirmedBalance} unconfirmed): waiting for more" }
                         reservedUtxos
                     }.intersect(wallet.utxos) // drop utxos no longer in wallet
                 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
@@ -463,7 +463,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
                 val parentTx = Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 1), 0)), listOf(TxOut(30_000.sat, Script.pay2wpkh(priv.publicKey()))), 0)
                 val address = Bitcoin.computeP2WpkhAddress(priv.publicKey(), Block.RegtestGenesisBlock.hash)
                 val wallet = WalletState(
-                    walletAlice.addresses + (address to (walletAlice.addresses[address] ?: listOf()) + UnspentItem(parentTx.txid, 0, 30_000, 0)),
+                    walletAlice.addresses + (address to (walletAlice.addresses[address] ?: listOf()) + UnspentItem(parentTx.txid, 0, 30_000, 654321)),
                     walletAlice.parentTxs + (parentTx.txid to parentTx),
                 )
                 CMD_BUMP_FUNDING_FEE(fundingTx.feerate * 1.1, alice0.fundingParams.localAmount + 20_000.sat, wallet, fundingTx.tx.lockTime + 1)


### PR DESCRIPTION
This PR fixes 2 separate (but related) bugs.

### Bug 1:

Previously, the Peer was structured like this:

```kotlin
launch {
  swapInWallet.walletStateFlow
    .filter { it.consistent }
    .fold(false) { swapAlreadyAttempted, wallet ->
        if (wallet.confirmedBalance > 10_000.sat) {
          if (swapAlreadyAttempted) {
            // swap-in already attempted: not doing anything
          } else {
            // send command RequestChannelOpen ...
          }
          true // ^fold
        } else {
          // balance insufficient: waiting for more
          swapAlreadyAttempted // ^fold
        }
    }
}
```

The end result is that the Dual-Funding flow is only initiated once per app launch. Because once the `swapAlreadyAttempted` flag is set, it is never un-set.

### Bug 2:

In PR #396, we fixed a bug related to the confirmed vs unconfirmed balance. We noted that:

> initiating the Dual-Funding flow with unconfirmed inputs would ultimately fail, with the server sending a `TxAbort` message

And although we no longer start the Dual-Funding flow until the `confirmedBalance` is sufficient, we still use the FULL set of `utxos`, regardless of whether or not these are confirmed or unconfirmed.

For example, in `WaitForAcceptChannel`:

```kotlin
val fundingContributions = FundingContributions.create(fundingParams, init.wallet.utxos) // <- ALL utxos
```

If the user is attempting to move funds into Phoenix, there may be a mixture of confirmed vs unconfirmed utxos. And although we wait until `confirmedBalance` is sufficient, this doesn't guarantee there aren't any unconfirmed utxos in the set.

### Proposed solution

First we expose the `confirmedUtxos` in `ElectrumMiniWallet`:

```kotlin
val confirmedUtxos: List<Utxo> = utxos.filter { it.blockHeight > 0L }
val unconfirmedUtxos: List<Utxo> = utxos.filter { it.blockHeight == 0L }
```

And use only `confirmedUtxos` when appropriate:

```kotlin
val fundingContributions = FundingContributions.create(fundingParams, init.wallet.confirmedUtxos)
```

Next we fix the Peer with the following logic:

- when we start a swap-in, what we want to do is **reserve** a set of utxos for the dual-funding flow
- we keep track of this reserved `Set<Utxo>`, and exclude them from consideration when calculating the balance

So it looks like this:

```kotlin
launch {
  swapInWallet.walletStateFlow
    .filter { it.consistent }
    .fold(setOf<WalletState.Utxo>()) { reservedUtxos, wallet ->
      // reservedUtxos are part of a previously issued RequestChannelOpen command
      val availableWallet = wallet.drop(reservedUtxos)
      val balance = availableWallet.confirmedBalance
      if (balance > 10_000.sat) {
        logger.info { "$balance available on swap-in wallet: requesting channel" }
        input.send(RequestChannelOpen(uuid, availableWallet, other, params))
        reservedUtxos + availableWallet.confirmedUtxos // ^fold
      } else {
        logger.info { "$balance available on swap-in wallet but amount insufficient: waiting for more" }
        reservedUtxos.intersect(wallet.utxos) // drop items from reservedUtxos that are no longer in wallet
      }
    }
}
```

So by calling `wallet.drop(reservedUtxos)` we're creating a WalletState subset. Which we then pass to `RequestChannelOpen` ensuring that it will only use what we've newly reserved for it.

And the `reservedUtxos` doesn't grow forever, as we drop items as they get removed from the wallet. I.e. when we spend those Utxos.
