### PR TITLE
Dual funding isn't mandatory yet

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -126,7 +126,10 @@ data class NodeParams(
         require(features.hasFeature(Feature.VariableLengthOnion, FeatureSupport.Mandatory)) { "${Feature.VariableLengthOnion.rfcName} should be mandatory" }
         require(features.hasFeature(Feature.PaymentSecret, FeatureSupport.Mandatory)) { "${Feature.PaymentSecret.rfcName} should be mandatory" }
         require(features.hasFeature(Feature.ChannelType, FeatureSupport.Mandatory)) { "${Feature.ChannelType.rfcName} should be mandatory" }
-        require(features.hasFeature(Feature.DualFunding, FeatureSupport.Mandatory)) { "${Feature.DualFunding.rfcName} should be mandatory" }
+        // TODO: the ACINQ node cannot activate the dual-funding feature yet as the spec hasn't been merged and some cln nodes on mainnet
+        //  are running an outdated version of dual-funding using the same feature bit, so we currently implicitly assume dual-funding support.
+        //  This should be changed as soon as the dual-funding spec PR is merged and cln ships with an updated implementation.
+        // require(features.hasFeature(Feature.DualFunding, FeatureSupport.Mandatory)) { "${Feature.DualFunding.rfcName} should be mandatory" }
         require(!features.hasFeature(Feature.ZeroConfChannels)) { "${Feature.ZeroConfChannels.rfcName} has been deprecated: use the zeroConfPeers whitelist instead" }
         require(!features.hasFeature(Feature.TrustedSwapInClient)) { "${Feature.TrustedSwapInClient.rfcName} has been deprecated" }
         require(!features.hasFeature(Feature.TrustedSwapInProvider)) { "${Feature.TrustedSwapInProvider.rfcName} has been deprecated" }


### PR DESCRIPTION
While we only support dual-funding, we cannot yet make it mandatory in our `init` message because it would force our peer to activate it, whereas the specification hasn't been merged yet and cln nodes are using the feature bit with an incompatible implementation.

@dpad85 Phoenix should activate the dual-funding feature bit, but only make it `optional` for now, not `mandatory`, otherwise it won't be able to connect to the ACINQ node.