### PR TITLE
`assertIs<LNChannel<X>>` doesn't work as expected

### DIFF
--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/ChannelDataTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/ChannelDataTestsCommon.kt
@@ -275,11 +275,11 @@ class ChannelDataTestsCommon : LightningTestSuite(), LoggingContext {
             val (bob7, _) = bob6.process(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlcAlice.id, preimageAlice)))
             // Alice publishes her commitment.
             val (aliceClosing, _) = alice7.process(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
-            assertIs<LNChannel<Closing>>(aliceClosing)
+            assertIs<Closing>(aliceClosing.state)
             val lcp = aliceClosing.state.localCommitPublished
             assertNotNull(lcp)
             val (bobClosing, _) = bob7.process(ChannelCommand.WatchReceived(WatchEventSpent(alice0.state.channelId, BITCOIN_FUNDING_SPENT, lcp.commitTx)))
-            assertIs<LNChannel<Closing>>(bobClosing)
+            assertIs<Closing>(bobClosing.state)
             val rcp = bobClosing.state.remoteCommitPublished
             assertNotNull(rcp)
             Pair(lcp, rcp)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
@@ -428,11 +428,13 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
             val (bob9, _) = bob8.process(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlcAlice2.id, preimageAlice2)))
             // Alice publishes her commitment.
             val (aliceClosing, _) = alice9.process(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
-            assertIs<LNChannel<Closing>>(aliceClosing)
+            assertIs<Closing>(aliceClosing.state)
+            assertIs<LNChannel<Closing>>(aliceClosing) // for compiler: only tests LNChannel<Any>
             val lcp = aliceClosing.state.localCommitPublished
             assertNotNull(lcp)
             val (bobClosing, _) = bob9.process(ChannelCommand.WatchReceived(WatchEventSpent(alice0.state.channelId, BITCOIN_FUNDING_SPENT, lcp.commitTx)))
-            assertIs<LNChannel<Closing>>(bobClosing)
+            assertIs<Closing>(bobClosing.state)
+            assertIs<LNChannel<Closing>>(bobClosing) // for compiler: only tests LNChannel<Any>
             val rcp = bobClosing.state.remoteCommitPublished
             assertNotNull(rcp)
             Triple(aliceClosing, bobClosing, listOf(htlcAlice1a, htlcAlice1b, htlcAlice2, htlcBob1a, htlcBob1b, htlcBob2))

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
@@ -37,7 +37,7 @@ class LegacyWaitForFundingConfirmedTestsCommon {
             OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)
         )
         val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Restore(state))
-        assertIs<LNChannel<Offline>>(state1)
+        assertIs<Offline>(state1.state)
         assertEquals(actions1.size, 1)
         val watchConfirmed = actions1.findWatch<WatchConfirmed>()
         assertEquals(watchConfirmed.event, BITCOIN_FUNDING_DEPTHOK)
@@ -46,7 +46,7 @@ class LegacyWaitForFundingConfirmedTestsCommon {
         val localInit = Init(state.commitments.localParams.features.toByteArray().byteVector())
         val remoteInit = Init(state.commitments.remoteParams.features.toByteArray().byteVector())
         val (state2, actions2) = state1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(state2)
+        assertIs<Syncing>(state2.state)
         assertTrue(actions2.isEmpty())
         val channelReestablish = ChannelReestablish(
             state.channelId,
@@ -62,7 +62,7 @@ class LegacyWaitForFundingConfirmedTestsCommon {
         assertEquals(watchConfirmed, actions3.findWatch())
         // The funding tx confirms.
         val (state4, actions4) = state3.process(ChannelCommand.WatchReceived(WatchEventConfirmed(state.channelId, watchConfirmed.event, 1105, 3, fundingTx)))
-        assertIs<LNChannel<LegacyWaitForFundingLocked>>(state4)
+        assertIs<LegacyWaitForFundingLocked>(state4.state)
         assertEquals(actions4.size, 2)
         actions4.hasOutgoingMessage<ChannelReady>()
         actions4.has<ChannelAction.Storage.StoreState>()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
@@ -40,7 +40,7 @@ class LegacyWaitForFundingLockedTestsCommon {
             OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)
         )
         val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Restore(state))
-        assertIs<LNChannel<Offline>>(state1)
+        assertIs<Offline>(state1.state)
         assertEquals(actions1.size, 1)
         val watchSpent = actions1.findWatch<WatchSpent>()
         assertEquals(watchSpent.event, BITCOIN_FUNDING_SPENT)
@@ -49,7 +49,7 @@ class LegacyWaitForFundingLockedTestsCommon {
         val localInit = Init(state.commitments.localParams.features.toByteArray().byteVector())
         val remoteInit = Init(state.commitments.remoteParams.features.toByteArray().byteVector())
         val (state2, actions2) = state1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(state2)
+        assertIs<Syncing>(state2.state)
         assertTrue(actions2.isEmpty())
         val channelReestablish = ChannelReestablish(
             state.channelId,
@@ -65,7 +65,7 @@ class LegacyWaitForFundingLockedTestsCommon {
         actions3.hasOutgoingMessage<ChannelReady>()
         // Our peer sends us funding_locked.
         val (state4, actions4) = state3.process(ChannelCommand.MessageReceived(ChannelReady(state.channelId, randomKey().publicKey())))
-        assertIs<LNChannel<Normal>>(state4)
+        assertIs<Normal>(state4.state)
         assertEquals(actions4.size, 3)
         val watchConfirmed = actions4.hasWatch<WatchConfirmed>()
         assertEquals(watchConfirmed.event, BITCOIN_FUNDING_DEEPLYBURIED)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NegotiatingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NegotiatingTestsCommon.kt
@@ -26,7 +26,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         val (alice, _, _) = init()
         val (_, add) = makeCmdAdd(500_000.msat, alice.staticParams.remoteNodeId, TestConstants.defaultBlockHeight.toLong())
         val (alice1, actions1) = alice.process(ChannelCommand.ExecuteCommand(add))
-        assertIs<LNChannel<Negotiating>>(alice1)
+        assertIs<Negotiating>(alice1.state)
         assertEquals(1, actions1.size)
         actions1.hasCommandError<ChannelUnavailable>()
     }
@@ -49,7 +49,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         // bob answers with a counter proposition in alice's fee range
         val (bob3, bobActions3) = bob2.process(ChannelCommand.MessageReceived(aliceCloseSig1))
-        assertIs<LNChannel<Negotiating>>(bob3)
+        assertIs<Negotiating>(bob3.state)
         val bobCloseSig1 = bobActions3.findOutgoingMessage<ClosingSigned>()
         assertTrue(aliceFeeRange.min < bobCloseSig1.feeSatoshis)
         assertTrue(bobCloseSig1.feeSatoshis < aliceFeeRange.max)
@@ -59,14 +59,14 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         // alice accepts this proposition
         val (alice3, aliceActions3) = alice2.process(ChannelCommand.MessageReceived(bobCloseSig1))
-        assertIs<LNChannel<Closing>>(alice3)
+        assertIs<Closing>(alice3.state)
         val mutualCloseTx = aliceActions3.findTxs().first()
         assertEquals(aliceActions3.findWatch<WatchConfirmed>().txId, mutualCloseTx.txid)
         assertEquals(mutualCloseTx.txOut.size, 2) // NB: anchors are removed from the closing tx
         val aliceCloseSig2 = aliceActions3.findOutgoingMessage<ClosingSigned>()
         assertEquals(aliceCloseSig2.feeSatoshis, bobCloseSig1.feeSatoshis)
         val (bob4, bobActions4) = bob3.process(ChannelCommand.MessageReceived(aliceCloseSig2))
-        assertIs<LNChannel<Closing>>(bob4)
+        assertIs<Closing>(bob4.state)
         bobActions4.hasTx(mutualCloseTx)
         assertEquals(bobActions4.findWatch<WatchConfirmed>().txId, mutualCloseTx.txid)
         assertEquals(alice3.state.mutualClosePublished.map { it.tx }, listOf(mutualCloseTx))
@@ -93,7 +93,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         val (_, bob2, aliceCloseSig) = mutualCloseAlice(alice1, bob1)
         val (bob3, actions) = bob2.process(ChannelCommand.MessageReceived(aliceCloseSig))
-        assertIs<LNChannel<Closing>>(bob3)
+        assertIs<Closing>(bob3.state)
         val bobCloseSig = actions.findOutgoingMessage<ClosingSigned>()
         assertEquals(bobCloseSig.feeSatoshis, aliceCloseSig.feeSatoshis)
     }
@@ -122,7 +122,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         // bob agrees with that proposal
         val (bob3, bobActions3) = bob2.process(ChannelCommand.MessageReceived(aliceCloseSig1))
-        assertIs<LNChannel<Closing>>(bob3)
+        assertIs<Closing>(bob3.state)
         val bobCloseSig1 = bobActions3.findOutgoingMessage<ClosingSigned>()
         assertNotNull(bobCloseSig1.tlvStream.get<ClosingSignedTlv.FeeRange>())
         assertEquals(aliceCloseSig1.feeSatoshis, bobCloseSig1.feeSatoshis)
@@ -130,7 +130,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         assertEquals(mutualCloseTx.txOut.size, 2) // NB: anchors are removed from the closing tx
 
         val (alice3, aliceActions3) = alice2.process(ChannelCommand.MessageReceived(bobCloseSig1))
-        assertIs<LNChannel<Closing>>(alice3)
+        assertIs<Closing>(alice3.state)
         aliceActions3.hasTx(mutualCloseTx)
     }
 
@@ -164,13 +164,13 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         // alice accepts this proposition
         val (alice3, aliceActions3) = alice2.process(ChannelCommand.MessageReceived(bobCloseSig))
-        assertIs<LNChannel<Closing>>(alice3)
+        assertIs<Closing>(alice3.state)
         val mutualCloseTx = aliceActions3.findTxs().first()
         val aliceCloseSig2 = aliceActions3.findOutgoingMessage<ClosingSigned>()
         assertEquals(aliceCloseSig2.feeSatoshis, 2022.sat)
 
         val (bob4, bobActions4) = bob3.process(ChannelCommand.MessageReceived(aliceCloseSig2))
-        assertIs<LNChannel<Closing>>(bob4)
+        assertIs<Closing>(bob4.state)
         bobActions4.hasTx(mutualCloseTx)
     }
 
