### PR TITLE
Put back deserialization of  `FundingCreated`/`FundingSigned`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/Serialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/Serialization.kt
@@ -3,7 +3,6 @@ package fr.acinq.lightning.serialization
 import fr.acinq.lightning.channel.PersistedChannelState
 import fr.acinq.lightning.serialization.v4.Deserialization.fromBinV4
 import fr.acinq.lightning.serialization.v4.Serialization.toBinV4
-import fr.acinq.lightning.utils.runTrying
 
 object Serialization {
 
@@ -12,13 +11,14 @@ object Serialization {
     }
 
     fun deserialize(bin: ByteArray): PersistedChannelState {
-        return runTrying {
-            bin.fromBinV4()
-        }.recoverWith {
-            runTrying { fr.acinq.lightning.serialization.v3.Serialization.deserialize(bin) }
-        }.recoverWith {
-            runTrying { fr.acinq.lightning.serialization.v2.Serialization.deserialize(bin) }
-        }.get()
+        return when {
+            // v4 uses a 1-byte version discriminator
+            bin[0].toInt() == 4 -> bin.fromBinV4()
+            // v2/v3 use a 4-bytes version discriminator
+            bin.sliceArray(0..3).contentEquals(byteArrayOf(0, 0, 0, 3)) -> fr.acinq.lightning.serialization.v3.Serialization.deserialize(bin)
+            bin.sliceArray(0..3).contentEquals(byteArrayOf(0, 0, 0, 2)) -> fr.acinq.lightning.serialization.v2.Serialization.deserialize(bin)
+            else -> error("unknown serialization version")
+        }
     }
 
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/Serialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/Serialization.kt
@@ -1,5 +1,6 @@
 package fr.acinq.lightning.serialization
 
+import fr.acinq.bitcoin.crypto.Pack
 import fr.acinq.lightning.channel.PersistedChannelState
 import fr.acinq.lightning.serialization.v4.Deserialization.fromBinV4
 import fr.acinq.lightning.serialization.v4.Serialization.toBinV4
@@ -15,8 +16,8 @@ object Serialization {
             // v4 uses a 1-byte version discriminator
             bin[0].toInt() == 4 -> bin.fromBinV4()
             // v2/v3 use a 4-bytes version discriminator
-            bin.sliceArray(0..3).contentEquals(byteArrayOf(0, 0, 0, 3)) -> fr.acinq.lightning.serialization.v3.Serialization.deserialize(bin)
-            bin.sliceArray(0..3).contentEquals(byteArrayOf(0, 0, 0, 2)) -> fr.acinq.lightning.serialization.v2.Serialization.deserialize(bin)
+            Pack.int32BE(bin) == 3 -> fr.acinq.lightning.serialization.v3.Serialization.deserialize(bin)
+            Pack.int32BE(bin) == 2  -> fr.acinq.lightning.serialization.v2.Serialization.deserialize(bin)
             else -> error("unknown serialization version")
         }
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/Serialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/Serialization.kt
@@ -2,22 +2,20 @@ package fr.acinq.lightning.serialization
 
 import fr.acinq.bitcoin.crypto.Pack
 import fr.acinq.lightning.channel.PersistedChannelState
-import fr.acinq.lightning.serialization.v4.Deserialization.fromBinV4
-import fr.acinq.lightning.serialization.v4.Serialization.toBinV4
 
 object Serialization {
 
     fun serialize(state: PersistedChannelState): ByteArray {
-        return state.toBinV4()
+        return fr.acinq.lightning.serialization.v4.Serialization.serialize(state)
     }
 
     fun deserialize(bin: ByteArray): PersistedChannelState {
         return when {
             // v4 uses a 1-byte version discriminator
-            bin[0].toInt() == 4 -> bin.fromBinV4()
+            bin[0].toInt() == 4 -> fr.acinq.lightning.serialization.v4.Deserialization.deserialize(bin)
             // v2/v3 use a 4-bytes version discriminator
             Pack.int32BE(bin) == 3 -> fr.acinq.lightning.serialization.v3.Serialization.deserialize(bin)
-            Pack.int32BE(bin) == 2  -> fr.acinq.lightning.serialization.v2.Serialization.deserialize(bin)
+            Pack.int32BE(bin) == 2 -> fr.acinq.lightning.serialization.v2.Serialization.deserialize(bin)
             else -> error("unknown serialization version")
         }
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
@@ -299,7 +299,8 @@ object Deserialization {
             }.toMap(),
             lastIndex = readNullable { readNumber() }
         ),
-        channelId = readByteVector32()
+        channelId = readByteVector32(),
+        remoteChannelData = EncryptedChannelData(readDelimitedByteArray().toByteVector())
     )
 
     private fun Input.readCommitmentSpec(): CommitmentSpec = CommitmentSpec(

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
@@ -16,8 +16,8 @@ import fr.acinq.lightning.wire.*
 
 object Deserialization {
 
-    fun ByteArray.fromBinV4(): PersistedChannelState {
-        val input = ByteArrayInput(this)
+    fun deserialize(bin: ByteArray): PersistedChannelState {
+        val input = ByteArrayInput(bin)
         val version = input.read()
         require(version == Serialization.versionMagic) { "incorrect version $version, expected ${Serialization.versionMagic}" }
         return input.readPersistedChannelState()

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
@@ -37,10 +37,10 @@ object Serialization {
 
     const val versionMagic = 4
 
-    fun PersistedChannelState.toBinV4(): ByteArray {
+    fun serialize(o: PersistedChannelState): ByteArray {
         val out = ByteArrayOutput()
         out.write(versionMagic)
-        out.writePersistedChannelState(this)
+        out.writePersistedChannelState(o)
         return out.toByteArray()
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
@@ -350,7 +350,8 @@ object Serialization {
             }
             writeNullable(lastIndex) { writeNumber(it) }
         }
-        write(channelId.toByteArray())
+        writeByteVector32(channelId)
+        writeDelimited(remoteChannelData.data.toByteArray())
     }
 
     private fun Output.write(o: CommitmentSpec): Unit = o.run {

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -50,6 +50,8 @@ interface LightningMessage {
                 Pong.type -> Pong.read(stream)
                 OpenDualFundedChannel.type -> OpenDualFundedChannel.read(stream)
                 AcceptDualFundedChannel.type -> AcceptDualFundedChannel.read(stream)
+                FundingCreated.type -> FundingCreated.read(stream)
+                FundingSigned.type -> FundingSigned.read(stream)
                 ChannelReady.type -> ChannelReady.read(stream)
                 TxAddInput.type -> TxAddInput.read(stream)
                 TxAddOutput.type -> TxAddOutput.read(stream)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -106,20 +106,6 @@ data class LNChannel<out S : ChannelState>(
     // we check that serialization works by checking that deserialize(serialize(state)) == state
     private fun checkSerialization(state: PersistedChannelState) {
 
-        // We never persist remote channel data.
-        fun removeChannelData(state: PersistedChannelState): PersistedChannelState = when (state) {
-            is LegacyWaitForFundingConfirmed -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-            is LegacyWaitForFundingLocked -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-            is WaitForFundingConfirmed -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-            is WaitForChannelReady -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-            is Normal -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-            is ShuttingDown -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-            is Negotiating -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-            is Closing -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-            is WaitForRemotePublishFutureCommitment -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-            is Closed -> state.copy(state = state.state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty)))
-        }
-
         // We never persist a funding RBF attempt.
         fun removeRbfAttempt(state: PersistedChannelState): PersistedChannelState = when (state) {
             is WaitForFundingConfirmed -> state.copy(rbfStatus = WaitForFundingConfirmed.Companion.RbfStatus.None)
@@ -129,7 +115,7 @@ data class LNChannel<out S : ChannelState>(
         val serialized = Serialization.serialize(state)
         val deserialized = Serialization.deserialize(serialized)
 
-        assertEquals(removeChannelData(removeRbfAttempt(state)), deserialized, "serialization error")
+        assertEquals(removeRbfAttempt(state), deserialized, "serialization error")
     }
 
     private fun checkSerialization(actions: List<ChannelAction>) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationNonRegTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationNonRegTestsCommon.kt
@@ -1,6 +1,8 @@
 package fr.acinq.lightning.serialization
 
+import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.json.JsonSerializers
+import fr.acinq.lightning.wire.EncryptedChannelData
 import fr.acinq.secp256k1.Hex
 import kotlinx.serialization.encodeToString
 import org.kodein.memory.file.*
@@ -36,6 +38,20 @@ class StateSerializationNonRegTestsCommon {
                 if (debug) {
                     tmpFile.delete()
                 }
+                val state1 = when (state) {
+                    is LegacyWaitForFundingConfirmed -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
+                    is LegacyWaitForFundingLocked -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
+                    is WaitForFundingConfirmed -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
+                    is WaitForChannelReady -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
+                    is Normal -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
+                    is ShuttingDown -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
+                    is Negotiating -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
+                    is Closing -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
+                    is WaitForRemotePublishFutureCommitment -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
+                    is Closed -> state
+                }
+                val state2 = Serialization.deserialize(Serialization.serialize(state))
+                assertEquals(state1, state2, path.toString())
             }
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationNonRegTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationNonRegTestsCommon.kt
@@ -1,8 +1,6 @@
 package fr.acinq.lightning.serialization
 
-import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.json.JsonSerializers
-import fr.acinq.lightning.wire.EncryptedChannelData
 import fr.acinq.secp256k1.Hex
 import kotlinx.serialization.encodeToString
 import org.kodein.memory.file.*
@@ -38,20 +36,6 @@ class StateSerializationNonRegTestsCommon {
                 if (debug) {
                     tmpFile.delete()
                 }
-                val state1 = when (state) {
-                    is LegacyWaitForFundingConfirmed -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-                    is LegacyWaitForFundingLocked -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-                    is WaitForFundingConfirmed -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-                    is WaitForChannelReady -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-                    is Normal -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-                    is ShuttingDown -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-                    is Negotiating -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-                    is Closing -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-                    is WaitForRemotePublishFutureCommitment -> state.copy(commitments = state.commitments.copy(remoteChannelData = EncryptedChannelData.empty))
-                    is Closed -> state
-                }
-                val state2 = Serialization.deserialize(Serialization.serialize(state))
-                assertEquals(state1, state2, path.toString())
             }
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationNonRegTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationNonRegTestsCommon.kt
@@ -32,10 +32,13 @@ class StateSerializationNonRegTestsCommon {
                         close()
                     }
                 }
+                // deserialized data must match static json reference file
                 assertEquals(ref, json, path.toString())
                 if (debug) {
                     tmpFile.delete()
                 }
+                // we also make sure that serialization round-trip is identity
+                assertEquals(state, Serialization.deserialize(Serialization.serialize(state)), path.toString())
             }
     }
 


### PR DESCRIPTION
Deserializers for messages `FundingCreated` and `FundingSigned` were removed in dd6c84cb5ec84ebfec222f67270197be92af80f0 as part of implementing dual funding.

But we now use LN protocol format in v4 serialization. This means that we need to be able to read/write all LN messages that are persisted. Even if those messages have been deprecated by dual funding, we may have existing channels in the process of being created at the time when the user upgrades Phoenix. This is the purpose of
`LegacyWaitForFundingConfirmed`/`LegacyWaitForFundingLocked`. If these states are written back to disk, they will use v4 format, therefore we need to be able to serialize and deserialize all LN messages that are part of those states, which includes `FundingCreated` and `FundingSigned`.

Why wasn't this caught in tests?

Channel state tests do a serialization roundtrip at each state transition, but we never serialize
`LegacyWaitForFundingConfirmed`, it is only read and then we move to the next state. To be fair, in reality there is probably no code path where we would need to actually serialize this state, but this seems a bit risky to take chances for such a little change.

Static non-reg tests only deserializes data and compare it to reference json. This PR also adds a serialization roundtrip test, which succesfully reproduces the issue.

Why is the error in the v2 serialization whereas the bug affects v4?

Because of the try-and-fallback logic that we used for deserializing data. All deserialization failures end up with an error in the last codec in the list, which happens to be v2 (cc @robbiehanson). This logic has been changed and we now explicitly try the correct serialization based on the version discriminator.