### PR TITLE
Handle disconnects during dual-funding flow

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -7,6 +7,7 @@ import fr.acinq.lightning.Lightning.nodeFee
 import fr.acinq.lightning.blockchain.fee.OnChainFeeConf
 import fr.acinq.lightning.crypto.KeyManager
 import fr.acinq.lightning.utils.toMilliSatoshi
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -119,7 +120,7 @@ data class NodeParams(
     val nodePrivateKey get() = keyManager.nodeKey.privateKey
     val nodeId get() = keyManager.nodeId
 
-    internal val _nodeEvents = MutableSharedFlow<NodeEvents>()
+    internal val _nodeEvents = MutableSharedFlow<NodeEvents>(replay = 0, extraBufferCapacity = 64, onBufferOverflow = BufferOverflow.SUSPEND)
     val nodeEvents: SharedFlow<NodeEvents> get() = _nodeEvents.asSharedFlow()
 
     init {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -236,7 +236,7 @@ class Peer(
                     val availableWallet = wallet.minus(reservedUtxos)
                     val balance = availableWallet.confirmedBalance
                     logger.info { "swap-in wallet balance: $balance, ${availableWallet.unconfirmedBalance} unconfirmed" }
-                    if (balance > 10_000.sat) {
+                    if (balance >= 10_000.sat) {
                         logger.info { "swap-in wallet: requesting channel using confirmed balance: $balance" }
                         input.send(RequestChannelOpen(Lightning.randomBytes32(), availableWallet, maxFeeBasisPoints = 100, maxFeeFloor = 3_000.sat)) // 100 bips = 1 %
                         reservedUtxos.union(availableWallet.confirmedUtxos)


### PR DESCRIPTION
During the dual-funding flow, a disconnect will lead to a bad state. (e.g. disconnect occurs while in state `WaitForFundingCreated`) Specifically, the UTXOs remain "reserved", and the corresponding sats are stuck in the user's swap-in wallet until they restart the app.

This PR addresses the problem by assigning the UTXOs to a `reserved.pending` state when the flow is started. And from there:

- if `ChannelEvents.Created` is seen, UTXOs move to `reserved.reserved` state
- if `Disconnected` is seen, UTXOs are removed from `reserved.pending`

It would be nice to add a unit test for this. But, if I understand correctly, this would require injecting Electrum messages into the ElectrumClient. Which isn't possible now (it's a private API). But the `electrum-client-rework` branch might help us here.