@@ -186,14 +186,14 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         // bob directly agrees because their fee estimator matches
         val (bob3, bobActions3) = bob2.process(ChannelCommand.MessageReceived(aliceCloseSig))
-        assertIs<LNChannel<Closing>>(bob3)
+        assertIs<Closing>(bob3.state)
         val mutualCloseTx = bobActions3.findTxs().first()
         val bobCloseSig = bobActions3.findOutgoingMessage<ClosingSigned>()
         assertEquals(bobCloseSig.feeSatoshis, aliceCloseSig.feeSatoshis)
 
         // alice accepts this proposition
         val (alice3, aliceActions3) = alice2.process(ChannelCommand.MessageReceived(bobCloseSig))
-        assertIs<LNChannel<Closing>>(alice3)
+        assertIs<Closing>(alice3.state)
         aliceActions3.hasTx(mutualCloseTx)
     }
 
@@ -206,7 +206,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         // Bob has nothing at stake
         val (_, bob2, aliceCloseSig) = mutualCloseBob(alice1, bob1)
         val (bob3, bobActions3) = bob2.process(ChannelCommand.MessageReceived(aliceCloseSig))
-        assertIs<LNChannel<Closing>>(bob3)
+        assertIs<Closing>(bob3.state)
         val mutualCloseTx = bobActions3.findTxs().first()
         assertEquals(bob3.state.mutualClosePublished.map { it.tx }, listOf(mutualCloseTx))
         assertEquals(bobActions3.findWatches<WatchConfirmed>().map { it.event }, listOf(BITCOIN_TX_CONFIRMED(mutualCloseTx)))
@@ -227,7 +227,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         // bob makes a proposal outside our fee range
         val (_, bobCloseSig1) = makeLegacyClosingSigned(alice2, bob2, 2_500.sat)
         val (alice3, actions3) = alice2.process(ChannelCommand.MessageReceived(bobCloseSig1))
-        assertIs<LNChannel<Negotiating>>(alice3)
+        assertIs<Negotiating>(alice3.state)
         val aliceCloseSig2 = actions3.findOutgoingMessage<ClosingSigned>()
         assertTrue(aliceCloseSig1.feeSatoshis < aliceCloseSig2.feeSatoshis)
         assertTrue(aliceCloseSig2.feeSatoshis < 1600.sat)
@@ -236,7 +236,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         val (_, bobCloseSig2) = makeLegacyClosingSigned(alice2, bob2, 2_000.sat)
         val (alice4, actions4) = alice3.process(ChannelCommand.MessageReceived(bobCloseSig2))
-        assertIs<LNChannel<Negotiating>>(alice4)
+        assertIs<Negotiating>(alice4.state)
         val aliceCloseSig3 = actions4.findOutgoingMessage<ClosingSigned>()
         assertTrue(aliceCloseSig2.feeSatoshis < aliceCloseSig3.feeSatoshis)
         assertTrue(aliceCloseSig3.feeSatoshis < 1800.sat)
@@ -245,7 +245,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         val (_, bobCloseSig3) = makeLegacyClosingSigned(alice2, bob2, 1_800.sat)
         val (alice5, actions5) = alice4.process(ChannelCommand.MessageReceived(bobCloseSig3))
-        assertIs<LNChannel<Negotiating>>(alice5)
+        assertIs<Negotiating>(alice5.state)
         val aliceCloseSig4 = actions5.findOutgoingMessage<ClosingSigned>()
         assertTrue(aliceCloseSig3.feeSatoshis < aliceCloseSig4.feeSatoshis)
         assertTrue(aliceCloseSig4.feeSatoshis < 1800.sat)
@@ -254,7 +254,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         val (_, bobCloseSig4) = makeLegacyClosingSigned(alice2, bob2, aliceCloseSig4.feeSatoshis)
         val (alice6, actions6) = alice5.process(ChannelCommand.MessageReceived(bobCloseSig4))
-        assertIs<LNChannel<Closing>>(alice6)
+        assertIs<Closing>(alice6.state)
         val mutualCloseTx = actions6.findTxs().first()
         assertEquals(alice6.state.mutualClosePublished.size, 1)
         assertEquals(mutualCloseTx, alice6.state.mutualClosePublished.first().tx)
@@ -269,7 +269,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         // alice starts with a very low proposal
         val (aliceCloseSig1, _) = makeLegacyClosingSigned(alice2, bob2, 500.sat)
         val (bob3, actions3) = bob2.process(ChannelCommand.MessageReceived(aliceCloseSig1))
-        assertIs<LNChannel<Negotiating>>(bob3)
+        assertIs<Negotiating>(bob3.state)
         val bobCloseSig1 = actions3.findOutgoingMessage<ClosingSigned>()
         assertTrue(3000.sat < bobCloseSig1.feeSatoshis)
         assertEquals(bob3.state.closingTxProposed.last().size, 1)
@@ -277,7 +277,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         val (aliceCloseSig2, _) = makeLegacyClosingSigned(alice2, bob2, 750.sat)
         val (bob4, actions4) = bob3.process(ChannelCommand.MessageReceived(aliceCloseSig2))
-        assertIs<LNChannel<Negotiating>>(bob4)
+        assertIs<Negotiating>(bob4.state)
         val bobCloseSig2 = actions4.findOutgoingMessage<ClosingSigned>()
         assertTrue(2000.sat < bobCloseSig2.feeSatoshis)
         assertEquals(bob4.state.closingTxProposed.last().size, 2)
@@ -285,7 +285,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         val (aliceCloseSig3, _) = makeLegacyClosingSigned(alice2, bob2, 1000.sat)
         val (bob5, actions5) = bob4.process(ChannelCommand.MessageReceived(aliceCloseSig3))
-        assertIs<LNChannel<Negotiating>>(bob5)
+        assertIs<Negotiating>(bob5.state)
         val bobCloseSig3 = actions5.findOutgoingMessage<ClosingSigned>()
         assertTrue(1500.sat < bobCloseSig3.feeSatoshis)
         assertEquals(bob5.state.closingTxProposed.last().size, 3)
@@ -293,7 +293,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         val (aliceCloseSig4, _) = makeLegacyClosingSigned(alice2, bob2, 1300.sat)
         val (bob6, actions6) = bob5.process(ChannelCommand.MessageReceived(aliceCloseSig4))
-        assertIs<LNChannel<Negotiating>>(bob6)
+        assertIs<Negotiating>(bob6.state)
         val bobCloseSig4 = actions6.findOutgoingMessage<ClosingSigned>()
         assertTrue(1300.sat < bobCloseSig4.feeSatoshis)
         assertEquals(bob6.state.closingTxProposed.last().size, 4)
@@ -301,7 +301,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         val (aliceCloseSig5, _) = makeLegacyClosingSigned(alice2, bob2, bobCloseSig4.feeSatoshis)
         val (bob7, actions7) = bob6.process(ChannelCommand.MessageReceived(aliceCloseSig5))
-        assertIs<LNChannel<Closing>>(bob7)
+        assertIs<Closing>(bob7.state)
         val mutualCloseTx = actions7.findTxs().first()
         assertEquals(bob7.state.mutualClosePublished.size, 1)
         assertEquals(mutualCloseTx, bob7.state.mutualClosePublished.first().tx)
@@ -312,7 +312,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         val (alice, bob) = reachNormal()
         val alice1 = alice.updateFeerate(FeeratePerKw(1_000.sat))
         val (alice2, bob2, aliceCloseSig1) = mutualCloseAlice(alice1, bob)
-        assertIs<LNChannel<ChannelStateWithCommitments>>(alice2)
+        assertIs<ChannelStateWithCommitments>(alice2.state)
         var mutableAlice: LNChannel<ChannelStateWithCommitments> = alice2
         var aliceCloseSig = aliceCloseSig1
 
@@ -323,11 +323,13 @@ class NegotiatingTestsCommon : LightningTestSuite() {
             val (_, bobClosing) = makeLegacyClosingSigned(alice2, bob2, bobNextFee)
             val (aliceNew, actions) = mutableAlice.process(ChannelCommand.MessageReceived(bobClosing))
             aliceCloseSig = actions.findOutgoingMessage()
-            assertIs<LNChannel<ChannelStateWithCommitments>>(aliceNew)
+            assertIs<ChannelStateWithCommitments>(aliceNew.state)
+            assertIs<LNChannel<ChannelStateWithCommitments>>(aliceNew) // for compiler: only tests LNChannel<Any>
             mutableAlice = aliceNew
         }
 
-        assertIs<LNChannel<Closing>>(mutableAlice)
+        assertIs<Closing>(mutableAlice.state)
+        assertIs<LNChannel<Closing>>(mutableAlice) // for compiler: only tests LNChannel<Any>
         assertEquals(mutableAlice.state.mutualClosePublished.size, 1)
     }
 
