### PR TITLE
Update visibility of `privateKey` methods to public

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
@@ -10,7 +10,7 @@ import fr.acinq.lightning.transactions.Transactions
 
 data class LocalKeyManager(val seed: ByteVector, val chainHash: ByteVector32) : KeyManager {
 
-    val master = DeterministicWallet.generate(seed)
+    private val master = DeterministicWallet.generate(seed)
     override val legacyNodeKey: DeterministicWallet.ExtendedPrivateKey = derivePrivateKey(master, eclairNodeKeyBasePath(chainHash))
     override val nodeKey: DeterministicWallet.ExtendedPrivateKey = derivePrivateKey(master, nodeKeyBasePath(chainHash))
     override val nodeId: PublicKey get() = nodeKey.publicKey
@@ -23,9 +23,9 @@ data class LocalKeyManager(val seed: ByteVector, val chainHash: ByteVector32) : 
 
     private fun internalKeyPath(channelKeyPath: KeyPath, index: Long): List<Long> = internalKeyPath(channelKeyPath.path, index)
 
-    private fun privateKey(keyPath: KeyPath): DeterministicWallet.ExtendedPrivateKey = derivePrivateKey(master, keyPath)
+    fun privateKey(keyPath: KeyPath): DeterministicWallet.ExtendedPrivateKey = derivePrivateKey(master, keyPath)
 
-    private fun privateKey(keyPath: List<Long>): DeterministicWallet.ExtendedPrivateKey = derivePrivateKey(master, keyPath)
+    fun privateKey(keyPath: List<Long>): DeterministicWallet.ExtendedPrivateKey = derivePrivateKey(master, keyPath)
 
     private fun publicKey(keyPath: KeyPath): DeterministicWallet.ExtendedPublicKey = DeterministicWallet.publicKey(privateKey(keyPath))
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
@@ -10,7 +10,7 @@ import fr.acinq.lightning.transactions.Transactions
 
 data class LocalKeyManager(val seed: ByteVector, val chainHash: ByteVector32) : KeyManager {
 
-    private val master = DeterministicWallet.generate(seed)
+    val master = DeterministicWallet.generate(seed)
     override val legacyNodeKey: DeterministicWallet.ExtendedPrivateKey = derivePrivateKey(master, eclairNodeKeyBasePath(chainHash))
     override val nodeKey: DeterministicWallet.ExtendedPrivateKey = derivePrivateKey(master, nodeKeyBasePath(chainHash))
     override val nodeId: PublicKey get() = nodeKey.publicKey


### PR DESCRIPTION
In Phoenix we need to create several custom keys (like the lnurl-auth key or the iCloud encryption key). Those keys are derived from the wallet `master` key. So we have to access `master` key from Phoenix.

To do so we make the `privateKey` methods public in the `LocalKeyManager` class. Those methods derive `master` given a a key path.

Note : the key manager is instantiated by the library client (in our case, Phoenix). Any client will have access to the key manager.

Note 2 : we could implement the logic for all custom keys in lightning-kmp, but I don't think this is a good solution as this would pollute the library with things unrelated to lightning.