### PR TITLE
Use MDC instead of hardcoding "key:value" in log messages.

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/CltvExpiry.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/CltvExpiry.kt
@@ -16,6 +16,7 @@ data class CltvExpiry(private val underlying: Long) : Comparable<CltvExpiry> {
     operator fun minus(other: CltvExpiry): CltvExpiryDelta = CltvExpiryDelta((underlying - other.underlying).toInt())
     override fun compareTo(other: CltvExpiry): Int = underlying.compareTo(other.underlying)
     fun toLong(): Long = underlying
+    override fun toString(): String = "CltvExpiry($underlying)"
     // @formatter:on
 }
 
@@ -42,6 +43,7 @@ data class CltvExpiryDelta(private val underlying: Int) : Comparable<CltvExpiryD
     override fun compareTo(other: CltvExpiryDelta): Int = underlying.compareTo(other.underlying)
     fun toInt(): Int = underlying
     fun toLong(): Long = underlying.toLong()
+    override fun toString(): String = "CltvExpiryDelta($underlying)"
     // @formatter:on
 
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
@@ -224,7 +224,7 @@ class ElectrumClient(
         launch {
             var previousState = _connectionState.value
             _connectionState.filter { it != previousState }.collect {
-                logger.info { "connection state changed: $it" }
+                logger.info { "connection state changed: ${it::class.simpleName}" }
                 if (it is Connection.CLOSED) mailbox.send(Disconnected)
                 previousState = it
             }
@@ -235,7 +235,7 @@ class ElectrumClient(
     private suspend fun run() {
         mailbox.consumeEach { cmd ->
 
-            logger.debug { "processing command $cmd in state ${state::class}" }
+            logger.debug { "processing command $cmd in state ${state::class.simpleName}" }
 
             val (newState, actions) = state.process(cmd, logger)
             state = newState

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -110,7 +110,7 @@ class ElectrumMiniWallet(
     fun Logger.mdcinfo(msgCreator: () -> String) {
         log(
             level = Logger.Level.INFO,
-            meta = mapOf("wallet" to name, "state" to walletStateFlow.value),
+            meta = mapOf("wallet" to name, "confirmed" to walletStateFlow.value.confirmedBalance, "unconfirmed" to walletStateFlow.value.unconfirmedBalance),
             msgCreator = msgCreator
         )
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
@@ -285,20 +285,6 @@ sealed class ChannelState {
             else -> Pair(Aborted, listOf())
         }
     }
-
-    fun mdc(): Map<String, Any> = buildMap {
-        this@ChannelState::class.simpleName?.let { put("state", it) }
-        when (val state = this@ChannelState) {
-            is WaitForOpenChannel -> put("temporaryChannelId", state.temporaryChannelId)
-            is WaitForAcceptChannel -> put("temporaryChannelId", state.temporaryChannelId)
-            is WaitForFundingCreated -> put("channelId", state.channelId)
-            is WaitForFundingSigned -> put("channelId", state.channelId)
-            is ChannelStateWithCommitments -> put("channelId", state.channelId)
-            is Offline -> put("channelId", state.state.channelId)
-            is Syncing -> put("channelId", state.state.channelId)
-            else -> {}
-        }
-    }
 }
 
 sealed class ChannelStateWithCommitments : ChannelState() {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
@@ -226,7 +226,7 @@ sealed class ChannelState {
     abstract fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>>
 
     internal fun ChannelContext.unhandled(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
-        logger.warning { "unhandled event ${cmd::class} in state ${this@ChannelState::class}" }
+        logger.warning { "unhandled command ${cmd::class.simpleName} in state ${this@ChannelState::class.simpleName}" }
         return Pair(this@ChannelState, listOf())
     }
 
@@ -248,7 +248,7 @@ sealed class ChannelState {
     }
 
     internal fun ChannelContext.handleCommandError(cmd: Command, error: ChannelException, channelUpdate: ChannelUpdate? = null): Pair<ChannelState, List<ChannelAction>> {
-        logger.warning(error) { "c:${error.channelId} processing ${cmd::class} in state ${this::class} failed" }
+        logger.warning(error) { "processing command ${cmd::class.simpleName} in state ${this@ChannelState::class.simpleName} failed" }
         return when (cmd) {
             is CMD_ADD_HTLC -> Pair(this@ChannelState, listOf(ChannelAction.ProcessCmdRes.AddFailed(cmd, error, channelUpdate)))
             else -> Pair(this@ChannelState, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmd, error)))
@@ -262,7 +262,7 @@ sealed class ChannelState {
 
     fun ChannelContext.handleRemoteError(e: Error): Pair<ChannelState, List<ChannelAction>> {
         // see BOLT 1: only print out data verbatim if is composed of printable ASCII characters
-        logger.error { "c:${e.channelId} peer sent error: ascii='${e.toAscii()}' bin=${e.data.toHex()}" }
+        logger.error { "peer sent error: ascii='${e.toAscii()}' bin=${e.data.toHex()}" }
         return when {
             this@ChannelState is Closing -> Pair(this@ChannelState, listOf()) // nothing to do, there is already a spending tx published
             this@ChannelState is Negotiating && this@ChannelState.bestUnpublishedClosingTx != null -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelData.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelData.kt
@@ -108,7 +108,7 @@ data class LocalCommitPublished(
             addAll(htlcTxs.values.mapNotNull { it?.tx })
             addAll(claimHtlcDelayedTxs.map { it.tx })
         }
-        val publishList = publishIfNeeded(publishQueue, irrevocablySpent, channelId)
+        val publishList = publishIfNeeded(publishQueue, irrevocablySpent)
 
         // we watch:
         // - the commitment tx itself, so that we can handle the case where we don't have any outputs
@@ -213,7 +213,7 @@ data class RemoteCommitPublished(
             claimMainOutputTx?.let { add(it.tx) }
             addAll(claimHtlcTxs.values.mapNotNull { it?.tx })
         }
-        val publishList = publishIfNeeded(publishQueue, irrevocablySpent, channelId)
+        val publishList = publishIfNeeded(publishQueue, irrevocablySpent)
 
         // we watch:
         // - the commitment tx itself, so that we can handle the case where we don't have any outputs
@@ -315,7 +315,7 @@ data class RevokedCommitPublished(
             addAll(htlcPenaltyTxs.map { it.tx })
             addAll(claimHtlcDelayedPenaltyTxs.map { it.tx })
         }
-        val publishList = publishIfNeeded(publishQueue, irrevocablySpent, channelId)
+        val publishList = publishIfNeeded(publishQueue, irrevocablySpent)
 
         // we watch:
         // - the commitment tx itself, so that we can handle the case where we don't have any outputs

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Closed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Closed.kt
@@ -15,7 +15,7 @@ data class Closed(val state: Closing) : PersistedChannelState() {
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@Closed::class.simpleName}" }
         return Pair(this@Closed, listOf())
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Closed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Closed.kt
@@ -15,7 +15,7 @@ data class Closed(val state: Closing) : PersistedChannelState() {
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "c:$channelId error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
         return Pair(this@Closed, listOf())
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -463,7 +463,7 @@ data class Commitments(
 
     fun remoteHasChanges(): Boolean = localChanges.acked.isNotEmpty() || remoteChanges.proposed.isNotEmpty()
 
-    fun sendCommit(keyManager: KeyManager, log: Logger): Either<ChannelException, Pair<Commitments, CommitSig>> {
+    fun sendCommit(keyManager: KeyManager, log: MDCLogger): Either<ChannelException, Pair<Commitments, CommitSig>> {
         val remoteNextPerCommitmentPoint = remoteNextCommitInfo.right ?: return Either.Left(CannotSignBeforeRevocation(channelId))
         if (!localHasChanges()) return Either.Left(CannotSignWithoutChanges(channelId))
 
@@ -480,7 +480,7 @@ data class Commitments(
         log.info {
             val htlcsIn = spec.htlcs.outgoings().map { it.id }.joinToString(",")
             val htlcsOut = spec.htlcs.incomings().map { it.id }.joinToString(",")
-            "c:$channelId built remote commit number=${remoteCommit.index + 1} toLocalMsat=${spec.toLocal.toLong()} toRemoteMsat=${spec.toRemote.toLong()} htlc_in=$htlcsIn htlc_out=$htlcsOut feeratePerKw=${spec.feerate} txid=${remoteCommitTx.tx.txid} tx=${remoteCommitTx.tx}"
+            "built remote commit number=${remoteCommit.index + 1} toLocalMsat=${spec.toLocal.toLong()} toRemoteMsat=${spec.toRemote.toLong()} htlc_in=$htlcsIn htlc_out=$htlcsOut feeratePerKw=${spec.feerate} txid=${remoteCommitTx.tx.txid} tx=${remoteCommitTx.tx}"
         }
 
         val commitSig = CommitSig(channelId, sig, htlcSigs.toList())
@@ -492,7 +492,7 @@ data class Commitments(
         return Either.Right(Pair(commitments1, commitSig))
     }
 
-    fun receiveCommit(commit: CommitSig, keyManager: KeyManager, log: Logger): Either<ChannelException, Pair<Commitments, RevokeAndAck>> {
+    fun receiveCommit(commit: CommitSig, keyManager: KeyManager, log: MDCLogger): Either<ChannelException, Pair<Commitments, RevokeAndAck>> {
         // they sent us a signature for *their* view of *our* next commit tx
         // so in terms of rev.hashes and indexes we have:
         // ourCommit.index -> our current revocation hash, which is about to become our old revocation hash
@@ -505,7 +505,7 @@ data class Commitments(
         // lnd sometimes sends a new signature without any changes, which is a (harmless) spec violation
         if (!remoteHasChanges()) {
             //  return Either.Left(CannotSignWithoutChanges(commitments.channelId))
-            log.warning { "c:$channelId received a commit sig with no changes (probably coming from lnd)" }
+            log.warning { "received a commit sig with no changes (probably coming from lnd)" }
         }
 
         // check that their signature is valid
@@ -520,14 +520,14 @@ data class Commitments(
         log.info {
             val htlcsIn = spec.htlcs.incomings().map { it.id }.joinToString(",")
             val htlcsOut = spec.htlcs.outgoings().map { it.id }.joinToString(",")
-            "c:$channelId built local commit number=${localCommit.index + 1} toLocalMsat=${spec.toLocal.toLong()} toRemoteMsat=${spec.toRemote.toLong()} htlc_in=$htlcsIn htlc_out=$htlcsOut feeratePerKw=${spec.feerate} txid=${localCommitTx.tx.txid} tx=${localCommitTx.tx}"
+            "built local commit number=${localCommit.index + 1} toLocalMsat=${spec.toLocal.toLong()} toRemoteMsat=${spec.toRemote.toLong()} htlc_in=$htlcsIn htlc_out=$htlcsOut feeratePerKw=${spec.feerate} txid=${localCommitTx.tx.txid} tx=${localCommitTx.tx}"
         }
 
         // no need to compute htlc sigs if commit sig doesn't check out
         val signedCommitTx = Transactions.addSigs(localCommitTx, localParams.channelKeys(keyManager).fundingPubKey, remoteParams.fundingPubKey, sig, commit.signature)
         when (val check = Transactions.checkSpendable(signedCommitTx)) {
             is Try.Failure -> {
-                log.error(check.error) { "c:$channelId remote signature $commit is invalid" }
+                log.error(check.error) { "remote signature $commit is invalid" }
                 return Either.Left(InvalidCommitmentSignature(channelId, signedCommitTx.tx.txid))
             }
             else -> {}

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -733,7 +733,7 @@ object Helpers {
             // this tx has been published by remote, so we need to invert local/remote params
             val txNumber = Transactions.obscuredCommitTxNumber(obscuredTxNumber, !commitments.localParams.isInitiator, commitments.remoteParams.paymentBasepoint, localPaymentPoint.publicKey)
             require(txNumber <= 0xffffffffffffL) { "txNumber must be lesser than 48 bits long" }
-            logger.warning { "c:${commitments.channelId} a revoked commit has been published with txNumber=$txNumber" }
+            logger.warning { "a revoked commit has been published with txNumber=$txNumber" }
             return txNumber
         }
 
@@ -813,7 +813,7 @@ object Helpers {
             val localHtlcPubkey = Generators.derivePubKey(commitments.localParams.channelKeys(keyManager).htlcBasepoint, remotePerCommitmentPoint)
 
             // we retrieve the information needed to rebuild htlc scripts
-            logger.info { "c:${commitments.channelId} found ${htlcInfos.size} htlcs for txid=${revokedCommitPublished.commitTx.txid}" }
+            logger.info { "found ${htlcInfos.size} htlcs for txid=${revokedCommitPublished.commitTx.txid}" }
             val htlcsRedeemScripts = htlcInfos.flatMap { htlcInfo ->
                 val htlcReceived = Scripts.htlcReceived(remoteHtlcPubkey, localHtlcPubkey, remoteRevocationPubkey, ripemd160(htlcInfo.paymentHash), htlcInfo.cltvExpiry)
                 val htlcOffered = Scripts.htlcOffered(remoteHtlcPubkey, localHtlcPubkey, remoteRevocationPubkey, ripemd160(htlcInfo.paymentHash))
@@ -869,7 +869,7 @@ object Helpers {
             }
             val isHtlcTx = htlcTx.txIn.any { it.outPoint.txid == revokedCommitPublished.commitTx.txid } && !claimTxs.any { it.tx.txid == htlcTx.txid }
             if (isHtlcTx) {
-                logger.info { "c:${commitments.channelId} looks like txid=${htlcTx.txid} could be a 2nd level htlc tx spending revoked commit txid=${revokedCommitPublished.commitTx.txid}" }
+                logger.info { "looks like txid=${htlcTx.txid} could be a 2nd level htlc tx spending revoked commit txid=${revokedCommitPublished.commitTx.txid}" }
                 // Let's assume that htlcTx is an HtlcSuccessTx or HtlcTimeoutTx and try to generate a tx spending its output using a revocation key
                 val remotePerCommitmentPoint = revokedCommitPublished.remotePerCommitmentSecret.publicKey()
                 val remoteDelayedPaymentPubkey = Generators.derivePubKey(commitments.remoteParams.delayedPaymentBasepoint, remotePerCommitmentPoint)

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingConfirmed.kt
@@ -79,7 +79,7 @@ data class LegacyWaitForFundingConfirmed(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@LegacyWaitForFundingConfirmed::class.simpleName}" }
         val error = Error(channelId, t.message)
         return when {
             commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingConfirmed.kt
@@ -38,7 +38,7 @@ data class LegacyWaitForFundingConfirmed(
                             Transaction.correctlySpends(commitments.localCommit.publishableTxs.commitTx.tx, listOf(cmd.watch.tx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
                         }
                         if (result is Try.Failure) {
-                            logger.error { "c:$channelId funding tx verification failed: ${result.error}" }
+                            logger.error { "funding tx verification failed: ${result.error}" }
                             return handleLocalError(cmd, InvalidCommitmentSignature(channelId, cmd.watch.tx.txid))
                         }
                         val nextPerCommitmentPoint = keyManager.commitmentPoint(commitments.localParams.channelKeys(keyManager).shaSeed, 1)
@@ -55,7 +55,7 @@ data class LegacyWaitForFundingConfirmed(
                             ChannelAction.Storage.StoreState(nextState)
                         )
                         if (deferred != null) {
-                            logger.info { "c:$channelId funding_locked has already been received" }
+                            logger.info { "funding_locked has already been received" }
                             val resultPair = nextState.run { process(ChannelCommand.MessageReceived(deferred)) }
                             Pair(resultPair.first, actions + resultPair.second)
                         } else {
@@ -79,7 +79,7 @@ data class LegacyWaitForFundingConfirmed(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "c:$channelId error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
         val error = Error(channelId, t.message)
         return when {
             commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingLocked.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingLocked.kt
@@ -88,7 +88,7 @@ data class LegacyWaitForFundingLocked(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@LegacyWaitForFundingLocked::class.simpleName}" }
         val error = Error(channelId, t.message)
         return when {
             commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingLocked.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingLocked.kt
@@ -88,7 +88,7 @@ data class LegacyWaitForFundingLocked(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "c:$channelId error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
         val error = Error(channelId, t.message)
         return when {
             commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Negotiating.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Negotiating.kt
@@ -34,7 +34,7 @@ data class Negotiating(
         return when {
             cmd is ChannelCommand.MessageReceived && cmd.message is ClosingSigned -> {
                 val remoteClosingFee = cmd.message.feeSatoshis
-                logger.info { "c:$channelId received closing fee=$remoteClosingFee" }
+                logger.info { "received closing fee=$remoteClosingFee" }
                 when (val result = Helpers.Closing.checkClosingSignature(keyManager, commitments, localShutdown.scriptPubKey.toByteArray(), remoteShutdown.scriptPubKey.toByteArray(), cmd.message.feeSatoshis, cmd.message.signature)) {
                     is Either.Left -> handleLocalError(cmd, result.value)
                     is Either.Right -> {
@@ -42,20 +42,20 @@ data class Negotiating(
                         val lastLocalClosingSigned = closingTxProposed.last().lastOrNull()?.localClosingSigned
                         when {
                             lastLocalClosingSigned?.feeSatoshis == remoteClosingFee -> {
-                                logger.info { "c:$channelId they accepted our fee, publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
+                                logger.info { "they accepted our fee, publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
                                 completeMutualClose(signedClosingTx, null)
                             }
                             closingTxProposed.flatten().size >= MAX_NEGOTIATION_ITERATIONS -> {
-                                logger.warning { "c:$channelId could not agree on closing fees after $MAX_NEGOTIATION_ITERATIONS iterations, publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
+                                logger.warning { "could not agree on closing fees after $MAX_NEGOTIATION_ITERATIONS iterations, publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
                                 completeMutualClose(signedClosingTx, closingSignedRemoteFees)
                             }
                             lastLocalClosingSigned?.tlvStream?.get<ClosingSignedTlv.FeeRange>()?.let { it.min <= remoteClosingFee && remoteClosingFee <= it.max } == true -> {
                                 val localFeeRange = lastLocalClosingSigned.tlvStream.get<ClosingSignedTlv.FeeRange>()!!
-                                logger.info { "c:$channelId they chose closing fee=$remoteClosingFee within our fee range (min=${localFeeRange.max} max=${localFeeRange.max}), publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
+                                logger.info { "they chose closing fee=$remoteClosingFee within our fee range (min=${localFeeRange.max} max=${localFeeRange.max}), publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
                                 completeMutualClose(signedClosingTx, closingSignedRemoteFees)
                             }
                             commitments.localCommit.spec.toLocal == 0.msat -> {
-                                logger.info { "c:$channelId we have nothing at stake, publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
+                                logger.info { "we have nothing at stake, publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
                                 completeMutualClose(signedClosingTx, closingSignedRemoteFees)
                             }
                             else -> {
@@ -73,7 +73,7 @@ data class Negotiating(
                                             else -> closingFees.preferred
                                         }
                                         if (closingFee == remoteClosingFee) {
-                                            logger.info { "c:$channelId accepting their closing fee=$remoteClosingFee, publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
+                                            logger.info { "accepting their closing fee=$remoteClosingFee, publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
                                             completeMutualClose(signedClosingTx, closingSignedRemoteFees)
                                         } else {
                                             val (closingTx, closingSigned) = Helpers.Closing.makeClosingTx(
@@ -83,7 +83,7 @@ data class Negotiating(
                                                 remoteShutdown.scriptPubKey.toByteArray(),
                                                 ClosingFees(closingFee, theirFeeRange.min, theirFeeRange.max)
                                             )
-                                            logger.info { "c:$channelId proposing closing fee=${closingSigned.feeSatoshis}" }
+                                            logger.info { "proposing closing fee=${closingSigned.feeSatoshis}" }
                                             val closingProposed1 = closingTxProposed.updated(
                                                 closingTxProposed.lastIndex,
                                                 closingTxProposed.last() + listOf(ClosingTxProposed(closingTx, closingSigned))
@@ -107,15 +107,15 @@ data class Negotiating(
                                         when {
                                             lastLocalClosingSigned?.feeSatoshis == closingSigned.feeSatoshis -> {
                                                 // next computed fee is the same than the one we previously sent (probably because of rounding)
-                                                logger.info { "c:$channelId accepting their closing fee=$remoteClosingFee, publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
+                                                logger.info { "accepting their closing fee=$remoteClosingFee, publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
                                                 completeMutualClose(signedClosingTx, null)
                                             }
                                             closingSigned.feeSatoshis == remoteClosingFee -> {
-                                                logger.info { "c:$channelId we have converged, publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
+                                                logger.info { "we have converged, publishing closing tx: closingTxId=${signedClosingTx.tx.txid}" }
                                                 completeMutualClose(signedClosingTx, closingSigned)
                                             }
                                             else -> {
-                                                logger.info { "c:$channelId proposing closing fee=${closingSigned.feeSatoshis}" }
+                                                logger.info { "proposing closing fee=${closingSigned.feeSatoshis}" }
                                                 val closingProposed1 = closingTxProposed.updated(
                                                     closingTxProposed.lastIndex,
                                                     closingTxProposed.last() + listOf(ClosingTxProposed(closingTx, closingSigned))
@@ -141,7 +141,7 @@ data class Negotiating(
                 is WatchEventSpent -> when {
                     watch.event is BITCOIN_FUNDING_SPENT && closingTxProposed.flatten().any { it.unsignedTx.tx.txid == watch.tx.txid } -> {
                         // they can publish a closing tx with any sig we sent them, even if we are not done negotiating
-                        logger.info { "c:$channelId closing tx published: closingTxId=${watch.tx.txid}" }
+                        logger.info { "closing tx published: closingTxId=${watch.tx.txid}" }
                         val closingTx = getMutualClosePublished(watch.tx)
                         val nextState = Closing(
                             commitments,
@@ -198,7 +198,7 @@ data class Negotiating(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "c:$channelId error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
         val error = Error(channelId, t.message)
         return when {
             nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Negotiating.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Negotiating.kt
@@ -198,7 +198,7 @@ data class Negotiating(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@Negotiating::class.simpleName}" }
         val error = Error(channelId, t.message)
         return when {
             nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
@@ -293,7 +293,7 @@ data class Normal(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@Normal::class.simpleName}" }
         val error = Error(channelId, t.message)
         return when {
             nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
@@ -41,11 +41,11 @@ data class Normal(
                     is CMD_UPDATE_FEE -> handleCommandResult(cmd.command, commitments.sendFee(cmd.command), cmd.command.commit)
                     is CMD_SIGN -> when {
                         !commitments.localHasChanges() -> {
-                            logger.warning { "c:$channelId no changes to sign" }
+                            logger.warning { "no changes to sign" }
                             Pair(this@Normal, listOf())
                         }
                         commitments.remoteNextCommitInfo is Either.Left -> {
-                            logger.debug { "c:$channelId already in the process of signing, will sign again as soon as possible" }
+                            logger.debug { "already in the process of signing, will sign again as soon as possible" }
                             val commitments1 = commitments.copy(remoteNextCommitInfo = Either.Left(commitments.remoteNextCommitInfo.left!!.copy(reSignAsap = true)))
                             Pair(this@Normal.copy(commitments = commitments1), listOf())
                         }
@@ -59,7 +59,7 @@ data class Normal(
                                 // counterparty, so only htlcs above remote's dust_limit matter
                                 val trimmedHtlcs = Transactions.trimOfferedHtlcs(commitments.remoteParams.dustLimit, nextRemoteCommit.spec) + Transactions.trimReceivedHtlcs(commitments.remoteParams.dustLimit, nextRemoteCommit.spec)
                                 val htlcInfos = trimmedHtlcs.map { it.add }.map {
-                                    logger.info { "c:$channelId adding paymentHash=${it.paymentHash} cltvExpiry=${it.cltvExpiry} to htlcs db for commitNumber=$nextCommitNumber" }
+                                    logger.info { "adding paymentHash=${it.paymentHash} cltvExpiry=${it.cltvExpiry} to htlcs db for commitNumber=$nextCommitNumber" }
                                     ChannelAction.Storage.HtlcInfo(channelId, nextCommitNumber, it.paymentHash, it.cltvExpiry)
                                 }
                                 val nextState = this@Normal.copy(commitments = commitments1)
@@ -152,7 +152,7 @@ data class Normal(
                                     // we just signed htlcs that need to be resolved now
                                     ShuttingDown(commitments1, localShutdown, remoteShutdown, closingFeerates)
                                 } else {
-                                    logger.warning { "c:$channelId we have no htlcs but have not replied with our Shutdown yet, this should never happen" }
+                                    logger.warning { "we have no htlcs but have not replied with our Shutdown yet, this should never happen" }
                                     val closingTxProposed = if (isInitiator) {
                                         val (closingTx, closingSigned) = Helpers.Closing.makeFirstClosingTx(
                                             keyManager,
@@ -278,12 +278,12 @@ data class Normal(
                 val failedHtlcs = mutableListOf<ChannelAction>()
                 val proposedHtlcs = commitments.localChanges.proposed.filterIsInstance<UpdateAddHtlc>()
                 if (proposedHtlcs.isNotEmpty()) {
-                    logger.info { "c:$channelId updating channel_update announcement (reason=disabled)" }
+                    logger.info { "updating channel_update announcement (reason=disabled)" }
                     val channelUpdate = Announcements.disableChannel(channelUpdate, staticParams.nodeParams.nodePrivateKey, staticParams.remoteNodeId)
                     proposedHtlcs.forEach { htlc ->
                         commitments.payments[htlc.id]?.let { paymentId ->
                             failedHtlcs.add(ChannelAction.ProcessCmdRes.AddSettledFail(paymentId, htlc, ChannelAction.HtlcResult.Fail.Disconnected(channelUpdate)))
-                        } ?: logger.warning { "c:$channelId cannot find payment for $htlc" }
+                        } ?: logger.warning { "cannot find payment for $htlc" }
                     }
                 }
                 Pair(Offline(this@Normal), failedHtlcs)
@@ -293,7 +293,7 @@ data class Normal(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "c:$channelId error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
         val error = Error(channelId, t.message)
         return when {
             nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Offline.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Offline.kt
@@ -112,7 +112,7 @@ data class Offline(val state: ChannelStateWithCommitments) : ChannelState() {
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@Offline::class.simpleName}" }
         return Pair(this@Offline, listOf(ChannelAction.ProcessLocalError(t, cmd)))
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ShuttingDown.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ShuttingDown.kt
@@ -188,7 +188,7 @@ data class ShuttingDown(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@ShuttingDown::class.simpleName}" }
         val error = Error(channelId, t.message)
         return spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error)) }
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
@@ -275,7 +275,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@Syncing::class.simpleName}" }
         return Pair(this@Syncing, listOf(ChannelAction.ProcessLocalError(t, cmd)))
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
@@ -35,7 +35,6 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                                     logger.warning { "they have a more recent commitment, using it instead" }
                                     decrypted.get()
                                 } else {
-                                    logger.info { "ignoring their older backup" }
                                     state
                                 }
                             }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
@@ -23,24 +23,24 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
     val channelId = state.channelId
 
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
-        logger.warning { "c:$channelId syncing processing ${cmd::class}" }
+        logger.warning { "syncing processing ${cmd::class}" }
         return when {
             cmd is ChannelCommand.MessageReceived && cmd.message is ChannelReestablish -> when {
                 waitForTheirReestablishMessage -> {
                     val nextState = if (!cmd.message.channelData.isEmpty()) {
-                        logger.info { "c:$channelId channel_reestablish includes a peer backup" }
+                        logger.info { "channel_reestablish includes a peer backup" }
                         when (val decrypted = runTrying { PersistedChannelState.from(staticParams.nodeParams.nodePrivateKey, cmd.message.channelData) }) {
                             is Try.Success -> {
                                 if (decrypted.get().commitments.isMoreRecent(state.commitments)) {
-                                    logger.warning { "c:$channelId they have a more recent commitment, using it instead" }
+                                    logger.warning { "they have a more recent commitment, using it instead" }
                                     decrypted.get()
                                 } else {
-                                    logger.info { "c:$channelId ignoring their older backup" }
+                                    logger.info { "ignoring their older backup" }
                                     state
                                 }
                             }
                             is Try.Failure -> {
-                                logger.error(decrypted.error) { "c:$channelId ignoring unreadable channel data" }
+                                logger.error(decrypted.error) { "ignoring unreadable channel data" }
                                 state
                             }
                         }
@@ -81,7 +81,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                     Pair(state, actions)
                 }
                 state is WaitForChannelReady || state is LegacyWaitForFundingLocked -> {
-                    logger.debug { "c:$channelId re-sending channel_ready" }
+                    logger.debug { "re-sending channel_ready" }
                     val nextPerCommitmentPoint = keyManager.commitmentPoint(state.commitments.localParams.channelKeys(keyManager).shaSeed, 1)
                     val channelReady = ChannelReady(state.commitments.channelId, nextPerCommitmentPoint)
                     val actions = listOf(ChannelAction.Message.Send(channelReady))
@@ -93,7 +93,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                             // if next_remote_revocation_number is greater than our local commitment index, it means that either we are using an outdated commitment, or they are lying
                             // but first we need to make sure that the last per_commitment_secret that they claim to have received from us is correct for that next_remote_revocation_number minus 1
                             if (keyManager.commitmentSecret(state.commitments.localParams.channelKeys(keyManager).shaSeed, cmd.message.nextRemoteRevocationNumber - 1) == cmd.message.yourLastCommitmentSecret) {
-                                logger.warning { "c:$channelId counterparty proved that we have an outdated (revoked) local commitment!!! ourCommitmentNumber=${state.commitments.localCommit.index} theirCommitmentNumber=${cmd.message.nextRemoteRevocationNumber}" }
+                                logger.warning { "counterparty proved that we have an outdated (revoked) local commitment!!! ourCommitmentNumber=${state.commitments.localCommit.index} theirCommitmentNumber=${cmd.message.nextRemoteRevocationNumber}" }
                                 // their data checks out, we indeed seem to be using an old revoked commitment, and must absolutely *NOT* publish it, because that would be a cheating attempt and they
                                 // would punish us by taking all the funds in the channel
                                 val exc = PleasePublishYourCommitment(channelId)
@@ -105,7 +105,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                                 )
                                 Pair(nextState, actions)
                             } else {
-                                logger.warning { "c:$channelId they lied! the last per_commitment_secret they claimed to have received from us is invalid" }
+                                logger.warning { "they lied! the last per_commitment_secret they claimed to have received from us is invalid" }
                                 val exc = InvalidRevokedCommitProof(channelId, state.commitments.localCommit.index, cmd.message.nextRemoteRevocationNumber, cmd.message.yourLastCommitmentSecret)
                                 val error = Error(channelId, exc.message.encodeToByteArray().toByteVector())
                                 val (nextState, spendActions) = state.run { spendLocalCurrent() }
@@ -118,7 +118,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                         }
                         !Helpers.checkRemoteCommit(state.commitments, cmd.message.nextLocalCommitmentNumber) -> {
                             // if next_local_commit_number is more than one more our remote commitment index, it means that either we are using an outdated commitment, or they are lying
-                            logger.warning { "c:$channelId counterparty says that they have a more recent commitment than the one we know of!!! ourCommitmentNumber=${state.commitments.remoteNextCommitInfo.left?.nextRemoteCommit?.index ?: state.commitments.remoteCommit.index} theirCommitmentNumber=${cmd.message.nextLocalCommitmentNumber}" }
+                            logger.warning { "counterparty says that they have a more recent commitment than the one we know of!!! ourCommitmentNumber=${state.commitments.remoteNextCommitInfo.left?.nextRemoteCommit?.index ?: state.commitments.remoteCommit.index} theirCommitmentNumber=${cmd.message.nextLocalCommitmentNumber}" }
                             // there is no way to make sure that they are saying the truth, the best thing to do is ask them to publish their commitment right now
                             // maybe they will publish their commitment, in that case we need to remember their commitment point in order to be able to claim our outputs
                             // not that if they don't comply, we could publish our own commitment (it is not stale, otherwise we would be in the case above)
@@ -136,7 +136,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                             val actions = ArrayList<ChannelAction>()
                             if (cmd.message.nextLocalCommitmentNumber == 1L && state.commitments.localCommit.index == 0L) {
                                 // If next_local_commitment_number is 1 in both the channel_reestablish it sent and received, then the node MUST retransmit funding_locked, otherwise it MUST NOT
-                                logger.debug { "c:$channelId re-sending channel_ready" }
+                                logger.debug { "re-sending channel_ready" }
                                 val nextPerCommitmentPoint = keyManager.commitmentPoint(state.commitments.localParams.channelKeys(keyManager).shaSeed, 1)
                                 val channelReady = ChannelReady(state.commitments.channelId, nextPerCommitmentPoint)
                                 actions.add(ChannelAction.Message.Send(channelReady))
@@ -148,7 +148,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
 
                                 // BOLT 2: A node if it has sent a previous shutdown MUST retransmit shutdown.
                                 state.localShutdown?.let {
-                                    logger.debug { "c:$channelId re-sending local shutdown" }
+                                    logger.debug { "re-sending local shutdown" }
                                     actions.add(ChannelAction.Message.Send(it))
                                 }
 
@@ -165,7 +165,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                                     actions.add(ChannelAction.Blockchain.SendWatch(watchConfirmed))
                                 }
 
-                                logger.info { "c:$channelId switching to ${state::class.simpleName}" }
+                                logger.info { "switching to ${state::class.simpleName}" }
                                 Pair(state.copy(commitments = commitments1), actions)
                             } catch (e: RevocationSyncError) {
                                 val error = Error(channelId, e.message)
@@ -212,7 +212,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                 when {
                     watch is WatchEventSpent -> when {
                         state is Negotiating && state.closingTxProposed.flatten().any { it.unsignedTx.tx.txid == watch.tx.txid } -> {
-                            logger.info { "c:$channelId closing tx published: closingTxId=${watch.tx.txid}" }
+                            logger.info { "closing tx published: closingTxId=${watch.tx.txid}" }
                             val closingTx = state.getMutualClosePublished(watch.tx)
                             val nextState = Closing(
                                 state.commitments,
@@ -238,12 +238,12 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                         val watchSpent = WatchSpent(channelId, watch.tx, state.commitments.commitInput.outPoint.index.toInt(), BITCOIN_FUNDING_SPENT)
                         val nextState = when {
                             state is WaitForFundingConfirmed && watch.tx.txid == state.commitments.fundingTxId -> {
-                                logger.info { "c:$channelId was confirmed while offline at blockHeight=${watch.blockHeight} txIndex=${watch.txIndex} with funding txid=${watch.tx.txid}" }
+                                logger.info { "was confirmed while offline at blockHeight=${watch.blockHeight} txIndex=${watch.txIndex} with funding txid=${watch.tx.txid}" }
                                 state.copy(previousFundingTxs = listOf())
                             }
                             state is WaitForFundingConfirmed && state.previousFundingTxs.find { watch.tx.txid == it.second.fundingTxId } != null -> {
                                 val (fundingTx, commitments) = state.previousFundingTxs.first { watch.tx.txid == it.second.fundingTxId }
-                                logger.info { "c:$channelId was confirmed while offline at blockHeight=${watch.blockHeight} txIndex=${watch.txIndex} with a previous funding txid=${watch.tx.txid}" }
+                                logger.info { "was confirmed while offline at blockHeight=${watch.blockHeight} txIndex=${watch.txIndex} with a previous funding txid=${watch.tx.txid}" }
                                 state.copy(fundingTx = fundingTx, commitments = commitments, previousFundingTxs = listOf())
                             }
                             else -> state
@@ -275,7 +275,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "c:$channelId error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
         return Pair(this@Syncing, listOf(ChannelAction.ProcessLocalError(t, cmd)))
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForAcceptChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForAcceptChannel.kt
@@ -49,7 +49,6 @@ data class WaitForAcceptChannel(
                             features = Features(init.remoteInit.features)
                         )
                         val channelId = computeChannelId(lastSent, accept)
-                        val channelIdAssigned = ChannelAction.ChannelId.IdAssigned(staticParams.remoteNodeId, temporaryChannelId, channelId)
                         val localFundingPubkey = init.localParams.channelKeys(keyManager).fundingPubKey
                         val fundingPubkeyScript = ByteVector(Script.write(Script.pay2wsh(Scripts.multiSig2of2(localFundingPubkey, remoteParams.fundingPubKey))))
                         val dustLimit = accept.dustLimit.max(init.localParams.dustLimit)
@@ -79,7 +78,7 @@ data class WaitForAcceptChannel(
                                             null
                                         )
                                         val actions = listOf(
-                                            channelIdAssigned,
+                                            ChannelAction.ChannelId.IdAssigned(staticParams.remoteNodeId, temporaryChannelId, channelId),
                                             ChannelAction.Message.Send(interactiveTxAction.msg),
                                             ChannelAction.EmitEvent(ChannelEvents.Creating(nextState))
                                         )

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForAcceptChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForAcceptChannel.kt
@@ -108,7 +108,7 @@ data class WaitForAcceptChannel(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForAcceptChannel::class.simpleName}" }
         val error = Error(temporaryChannelId, t.message)
         return Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForChannelReady.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForChannelReady.kt
@@ -107,7 +107,7 @@ data class WaitForChannelReady(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForChannelReady::class.simpleName}" }
         val error = Error(channelId, t.message)
         return when {
             nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForChannelReady.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForChannelReady.kt
@@ -25,12 +25,12 @@ data class WaitForChannelReady(
             cmd is ChannelCommand.MessageReceived && cmd.message is TxSignatures -> when (fundingTx) {
                 is PartiallySignedSharedTransaction -> when (val fullySignedTx = fundingTx.addRemoteSigs(cmd.message)) {
                     null -> {
-                        logger.warning { "c:$channelId received invalid remote funding signatures for txId=${cmd.message.txId}" }
+                        logger.warning { "received invalid remote funding signatures for txId=${cmd.message.txId}" }
                         // The funding transaction may still confirm (since our peer should be able to generate valid signatures), so we cannot close the channel yet.
                         Pair(this@WaitForChannelReady, listOf(ChannelAction.Message.Send(Warning(channelId, InvalidFundingSignature(channelId, cmd.message.txId).message))))
                     }
                     else -> {
-                        logger.info { "c:$channelId received remote funding signatures, publishing txId=${fullySignedTx.signedTx.txid}" }
+                        logger.info { "received remote funding signatures, publishing txId=${fullySignedTx.signedTx.txid}" }
                         val nextState = this@WaitForChannelReady.copy(fundingTx = fullySignedTx)
                         val actions = buildList {
                             // If we haven't sent our signatures yet, we do it now.
@@ -42,12 +42,12 @@ data class WaitForChannelReady(
                     }
                 }
                 is FullySignedSharedTransaction -> {
-                    logger.info { "c:$channelId ignoring duplicate remote funding signatures" }
+                    logger.info { "ignoring duplicate remote funding signatures" }
                     Pair(this@WaitForChannelReady, listOf())
                 }
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is TxInitRbf -> {
-                logger.info { "c:$channelId rejecting tx_init_rbf, we have already accepted the channel" }
+                logger.info { "rejecting tx_init_rbf, we have already accepted the channel" }
                 Pair(this@WaitForChannelReady, listOf(ChannelAction.Message.Send(TxAbort(channelId, InvalidRbfTxConfirmed(channelId, commitments.fundingTxId).message))))
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is ChannelReady -> {
@@ -107,7 +107,7 @@ data class WaitForChannelReady(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "c:$channelId error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
         val error = Error(channelId, t.message)
         return when {
             nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingConfirmed.kt
@@ -332,7 +332,7 @@ data class WaitForFundingConfirmed(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForFundingConfirmed::class.simpleName}" }
         val error = Error(channelId, t.message)
         return when {
             nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingCreated.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingCreated.kt
@@ -136,7 +136,7 @@ data class WaitForFundingCreated(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForFundingCreated::class.simpleName}" }
         val error = Error(channelId, t.message)
         return Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingCreated.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingCreated.kt
@@ -68,7 +68,7 @@ data class WaitForFundingCreated(
                         )
                         when (firstCommitTxRes) {
                             is Either.Left -> {
-                                logger.error(firstCommitTxRes.value) { "c:$channelId cannot create first commit tx" }
+                                logger.error(firstCommitTxRes.value) { "cannot create first commit tx" }
                                 handleLocalError(cmd, firstCommitTxRes.value)
                             }
                             is Either.Right -> {
@@ -99,33 +99,33 @@ data class WaitForFundingCreated(
                         }
                     }
                     is InteractiveTxSessionAction.RemoteFailure -> {
-                        logger.warning { "c:$channelId interactive-tx failed: $interactiveTxAction" }
+                        logger.warning { "interactive-tx failed: $interactiveTxAction" }
                         handleLocalError(cmd, DualFundingAborted(channelId, interactiveTxAction.toString()))
                     }
                 }
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is CommitSig -> {
-                logger.warning { "c:$channelId received commit_sig too early, aborting" }
+                logger.warning { "received commit_sig too early, aborting" }
                 handleLocalError(cmd, UnexpectedCommitSig(channelId))
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is TxSignatures -> {
-                logger.warning { "c:$channelId received tx_signatures too early, aborting" }
+                logger.warning { "received tx_signatures too early, aborting" }
                 handleLocalError(cmd, UnexpectedFundingSignatures(channelId))
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is TxInitRbf -> {
-                logger.info { "c:$channelId ignoring unexpected tx_init_rbf message" }
+                logger.info { "ignoring unexpected tx_init_rbf message" }
                 Pair(this@WaitForFundingCreated, listOf(ChannelAction.Message.Send(Warning(channelId, InvalidRbfAttempt(channelId).message))))
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is TxAckRbf -> {
-                logger.info { "c:$channelId ignoring unexpected tx_ack_rbf message" }
+                logger.info { "ignoring unexpected tx_ack_rbf message" }
                 Pair(this@WaitForFundingCreated, listOf(ChannelAction.Message.Send(Warning(channelId, InvalidRbfAttempt(channelId).message))))
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is TxAbort -> {
-                logger.warning { "c:$channelId our peer aborted the dual funding flow: ascii='${cmd.message.toAscii()}' bin=${cmd.message.data.toHex()}" }
+                logger.warning { "our peer aborted the dual funding flow: ascii='${cmd.message.toAscii()}' bin=${cmd.message.data.toHex()}" }
                 Pair(Aborted, listOf())
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is Error -> {
-                logger.error { "c:$channelId peer sent error: ascii=${cmd.message.toAscii()} bin=${cmd.message.data.toHex()}" }
+                logger.error { "peer sent error: ascii=${cmd.message.toAscii()} bin=${cmd.message.data.toHex()}" }
                 Pair(Aborted, listOf())
             }
             cmd is ChannelCommand.ExecuteCommand && cmd.command is CloseCommand -> handleLocalError(cmd, ChannelFundingError(channelId))
@@ -136,7 +136,7 @@ data class WaitForFundingCreated(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "c:$channelId error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
         val error = Error(channelId, t.message)
         return Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingSigned.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingSigned.kt
@@ -126,7 +126,7 @@ data class WaitForFundingSigned(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForFundingSigned::class.simpleName}" }
         val error = Error(channelId, t.message)
         return Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForOpenChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForOpenChannel.kt
@@ -79,7 +79,6 @@ data class WaitForOpenChannel(
                                     features = Features(remoteInit.features)
                                 )
                                 val channelId = computeChannelId(open, accept)
-                                val channelIdAssigned = ChannelAction.ChannelId.IdAssigned(staticParams.remoteNodeId, temporaryChannelId, channelId)
                                 val localFundingPubkey = localParams.channelKeys(keyManager).fundingPubKey
                                 val fundingPubkeyScript = ByteVector(Script.write(Script.pay2wsh(Scripts.multiSig2of2(localFundingPubkey, remoteParams.fundingPubKey))))
                                 val dustLimit = open.dustLimit.max(localParams.dustLimit)
@@ -106,7 +105,7 @@ data class WaitForOpenChannel(
                                             open.origin
                                         )
                                         val actions = listOf(
-                                            channelIdAssigned,
+                                            ChannelAction.ChannelId.IdAssigned(staticParams.remoteNodeId, temporaryChannelId, channelId),
                                             ChannelAction.Message.Send(accept),
                                             ChannelAction.EmitEvent(ChannelEvents.Creating(nextState))
                                         )

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForOpenChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForOpenChannel.kt
@@ -133,7 +133,7 @@ data class WaitForOpenChannel(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForOpenChannel::class.simpleName}" }
         val error = Error(temporaryChannelId, t.message)
         return Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForOpenChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForOpenChannel.kt
@@ -86,7 +86,7 @@ data class WaitForOpenChannel(
                                 val fundingParams = InteractiveTxParams(channelId, false, fundingAmount, open.fundingAmount, fundingPubkeyScript, open.lockTime, dustLimit, open.fundingFeerate)
                                 when (val fundingContributions = FundingContributions.create(fundingParams, wallet.confirmedUtxos)) {
                                     is Either.Left -> {
-                                        logger.error { "c:$temporaryChannelId could not fund channel: ${fundingContributions.value}" }
+                                        logger.error { "could not fund channel: ${fundingContributions.value}" }
                                         Pair(Aborted, listOf(ChannelAction.Message.Send(Error(temporaryChannelId, ChannelFundingError(temporaryChannelId).message))))
                                     }
                                     is Either.Right -> {
@@ -115,13 +115,13 @@ data class WaitForOpenChannel(
                                 }
                             }
                             is Either.Left -> {
-                                logger.error(res.value) { "c:$temporaryChannelId invalid ${cmd.message::class} in state ${this::class}" }
+                                logger.error(res.value) { "invalid ${cmd.message::class} in state ${this::class}" }
                                 Pair(Aborted, listOf(ChannelAction.Message.Send(Error(temporaryChannelId, res.value.message))))
                             }
                         }
                     }
                     is Error -> {
-                        logger.error { "c:$temporaryChannelId peer sent error: ascii=${cmd.message.toAscii()} bin=${cmd.message.data.toHex()}" }
+                        logger.error { "peer sent error: ascii=${cmd.message.toAscii()} bin=${cmd.message.data.toHex()}" }
                         return Pair(Aborted, listOf())
                     }
                     else -> unhandled(cmd)
@@ -134,7 +134,7 @@ data class WaitForOpenChannel(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "c:$temporaryChannelId error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on event ${cmd::class} in state ${this::class}" }
         val error = Error(temporaryChannelId, t.message)
         return Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForRemotePublishFutureCommitment.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForRemotePublishFutureCommitment.kt
@@ -22,13 +22,13 @@ data class WaitForRemotePublishFutureCommitment(
     }
 
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "c:${commitments.channelId} error on event ${cmd::class} in state ${this::class}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForRemotePublishFutureCommitment::class}" }
         val error = Error(channelId, t.message)
         return Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
     }
 
     internal fun ChannelContext.handleRemoteSpentFuture(tx: Transaction): Pair<ChannelState, List<ChannelAction>> {
-        logger.warning { "c:${commitments.channelId} they published their future commit (because we asked them to) in txid=${tx.txid}" }
+        logger.warning { "they published their future commit (because we asked them to) in txid=${tx.txid}" }
         val remoteCommitPublished = claimRemoteCommitMainOutput(
             keyManager,
             commitments,

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -388,6 +388,13 @@ data class OutgoingPayment(
         val closingType: ChannelClosingType,
         override val createdAt: Long,
     ) : Part()
+
+    fun mdc(): Map<String, Any> = mapOf(
+        "paymentId" to id,
+        "paymentHash" to paymentHash,
+        "amount" to amount,
+        "recipient" to recipient
+    )
 }
 
 enum class ChannelClosingType {

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -388,13 +388,6 @@ data class OutgoingPayment(
         val closingType: ChannelClosingType,
         override val createdAt: Long,
     ) : Part()
-
-    fun mdc(): Map<String, Any> = mapOf(
-        "paymentId" to id,
-        "paymentHash" to paymentHash,
-        "amount" to amount,
-        "recipient" to recipient
-    )
 }
 
 enum class ChannelClosingType {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -73,13 +73,6 @@ interface SendPayment {
     val trampolineFeesOverride: List<TrampolineFees>?
     val paymentRequest: PaymentRequest
     val paymentHash: ByteVector32 get() = details.paymentHash
-
-    fun mdc(): Map<String, Any> = mapOf(
-        "paymentId" to paymentId,
-        "paymentHash" to paymentHash,
-        "amount" to amount,
-        "recipient" to recipient
-    )
 }
 
 data class SendPaymentNormal(

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -73,6 +73,13 @@ interface SendPayment {
     val trampolineFeesOverride: List<TrampolineFees>?
     val paymentRequest: PaymentRequest
     val paymentHash: ByteVector32 get() = details.paymentHash
+
+    fun mdc(): Map<String, Any> = mapOf(
+        "paymentId" to paymentId,
+        "paymentHash" to paymentHash,
+        "amount" to amount,
+        "recipient" to recipient
+    )
 }
 
 data class SendPaymentNormal(

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.flow
 import org.kodein.log.LoggerFactory
 
 
-@OptIn(ExperimentalStdlibApi::class)
 interface TcpSocket {
 
     sealed class IOException(override val message: String, cause: Throwable? = null) : Exception(message, cause) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -24,12 +24,6 @@ sealed class PaymentPart {
     abstract val totalAmount: MilliSatoshi
     abstract val paymentHash: ByteVector32
     abstract val finalPayload: PaymentOnion.FinalPayload
-
-    fun mdc(): Map<String, Any> = mapOf(
-        "paymentHash" to paymentHash,
-        "amount" to amount,
-        "totalAmount" to totalAmount
-    )
 }
 
 data class HtlcPart(val htlc: UpdateAddHtlc, override val finalPayload: PaymentOnion.FinalPayload) : PaymentPart() {

--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/logger.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/logger.kt
@@ -1,10 +1,32 @@
 package fr.acinq.lightning.utils
 
 import org.kodein.log.Logger
+import org.kodein.log.Logger.Level.*
 
 /**
  * This should be used more largely once https://kotlinlang.org/docs/whatsnew1620.html#prototype-of-context-receivers-for-kotlin-jvm is stable
  */
 interface LoggingContext {
     val logger: Logger
+}
+
+/**
+ * A simpler wrapper on top of [Logger] with better MDC support.
+ */
+data class MDCLogger(val logger: Logger, val staticMdc: Map<String, Any> = emptyMap()) {
+    inline fun debug(mdc: Map<String, Any> = emptyMap(), msgCreator: () -> String) {
+        logger.log(level = DEBUG, msgCreator = msgCreator, meta = staticMdc + mdc)
+    }
+
+    inline fun info(mdc: Map<String, Any> = emptyMap(), msgCreator: () -> String) {
+        logger.log(level = INFO, msgCreator = msgCreator, meta = staticMdc + mdc)
+    }
+
+    inline fun warning(ex: Throwable? = null, mdc: Map<String, Any> = emptyMap(), msgCreator: () -> String) {
+        logger.log(level = WARNING, error = ex, msgCreator = msgCreator, meta = staticMdc + mdc)
+    }
+
+    inline fun error(ex: Throwable? = null, mdc: Map<String, Any> = emptyMap(), msgCreator: () -> String) {
+        logger.log(level = ERROR, error = ex, msgCreator = msgCreator, meta = staticMdc + mdc)
+    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/logger.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/logger.kt
@@ -35,6 +35,11 @@ data class MDCLogger(val logger: Logger, val staticMdc: Map<String, Any> = empty
     }
 }
 
+suspend fun <T> MDCLogger.withMDC(mdc: Map<String, Any>, f: suspend (MDCLogger) -> T): T {
+    val logger = this.copy(staticMdc = this.staticMdc + mdc)
+    return f(logger)
+}
+
 /**
  * Utility functions to build MDC for various objects without polluting main classes
  */

--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/logger.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/logger.kt
@@ -7,7 +7,7 @@ import org.kodein.log.Logger.Level.*
  * This should be used more largely once https://kotlinlang.org/docs/whatsnew1620.html#prototype-of-context-receivers-for-kotlin-jvm is stable
  */
 interface LoggingContext {
-    val logger: Logger
+    val logger: MDCLogger
 }
 
 /**

--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/logger.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/logger.kt
@@ -4,6 +4,9 @@ import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.io.SendPayment
 import fr.acinq.lightning.payment.PaymentPart
+import fr.acinq.lightning.wire.HasChannelId
+import fr.acinq.lightning.wire.HasTemporaryChannelId
+import fr.acinq.lightning.wire.LightningMessage
 import org.kodein.log.Logger
 import org.kodein.log.Logger.Level.*
 
@@ -76,6 +79,17 @@ fun ChannelState.mdc(): Map<String, Any> {
             is ChannelStateWithCommitments -> put("channelId", state.channelId)
             is Offline -> put("channelId", state.state.channelId)
             is Syncing -> put("channelId", state.state.channelId)
+            else -> {}
+        }
+    }
+}
+
+fun LightningMessage.mdc(): Map<String, Any> {
+    val msg = this
+    return buildMap {
+        when(msg) {
+            is HasTemporaryChannelId -> put("temporaryChannelId", msg.temporaryChannelId)
+            is HasChannelId -> put("channelId", msg.channelId)
             else -> {}
         }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/ChannelDataTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/ChannelDataTestsCommon.kt
@@ -22,6 +22,7 @@ import fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.Cla
 import fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx
 import fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx
 import fr.acinq.lightning.utils.LoggingContext
+import fr.acinq.lightning.utils.MDCLogger
 import fr.acinq.lightning.utils.msat
 import fr.acinq.lightning.utils.sat
 import org.kodein.log.Logger
@@ -31,7 +32,7 @@ import kotlin.test.*
 
 class ChannelDataTestsCommon : LightningTestSuite(), LoggingContext {
 
-    override val logger: Logger = LoggerFactory.default.newLogger(this::class)
+    override val logger: MDCLogger = MDCLogger(LoggerFactory.default.newLogger(this::class))
 
     @Test
     fun `local commit published`() {

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
@@ -25,14 +25,13 @@ import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.*
 import fr.acinq.lightning.wire.IncorrectOrUnknownPaymentDetails
 import fr.acinq.lightning.wire.UpdateAddHtlc
-import org.kodein.log.Logger
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 import kotlin.test.*
 
 class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
 
-    override val logger: Logger = LoggerFactory.default.newLogger(this::class)
+    override val logger: MDCLogger = MDCLogger(LoggerFactory.default.newLogger(this::class))
 
     @Test
     fun `reach normal state`() {

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -19,6 +19,8 @@ import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.*
 import fr.acinq.lightning.wire.*
 import kotlinx.serialization.encodeToString
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 import kotlin.test.*
 
 // LN Message
@@ -93,7 +95,7 @@ data class LNChannel<out S : ChannelState>(
             .let { (newState, actions) ->
                 checkSerialization(actions)
                 JsonSerializers.json.encodeToString(newState)
-                LNChannel(ctx, newState) to actions
+                LNChannel(ctx.copy(logger = ctx.logger.copy(staticMdc = newState.mdc())), newState) to actions
             }
 
     /** same as [process] but with the added assumption that we stay in the same state */
@@ -153,7 +155,8 @@ object TestsHelper {
             ChannelContext(
                 StaticParams(aliceNodeParams, TestConstants.Bob.keyManager.nodeId),
                 currentBlockHeight = currentHeight,
-                currentOnChainFeerates = OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)
+                currentOnChainFeerates = OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
+                logger = MDCLogger(LoggerFactory.default.newLogger(ChannelState::class))
             ),
             WaitForInit
         )
@@ -161,7 +164,8 @@ object TestsHelper {
             ChannelContext(
                 StaticParams(bobNodeParams, TestConstants.Alice.keyManager.nodeId),
                 currentBlockHeight = currentHeight,
-                currentOnChainFeerates = OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)
+                currentOnChainFeerates = OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
+                logger = MDCLogger(LoggerFactory.default.newLogger(ChannelState::class))
             ),
             WaitForInit
         )

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
@@ -1645,7 +1645,7 @@ class ClosingTestsCommon : LightningTestSuite() {
         run {
             val alice1 = aliceClosing.copy(ctx = alice.ctx.copy(currentBlockHeight = htlc.cltvExpiry.toLong().toInt()))
             val (alice2, actions) = alice1.process(ChannelCommand.CheckHtlcTimeout)
-            assertEquals(alice1, alice2)
+            assertEquals(alice1.state, alice2.state)
             assertTrue(actions.isEmpty())
         }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
@@ -1,20 +1,21 @@
 package fr.acinq.lightning.channel.states
 
 import fr.acinq.bitcoin.*
-import fr.acinq.lightning.Lightning
 import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.blockchain.BITCOIN_FUNDING_DEPTHOK
 import fr.acinq.lightning.blockchain.WatchConfirmed
 import fr.acinq.lightning.blockchain.WatchEventConfirmed
 import fr.acinq.lightning.blockchain.fee.OnChainFeerates
 import fr.acinq.lightning.channel.*
-
 import fr.acinq.lightning.serialization.Encryption.from
 import fr.acinq.lightning.tests.TestConstants
+import fr.acinq.lightning.utils.MDCLogger
 import fr.acinq.lightning.wire.ChannelReady
 import fr.acinq.lightning.wire.ChannelReestablish
 import fr.acinq.lightning.wire.EncryptedChannelData
 import fr.acinq.lightning.wire.Init
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -34,7 +35,8 @@ class LegacyWaitForFundingConfirmedTestsCommon {
         val ctx = ChannelContext(
             StaticParams(TestConstants.Bob.nodeParams, TestConstants.Alice.keyManager.nodeId),
             TestConstants.defaultBlockHeight ,
-            OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)
+            OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
+            MDCLogger(LoggerFactory.default.newLogger(ChannelState::class))
         )
         val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Restore(state))
         assertIs<LNChannel<Offline>>(state1)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
@@ -1,7 +1,6 @@
 package fr.acinq.lightning.channel.states
 
 import fr.acinq.bitcoin.*
-import fr.acinq.lightning.Lightning.randomBytes32
 import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.blockchain.BITCOIN_FUNDING_DEEPLYBURIED
 import fr.acinq.lightning.blockchain.BITCOIN_FUNDING_SPENT
@@ -9,15 +8,15 @@ import fr.acinq.lightning.blockchain.WatchConfirmed
 import fr.acinq.lightning.blockchain.WatchSpent
 import fr.acinq.lightning.blockchain.fee.OnChainFeerates
 import fr.acinq.lightning.channel.*
-
-import fr.acinq.lightning.serialization.Serialization
 import fr.acinq.lightning.serialization.Encryption.from
 import fr.acinq.lightning.tests.TestConstants
+import fr.acinq.lightning.utils.MDCLogger
 import fr.acinq.lightning.wire.ChannelReady
 import fr.acinq.lightning.wire.ChannelReestablish
 import fr.acinq.lightning.wire.EncryptedChannelData
 import fr.acinq.lightning.wire.Init
-import fr.acinq.secp256k1.Hex
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -37,7 +36,8 @@ class LegacyWaitForFundingLockedTestsCommon {
         val ctx = ChannelContext(
             StaticParams(TestConstants.Bob.nodeParams, TestConstants.Alice.keyManager.nodeId),
             TestConstants.defaultBlockHeight,
-            OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)
+            OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
+            MDCLogger(LoggerFactory.default.newLogger(ChannelState::class))
         )
         val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Restore(state))
         assertIs<LNChannel<Offline>>(state1)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannelTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannelTestsCommon.kt
@@ -12,11 +12,10 @@ import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.channel.TestsHelper.createWallet
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
-import fr.acinq.lightning.utils.msat
-import fr.acinq.lightning.utils.sat
-import fr.acinq.lightning.utils.toByteVector
-import fr.acinq.lightning.utils.toMilliSatoshi
+import fr.acinq.lightning.utils.*
 import fr.acinq.lightning.wire.*
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -30,7 +29,8 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
             ChannelContext(
                 StaticParams(TestConstants.Alice.nodeParams, TestConstants.Bob.keyManager.nodeId),
                 TestConstants.defaultBlockHeight,
-                OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)
+                OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
+                MDCLogger(LoggerFactory.default.newLogger(ChannelState::class))
             ),
             WaitForInit
         )


### PR DESCRIPTION
It should make debugging easier.

Formatting is not necessarily great, by default kodein logs puts one indented MDC item per line below the message. Although it may not be a bad thing on small mobile screens.

Examples:

```
13:38:52.835 INFO  IncomingPaymentHandler - generated payment request lnbcrt1500n1p3keuxupp5unfkc90kv6rz24djsf2e5ycl6zgge22qen29dxr7d9fels7njyxsdq0w4hxjapqw3jhxaqcqpjsp5lf7yykx3prkmr8d6z5nm3hyvu2pdhzrkqe9qtdlgvadllm6h8l4q9q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqmqz9g3lpvuzjwzeerq6mr7u08ge6pjcgd60gs65fwkq23wj2qfvpm2mdjrsa02939g2039jcyred823l4c4x06w59nz9e4j99ugpe2u608jqpv3gfat
    paymentHash: e4d36c15f666862555b282559a131fd0908ca940ccd456987e69539fc3d3910d
13:38:52.837 INFO  IncomingPaymentHandler - processing htlc part expiry=CltvExpiry(400144)
    paymentHash: e4d36c15f666862555b282559a131fd0908ca940ccd456987e69539fc3d3910d
    amount: 100000 msat
    totalAmount: 150000 msat
13:38:52.839 INFO  IncomingPaymentHandler - processing pay-to-open part amount=30000 msat funding=100000 sat fees=3 sat
    paymentHash: e4d36c15f666862555b282559a131fd0908ca940ccd456987e69539fc3d3910d
    amount: 30000 msat
    totalAmount: 150000 msat
13:38:52.841 INFO  IncomingPaymentHandler - processing pay-to-open part amount=20000 msat funding=100000 sat fees=2 sat
    paymentHash: e4d36c15f666862555b282559a131fd0908ca940ccd456987e69539fc3d3910d
    amount: 20000 msat
    totalAmount: 150000 msat
13:38:52.841 WARN  IncomingPaymentHandler - amount too low for a pay-to-open: 50000 msat, min is 75000 msat
    paymentHash: e4d36c15f666862555b282559a131fd0908ca940ccd456987e69539fc3d3910d
    amount: 20000 msat
    totalAmount: 150000 msat
```

```
14:14:14.364 INFO  OutgoingPaymentHandler - sending 200000 msat to 0351042257e1bf95b260049387e80585e710b32bffb061b3cf904ced8dad1758dc
    paymentId: 92b27518-f5c7-4c17-9d93-a5a70d43616d
    paymentHash: bab218e65f2dff2318922f5276b2f54d39e0b449d1f014580cbe7b69b9e46a06
    amount: 200000 msat
    recipient: 0351042257e1bf95b260049387e80585e710b32bffb061b3cf904ced8dad1758dc
14:14:14.368 INFO  RouteCalculation - routes found: [0x0x1->205000 msat]
    paymentId: 92b27518-f5c7-4c17-9d93-a5a70d43616d
    amount: 205000 msat
14:14:14.373 INFO  OutgoingPaymentHandler - sending 205000 msat to channel 1b397a0b71e34fe36e84541b70885a5b8b846c0cc1723db7a679b89f6b3f8b43
    paymentId: 92b27518-f5c7-4c17-9d93-a5a70d43616d
    paymentHash: bab218e65f2dff2318922f5276b2f54d39e0b449d1f014580cbe7b69b9e46a06
    amount: 200000 msat
    recipient: 0351042257e1bf95b260049387e80585e710b32bffb061b3cf904ced8dad1758dc
    childPaymentId: 7dc81700-9463-41aa-ab88-9ab4d2c7ef72
14:14:14.386 INFO  OutgoingPaymentHandler - payment successfully sent (fees=5000 msat)
    childPaymentId: 7dc81700-9463-41aa-ab88-9ab4d2c7ef72
    paymentId: 92b27518-f5c7-4c17-9d93-a5a70d43616d
    paymentHash: bab218e65f2dff2318922f5276b2f54d39e0b449d1f014580cbe7b69b9e46a06
    amount: 200000 msat
    recipient: 0351042257e1bf95b260049387e80585e710b32bffb061b3cf904ced8dad1758dc
```