@@ -335,7 +337,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
     fun `recv ClosingSigned -- invalid signature`() {
         val (_, bob, aliceCloseSig) = init()
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(aliceCloseSig.copy(feeSatoshis = 99_000.sat)))
-        assertIs<LNChannel<Closing>>(bob1)
+        assertIs<Closing>(bob1.state)
         actions.hasOutgoingMessage<Error>()
         actions.hasWatch<WatchConfirmed>()
         actions.findTxs().contains(bob.commitments.localCommit.publishableTxs.commitTx.tx)
@@ -371,7 +373,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         // Alice agrees with Bob's closing fee, publishes her closing tx and replies with her own ClosingSigned
         val (alice2, _) = alice1.process(ChannelCommand.MessageReceived(shutdownB))
         val (alice3, actions4) = alice2.process(ChannelCommand.MessageReceived(closingSignedB))
-        assertIs<LNChannel<Closing>>(alice3)
+        assertIs<Closing>(alice3.state)
         val closingTxA = actions4.filterIsInstance<ChannelAction.Blockchain.PublishTx>().first().tx
         val closingSignedA = actions4.findOutgoingMessage<ClosingSigned>()
         val watch = actions4.findWatch<WatchConfirmed>()
@@ -383,16 +385,16 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         // Bob published his closing tx (which should be the same as Alice's)
         val (bob2, actions5) = bob1.process(ChannelCommand.MessageReceived(closingSignedA))
-        assertIs<LNChannel<Closing>>(bob2)
+        assertIs<Closing>(bob2.state)
         val closingTxB = actions5.filterIsInstance<ChannelAction.Blockchain.PublishTx>().first().tx
         assertEquals(closingTxA, closingTxB)
 
         // Alice sees Bob's closing tx (which should be the same as the one she published)
         val (alice4, _) = alice3.process(ChannelCommand.WatchReceived(WatchEventSpent(alice3.channelId, BITCOIN_FUNDING_SPENT, closingTxB)))
-        assertIs<LNChannel<Closing>>(alice4)
+        assertIs<Closing>(alice4.state)
 
         val (alice5, _) = alice4.process(ChannelCommand.WatchReceived(WatchEventConfirmed(alice3.channelId, BITCOIN_TX_CONFIRMED(closingTxA), 144, 0, closingTxA)))
-        assertIs<LNChannel<Closed>>(alice5)
+        assertIs<Closed>(alice5.state)
     }
 
     @Test
@@ -403,7 +405,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         val (alice2, bob2, aliceCloseSig1) = mutualCloseAlice(alice1, bob1)
 
         val (bob3, bobActions3) = bob2.process(ChannelCommand.MessageReceived(aliceCloseSig1))
-        assertIs<LNChannel<Negotiating>>(bob3)
+        assertIs<Negotiating>(bob3.state)
         bobActions3.findOutgoingMessage<ClosingSigned>()
         val firstMutualCloseTx = bob3.state.bestUnpublishedClosingTx
         assertNotNull(firstMutualCloseTx)
@@ -411,7 +413,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         val (_, bobCloseSig1) = makeLegacyClosingSigned(alice2, bob2, 3_000.sat)
         assertNotEquals(bobCloseSig1.feeSatoshis, aliceCloseSig1.feeSatoshis)
         val (alice3, aliceActions3) = alice2.process(ChannelCommand.MessageReceived(bobCloseSig1))
-        assertIs<LNChannel<Negotiating>>(alice3)
+        assertIs<Negotiating>(alice3.state)
         val aliceCloseSig2 = aliceActions3.findOutgoingMessage<ClosingSigned>()
         assertNotEquals(aliceCloseSig2.feeSatoshis, bobCloseSig1.feeSatoshis)
         val latestMutualCloseTx = alice3.state.bestUnpublishedClosingTx
@@ -420,7 +422,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
 
         // at this point bob will receive a new signature, but he decides instead to publish the first mutual close
         val (alice4, aliceActions4) = alice3.process(ChannelCommand.WatchReceived(WatchEventSpent(alice3.channelId, BITCOIN_FUNDING_SPENT, firstMutualCloseTx.tx)))
-        assertIs<LNChannel<Closing>>(alice4)
+        assertIs<Closing>(alice4.state)
         aliceActions4.has<ChannelAction.Storage.StoreState>()
         aliceActions4.hasTx(firstMutualCloseTx.tx)
         assertEquals(aliceActions4.hasWatch<WatchConfirmed>().txId, firstMutualCloseTx.tx.txid)
