### PR TITLE
Check that channel creation fee is below max

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -1526,9 +1526,6 @@ data class PleaseOpenChannel(
 
     val grandParents: List<OutPoint> = tlvs.get<PleaseOpenChannelTlv.GrandParents>()?.outpoints ?: listOf()
 
-    // NB: we use ceil(a/b) = (a+b-1)/b
-    fun maxFees(fundingAmount: Satoshi): MilliSatoshi? = tlvs.get<PleaseOpenChannelTlv.MaxFees>()?.basisPoints?.let { bp -> (fundingAmount.toMilliSatoshi() * bp + 10_000.msat - 1.msat) / 10_000 }
-
     override fun write(out: Output) {
         LightningCodecs.writeBytes(chainHash.toByteArray(), out)
         LightningCodecs.writeBytes(requestId.toByteArray(), out)

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -235,7 +235,7 @@ class PeerTest : LightningTestSuite() {
             tlvStream = TlvStream(
                 listOf(
                     ChannelTlv.ChannelTypeTlv(ChannelType.SupportedChannelType.AnchorOutputsZeroReserve),
-                    ChannelTlv.ChannelOriginTlv(ChannelOrigin.PleaseOpenChannelOrigin(requestId, serviceFee, 100.sat))
+                    ChannelTlv.ChannelOriginTlv(ChannelOrigin.PleaseOpenChannelOrigin(requestId, serviceFee, fundingFee))
                 )
             )
         )
@@ -294,7 +294,7 @@ class PeerTest : LightningTestSuite() {
             tlvStream = TlvStream(
                 listOf(
                     ChannelTlv.ChannelTypeTlv(ChannelType.SupportedChannelType.AnchorOutputsZeroReserve),
-                    ChannelTlv.ChannelOriginTlv(ChannelOrigin.PleaseOpenChannelOrigin(requestId, serviceFee, 100.sat))
+                    ChannelTlv.ChannelOriginTlv(ChannelOrigin.PleaseOpenChannelOrigin(requestId, serviceFee, fundingFee))
                 )
             )
         )

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -273,7 +273,7 @@ class PeerTest : LightningTestSuite() {
     }
 
     @Test
-    fun `reject swap-in (fee too high)`() = runSuspendTest {
+    fun `reject swap-in -- fee too high`() = runSuspendTest {
         val nodeParams = Pair(TestConstants.Alice.nodeParams, TestConstants.Bob.nodeParams)
         val walletParams = Pair(TestConstants.Alice.walletParams, TestConstants.Bob.walletParams)
         val (alice, bob, alice2bob, bob2alice) = newPeers(this, nodeParams, walletParams, automateMessaging = false)
@@ -303,7 +303,7 @@ class PeerTest : LightningTestSuite() {
     }
 
     @Test
-    fun `reject swap-in (no associated channel request)`() = runSuspendTest {
+    fun `reject swap-in -- no associated channel request`() = runSuspendTest {
         val nodeParams = Pair(TestConstants.Alice.nodeParams, TestConstants.Bob.nodeParams)
         val walletParams = Pair(TestConstants.Alice.walletParams, TestConstants.Bob.walletParams)
         val (alice, bob, alice2bob, bob2alice) = newPeers(this, nodeParams, walletParams, automateMessaging = false)


### PR DESCRIPTION
We do send our max acceptable fee in `PleaseOpenChannel`, but we must double check that the actual fee is indeed within this limit, even if the LSP should in theory have sent an error.

Also, failing to find an associated pending channel request is an error.