### PR TITLE
Send `tx_signatures` immediately

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
@@ -31,14 +31,6 @@ data class InteractiveTxParams(
 
     // BOLT 2: MUST set `feerate` greater than or equal to 25/24 times the `feerate` of the previously constructed transaction, rounded down.
     val minNextFeerate: FeeratePerKw = targetFeerate * 25 / 24
-
-    fun shouldSignFirst(localNodeId: PublicKey, remoteNodeId: PublicKey): Boolean = when {
-        // The peer with the lowest total of input amount must transmit its `tx_signatures` first.
-        localAmount < remoteAmount -> true
-        // When both peers contribute the same amount, the peer with the lowest pubkey must transmit its `tx_signatures` first.
-        localAmount == remoteAmount -> LexicographicalOrdering.isLessThan(localNodeId, remoteNodeId)
-        else -> false
-    }
 }
 
 sealed class FundingContributionFailure {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForChannelReady.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForChannelReady.kt
@@ -33,8 +33,6 @@ data class WaitForChannelReady(
                         logger.info { "received remote funding signatures, publishing txId=${fullySignedTx.signedTx.txid}" }
                         val nextState = this@WaitForChannelReady.copy(fundingTx = fullySignedTx)
                         val actions = buildList {
-                            // If we haven't sent our signatures yet, we do it now.
-                            if (!fundingParams.shouldSignFirst(commitments.localParams.nodeId, commitments.remoteParams.nodeId)) add(ChannelAction.Message.Send(fullySignedTx.localSigs))
                             add(ChannelAction.Blockchain.PublishTx(fullySignedTx.signedTx))
                             add(ChannelAction.Storage.StoreState(nextState))
                         }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingConfirmed.kt
@@ -37,8 +37,6 @@ data class WaitForFundingConfirmed(
                         logger.info { "received remote funding signatures, publishing txId=${fullySignedTx.signedTx.txid}" }
                         val nextState = this@WaitForFundingConfirmed.copy(fundingTx = fullySignedTx)
                         val actions = buildList {
-                            // If we haven't sent our signatures yet, we do it now.
-                            if (!fundingParams.shouldSignFirst(commitments.localParams.nodeId, commitments.remoteParams.nodeId)) add(ChannelAction.Message.Send(fullySignedTx.localSigs))
                             add(ChannelAction.Blockchain.PublishTx(fullySignedTx.signedTx))
                             add(ChannelAction.Storage.StoreState(nextState))
                         }
@@ -238,7 +236,7 @@ data class WaitForFundingConfirmed(
                             val actions = buildList {
                                 add(ChannelAction.Blockchain.SendWatch(watchConfirmed))
                                 add(ChannelAction.Storage.StoreState(nextState))
-                                if (fundingParams.shouldSignFirst(commitments.localParams.nodeId, commitments.remoteParams.nodeId)) add(ChannelAction.Message.Send(signedFundingTx.localSigs))
+                                add(ChannelAction.Message.Send(signedFundingTx.localSigs))
                             }
                             Pair(nextState, actions)
                         }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingSigned.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingSigned.kt
@@ -69,7 +69,8 @@ data class WaitForFundingSigned(
                             val nextState = WaitForChannelReady(commitments, fundingParams, signedFundingTx, shortChannelId, channelReady)
                             val actions = buildList {
                                 add(ChannelAction.Blockchain.SendWatch(watchSpent))
-                                if (fundingParams.shouldSignFirst(localParams.nodeId, remoteParams.nodeId)) add(ChannelAction.Message.Send(signedFundingTx.localSigs))
+                                // We're not a liquidity provider, so we don't mind sending our signatures immediately.
+                                add(ChannelAction.Message.Send(signedFundingTx.localSigs))
                                 add(ChannelAction.Message.Send(channelReady))
                                 add(ChannelAction.Storage.StoreState(nextState))
                             }
@@ -91,7 +92,8 @@ data class WaitForFundingSigned(
                             val actions = buildList {
                                 add(ChannelAction.Blockchain.SendWatch(watchConfirmed))
                                 add(ChannelAction.Storage.StoreState(nextState))
-                                if (fundingParams.shouldSignFirst(localParams.nodeId, remoteParams.nodeId)) add(ChannelAction.Message.Send(signedFundingTx.localSigs))
+                                // We're not a liquidity provider, so we don't mind sending our signatures immediately.
+                                add(ChannelAction.Message.Send(signedFundingTx.localSigs))
                             }
                             Pair(nextState, actions)
                         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
@@ -260,30 +260,6 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `signatures ordering`() {
-        val channelId = randomBytes32()
-        val feerate = FeeratePerKw(2500.sat)
-        val alice = PublicKey.fromHex("0388a99397c5a599c4c56ea2b9f938bd2893744a590af7c1f05c9c3ee822c13fdc")
-        val bob = PublicKey.fromHex("0392ea6e914abcee840dc8a763b02ba5ac47e0ac3fadcd5294f9516fe353882522")
-        assertTrue(LexicographicalOrdering.isLessThan(alice, bob))
-        // The node that contributes the most always signs last.
-        assertTrue(!InteractiveTxParams(channelId, true, 500.sat, 400.sat, ByteVector.empty, 0, 0.sat, feerate).shouldSignFirst(alice, bob))
-        assertTrue(!InteractiveTxParams(channelId, false, 500.sat, 400.sat, ByteVector.empty, 0, 0.sat, feerate).shouldSignFirst(alice, bob))
-        assertTrue(!InteractiveTxParams(channelId, true, 500.sat, 400.sat, ByteVector.empty, 0, 0.sat, feerate).shouldSignFirst(bob, alice))
-        assertTrue(!InteractiveTxParams(channelId, false, 500.sat, 400.sat, ByteVector.empty, 0, 0.sat, feerate).shouldSignFirst(bob, alice))
-        // The node that contributes the least always signs first.
-        assertTrue(InteractiveTxParams(channelId, true, 400.sat, 500.sat, ByteVector.empty, 0, 0.sat, feerate).shouldSignFirst(alice, bob))
-        assertTrue(InteractiveTxParams(channelId, false, 400.sat, 500.sat, ByteVector.empty, 0, 0.sat, feerate).shouldSignFirst(alice, bob))
-        assertTrue(InteractiveTxParams(channelId, true, 400.sat, 500.sat, ByteVector.empty, 0, 0.sat, feerate).shouldSignFirst(bob, alice))
-        assertTrue(InteractiveTxParams(channelId, false, 400.sat, 500.sat, ByteVector.empty, 0, 0.sat, feerate).shouldSignFirst(bob, alice))
-        // When both nodes contribute the same amount, the lowest public key signs first.
-        assertTrue(InteractiveTxParams(channelId, true, 500.sat, 500.sat, ByteVector.empty, 0, 0.sat, feerate).shouldSignFirst(alice, bob))
-        assertTrue(InteractiveTxParams(channelId, false, 500.sat, 500.sat, ByteVector.empty, 0, 0.sat, feerate).shouldSignFirst(alice, bob))
-        assertTrue(!InteractiveTxParams(channelId, true, 500.sat, 500.sat, ByteVector.empty, 0, 0.sat, feerate).shouldSignFirst(bob, alice))
-        assertTrue(!InteractiveTxParams(channelId, false, 500.sat, 500.sat, ByteVector.empty, 0, 0.sat, feerate).shouldSignFirst(bob, alice))
-    }
-
-    @Test
     fun `cannot contribute unusable or invalid inputs`() {
         val privKey = randomKey()
         val pubKey = privKey.publicKey()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
@@ -486,10 +486,9 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice, bob, txSigsBob) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs, alicePushAmount = 0.msat)
         val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(txSigsBob))
         assertIs<LNChannel<WaitForFundingConfirmed>>(alice1)
-        val txSigsAlice = actionsAlice1.findOutgoingMessage<TxSignatures>()
         val fundingTx = actionsAlice1.find<ChannelAction.Blockchain.PublishTx>().tx
-        assertEquals(fundingTx.hash, txSigsAlice.txHash)
-        val (bob1, _) = bob.process(ChannelCommand.MessageReceived(txSigsAlice))
+        assertEquals(fundingTx.hash, alice1.state.fundingTx.localSigs.txHash)
+        val (bob1, _) = bob.process(ChannelCommand.MessageReceived(alice1.state.fundingTx.localSigs))
         assertIs<LNChannel<WaitForFundingConfirmed>>(bob1)
         // Alice restarts:
         val (alice2, actionsAlice2) = LNChannel(alice1.ctx, WaitForInit).process(ChannelCommand.Restore(alice1.state))

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
@@ -29,9 +29,8 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
         run {
             val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(commitSigBob))
             assertIs<LNChannel<WaitForFundingConfirmed>>(alice1)
-            // Alice contributed more than Bob, so Bob must send their signatures first.
-            assertEquals(actionsAlice1.size, 3)
-            assertNull(actionsAlice1.findOutgoingMessageOpt<TxSignatures>())
+            assertEquals(actionsAlice1.size, 4)
+            actionsAlice1.hasOutgoingMessage<TxSignatures>()
             actionsAlice1.has<ChannelAction.Storage.StoreState>()
             val watchConfirmed = actionsAlice1.findWatch<WatchConfirmed>()
             assertEquals(WatchConfirmed(alice1.channelId, commitInput.outPoint.txid, commitInput.txOut.publicKeyScript, 3, BITCOIN_FUNDING_DEPTHOK), watchConfirmed)
@@ -40,7 +39,6 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
         run {
             val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(commitSigAlice))
             assertIs<LNChannel<WaitForFundingConfirmed>>(bob1)
-            // Bob contributed less than Alice, so Bob must send their signatures first.
             assertEquals(actionsBob1.size, 5)
             actionsBob1.hasOutgoingMessage<TxSignatures>()
             actionsBob1.has<ChannelAction.Storage.StoreState>()
@@ -58,7 +56,8 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
         run {
             val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(commitSigBob))
             assertIs<LNChannel<WaitForChannelReady>>(alice1)
-            assertEquals(actionsAlice1.size, 4)
+            assertEquals(actionsAlice1.size, 5)
+            actionsAlice1.hasOutgoingMessage<TxSignatures>()
             assertEquals(actionsAlice1.hasOutgoingMessage<ChannelReady>().alias, ShortChannelId.peerId(alice.staticParams.nodeParams.nodeId))
             assertEquals(actionsAlice1.findWatch<WatchSpent>().txId, alice1.commitments.fundingTxId)
             actionsAlice1.has<ChannelAction.Storage.StoreState>()

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -139,7 +139,7 @@ class PeerTest : LightningTestSuite() {
         alice.forward(txSigsBob)
         val txSigsAlice = alice2bob.expect<TxSignatures>()
         bob.forward(txSigsAlice)
-        val (channelId, aliceState) = alice.expectState<WaitForFundingConfirmed>()
+        val (channelId, aliceState) = alice.expectState<WaitForFundingConfirmed> { fundingTx.signedTx != null }
         assertEquals(channelId, txAddInput.channelId)
         bob.expectState<WaitForFundingConfirmed>()
         val fundingTx = aliceState.fundingTx.signedTx
@@ -197,8 +197,8 @@ class PeerTest : LightningTestSuite() {
         bob.forward(commitSigAlice)
         val txSigsBob = bob2alice.expect<TxSignatures>()
         alice.forward(txSigsBob)
-        val channelReadyAlice = alice2bob.expect<ChannelReady>()
         val txSigsAlice = alice2bob.expect<TxSignatures>()
+        val channelReadyAlice = alice2bob.expect<ChannelReady>()
         bob.forward(txSigsAlice)
         val channelReadyBob = bob2alice.expect<ChannelReady>()
         alice.forward(channelReadyBob)
@@ -227,7 +227,7 @@ class PeerTest : LightningTestSuite() {
         val fundingFee = 100.sat
         val serviceFee = (internalRequestBob.maxFee - fundingFee - 1.sat).toMilliSatoshi()
         // total fee is below max acceptable
-        assert(fundingFee + serviceFee.truncateToSatoshi() < internalRequestBob.maxFee)
+        assertTrue(fundingFee + serviceFee.truncateToSatoshi() < internalRequestBob.maxFee)
         val walletAlice = createWallet(nodeParams.first.keyManager, 50_000.sat).second
         val openAlice = OpenChannel(40_000.sat, 0.msat, walletAlice, FeeratePerKw(3500.sat), FeeratePerKw(2500.sat), 0, ChannelType.SupportedChannelType.AnchorOutputsZeroReserve)
         alice.send(openAlice)
@@ -286,7 +286,7 @@ class PeerTest : LightningTestSuite() {
         assertEquals(request.localFundingAmount, 260_000.sat)
         val fundingFee = 100.sat
         val serviceFee = (internalRequestBob.maxFee - fundingFee + 1.sat).toMilliSatoshi()
-        assert(fundingFee + serviceFee.truncateToSatoshi() > internalRequestBob.maxFee)
+        assertTrue(fundingFee + serviceFee.truncateToSatoshi() > internalRequestBob.maxFee)
         val walletAlice = createWallet(nodeParams.first.keyManager, 50_000.sat).second
         val openAlice = OpenChannel(40_000.sat, 0.msat, walletAlice, FeeratePerKw(3500.sat), FeeratePerKw(2500.sat), 0, ChannelType.SupportedChannelType.AnchorOutputsZeroReserve)
         alice.send(openAlice)


### PR DESCRIPTION
We're not a liquidity provider and we're not actually locking utxos, so we don't mind sending our `tx_signatures` first regardless of whether we've contributed more than our peer. This guarantees that there will be no deadlocks waiting for `tx_signatures`.