@@ -438,7 +440,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
     fun `recv Error`() {
         val (alice, _, _) = init()
         val (alice1, actions) = alice.process(ChannelCommand.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
-        assertIs<LNChannel<Closing>>(alice1)
+        assertIs<Closing>(alice1.state)
         actions.hasTx(alice.commitments.localCommit.publishableTxs.commitTx.tx)
         assertTrue(actions.findWatches<WatchConfirmed>().map { it.event }.contains(BITCOIN_TX_CONFIRMED(alice.commitments.localCommit.publishableTxs.commitTx.tx)))
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
@@ -27,10 +27,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val remoteInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
 
         val (alice2, actions) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         val channelReestablishA = actions.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actions1) = bob1.process(ChannelCommand.Connected(remoteInit, localInit))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         val channelReestablishB = actions1.findOutgoingMessage<ChannelReestablish>()
 
         val bobCommitments = bob.commitments
@@ -75,10 +75,12 @@ class OfflineTestsCommon : LightningTestSuite() {
             val (alice1, actions1) = alice0.process(ChannelCommand.ExecuteCommand(cmdAdd))
             val add = actions1.hasOutgoingMessage<UpdateAddHtlc>()
             val (alice2, actions2) = alice1.process(ChannelCommand.ExecuteCommand(CMD_SIGN))
-            assertIs<LNChannel<Normal>>(alice2)
+            assertIs<Normal>(alice2.state)
+            assertIs<LNChannel<Normal>>(alice2) // for compiler: only tests LNChannel<Any>
             actions2.hasOutgoingMessage<CommitSig>()
             val (bob1, _) = bob0.process(ChannelCommand.MessageReceived(add))
-            assertIs<LNChannel<Normal>>(bob1)
+            assertIs<Normal>(bob1.state)
+            assertIs<LNChannel<Normal>>(bob1) // for compiler: only tests LNChannel<Any>
             // bob doesn't receive the sig
             Pair(alice2, bob1)
         }
@@ -88,10 +90,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val remoteInit = Init(ByteVector(bob0.commitments.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         val channelReestablishA = actionsAlice2.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.Connected(remoteInit, localInit))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>()
 
         val bobCommitments = bob0.commitments
@@ -131,11 +133,11 @@ class OfflineTestsCommon : LightningTestSuite() {
 
         val (alice4, _) = alice3.process(ChannelCommand.MessageReceived(revB))
         val (alice5, actionsAlice5) = alice4.process(ChannelCommand.MessageReceived(sigB))
-        assertIs<LNChannel<Normal>>(alice5)
+        assertIs<Normal>(alice5.state)
         val revA = actionsAlice5.hasOutgoingMessage<RevokeAndAck>()
 
         val (bob7, _) = bob6.process(ChannelCommand.MessageReceived(revA))
-        assertIs<LNChannel<Normal>>(bob7)
+        assertIs<Normal>(bob7.state)
 
         assertEquals(1, alice5.commitments.localNextHtlcId)
         assertEquals(1, bob7.commitments.remoteNextHtlcId)
@@ -149,14 +151,16 @@ class OfflineTestsCommon : LightningTestSuite() {
             val (alice1, actionsAlice1) = alice0.process(ChannelCommand.ExecuteCommand(cmdAdd))
             val add = actionsAlice1.hasOutgoingMessage<UpdateAddHtlc>()
             val (alice2, actionsAlice2) = alice1.process(ChannelCommand.ExecuteCommand(CMD_SIGN))
-            assertIs<LNChannel<Normal>>(alice2)
+            assertIs<Normal>(alice2.state)
+            assertIs<LNChannel<Normal>>(alice2) // for compiler: only tests LNChannel<Any>
             val sig = actionsAlice2.hasOutgoingMessage<CommitSig>()
             val (bob1, _) = bob0.process(ChannelCommand.MessageReceived(add))
             val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(sig))
             actionsBob2.hasOutgoingMessage<RevokeAndAck>()
             actionsBob2.hasCommand<CMD_SIGN>()
             val (bob3, actionsBob3) = bob2.process(ChannelCommand.ExecuteCommand(CMD_SIGN))
-            assertIs<LNChannel<Normal>>(bob3)
+            assertIs<Normal>(bob3.state)
+            assertIs<LNChannel<Normal>>(bob3) // for compiler: only tests LNChannel<Any>
             actionsBob3.hasOutgoingMessage<CommitSig>()
             // bob received the sig, but alice didn't receive the revocation
             Pair(alice2, bob3)
@@ -167,10 +171,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val remoteInit = Init(ByteVector(bob0.commitments.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         val channelReestablishA = actionsAlice2.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.Connected(remoteInit, localInit))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>()
 
         val bobCommitments = bob0.commitments
@@ -201,11 +205,11 @@ class OfflineTestsCommon : LightningTestSuite() {
 
         val (alice4, _) = alice3.process(ChannelCommand.MessageReceived(revB))
         val (alice5, actionsAlice5) = alice4.process(ChannelCommand.MessageReceived(sigB))
-        assertIs<LNChannel<Normal>>(alice5)
+        assertIs<Normal>(alice5.state)
         val revA = actionsAlice5.hasOutgoingMessage<RevokeAndAck>()
 
         val (bob4, _) = bob3.process(ChannelCommand.MessageReceived(revA))
-        assertIs<LNChannel<Normal>>(bob4)
+        assertIs<Normal>(bob4.state)
 
         assertEquals(1, alice5.commitments.localNextHtlcId)
         assertEquals(1, bob4.commitments.remoteNextHtlcId)
@@ -226,8 +230,10 @@ class OfflineTestsCommon : LightningTestSuite() {
             val commitSig = actionsAlice.findOutgoingMessage<CommitSig>()
             val (bob6, actionsBob) = bob5.process(ChannelCommand.MessageReceived(commitSig))
             val revokeAndAck = actionsBob.findOutgoingMessage<RevokeAndAck>()
-            assertIs<LNChannel<Normal>>(alice6)
-            assertIs<LNChannel<Normal>>(bob6)
+            assertIs<Normal>(alice6.state)
+            assertIs<LNChannel<Normal>>(alice6) // for compiler: only tests LNChannel<Any>
+            assertIs<Normal>(bob6.state)
+            assertIs<LNChannel<Normal>>(bob6) // for compiler: only tests LNChannel<Any>
             Triple(alice6, bob6, revokeAndAck)
         }
 
@@ -235,10 +241,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val initA = Init(ByteVector(alice0.commitments.localParams.features.toByteArray()))
         val initB = Init(ByteVector(bob0.commitments.localParams.features.toByteArray()))
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(initA, initB))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         val channelReestablishA = actionsAlice2.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.Connected(initB, initA))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>()
         assertEquals(channelReestablishA.nextLocalCommitmentNumber, 4)
         assertEquals(channelReestablishA.nextRemoteRevocationNumber, 3)
@@ -264,8 +270,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (bob5, actionsBob5) = bob4.process(ChannelCommand.MessageReceived(revA))
         assertTrue(actionsBob5.filterIsInstance<ChannelAction.Message.Send>().isEmpty())
 
-        assertIs<LNChannel<Normal>>(alice5)
-        assertIs<LNChannel<Normal>>(bob5)
+        assertIs<Normal>(alice5.state)
+        assertIs<Normal>(bob5.state)
         assertEquals(4, alice5.commitments.localCommit.index)
         assertEquals(4, bob5.commitments.localCommit.index)
     }
@@ -280,7 +286,7 @@ class OfflineTestsCommon : LightningTestSuite() {
             val (alice2, bob2) = TestsHelper.crossSign(nodes2.first, nodes2.second)
             val (nodes3, r3, htlc3) = TestsHelper.addHtlc(10_000.msat, alice2, bob2)
             val (alice3, bob3) = TestsHelper.crossSign(nodes3.first, nodes3.second)
-            assertIs<LNChannel<Normal>>(alice3)
+            assertIs<Normal>(alice3.state)
             // alice will lose the following updates
             val (alice4, bob4) = TestsHelper.fulfillHtlc(htlc1.id, r1, alice3, bob3)
             val (bob5, alice5) = TestsHelper.crossSign(bob4, alice4)
@@ -288,8 +294,8 @@ class OfflineTestsCommon : LightningTestSuite() {
             val (bob7, alice7) = TestsHelper.crossSign(bob6, alice6)
             val (alice8, bob8) = TestsHelper.fulfillHtlc(htlc3.id, r3, alice7, bob7)
             val (bob9, alice9) = TestsHelper.crossSign(bob8, alice8)
-            assertIs<LNChannel<Normal>>(alice9)
-            assertIs<LNChannel<Normal>>(bob9)
+            assertIs<Normal>(alice9.state)
+            assertIs<Normal>(bob9.state)
             Triple(alice9, alice3, bob9)
         }
 
@@ -301,10 +307,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val remoteInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         val channelReestablishA = actionsAlice2.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.Connected(remoteInit, localInit))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>()
 
         // alice realizes she has an old state...
@@ -312,18 +318,18 @@ class OfflineTestsCommon : LightningTestSuite() {
         // ...and asks bob to publish its current commitment
         val error = actionsAlice3.findOutgoingMessage<Error>()
         assertEquals(error.toAscii(), PleasePublishYourCommitment(aliceOld.channelId).message)
-        assertIs<LNChannel<WaitForRemotePublishFutureCommitment>>(alice3)
+        assertIs<WaitForRemotePublishFutureCommitment>(alice3.state)
 
         // bob is nice and publishes its commitment as soon as it detects that alice has an outdated commitment
         val (bob3, actionsBob3) = bob2.process(ChannelCommand.MessageReceived(channelReestablishA))
-        assertIs<LNChannel<Closing>>(bob3)
+        assertIs<Closing>(bob3.state)
         assertNotNull(bob3.state.localCommitPublished)
         val bobCommitTx = bob3.state.localCommitPublished!!.commitTx
         actionsBob3.hasTx(bobCommitTx)
 
         // alice is able to claim her main output
         val (alice4, actionsAlice4) = alice3.process(ChannelCommand.WatchReceived(WatchEventSpent(aliceOld.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)))
-        assertIs<LNChannel<Closing>>(alice4)
+        assertIs<Closing>(alice4.state)
         assertNotNull(alice4.state.futureRemoteCommitPublished)
         assertEquals(bobCommitTx, alice4.state.futureRemoteCommitPublished!!.commitTx)
         assertNotNull(alice4.state.futureRemoteCommitPublished!!.claimMainOutputTx)
@@ -341,16 +347,16 @@ class OfflineTestsCommon : LightningTestSuite() {
         val remoteInit = Init(ByteVector(bob0.commitments.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         actionsAlice2.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.Connected(remoteInit, localInit))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         // let's forge a dishonest channel_reestablish
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>().copy(nextRemoteRevocationNumber = 42)
 
         // alice finds out bob is lying
         val (alice3, actionsAlice3) = alice2.process(ChannelCommand.MessageReceived(channelReestablishB))
-        assertIs<LNChannel<Closing>>(alice3)
+        assertIs<Closing>(alice3.state)
         assertNotNull(alice3.state.localCommitPublished)
         actionsAlice3.hasTx(alice3.state.localCommitPublished!!.commitTx)
         actionsAlice3.hasTx(alice3.state.localCommitPublished!!.claimMainDelayedOutputTx!!.tx)
@@ -375,27 +381,27 @@ class OfflineTestsCommon : LightningTestSuite() {
             // And some htlcs aren't signed yet: they will be dropped when disconnecting, and may be retransmitted later.
             val (bob7, alice7, _) = TestsHelper.addHtlc(TestsHelper.makeCmdAdd(50_000.msat, aliceId, currentBlockHeight, randomBytes32()).second, bob6, alice6)
             val (alice8, bob8, _) = TestsHelper.addHtlc(TestsHelper.makeCmdAdd(70_000.msat, bobId, currentBlockHeight, randomBytes32()).second, alice7, bob7)
-            assertIs<LNChannel<Normal>>(alice8)
-            assertIs<LNChannel<Normal>>(bob8)
+            assertIs<Normal>(alice8.state)
+            assertIs<Normal>(bob8.state)
             Triple(alice8, bob8, listOf(htlc1, htlc2, htlc3, htlc4, htlc5))
         }
 
         // Bob's wallet disconnects, but doesn't restart.
         val (bob1, _) = bob.process(ChannelCommand.Disconnected)
-        assertIs<LNChannel<Offline>>(bob1)
+        assertIs<Offline>(bob1.state)
 
         // Alice's wallet restarts.
         val initState = LNChannel(alice.ctx, WaitForInit)
         val (alice1, actions1) = initState.process(ChannelCommand.Restore(alice.state))
         assertEquals(1, actions1.size)
         actions1.hasWatch<WatchSpent>()
-        assertIs<LNChannel<Offline>>(alice1)
+        assertIs<Offline>(alice1.state)
 
         val localInit = Init(ByteVector(alice.commitments.localParams.features.toByteArray()))
         val remoteInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         assertTrue(actionsAlice2.filterIsInstance<ChannelAction.ProcessIncomingHtlc>().isEmpty())
         val channelReestablishAlice = actionsAlice2.hasOutgoingMessage<ChannelReestablish>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.Connected(localInit, remoteInit))
@@ -436,8 +442,10 @@ class OfflineTestsCommon : LightningTestSuite() {
             val (bob7, _) = bob6.process(ChannelCommand.ExecuteCommand(CMD_FAIL_HTLC(htlc1.id, CMD_FAIL_HTLC.Reason.Failure(PaymentTimeout), commit = false)))
             val (bob8, _) = bob7.process(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlc2.id, preimage, commit = false)))
             val (bob9, _) = bob8.process(ChannelCommand.ExecuteCommand(CMD_SIGN))
-            assertIs<LNChannel<Normal>>(alice6)
-            assertIs<LNChannel<Normal>>(bob9)
+            assertIs<Normal>(alice6.state)
+            assertIs<LNChannel<Normal>>(alice6) // for compiler: only tests LNChannel<Any>
+            assertIs<Normal>(bob9.state)
+            assertIs<LNChannel<Normal>>(bob9) // for compiler: only tests LNChannel<Any>
             Triple(alice6, bob9, listOf(htlc1, htlc2, htlc3, htlc4, htlc5))
         }
 
@@ -448,8 +456,8 @@ class OfflineTestsCommon : LightningTestSuite() {
 
         val (alice2, actionsAlice) = alice1.process(ChannelCommand.Connected(aliceInit, bobInit))
         val (bob2, _) = bob1.process(ChannelCommand.Connected(bobInit, aliceInit))
-        assertIs<LNChannel<Syncing>>(alice2)
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(alice2.state)
+        assertIs<Syncing>(bob2.state)
         val channelReestablishAlice = actionsAlice.hasOutgoingMessage<ChannelReestablish>()
 
         // Bob resends htlc settlement messages to Alice and reprocesses unsettled htlcs.
@@ -473,10 +481,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val remoteInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
 
         val (alice2, actions) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         actions.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actions1) = bob1.process(ChannelCommand.Connected(remoteInit, localInit))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         // Bob waits to receive Alice's channel reestablish before sending his own.
         assertTrue(actions1.isEmpty())
     }
@@ -485,12 +493,12 @@ class OfflineTestsCommon : LightningTestSuite() {
     fun `republish unconfirmed funding tx after restart`() {
         val (alice, bob, txSigsBob) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs, alicePushAmount = 0.msat)
         val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(txSigsBob))
-        assertIs<LNChannel<WaitForFundingConfirmed>>(alice1)
+        assertIs<WaitForFundingConfirmed>(alice1.state)
         val txSigsAlice = actionsAlice1.findOutgoingMessage<TxSignatures>()
         val fundingTx = actionsAlice1.find<ChannelAction.Blockchain.PublishTx>().tx
         assertEquals(fundingTx.hash, txSigsAlice.txHash)
         val (bob1, _) = bob.process(ChannelCommand.MessageReceived(txSigsAlice))
-        assertIs<LNChannel<WaitForFundingConfirmed>>(bob1)
+        assertIs<WaitForFundingConfirmed>(bob1.state)
         // Alice restarts:
         val (alice2, actionsAlice2) = LNChannel(alice1.ctx, WaitForInit).process(ChannelCommand.Restore(alice1.state))
         assertEquals(alice2.state, Offline(alice1.state))
@@ -527,7 +535,7 @@ class OfflineTestsCommon : LightningTestSuite() {
         val previousFundingTx = alice1.state.previousFundingTxs.first().first.signedTx!!
         val (alice2, bob2) = disconnect(alice1, bob1)
         val (alice3, actionsAlice3) = alice2.process(ChannelCommand.WatchReceived(WatchEventConfirmed(alice.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, previousFundingTx)))
-        assertIs<LNChannel<Offline>>(alice3)
+        assertIs<Offline>(alice3.state)
         val aliceState3 = alice3.state.state
         assertIs<WaitForFundingConfirmed>(aliceState3)
         assertEquals(aliceState3.commitments.fundingTxId, previousFundingTx.txid)
@@ -535,7 +543,7 @@ class OfflineTestsCommon : LightningTestSuite() {
         assertEquals(actionsAlice3.size, 1)
         assertEquals(actionsAlice3.hasWatch<WatchSpent>().txId, previousFundingTx.txid)
         val (bob3, actionsBob3) = bob2.process(ChannelCommand.WatchReceived(WatchEventConfirmed(bob.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, previousFundingTx)))
-        assertIs<LNChannel<Offline>>(bob3)
+        assertIs<Offline>(bob3.state)
         val bobState3 = bob3.state.state
         assertIs<WaitForFundingConfirmed>(bobState3)
         assertEquals(bobState3.commitments.fundingTxId, previousFundingTx.txid)
@@ -550,10 +558,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (nodes, _, _) = TestsHelper.addHtlc(50_000_000.msat, alice0, bob0)
         val (alice1, _) = TestsHelper.crossSign(nodes.first, nodes.second)
         val (alice2, _) = alice1.process(ChannelCommand.Disconnected)
-        assertIs<LNChannel<Offline>>(alice2)
+        assertIs<Offline>(alice2.state)
 
         val (alice3, actions3) = alice2.process(ChannelCommand.CheckHtlcTimeout)
-        assertIs<LNChannel<Offline>>(alice3)
+        assertIs<Offline>(alice3.state)
         assertEquals(alice2.state.state, alice3.state.state)
         assertTrue(actions3.isEmpty())
     }
@@ -564,7 +572,7 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (nodes, _, htlc) = TestsHelper.addHtlc(50_000_000.msat, alice0, bob0)
         val (alice1, _) = TestsHelper.crossSign(nodes.first, nodes.second)
         val (alice2, _) = alice1.process(ChannelCommand.Disconnected)
-        assertIs<LNChannel<Offline>>(alice2)
+        assertIs<Offline>(alice2.state)
 
         // alice restarted after the htlc timed out
         val alice3 = alice2.copy(
@@ -572,7 +580,7 @@ class OfflineTestsCommon : LightningTestSuite() {
             state = alice2.state.state
         )
         val (alice4, actions) = alice3.process(ChannelCommand.CheckHtlcTimeout)
-        assertIs<LNChannel<Closing>>(alice4)
+        assertIs<Closing>(alice4.state)
         assertNotNull(alice4.state.localCommitPublished)
         actions.hasOutgoingMessage<Error>()
         actions.has<ChannelAction.Storage.StoreState>()
@@ -593,14 +601,14 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (bob2, actions2) = bob1.process(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, preimage)))
         actions2.hasOutgoingMessage<UpdateFulfillHtlc>()
         val (bob3, _) = bob2.process(ChannelCommand.Disconnected)
-        assertIs<LNChannel<Offline>>(bob3)
+        assertIs<Offline>(bob3.state)
 
         // bob restarts when the fulfilled htlc is close to timing out: alice hasn't signed, so bob closes the channel
         val (bob4, actions4) = run {
             val tmp = bob3.copy(ctx = bob3.ctx.copy(currentBlockHeight = htlc.cltvExpiry.toLong().toInt()))
             tmp.process(ChannelCommand.CheckHtlcTimeout)
         }
-        assertIs<LNChannel<Closing>>(bob4)
+        assertIs<Closing>(bob4.state)
         assertNotNull(bob4.state.localCommitPublished)
         actions4.has<ChannelAction.Storage.StoreState>()
 
@@ -623,10 +631,10 @@ class OfflineTestsCommon : LightningTestSuite() {
     fun `recv CMD_FORCECLOSE`() {
         val (alice, _) = TestsHelper.reachNormal()
         val (alice1, _) = alice.process(ChannelCommand.Disconnected)
-        assertIs<LNChannel<Offline>>(alice1)
+        assertIs<Offline>(alice1.state)
         val commitTx = alice1.state.state.commitments.localCommit.publishableTxs.commitTx.tx
         val (alice2, actions2) = alice1.process(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
-        assertIs<LNChannel<Closing>>(alice2)
+        assertIs<Closing>(alice2.state)
         actions2.hasTx(commitTx)
         assertNull(actions2.findOutgoingMessageOpt<Error>()) // we're offline so we shouldn't try to send messages
     }
@@ -637,14 +645,15 @@ class OfflineTestsCommon : LightningTestSuite() {
             val (alice, bob) = TestsHelper.reachNormal()
             // alice publishes her commitment tx
             val (bob1, _) = bob.process(ChannelCommand.WatchReceived(WatchEventSpent(bob.channelId, BITCOIN_FUNDING_SPENT, alice.commitments.localCommit.publishableTxs.commitTx.tx)))
-            assertIs<LNChannel<Closing>>(bob1)
+            assertIs<Closing>(bob1.state)
+            assertIs<LNChannel<Closing>>(bob1) // for compiler: only tests LNChannel<Any>
             assertNull(bob1.state.closingTypeAlreadyKnown())
             bob1
         }
 
         val state = LNChannel(bob.ctx, WaitForInit)
         val (state1, actions) = state.process(ChannelCommand.Restore(bob.state))
-        assertIs<LNChannel<Closing>>(state1)
+        assertIs<Closing>(state1.state)
         assertEquals(4, actions.size)
         val watchSpent = actions.hasWatch<WatchSpent>()
         assertEquals(bob.commitments.commitInput.outPoint.txid, watchSpent.txId)
@@ -663,9 +672,11 @@ class OfflineTestsCommon : LightningTestSuite() {
         fun disconnect(alice: LNChannel<ChannelStateWithCommitments>, bob: LNChannel<ChannelStateWithCommitments>): Pair<LNChannel<Offline>, LNChannel<Offline>> {
             val (alice1, actionsAlice1) = alice.process(ChannelCommand.Disconnected)
             val (bob1, actionsBob1) = bob.process(ChannelCommand.Disconnected)
-            assertIs<LNChannel<Offline>>(alice1)
+            assertIs<Offline>(alice1.state)
+            assertIs<LNChannel<Offline>>(alice1) // for compiler: only tests LNChannel<Any>
             assertTrue(actionsAlice1.isEmpty())
-            assertIs<LNChannel<Offline>>(bob1)
+            assertIs<Offline>(bob1.state)
+            assertIs<LNChannel<Offline>>(bob1) // for compiler: only tests LNChannel<Any>
             assertTrue(actionsBob1.isEmpty())
             return Pair(alice1, bob1)
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
@@ -24,14 +24,14 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
     fun `recv TxSignatures -- zero conf`() {
         val (alice, _, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputsZeroReserve, zeroConf = true)
         val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(bob.state.fundingTx.localSigs))
-        assertIs<LNChannel<WaitForChannelReady>>(alice1)
+        assertIs<WaitForChannelReady>(alice1.state)
         assertEquals(actionsAlice1.size, 3)
         val fundingTx = actionsAlice1.find<ChannelAction.Blockchain.PublishTx>().tx
         assertEquals(alice.commitments.fundingTxId, fundingTx.txid)
         assertEquals(alice.state.fundingTx.localSigs, actionsAlice1.findOutgoingMessage())
         actionsAlice1.has<ChannelAction.Storage.StoreState>()
         val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(alice.state.fundingTx.localSigs))
-        assertIs<LNChannel<WaitForChannelReady>>(bob1)
+        assertIs<WaitForChannelReady>(bob1.state)
         assertEquals(actionsBob1.size, 2)
         assertEquals(actionsBob1.find<ChannelAction.Blockchain.PublishTx>().tx, fundingTx)
         actionsBob1.has<ChannelAction.Storage.StoreState>()
@@ -43,7 +43,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(bob.state.fundingTx.localSigs))
         val fundingTx = actionsAlice1.find<ChannelAction.Blockchain.PublishTx>().tx
         val (alice2, actionsAlice2) = LNChannel(alice1.ctx, WaitForInit).process(ChannelCommand.Restore(alice1.state))
-        assertIs<LNChannel<Offline>>(alice2)
+        assertIs<Offline>(alice2.state)
         assertEquals(actionsAlice2.size, 2)
         assertEquals(actionsAlice2.find<ChannelAction.Blockchain.PublishTx>().tx, fundingTx)
         assertEquals(actionsAlice2.findWatch<WatchSpent>().txId, fundingTx.txid)
@@ -70,12 +70,12 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
     fun `recv ChannelReady`() {
         val (alice, channelReadyAlice, bob, channelReadyBob) = init()
         val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(channelReadyBob))
-        assertIs<LNChannel<Normal>>(alice1)
+        assertIs<Normal>(alice1.state)
         assertEquals(3, actionsAlice1.size)
         actionsAlice1.has<ChannelAction.Storage.StoreState>()
         assertEquals(actionsAlice1.findWatch<WatchConfirmed>().event, BITCOIN_FUNDING_DEEPLYBURIED)
         val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(channelReadyAlice))
-        assertIs<LNChannel<Normal>>(bob1)
+        assertIs<Normal>(bob1.state)
         assertEquals(3, actionsBob1.size)
         actionsBob1.has<ChannelAction.Storage.StoreState>()
         assertEquals(actionsBob1.findWatch<WatchConfirmed>().event, BITCOIN_FUNDING_DEEPLYBURIED)
@@ -89,11 +89,11 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         val bobBalance = TestConstants.bobFundingAmount.toMilliSatoshi() - 25_000_000.msat + TestConstants.alicePushAmount
         assertEquals(bobBalance, 175_000_000.msat)
         val (alice1, _) = alice.process(ChannelCommand.MessageReceived(fundingLockedBob))
-        assertIs<LNChannel<Normal>>(alice1)
+        assertIs<Normal>(alice1.state)
         assertEquals(alice1.commitments.localCommit.spec.toLocal, aliceBalance)
         assertEquals(alice1.commitments.localCommit.spec.toRemote, bobBalance)
         val (bob1, _) = bob.process(ChannelCommand.MessageReceived(fundingLockedAlice))
-        assertIs<LNChannel<Normal>>(bob1)
+        assertIs<Normal>(bob1.state)
         assertEquals(bob1.commitments.localCommit.spec.toLocal, bobBalance)
         assertEquals(bob1.commitments.localCommit.spec.toRemote, aliceBalance)
     }
@@ -106,11 +106,11 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         val bobBalance = TestConstants.bobFundingAmount.toMilliSatoshi() - 25_000_000.msat + TestConstants.alicePushAmount
         assertEquals(bobBalance, 175_000_000.msat)
         val (alice1, _) = alice.process(ChannelCommand.MessageReceived(fundingLockedBob))
-        assertIs<LNChannel<Normal>>(alice1)
+        assertIs<Normal>(alice1.state)
         assertEquals(alice1.commitments.localCommit.spec.toLocal, aliceBalance)
         assertEquals(alice1.commitments.localCommit.spec.toRemote, bobBalance)
         val (bob1, _) = bob.process(ChannelCommand.MessageReceived(fundingLockedAlice))
-        assertIs<LNChannel<Normal>>(bob1)
+        assertIs<Normal>(bob1.state)
         assertEquals(bob1.commitments.localCommit.spec.toLocal, bobBalance)
         assertEquals(bob1.commitments.localCommit.spec.toRemote, aliceBalance)
     }
