### PR TITLE
Generate invoices using a descriptionHash (h tag)

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -61,7 +61,7 @@ data class WrappedChannelCommand(val channelId: ByteVector32, val channelCommand
 object Disconnected : PeerCommand()
 
 sealed class PaymentCommand : PeerCommand()
-data class ReceivePayment(val paymentPreimage: ByteVector32, val amount: MilliSatoshi?, val description: String, val expirySeconds: Long? = null, val result: CompletableDeferred<PaymentRequest>) : PaymentCommand()
+data class ReceivePayment(val paymentPreimage: ByteVector32, val amount: MilliSatoshi?, val description: Either<String, ByteVector32>, val expirySeconds: Long? = null, val result: CompletableDeferred<PaymentRequest>) : PaymentCommand()
 private object CheckPaymentsTimeout : PaymentCommand()
 data class PayToOpenResponseCommand(val payToOpenResponse: PayToOpenResponse) : PeerCommand()
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -74,7 +74,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
     suspend fun createInvoice(
         paymentPreimage: ByteVector32,
         amount: MilliSatoshi?,
-        description: String,
+        description: Either<String, ByteVector32>,
         extraHops: List<List<PaymentRequest.TaggedField.ExtraHop>>,
         expirySeconds: Long? = null,
         timestampSeconds: Long = currentTimestampSeconds()

--- a/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
@@ -628,12 +628,12 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         }
 
         private fun createInvoice(preimage: ByteVector32): PaymentRequest {
-            return PaymentRequest.create(Block.LivenetGenesisBlock.hash, 150_000.msat, Crypto.sha256(preimage).toByteVector32(), randomKey(), "invoice", CltvExpiryDelta(16), defaultFeatures)
+            return PaymentRequest.create(Block.LivenetGenesisBlock.hash, 150_000.msat, Crypto.sha256(preimage).toByteVector32(), randomKey(), Either.Left("invoice"), CltvExpiryDelta(16), defaultFeatures)
         }
 
         private fun createExpiredInvoice(preimage: ByteVector32 = randomBytes32()): PaymentRequest {
             val now = currentTimestampSeconds()
-            return PaymentRequest.create(Block.LivenetGenesisBlock.hash, 150_000.msat, Crypto.sha256(preimage).toByteVector32(), randomKey(), "invoice", CltvExpiryDelta(16), defaultFeatures, expirySeconds = 60, timestampSeconds = now - 120)
+            return PaymentRequest.create(Block.LivenetGenesisBlock.hash, 150_000.msat, Crypto.sha256(preimage).toByteVector32(), randomKey(), Either.Left("invoice"), CltvExpiryDelta(16), defaultFeatures, expirySeconds = 60, timestampSeconds = now - 120)
         }
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -398,7 +398,7 @@ class PeerTest : LightningTestSuite() {
 
         run {
             val deferredInvoice = CompletableDeferred<PaymentRequest>()
-            bob.send(ReceivePayment(randomBytes32(), 1.msat, "A description: \uD83D\uDE2C", 3600L * 3, deferredInvoice))
+            bob.send(ReceivePayment(randomBytes32(), 1.msat, Either.Left("A description: \uD83D\uDE2C"), 3600L * 3, deferredInvoice))
             val invoice = deferredInvoice.await()
             assertEquals(1.msat, invoice.amount)
             assertEquals(3600L * 3, invoice.expirySeconds)
@@ -416,7 +416,7 @@ class PeerTest : LightningTestSuite() {
 
         run {
             val deferredInvoice = CompletableDeferred<PaymentRequest>()
-            bob.send(ReceivePayment(randomBytes32(), 15_000_000.msat, "default routing hints", null, deferredInvoice))
+            bob.send(ReceivePayment(randomBytes32(), 15_000_000.msat, Either.Left("default routing hints"), null, deferredInvoice))
             val invoice = deferredInvoice.await()
             // The routing hint uses default values since no channel update has been sent by Alice yet.
             assertEquals(1, invoice.routingInfo.size)
@@ -430,7 +430,7 @@ class PeerTest : LightningTestSuite() {
             bob.forward(aliceUpdate)
 
             val deferredInvoice = CompletableDeferred<PaymentRequest>()
-            bob.send(ReceivePayment(randomBytes32(), 5_000_000.msat, "updated routing hints", null, deferredInvoice))
+            bob.send(ReceivePayment(randomBytes32(), 5_000_000.msat, Either.Left("updated routing hints"), null, deferredInvoice))
             val invoice = deferredInvoice.await()
             // The routing hint uses values from Alice's channel update.
             assertEquals(1, invoice.routingInfo.size)
@@ -454,7 +454,7 @@ class PeerTest : LightningTestSuite() {
         val (alice, bob, alice2bob, bob2alice) = newPeers(this, nodeParams, walletParams, listOf(alice0 to bob0), automateMessaging = false)
 
         val deferredInvoice = CompletableDeferred<PaymentRequest>()
-        bob.send(ReceivePayment(randomBytes32(), 15_000_000.msat, "test invoice", null, deferredInvoice))
+        bob.send(ReceivePayment(randomBytes32(), 15_000_000.msat, Either.Left("test invoice"), null, deferredInvoice))
         val invoice = deferredInvoice.await()
 
         alice.send(SendPaymentNormal(UUID.randomUUID(), invoice.amount!!, alice.remoteNodeId, OutgoingPayment.Details.Normal(invoice)))
@@ -500,7 +500,7 @@ class PeerTest : LightningTestSuite() {
         val (alice, bob) = newPeers(this, nodeParams, walletParams, listOf(alice0 to bob0))
 
         val deferredInvoice = CompletableDeferred<PaymentRequest>()
-        bob.send(ReceivePayment(randomBytes32(), 15_000_000.msat, "test invoice", null, deferredInvoice))
+        bob.send(ReceivePayment(randomBytes32(), 15_000_000.msat, Either.Left("test invoice"), null, deferredInvoice))
         val invoice = deferredInvoice.await()
 
         alice.send(SendPaymentNormal(UUID.randomUUID(), invoice.amount!!, alice.remoteNodeId, OutgoingPayment.Details.Normal(invoice)))

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -1219,19 +1219,19 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val paymentHandler = IncomingPaymentHandler(TestConstants.Bob.nodeParams, TestConstants.Bob.walletParams, InMemoryPaymentsDb())
 
         // create incoming payment that has expired and not been paid
-        val expiredInvoice = paymentHandler.createInvoice(randomBytes32(), defaultAmount, "expired", listOf(), expirySeconds = 3600,
+        val expiredInvoice = paymentHandler.createInvoice(randomBytes32(), defaultAmount, Either.Left("expired"), listOf(), expirySeconds = 3600,
             timestampSeconds = 1)
 
         // create incoming payment that has expired and been paid
         delay(100)
-        val paidInvoice = paymentHandler.createInvoice(defaultPreimage, defaultAmount, "paid", listOf(), expirySeconds = 3600,
+        val paidInvoice = paymentHandler.createInvoice(defaultPreimage, defaultAmount, Either.Left("paid"), listOf(), expirySeconds = 3600,
             timestampSeconds = 100)
         paymentHandler.db.receivePayment(paidInvoice.paymentHash, receivedWith = setOf(IncomingPayment.ReceivedWith.NewChannel(id = UUID.randomUUID(), amount = 15_000_000.msat, serviceFee = 1_000_000.msat, channelId = null)),
             receivedAt = 101) // simulate incoming payment being paid before it expired
 
         // create unexpired payment
         delay(100)
-        val unexpiredInvoice = paymentHandler.createInvoice(randomBytes32(), defaultAmount, "unexpired", listOf(), expirySeconds = 3600)
+        val unexpiredInvoice = paymentHandler.createInvoice(randomBytes32(), defaultAmount, Either.Left("unexpired"), listOf(), expirySeconds = 3600)
 
         val unexpiredPayment = paymentHandler.db.getIncomingPayment(unexpiredInvoice.paymentHash)!!
         val paidPayment = paymentHandler.db.getIncomingPayment(paidInvoice.paymentHash)!!
@@ -1307,7 +1307,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         }
 
         private suspend fun makeIncomingPayment(payee: IncomingPaymentHandler, amount: MilliSatoshi?, expirySeconds: Long? = null, timestamp: Long = currentTimestampSeconds()): Pair<IncomingPayment, ByteVector32> {
-            val paymentRequest = payee.createInvoice(defaultPreimage, amount, "unit test", listOf(), expirySeconds, timestamp)
+            val paymentRequest = payee.createInvoice(defaultPreimage, amount, Either.Left("unit test"), listOf(), expirySeconds, timestamp)
             assertNotNull(paymentRequest.paymentMetadata)
             return Pair(payee.db.getIncomingPayment(paymentRequest.paymentHash)!!, paymentRequest.paymentSecret)
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
@@ -247,7 +247,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
                 amount = 195_000.msat,
                 paymentHash = randomBytes32(),
                 privateKey = recipientKey,
-                description = "trampoline backwards-compatibility",
+                description = Either.Left("trampoline backwards-compatibility"),
                 minFinalCltvExpiryDelta = PaymentRequest.DEFAULT_MIN_FINAL_EXPIRY_DELTA,
                 features = Features(invoiceFeatures.toMap()),
             )
@@ -495,7 +495,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         // The invoice comes from Bob, our direct peer (and trampoline node).
         val preimage = randomBytes32()
         val incomingPaymentHandler = IncomingPaymentHandler(TestConstants.Bob.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
-        val invoice = incomingPaymentHandler.createInvoice(preimage, amount = null, "phoenix to phoenix", listOf())
+        val invoice = incomingPaymentHandler.createInvoice(preimage, amount = null, Either.Left("phoenix to phoenix"), listOf())
         val payment = SendPaymentNormal(UUID.randomUUID(), 300_000.msat, invoice.nodeId, OutgoingPayment.Details.Normal(invoice))
 
         val result = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
@@ -962,7 +962,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
             amount = amount,
             paymentHash = paymentHash,
             privateKey = privKey,
-            description = "unit test",
+            description = Either.Left("unit test"),
             minFinalCltvExpiryDelta = PaymentRequest.DEFAULT_MIN_FINAL_EXPIRY_DELTA,
             features = Features(invoiceFeatures.toMap()),
             extraHops = extraHops

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/PaymentRequestTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/PaymentRequestTestsCommon.kt
@@ -434,7 +434,7 @@ class PaymentRequestTestsCommon : LightningTestSuite() {
             mapOf(Feature.VariableLengthOnion to FeatureSupport.Mandatory, Feature.PaymentSecret to FeatureSupport.Mandatory, Feature.ShutdownAnySegwit to FeatureSupport.Optional),
             setOf(UnknownFeature(103), UnknownFeature(256))
         )
-        val pr = PaymentRequest.create(Block.LivenetGenesisBlock.hash, 500.msat, randomBytes32(), randomKey(), "non-invoice features", CltvExpiryDelta(6), nodeFeatures)
+        val pr = PaymentRequest.create(Block.LivenetGenesisBlock.hash, 500.msat, randomBytes32(), randomKey(), Either.Left("non-invoice features"), CltvExpiryDelta(6), nodeFeatures)
         assertEquals(Features(Feature.VariableLengthOnion to FeatureSupport.Mandatory, Feature.PaymentSecret to FeatureSupport.Mandatory), Features(pr.features))
     }
 
@@ -480,7 +480,7 @@ class PaymentRequestTestsCommon : LightningTestSuite() {
     @Test
     fun `payment secret`() {
         val features = Features(Feature.VariableLengthOnion to FeatureSupport.Mandatory, Feature.PaymentSecret to FeatureSupport.Mandatory, Feature.BasicMultiPartPayment to FeatureSupport.Optional)
-        val pr = PaymentRequest.create(Block.LivenetGenesisBlock.hash, 123.msat, ByteVector32.One, priv, "Some invoice", CltvExpiryDelta(18), features)
+        val pr = PaymentRequest.create(Block.LivenetGenesisBlock.hash, 123.msat, ByteVector32.One, priv, Either.Left("Some invoice"), CltvExpiryDelta(18), features)
         assertNotNull(pr.paymentSecret)
         assertEquals(ByteVector("024100"), pr.features)
 
@@ -500,7 +500,7 @@ class PaymentRequestTestsCommon : LightningTestSuite() {
                 123.msat,
                 ByteVector32.One,
                 priv,
-                "Invoice without secrets",
+                Either.Left("Invoice without secrets"),
                 CltvExpiryDelta(18),
                 Features(Feature.VariableLengthOnion to FeatureSupport.Optional, Feature.BasicMultiPartPayment to FeatureSupport.Optional)
             )

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/PaymentRequestTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/PaymentRequestTestsCommon.kt
@@ -507,6 +507,19 @@ class PaymentRequestTestsCommon : LightningTestSuite() {
         }
     }
 
+    @Test
+    fun `invoice with descriptionHash`() {
+        val descriptionHash = randomBytes32()
+        val features = Features(Feature.VariableLengthOnion to FeatureSupport.Mandatory, Feature.PaymentSecret to FeatureSupport.Mandatory, Feature.BasicMultiPartPayment to FeatureSupport.Optional)
+        val pr = PaymentRequest.create(Block.LivenetGenesisBlock.hash, 123.msat, ByteVector32.One, priv, Either.Right(descriptionHash), CltvExpiryDelta(18), features)
+        assertNotNull(pr.descriptionHash)
+        assertNull(pr.description)
+
+        val pr1 = PaymentRequest.read(pr.write())
+        assertEquals(pr1.descriptionHash, pr.descriptionHash)
+        assertNull(pr1.description)
+    }
+
     companion object {
         fun createInvoiceUnsafe(
             amount: MilliSatoshi? = null,


### PR DESCRIPTION
As per Bolt [11](https://github.com/lightning/bolts/blob/master/11-payment-encoding.md), an invoice:

> * MUST include either exactly one `d` (description) or exactly one `h` (descriptionHash) field.
>   * if `d` is included:
>     * MUST set d to a valid UTF-8 string.
>     * SHOULD use a complete description of the purpose of the payment.
>   * if `h` is included:
>     * MUST make the preimage of the hashed description in `h` available through some unspecified means.

The issue is that the existing API only supports a description, but not a descriptionHash. And the `h` field is required to use this library for things like:

- [lnurl-pay](https://github.com/lnurl/luds/blob/luds/06.md)
- [lightning identifiers](https://github.com/lnurl/luds/blob/luds/16.md)