@@ -122,7 +122,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         run {
             val bobCommitTx = bob.commitments.localCommit.publishableTxs.commitTx.tx
             val (alice1, actions1) = alice.process(ChannelCommand.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)))
-            assertIs<LNChannel<Closing>>(alice1)
+            assertIs<Closing>(alice1.state)
             assertNotNull(alice1.state.remoteCommitPublished)
             assertEquals(1, actions1.findTxs().size)
             assertEquals(2, actions1.findWatches<WatchConfirmed>().size) // commit tx + main output
@@ -131,7 +131,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         run {
             val aliceCommitTx = alice.commitments.localCommit.publishableTxs.commitTx.tx
             val (bob1, actions1) = bob.process(ChannelCommand.WatchReceived(WatchEventSpent(bob.channelId, BITCOIN_FUNDING_SPENT, aliceCommitTx)))
-            assertIs<LNChannel<Closing>>(bob1)
+            assertIs<Closing>(bob1.state)
             assertNotNull(bob1.state.remoteCommitPublished)
             assertEquals(1, actions1.findTxs().size)
             assertEquals(2, actions1.findWatches<WatchConfirmed>().size) // commit tx + main output
@@ -144,7 +144,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         val aliceCommitTx = alice.commitments.localCommit.publishableTxs.commitTx.tx
         val unknownTx = Transaction(2, aliceCommitTx.txIn, listOf(), 0)
         val (alice1, actions1) = alice.process(ChannelCommand.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, unknownTx)))
-        assertIs<LNChannel<ErrorInformationLeak>>(alice1)
+        assertIs<ErrorInformationLeak>(alice1.state)
         assertTrue(actions1.isEmpty())
     }
 
@@ -154,7 +154,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         listOf(alice, bob).forEach { state ->
             val commitTx = state.commitments.localCommit.publishableTxs.commitTx.tx
             val (state1, actions1) = state.process(ChannelCommand.MessageReceived(Error(state.channelId, "no lightning for you sir")))
-            assertIs<LNChannel<Closing>>(state1)
+            assertIs<Closing>(state1.state)
             assertNotNull(state1.state.localCommitPublished)
             assertNull(actions1.findOutgoingMessageOpt<Error>())
             actions1.hasTx(commitTx)
@@ -179,7 +179,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         listOf(alice, bob).forEach { state ->
             val commitTx = state.commitments.localCommit.publishableTxs.commitTx.tx
             val (state1, actions1) = state.process(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
-            assertIs<LNChannel<Closing>>(state1)
+            assertIs<Closing>(state1.state)
             assertNotNull(state1.state.localCommitPublished)
             val error = actions1.hasOutgoingMessage<Error>()
             assertEquals(ForcedLocalCommit(bob.channelId).message, error.toAscii())
@@ -192,7 +192,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
     fun `recv CMD_FORCECLOSE -- nothing at stake`() {
         val (_, _, bob, _) = init(bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
         val (bob1, actions1) = bob.process(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
         assertEquals(1, actions1.size)
         val error = actions1.hasOutgoingMessage<Error>()
         assertEquals(ForcedLocalCommit(bob.channelId).message, error.toAscii())
@@ -215,11 +215,13 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
             return if (zeroConf) {
                 val (alice, commitAlice, bob, commitBob) = WaitForFundingSignedTestsCommon.init(channelType, aliceFeatures, bobFeatures, currentHeight, aliceFundingAmount, bobFundingAmount, alicePushAmount, bobPushAmount, zeroConf)
                 val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(commitBob))
-                assertIs<LNChannel<WaitForChannelReady>>(alice1)
+                assertIs<WaitForChannelReady>(alice1.state)
+                assertIs<LNChannel<WaitForChannelReady>>(alice1) // for compiler: only tests LNChannel<Any>
                 assertEquals(actionsAlice1.findWatch<WatchSpent>().event, BITCOIN_FUNDING_SPENT)
                 val channelReadyAlice = actionsAlice1.findOutgoingMessage<ChannelReady>()
                 val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(commitAlice))
-                assertIs<LNChannel<WaitForChannelReady>>(bob1)
+                assertIs<WaitForChannelReady>(bob1.state)
+                assertIs<LNChannel<WaitForChannelReady>>(bob1) // for compiler: only tests LNChannel<Any>
                 assertEquals(actionsBob1.findWatch<WatchSpent>().event, BITCOIN_FUNDING_SPENT)
                 val channelReadyBob = actionsBob1.findOutgoingMessage<ChannelReady>()
                 Fixture(alice1, channelReadyAlice, bob1, channelReadyBob)
@@ -231,10 +233,12 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
                 assertEquals(fundingTx.hash, txSigsAlice.txHash)
                 val (bob1, _) = bob.process(ChannelCommand.MessageReceived(txSigsAlice))
                 val (alice2, actionsAlice2) = alice1.process(ChannelCommand.WatchReceived(WatchEventConfirmed(alice.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)))
-                assertIs<LNChannel<WaitForChannelReady>>(alice2)
+                assertIs<WaitForChannelReady>(alice2.state)
+                assertIs<LNChannel<WaitForChannelReady>>(alice2) // for compiler: only tests LNChannel<Any>
                 val channelReadyAlice = actionsAlice2.findOutgoingMessage<ChannelReady>()
                 val (bob2, actionsBob2) = bob1.process(ChannelCommand.WatchReceived(WatchEventConfirmed(bob.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)))
-                assertIs<LNChannel<WaitForChannelReady>>(bob2)
+                assertIs<WaitForChannelReady>(bob2.state)
+                assertIs<LNChannel<WaitForChannelReady>>(bob2) // for compiler: only tests LNChannel<Any>
                 val channelReadyBob = actionsBob2.findOutgoingMessage<ChannelReady>()
                 Fixture(alice2, channelReadyAlice, bob2, channelReadyBob)
             }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreatedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreatedTestsCommon.kt
@@ -56,8 +56,8 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
         assertTrue(commitSigAlice.channelData.isEmpty())
         assertTrue(commitSigBob.htlcSignatures.isEmpty())
         assertTrue(commitSigBob.channelData.isEmpty())
-        assertIs<LNChannel<WaitForFundingSigned>>(alice2)
-        assertIs<LNChannel<WaitForFundingSigned>>(bob3)
+        assertIs<WaitForFundingSigned>(alice2.state)
+        assertIs<WaitForFundingSigned>(bob3.state)
         assertEquals(alice2.state.channelFeatures, ChannelFeatures(setOf(Feature.StaticRemoteKey, Feature.AnchorOutputs)))
         assertEquals(bob3.state.channelFeatures, ChannelFeatures(setOf(Feature.StaticRemoteKey, Feature.AnchorOutputs)))
         verifyCommits(alice2.state.firstCommitTx, bob3.state.firstCommitTx, TestConstants.aliceFundingAmount.toMilliSatoshi() - TestConstants.alicePushAmount, TestConstants.alicePushAmount)
@@ -79,8 +79,8 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
         val commitSigAlice = actionsAlice2.findOutgoingMessage<CommitSig>()
         val commitSigBob = actionsBob3.findOutgoingMessage<CommitSig>()
         assertEquals(commitSigAlice.channelId, commitSigBob.channelId)
-        assertIs<LNChannel<WaitForFundingSigned>>(alice2)
-        assertIs<LNChannel<WaitForFundingSigned>>(bob3)
+        assertIs<WaitForFundingSigned>(alice2.state)
+        assertIs<WaitForFundingSigned>(bob3.state)
         assertEquals(alice2.state.channelFeatures, ChannelFeatures(setOf(Feature.StaticRemoteKey, Feature.AnchorOutputs)))
         assertEquals(bob3.state.channelFeatures, ChannelFeatures(setOf(Feature.StaticRemoteKey, Feature.AnchorOutputs)))
         verifyCommits(alice2.state.firstCommitTx, bob3.state.firstCommitTx, TestConstants.aliceFundingAmount.toMilliSatoshi() - TestConstants.alicePushAmount, TestConstants.bobFundingAmount.toMilliSatoshi() + TestConstants.alicePushAmount)
@@ -102,8 +102,8 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
         val commitSigAlice = actionsAlice2.findOutgoingMessage<CommitSig>()
         val commitSigBob = actionsBob3.findOutgoingMessage<CommitSig>()
         assertEquals(commitSigAlice.channelId, commitSigBob.channelId)
-        assertIs<LNChannel<WaitForFundingSigned>>(alice2)
-        assertIs<LNChannel<WaitForFundingSigned>>(bob3)
+        assertIs<WaitForFundingSigned>(alice2.state)
+        assertIs<WaitForFundingSigned>(bob3.state)
         assertEquals(alice2.state.channelFeatures, ChannelFeatures(setOf(Feature.StaticRemoteKey, Feature.AnchorOutputs, Feature.ZeroReserveChannels)))
         assertEquals(bob3.state.channelFeatures, ChannelFeatures(setOf(Feature.StaticRemoteKey, Feature.AnchorOutputs, Feature.ZeroReserveChannels)))
         verifyCommits(alice2.state.firstCommitTx, bob3.state.firstCommitTx, TestConstants.aliceFundingAmount.toMilliSatoshi(), TestConstants.bobFundingAmount.toMilliSatoshi())
@@ -120,11 +120,11 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(actionsAlice1.findOutgoingMessage<TxAddOutput>()))
         // Alice <--- tx_complete ----- Bob
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.MessageReceived(actionsBob2.findOutgoingMessage<TxComplete>()))
-        assertIs<LNChannel<WaitForFundingSigned>>(alice2)
+        assertIs<WaitForFundingSigned>(alice2.state)
         // Alice ---- tx_complete ----> Bob
         val (bob3, actionsBob3) = bob2.process(ChannelCommand.MessageReceived(actionsAlice2.findOutgoingMessage<TxComplete>()))
         actionsBob3.hasOutgoingMessage<Error>()
-        assertIs<LNChannel<Aborted>>(bob3)
+        assertIs<Aborted>(bob3.state)
     }
 
     @Test
@@ -134,14 +134,14 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
             // Invalid serial_id.
             val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(inputAlice.copy(serialId = 1)))
             actionsBob1.hasOutgoingMessage<Error>()
-            assertIs<LNChannel<Aborted>>(bob1)
+            assertIs<Aborted>(bob1.state)
         }
         run {
             // Below dust.
             val txAddOutput = TxAddOutput(inputAlice.channelId, 2, 100.sat, Script.write(Script.pay2wpkh(randomKey().publicKey())).toByteVector())
             val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(txAddOutput))
             actionsBob1.hasOutgoingMessage<Error>()
-            assertIs<LNChannel<Aborted>>(bob1)
+            assertIs<Aborted>(bob1.state)
         }
     }
 
@@ -151,12 +151,12 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
         run {
             val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(CommitSig(alice.channelId, ByteVector64.Zeroes, listOf())))
             assertEquals(actionsAlice1.findOutgoingMessage<Error>().toAscii(), UnexpectedCommitSig(alice.channelId).message)
-            assertIs<LNChannel<Aborted>>(alice1)
+            assertIs<Aborted>(alice1.state)
         }
         run {
             val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(CommitSig(bob.channelId, ByteVector64.Zeroes, listOf())))
             assertEquals(actionsBob1.findOutgoingMessage<Error>().toAscii(), UnexpectedCommitSig(bob.channelId).message)
-            assertIs<LNChannel<Aborted>>(bob1)
+            assertIs<Aborted>(bob1.state)
         }
     }
 
@@ -166,12 +166,12 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
         run {
             val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(TxSignatures(alice.channelId, randomBytes32(), listOf())))
             assertEquals(actionsAlice1.findOutgoingMessage<Error>().toAscii(), UnexpectedFundingSignatures(alice.channelId).message)
-            assertIs<LNChannel<Aborted>>(alice1)
+            assertIs<Aborted>(alice1.state)
         }
         run {
             val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(TxSignatures(bob.channelId, randomBytes32(), listOf())))
             assertEquals(actionsBob1.findOutgoingMessage<Error>().toAscii(), UnexpectedFundingSignatures(bob.channelId).message)
-            assertIs<LNChannel<Aborted>>(bob1)
+            assertIs<Aborted>(bob1.state)
         }
     }
 
@@ -181,12 +181,12 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
         run {
             val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(TxAbort(alice.channelId, "changed my mind")))
             assertTrue(actionsAlice1.isEmpty())
-            assertIs<LNChannel<Aborted>>(alice1)
+            assertIs<Aborted>(alice1.state)
         }
         run {
             val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(TxAbort(bob.channelId, "changed my mind")))
             assertTrue(actionsBob1.isEmpty())
-            assertIs<LNChannel<Aborted>>(bob1)
+            assertIs<Aborted>(bob1.state)
         }
     }
 
@@ -228,7 +228,7 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     fun `recv Error`() {
         val (_, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat)
         val (bob1, actions1) = bob.process(ChannelCommand.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
         assertTrue(actions1.isEmpty())
     }
 
@@ -237,7 +237,7 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
         val (_, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat)
         val (bob1, actions1) = bob.process(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
         assertEquals(actions1.findOutgoingMessage<Error>().toAscii(), ChannelFundingError(bob.channelId).message)
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
     }
 
     @Test
@@ -245,16 +245,16 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
         val (_, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat)
         val (bob1, actions1) = bob.process(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
         assertEquals(actions1.findOutgoingMessage<Error>().toAscii(), ChannelFundingError(bob.channelId).message)
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
     }
 
     @Test
     fun `recv Disconnected`() {
         val (_, bob, txAddInput) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat)
         val (bob1, _) = bob.process(ChannelCommand.MessageReceived(txAddInput))
-        assertIs<LNChannel<WaitForFundingCreated>>(bob1)
+        assertIs<WaitForFundingCreated>(bob1.state)
         val (bob2, actions2) = bob1.process(ChannelCommand.Disconnected)
-        assertIs<LNChannel<Aborted>>(bob2)
+        assertIs<Aborted>(bob2.state)
         assertTrue(actions2.isEmpty())
     }
 
@@ -274,10 +274,12 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
             val (a, b, open) = TestsHelper.init(channelType, aliceFeatures, bobFeatures, currentHeight, aliceFundingAmount, bobFundingAmount, alicePushAmount, bobPushAmount, zeroConf, channelOrigin)
             val (b1, actions) = b.process(ChannelCommand.MessageReceived(open))
             val accept = actions.findOutgoingMessage<AcceptDualFundedChannel>()
-            assertIs<LNChannel<WaitForFundingCreated>>(b1)
+            assertIs<WaitForFundingCreated>(b1.state)
+            assertIs<LNChannel<WaitForFundingCreated>>(b1) // for compiler: only tests LNChannel<Any>
             val (a1, actions2) = a.process(ChannelCommand.MessageReceived(accept))
             val aliceInput = actions2.findOutgoingMessage<TxAddInput>()
-            assertIs<LNChannel<WaitForFundingCreated>>(a1)
+            assertIs<WaitForFundingCreated>(a1.state)
+            assertIs<LNChannel<WaitForFundingCreated>>(a1) // for compiler: only tests LNChannel<Any>
             return Triple(a1, b1, aliceInput)
         }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannelTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannelTestsCommon.kt
@@ -52,7 +52,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
                     null
                 )
             )
-            assertIs<LNChannel<Aborted>>(alice1)
+            assertIs<Aborted>(alice1.state)
             assertTrue(actions1.isEmpty())
         }
     }
@@ -63,7 +63,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
         assertEquals(open.pushAmount, TestConstants.alicePushAmount)
         assertEquals(open.tlvStream.get(), ChannelTlv.ChannelTypeTlv(ChannelType.SupportedChannelType.AnchorOutputs))
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(open))
-        assertIs<LNChannel<WaitForFundingCreated>>(bob1)
+        assertIs<WaitForFundingCreated>(bob1.state)
         assertEquals(3, actions.size)
         assertTrue(bob1.state.channelConfig.hasOption(ChannelConfigOption.FundingPubKeyBasedChannelKeyPath))
         assertEquals(bob1.state.channelFeatures, ChannelFeatures(setOf(Feature.StaticRemoteKey, Feature.AnchorOutputs)))
@@ -77,7 +77,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
         val (_, bob, open) = TestsHelper.init(aliceFundingAmount = 20_000_000.sat)
         assertEquals(open.pushAmount, TestConstants.alicePushAmount)
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(open))
-        assertIs<LNChannel<WaitForFundingCreated>>(bob1)
+        assertIs<WaitForFundingCreated>(bob1.state)
         assertEquals(3, actions.size)
         assertEquals(bob1.state.channelFeatures, ChannelFeatures(setOf(Feature.StaticRemoteKey, Feature.AnchorOutputs)))
         actions.hasOutgoingMessage<AcceptDualFundedChannel>()
@@ -89,7 +89,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
     fun `recv OpenChannel -- zero conf -- zero reserve`() {
         val (_, bob, open) = TestsHelper.init(channelType = ChannelType.SupportedChannelType.AnchorOutputsZeroReserve, zeroConf = true)
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(open))
-        assertIs<LNChannel<WaitForFundingCreated>>(bob1)
+        assertIs<WaitForFundingCreated>(bob1.state)
         assertEquals(3, actions.size)
         assertTrue(bob1.state.channelConfig.hasOption(ChannelConfigOption.FundingPubKeyBasedChannelKeyPath))
         assertEquals(bob1.state.channelFeatures, ChannelFeatures(setOf(Feature.StaticRemoteKey, Feature.AnchorOutputs, Feature.ZeroReserveChannels)))
@@ -106,7 +106,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(open1))
         val error = actions.findOutgoingMessage<Error>()
         assertEquals(error, Error(open.temporaryChannelId, MissingChannelType(open.temporaryChannelId).message))
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
     }
 
     @Test
@@ -116,7 +116,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(open1))
         val error = actions.findOutgoingMessage<Error>()
         assertEquals(error, Error(open.temporaryChannelId, InvalidChannelType(open.temporaryChannelId, ChannelType.SupportedChannelType.AnchorOutputsZeroReserve, ChannelType.SupportedChannelType.StaticRemoteKey).message))
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
     }
 
     @Test
@@ -126,7 +126,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(open1))
         val error = actions.findOutgoingMessage<Error>()
         assertEquals(error, Error(open.temporaryChannelId, InvalidChainHash(open.temporaryChannelId, bob.staticParams.nodeParams.chainHash, Block.LivenetGenesisBlock.hash).message))
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
     }
 
     @Test
@@ -135,7 +135,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(open))
         val error = actions.findOutgoingMessage<Error>()
         assertEquals(error, Error(open.temporaryChannelId, InvalidFundingAmount(open.temporaryChannelId, 100.sat, bob.staticParams.nodeParams.minFundingSatoshis, bob.staticParams.nodeParams.maxFundingSatoshis).message))
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
     }
 
     @Test
@@ -144,7 +144,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(open))
         val error = actions.findOutgoingMessage<Error>()
         assertEquals(error, Error(open.temporaryChannelId, InvalidFundingAmount(open.temporaryChannelId, 30_000_000.sat, bob.staticParams.nodeParams.minFundingSatoshis, bob.staticParams.nodeParams.maxFundingSatoshis).message))
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
     }
 
     @Test
@@ -154,7 +154,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(open1))
         val error = actions.findOutgoingMessage<Error>()
         assertEquals(error, Error(open.temporaryChannelId, InvalidMaxAcceptedHtlcs(open.temporaryChannelId, Channel.MAX_ACCEPTED_HTLCS + 1, Channel.MAX_ACCEPTED_HTLCS).message))
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
     }
 
     @Test
@@ -164,7 +164,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(open))
         val error = actions.findOutgoingMessage<Error>()
         assertEquals(error, Error(open.temporaryChannelId, InvalidPushAmount(open.temporaryChannelId, open.fundingAmount.toMilliSatoshi() + 1.msat, open.fundingAmount.toMilliSatoshi()).message))
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
     }
 
     @Test
@@ -175,14 +175,14 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(open1))
         val error = actions.findOutgoingMessage<Error>()
         assertEquals(error, Error(open.temporaryChannelId, ToSelfDelayTooHigh(open.temporaryChannelId, invalidToSelfDelay, bob.staticParams.nodeParams.maxToLocalDelayBlocks).message))
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
     }
 
     @Test
     fun `recv OpenChannel -- zero-reserve below dust`() {
         val (_, bob, open) = TestsHelper.init(bobFeatures = TestConstants.Bob.nodeParams.features.add(Feature.ZeroReserveChannels to FeatureSupport.Optional))
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(open))
-        assertIs<LNChannel<WaitForFundingCreated>>(bob1)
+        assertIs<WaitForFundingCreated>(bob1.state)
         actions.hasOutgoingMessage<AcceptDualFundedChannel>()
     }
 
@@ -194,14 +194,14 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(open1))
         val error = actions.findOutgoingMessage<Error>()
         assertEquals(error, Error(open.temporaryChannelId, DustLimitTooLarge(open.temporaryChannelId, dustLimitTooHigh, bob.staticParams.nodeParams.maxRemoteDustLimit).message))
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
     }
 
     @Test
     fun `recv Error`() {
         val (_, bob, _) = TestsHelper.init()
         val (bob1, actions) = bob.process(ChannelCommand.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
         assertTrue(actions.isEmpty())
     }
 
@@ -209,7 +209,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
     fun `recv CMD_CLOSE`() {
         val (_, bob, _) = TestsHelper.init()
         val (bob1, actions) = bob.process(ChannelCommand.ExecuteCommand(CMD_CLOSE(null, null)))
-        assertIs<LNChannel<Aborted>>(bob1)
+        assertIs<Aborted>(bob1.state)
         assertTrue(actions.isEmpty())
     }
 
@@ -217,7 +217,7 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
     fun `recv Disconnected`() {
         val (_, bob, _) = TestsHelper.init()
         val (bob1, actions) = bob.process(ChannelCommand.Disconnected)
-        assertIs<LNChannel<WaitForOpenChannel>>(bob1)
+        assertIs<WaitForOpenChannel>(bob1.state)
         assertTrue(actions.isEmpty())
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -269,7 +269,7 @@ class PeerTest : LightningTestSuite() {
         val (alice0, bob0) = TestsHelper.reachNormal()
         val (nodes, _, htlc) = TestsHelper.addHtlc(50_000_000.msat, alice0, bob0)
         val (alice1, _) = TestsHelper.crossSign(nodes.first, nodes.second)
-        assertIs<LNChannel<Normal>>(alice1)
+        assertIs<Normal>(alice1.state)
         val channelId = alice0.channelId
 
         val peer = buildPeer(this,

--- a/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationTestsCommon.kt
@@ -59,8 +59,8 @@ class StateSerializationTestsCommon : LightningTestSuite() {
         tailrec fun addHtlcs(sender: LNChannel<Normal>, receiver: LNChannel<Normal>, amount: MilliSatoshi, count: Int): Pair<LNChannel<Normal>, LNChannel<Normal>> = if (count == 0) Pair(sender, receiver) else {
             val (p, _) = TestsHelper.addHtlc(amount, sender, receiver)
             val (alice1, bob1) = p
-            assertIs<LNChannel<Normal>>(alice1)
-            assertIs<LNChannel<Normal>>(bob1)
+            assertIs<Normal>(alice1.state)
+            assertIs<Normal>(bob1.state)
             addHtlcs(alice1, bob1, amount, count - 1)
         }
 


### PR DESCRIPTION
According to the docs for [assertIs](https://kotlinlang.org/api/latest/kotlin.test/kotlin.test/assert-is.html):

> Note that due to type erasure the type check may be partial (e.g. `assertIs<List<String>>(value)` only checks for the class being `List` and not the type of its elements because it's erased).

And we had a **LOT** of `assertIs<LNChannel<X>>` checks :grimacing:

Note that this PR isn't finished, because we still have code like this that we need to fix:

```
fun <T : ChannelState> someFun(): LNChannel<T> {
  // ...
  assertIs<LNChannel<T>>(state)
  return state
}
```