### PR TITLE
Add multiple commitments to `Commitments`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelException.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelException.kt
@@ -58,6 +58,7 @@ data class InvalidHtlcSignature                    (override val channelId: Byte
 data class InvalidCloseSignature                   (override val channelId: ByteVector32, val txId: ByteVector32) : ChannelException(channelId, "invalid close signature: txId=$txId")
 data class InvalidCloseFee                         (override val channelId: ByteVector32, val fee: Satoshi) : ChannelException(channelId, "invalid close fee: fee_satoshis=$fee")
 data class InvalidCloseAmountBelowDust             (override val channelId: ByteVector32, val txId: ByteVector32) : ChannelException(channelId, "invalid closing tx: some outputs are below dust: txId=$txId")
+data class CommitSigCountMismatch                  (override val channelId: ByteVector32, val expected: Int, val actual: Int) : ChannelException(channelId, "commit sig count mismatch: expected=$expected actual=$actual")
 data class HtlcSigCountMismatch                    (override val channelId: ByteVector32, val expected: Int, val actual: Int) : ChannelException(channelId, "htlc sig count mismatch: expected=$expected actual: $actual")
 data class ForcedLocalCommit                       (override val channelId: ByteVector32) : ChannelException(channelId, "forced local commit")
 data class UnexpectedHtlcId                        (override val channelId: ByteVector32, val expected: Long, val actual: Long) : ChannelException(channelId, "unexpected htlc id: expected=$expected actual=$actual")

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForChannelReady.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForChannelReady.kt
@@ -7,14 +7,12 @@ import fr.acinq.lightning.blockchain.WatchConfirmed
 import fr.acinq.lightning.blockchain.WatchEventSpent
 import fr.acinq.lightning.channel.Channel.ANNOUNCEMENTS_MINCONF
 import fr.acinq.lightning.router.Announcements
-import fr.acinq.lightning.utils.Either
+import fr.acinq.lightning.utils.toMilliSatoshi
 import fr.acinq.lightning.wire.*
 
 /** The channel funding transaction was confirmed, we exchange funding_locked messages. */
 data class WaitForChannelReady(
     override val commitments: Commitments,
-    val fundingParams: InteractiveTxParams,
-    val fundingTx: SignedSharedTransaction,
     val shortChannelId: ShortChannelId,
     val lastSent: ChannelReady
 ) : PersistedChannelState() {
@@ -22,38 +20,45 @@ data class WaitForChannelReady(
 
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when {
-            cmd is ChannelCommand.MessageReceived && cmd.message is TxSignatures -> when (fundingTx) {
-                is PartiallySignedSharedTransaction -> when (val fullySignedTx = fundingTx.addRemoteSigs(cmd.message)) {
-                    null -> {
-                        logger.warning { "received invalid remote funding signatures for txId=${cmd.message.txId}" }
-                        // The funding transaction may still confirm (since our peer should be able to generate valid signatures), so we cannot close the channel yet.
-                        Pair(this@WaitForChannelReady, listOf(ChannelAction.Message.Send(Warning(channelId, InvalidFundingSignature(channelId, cmd.message.txId).message))))
-                    }
-                    else -> {
-                        logger.info { "received remote funding signatures, publishing txId=${fullySignedTx.signedTx.txid}" }
-                        val nextState = this@WaitForChannelReady.copy(fundingTx = fullySignedTx)
-                        val actions = buildList {
-                            add(ChannelAction.Blockchain.PublishTx(fullySignedTx.signedTx))
-                            add(ChannelAction.Storage.StoreState(nextState))
+            cmd is ChannelCommand.MessageReceived && cmd.message is TxSignatures -> when (commitments.latest.localFundingStatus) {
+                is LocalFundingStatus.UnconfirmedFundingTx -> when (commitments.latest.localFundingStatus.sharedTx) {
+                    is PartiallySignedSharedTransaction -> when (val fullySignedTx = commitments.latest.localFundingStatus.sharedTx.addRemoteSigs(cmd.message)) {
+                        null -> {
+                            logger.warning { "received invalid remote funding signatures for txId=${cmd.message.txId}" }
+                            // The funding transaction may still confirm (since our peer should be able to generate valid signatures), so we cannot close the channel yet.
+                            Pair(this@WaitForChannelReady, listOf(ChannelAction.Message.Send(Warning(channelId, InvalidFundingSignature(channelId, cmd.message.txId).message))))
                         }
-                        Pair(nextState, actions)
+                        else -> {
+                            logger.info { "received remote funding signatures, publishing txId=${fullySignedTx.signedTx.txid}" }
+                            val commitments1 = commitments.updateLocalFundingStatus(fullySignedTx.signedTx.txid, commitments.latest.localFundingStatus.copy(sharedTx = fullySignedTx), logger)
+                            val nextState = this@WaitForChannelReady.copy(commitments = commitments1)
+                            val actions = buildList {
+                                add(ChannelAction.Blockchain.PublishTx(fullySignedTx.signedTx))
+                                add(ChannelAction.Storage.StoreState(nextState))
+                            }
+                            Pair(nextState, actions)
+                        }
+                    }
+                    is FullySignedSharedTransaction -> {
+                        logger.info { "ignoring duplicate remote funding signatures" }
+                        Pair(this@WaitForChannelReady, listOf())
                     }
                 }
-                is FullySignedSharedTransaction -> {
-                    logger.info { "ignoring duplicate remote funding signatures" }
+                is LocalFundingStatus.ConfirmedFundingTx -> {
+                    logger.info { "ignoring funding signatures for txId=${cmd.message.txId}, transaction is already confirmed" }
                     Pair(this@WaitForChannelReady, listOf())
                 }
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is TxInitRbf -> {
                 logger.info { "rejecting tx_init_rbf, we have already accepted the channel" }
-                Pair(this@WaitForChannelReady, listOf(ChannelAction.Message.Send(TxAbort(channelId, InvalidRbfTxConfirmed(channelId, commitments.fundingTxId).message))))
+                Pair(this@WaitForChannelReady, listOf(ChannelAction.Message.Send(TxAbort(channelId, InvalidRbfTxConfirmed(channelId, commitments.latest.fundingTxId).message))))
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is ChannelReady -> {
                 // used to get the final shortChannelId, used in announcements (if minDepth >= ANNOUNCEMENTS_MINCONF this event will fire instantly)
                 val watchConfirmed = WatchConfirmed(
                     this@WaitForChannelReady.channelId,
-                    commitments.commitInput.outPoint.txid,
-                    commitments.commitInput.txOut.publicKeyScript,
+                    commitments.latest.commitInput.outPoint.txid,
+                    commitments.latest.commitInput.txOut.publicKeyScript,
                     ANNOUNCEMENTS_MINCONF.toLong(),
                     BITCOIN_FUNDING_DEEPLYBURIED
                 )
@@ -64,10 +69,10 @@ data class WaitForChannelReady(
                     staticParams.remoteNodeId,
                     shortChannelId,
                     staticParams.nodeParams.expiryDeltaBlocks,
-                    commitments.remoteParams.htlcMinimum,
+                    commitments.params.remoteParams.htlcMinimum,
                     staticParams.nodeParams.feeBase,
                     staticParams.nodeParams.feeProportionalMillionth.toLong(),
-                    commitments.localCommit.spec.totalFunds,
+                    commitments.latest.fundingAmount.toMilliSatoshi(),
                     enable = Helpers.aboveReserve(commitments)
                 )
                 val nextState = Normal(
@@ -90,7 +95,7 @@ data class WaitForChannelReady(
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is Error -> handleRemoteError(cmd.message)
             cmd is ChannelCommand.WatchReceived && cmd.watch is WatchEventSpent -> when (cmd.watch.tx.txid) {
-                commitments.remoteCommit.txid -> handleRemoteSpentCurrent(cmd.watch.tx)
+                commitments.latest.remoteCommit.txid -> handleRemoteSpentCurrent(cmd.watch.tx, commitments.latest)
                 else -> handleRemoteSpentOther(cmd.watch.tx)
             }
             cmd is ChannelCommand.ExecuteCommand -> when (cmd.command) {
@@ -108,7 +113,7 @@ data class WaitForChannelReady(
         logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForChannelReady::class.simpleName}" }
         val error = Error(channelId, t.message)
         return when {
-            nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
+            commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
             else -> spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error)) }
         }
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForRemotePublishFutureCommitment.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForRemotePublishFutureCommitment.kt
@@ -31,15 +31,13 @@ data class WaitForRemotePublishFutureCommitment(
         logger.warning { "they published their future commit (because we asked them to) in txid=${tx.txid}" }
         val remoteCommitPublished = claimRemoteCommitMainOutput(
             keyManager,
-            commitments,
+            commitments.params,
             tx,
             currentOnChainFeerates.claimMainFeerate
         )
         val nextState = Closing(
             commitments = commitments,
-            fundingTx = null,
             waitingSinceBlock = currentBlockHeight.toLong(),
-            alternativeCommitments = listOf(),
             futureRemoteCommitPublished = remoteCommitPublished
         )
         val actions = mutableListOf<ChannelAction>(ChannelAction.Storage.StoreState(nextState))

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
@@ -322,10 +322,10 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
         val outgoingPayment = OutgoingPayment.LightningPart(
             id = childId,
             amount = route.amount,
-            route = listOf(HopDesc(nodeParams.nodeId, route.channel.commitments.remoteParams.nodeId, route.channel.shortChannelId), HopDesc(route.channel.commitments.remoteParams.nodeId, request.recipient)),
+            route = listOf(HopDesc(nodeParams.nodeId, route.channel.commitments.remoteNodeId, route.channel.shortChannelId), HopDesc(route.channel.commitments.remoteNodeId, request.recipient)),
             status = OutgoingPayment.LightningPart.Status.Pending
         )
-        val channelHops: List<ChannelHop> = listOf(ChannelHop(nodeParams.nodeId, route.channel.commitments.remoteParams.nodeId, route.channel.channelUpdate))
+        val channelHops: List<ChannelHop> = listOf(ChannelHop(nodeParams.nodeId, route.channel.commitments.remoteNodeId, route.channel.channelUpdate))
         val (add, secrets) = OutgoingPaymentPacket.buildCommand(childId, request.paymentHash, channelHops, trampolinePayload.createFinalPayload(route.amount))
         return Triple(outgoingPayment, secrets, WrappedChannelCommand(route.channel.channelId, ChannelCommand.ExecuteCommand(add)))
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/RouteCalculation.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/RouteCalculation.kt
@@ -23,7 +23,7 @@ class RouteCalculation(loggerFactory: LoggerFactory) {
 
         data class ChannelBalance(val c: Normal) {
             val balance: MilliSatoshi = c.commitments.availableBalanceForSend()
-            val capacity: Satoshi = c.commitments.commitInput.txOut.amount
+            val capacity: Satoshi = c.commitments.latest.fundingAmount
         }
 
         val sortedChannels = channels.values.filterIsInstance<Normal>().map { ChannelBalance(it) }.sortedBy { it.balance }.reversed()

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
@@ -219,9 +219,7 @@ internal data class RemoteCommit(
 }
 
 @Serializable
-internal data class WaitingForRevocation(val nextRemoteCommit: RemoteCommit, val sent: CommitSig, val sentAfterLocalCommitIndex: Long, val reSignAsap: Boolean = false) {
-    fun export() = fr.acinq.lightning.channel.WaitingForRevocation(nextRemoteCommit.export(), sent, sentAfterLocalCommitIndex, reSignAsap)
-}
+internal data class WaitingForRevocation(val nextRemoteCommit: RemoteCommit, val sent: CommitSig, val sentAfterLocalCommitIndex: Long, val reSignAsap: Boolean = false)
 
 @Serializable
 internal data class LocalCommitPublished(
@@ -375,22 +373,42 @@ internal data class Commitments(
     val remoteChannelData: EncryptedChannelData = EncryptedChannelData.empty
 ) {
     fun export() = fr.acinq.lightning.channel.Commitments(
-        ChannelVersion.channelConfig,
-        ChannelVersion.channelFeatures,
-        localParams.export(),
-        remoteParams.export(),
-        channelFlags,
-        localCommit.export(),
-        remoteCommit.export(),
-        localChanges.export(),
-        remoteChanges.export(),
-        localNextHtlcId,
-        remoteNextHtlcId,
+        fr.acinq.lightning.channel.ChannelParams(
+            channelId,
+            ChannelVersion.channelConfig,
+            ChannelVersion.channelFeatures,
+            localParams.export(),
+            remoteParams.export(),
+            channelFlags
+        ),
+        fr.acinq.lightning.channel.CommitmentChanges(
+            localChanges.export(),
+            remoteChanges.export(),
+            localNextHtlcId,
+            remoteNextHtlcId,
+        ),
+        listOf(
+            fr.acinq.lightning.channel.Commitment(
+                // We previously didn't store the funding transaction, so we act as if it were unconfirmed.
+                // We will put a WatchConfirmed when starting, which will return the confirmed transaction.
+                fr.acinq.lightning.channel.LocalFundingStatus.UnconfirmedFundingTx(
+                    fr.acinq.lightning.channel.PartiallySignedSharedTransaction(
+                        fr.acinq.lightning.channel.SharedTransaction(listOf(), listOf(), listOf(), listOf(), 0),
+                        // We must correctly set the txId here.
+                        TxSignatures(channelId, commitInput.outPoint.hash, listOf()),
+                    ),
+                    fr.acinq.lightning.channel.InteractiveTxParams(channelId, localParams.isFunder, commitInput.txOut.amount, commitInput.txOut.amount, commitInput.txOut.publicKeyScript, 0, localParams.dustLimit, localCommit.spec.feerate),
+                    0
+                ),
+                fr.acinq.lightning.channel.RemoteFundingStatus.Locked,
+                localCommit.export(),
+                remoteCommit.export(),
+                remoteNextCommitInfo.fold({ x -> fr.acinq.lightning.channel.NextRemoteCommit(x.sent, x.nextRemoteCommit.export()) }, { _ -> null })
+            )
+        ),
         payments,
-        remoteNextCommitInfo.transform({ x -> x.export() }, { y -> y }),
-        commitInput,
+        remoteNextCommitInfo.transform({ x -> fr.acinq.lightning.channel.WaitingForRevocation(x.sentAfterLocalCommitIndex) }, { y -> y }),
         remotePerCommitmentSecrets,
-        channelId,
         remoteChannelData
     )
 }
@@ -547,9 +565,7 @@ internal data class Closing(
 ) : ChannelStateWithCommitments() {
     override fun export() = fr.acinq.lightning.channel.Closing(
         commitments.export(),
-        fundingTx,
         waitingSinceBlock,
-        listOf(),
         mutualCloseProposed,
         mutualClosePublished,
         localCommitPublished?.export(),

--- a/src/commonMain/kotlin/fr/acinq/lightning/transactions/CommitmentSpec.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/transactions/CommitmentSpec.kt
@@ -44,15 +44,9 @@ data class CommitmentSpec(
     val toLocal: MilliSatoshi,
     val toRemote: MilliSatoshi
 ) {
+    fun findIncomingHtlcById(id: Long): IncomingHtlc? = htlcs.find { it is IncomingHtlc && it.add.id == id } as IncomingHtlc?
 
-    fun findIncomingHtlcById(id: Long): IncomingHtlc? =
-        htlcs.find { it is IncomingHtlc && it.add.id == id } as IncomingHtlc?
-
-    fun findOutgoingHtlcById(id: Long): OutgoingHtlc? =
-        htlcs.find { it is OutgoingHtlc && it.add.id == id } as OutgoingHtlc?
-
-    @Transient
-    val totalFunds: MilliSatoshi = toLocal + toRemote + MilliSatoshi(htlcs.map { it.add.amountMsat.toLong() }.sum())
+    fun findOutgoingHtlcById(id: Long): OutgoingHtlc? = htlcs.find { it is OutgoingHtlc && it.add.id == id } as OutgoingHtlc?
 
     companion object {
         fun removeHtlc(changes: List<UpdateMessage>, id: Long): List<UpdateMessage> =

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
@@ -31,7 +31,7 @@ class LegacyWaitForFundingConfirmedTestsCommon {
         val state = PersistedChannelState.from(TestConstants.Bob.nodeParams.nodePrivateKey, EncryptedChannelData(waitForFundingConfirmed))
         assertIs<LegacyWaitForFundingConfirmed>(state)
         val fundingTx = Transaction.read("020000000100000000000000000000000000000000000000000000000000000000000000000000000000ffffffff0140420f0000000000220020f9aafa9be1212d0d373760c279f3817f9be707d674cae5f38bb31c1fd85c202900000000")
-        assertEquals(state.commitments.fundingTxId, fundingTx.txid)
+        assertEquals(state.commitments.latest.fundingTxId, fundingTx.txid)
         val ctx = ChannelContext(
             StaticParams(TestConstants.Bob.nodeParams, TestConstants.Alice.keyManager.nodeId),
             TestConstants.defaultBlockHeight ,
@@ -45,15 +45,15 @@ class LegacyWaitForFundingConfirmedTestsCommon {
         assertEquals(watchConfirmed.event, BITCOIN_FUNDING_DEPTHOK)
         assertEquals(watchConfirmed.txId, fundingTx.txid)
         // Reconnect to our peer.
-        val localInit = Init(state.commitments.localParams.features.toByteArray().byteVector())
-        val remoteInit = Init(state.commitments.remoteParams.features.toByteArray().byteVector())
+        val localInit = Init(state.commitments.params.localParams.features.toByteArray().byteVector())
+        val remoteInit = Init(state.commitments.params.remoteParams.features.toByteArray().byteVector())
         val (state2, actions2) = state1.process(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<LNChannel<Syncing>>(state2)
         assertTrue(actions2.isEmpty())
         val channelReestablish = ChannelReestablish(
             state.channelId,
-            state.commitments.remoteCommit.index + 1,
-            state.commitments.localCommit.index,
+            state.commitments.remoteCommitIndex + 1,
+            state.commitments.localCommitIndex,
             PrivateKey(ByteVector32.Zeroes),
             randomKey().publicKey()
         )

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
@@ -32,7 +32,7 @@ class LegacyWaitForFundingLockedTestsCommon {
         val state = PersistedChannelState.from(TestConstants.Bob.nodeParams.nodePrivateKey, EncryptedChannelData(waitForFundingLocked))
         assertIs<LegacyWaitForFundingLocked>(state)
         val fundingTx = Transaction.read("020000000100000000000000000000000000000000000000000000000000000000000000000000000000ffffffff0140420f0000000000220020f9aafa9be1212d0d373760c279f3817f9be707d674cae5f38bb31c1fd85c202900000000")
-        assertEquals(state.commitments.fundingTxId, fundingTx.txid)
+        assertEquals(state.commitments.latest.fundingTxId, fundingTx.txid)
         val ctx = ChannelContext(
             StaticParams(TestConstants.Bob.nodeParams, TestConstants.Alice.keyManager.nodeId),
             TestConstants.defaultBlockHeight,
@@ -46,15 +46,15 @@ class LegacyWaitForFundingLockedTestsCommon {
         assertEquals(watchSpent.event, BITCOIN_FUNDING_SPENT)
         assertEquals(watchSpent.txId, fundingTx.txid)
         // Reconnect to our peer.
-        val localInit = Init(state.commitments.localParams.features.toByteArray().byteVector())
-        val remoteInit = Init(state.commitments.remoteParams.features.toByteArray().byteVector())
+        val localInit = Init(state.commitments.params.localParams.features.toByteArray().byteVector())
+        val remoteInit = Init(state.commitments.params.remoteParams.features.toByteArray().byteVector())
         val (state2, actions2) = state1.process(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<LNChannel<Syncing>>(state2)
         assertTrue(actions2.isEmpty())
         val channelReestablish = ChannelReestablish(
             state.channelId,
-            state.commitments.remoteCommit.index + 1,
-            state.commitments.localCommit.index,
+            state.commitments.remoteCommitIndex + 1,
+            state.commitments.localCommitIndex,
             PrivateKey(ByteVector32.Zeroes),
             randomKey().publicKey()
         )

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
@@ -23,8 +23,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice, bob) = TestsHelper.reachNormal(bobFeatures = TestConstants.Bob.nodeParams.features.remove(Feature.ChannelBackupClient))
         val (alice1, bob1) = disconnect(alice, bob)
 
-        val localInit = Init(ByteVector(alice.commitments.localParams.features.toByteArray()))
-        val remoteInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
+        val localInit = Init(ByteVector(alice.commitments.params.localParams.features.toByteArray()))
+        val remoteInit = Init(ByteVector(bob.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actions) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<LNChannel<Syncing>>(alice2)
@@ -36,12 +36,12 @@ class OfflineTestsCommon : LightningTestSuite() {
         val bobCommitments = bob.commitments
         val aliceCommitments = alice.commitments
         val bobCurrentPerCommitmentPoint = bob.ctx.keyManager.commitmentPoint(
-            bob.ctx.keyManager.channelKeyPath(bobCommitments.localParams, bobCommitments.channelConfig),
-            bobCommitments.localCommit.index
+            bob.ctx.keyManager.channelKeyPath(bobCommitments.params.localParams, bobCommitments.params.channelConfig),
+            bobCommitments.localCommitIndex
         )
         val aliceCurrentPerCommitmentPoint = alice.ctx.keyManager.commitmentPoint(
-            alice.ctx.keyManager.channelKeyPath(aliceCommitments.localParams, aliceCommitments.channelConfig),
-            aliceCommitments.localCommit.index
+            alice.ctx.keyManager.channelKeyPath(aliceCommitments.params.localParams, aliceCommitments.params.channelConfig),
+            aliceCommitments.localCommitIndex
         )
 
         // alice didn't receive any update or sig
@@ -84,8 +84,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         }
 
         val (alice1, bob1) = disconnect(alice0, bob0)
-        val localInit = Init(ByteVector(alice0.commitments.localParams.features.toByteArray()))
-        val remoteInit = Init(ByteVector(bob0.commitments.localParams.features.toByteArray()))
+        val localInit = Init(ByteVector(alice0.commitments.params.localParams.features.toByteArray()))
+        val remoteInit = Init(ByteVector(bob0.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<LNChannel<Syncing>>(alice2)
@@ -97,12 +97,12 @@ class OfflineTestsCommon : LightningTestSuite() {
         val bobCommitments = bob0.commitments
         val aliceCommitments = alice0.commitments
         val bobCurrentPerCommitmentPoint = bob0.ctx.keyManager.commitmentPoint(
-            bob0.ctx.keyManager.channelKeyPath(bobCommitments.localParams, bobCommitments.channelConfig),
-            bobCommitments.localCommit.index
+            bob0.ctx.keyManager.channelKeyPath(bobCommitments.params.localParams, bobCommitments.params.channelConfig),
+            bobCommitments.localCommitIndex
         )
         val aliceCurrentPerCommitmentPoint = alice0.ctx.keyManager.commitmentPoint(
-            alice0.ctx.keyManager.channelKeyPath(aliceCommitments.localParams, aliceCommitments.channelConfig),
-            aliceCommitments.localCommit.index
+            alice0.ctx.keyManager.channelKeyPath(aliceCommitments.params.localParams, aliceCommitments.params.channelConfig),
+            aliceCommitments.localCommitIndex
         )
 
         // alice didn't receive any update or sig
@@ -137,8 +137,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (bob7, _) = bob6.process(ChannelCommand.MessageReceived(revA))
         assertIs<LNChannel<Normal>>(bob7)
 
-        assertEquals(1, alice5.commitments.localNextHtlcId)
-        assertEquals(1, bob7.commitments.remoteNextHtlcId)
+        assertEquals(1, alice5.commitments.changes.localNextHtlcId)
+        assertEquals(1, bob7.commitments.changes.remoteNextHtlcId)
     }
 
     @Test
@@ -163,8 +163,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         }
 
         val (alice1, bob1) = disconnect(alice0, bob0)
-        val localInit = Init(ByteVector(alice0.commitments.localParams.features.toByteArray()))
-        val remoteInit = Init(ByteVector(bob0.commitments.localParams.features.toByteArray()))
+        val localInit = Init(ByteVector(alice0.commitments.params.localParams.features.toByteArray()))
+        val remoteInit = Init(ByteVector(bob0.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<LNChannel<Syncing>>(alice2)
@@ -176,12 +176,12 @@ class OfflineTestsCommon : LightningTestSuite() {
         val bobCommitments = bob0.commitments
         val aliceCommitments = alice0.commitments
         val bobCurrentPerCommitmentPoint = bob0.ctx.keyManager.commitmentPoint(
-            bob0.ctx.keyManager.channelKeyPath(bobCommitments.localParams, bobCommitments.channelConfig),
-            bobCommitments.localCommit.index
+            bob0.ctx.keyManager.channelKeyPath(bobCommitments.params.localParams, bobCommitments.params.channelConfig),
+            bobCommitments.localCommitIndex
         )
         val aliceCurrentPerCommitmentPoint = alice0.ctx.keyManager.commitmentPoint(
-            alice0.ctx.keyManager.channelKeyPath(aliceCommitments.localParams, aliceCommitments.channelConfig),
-            aliceCommitments.localCommit.index
+            alice0.ctx.keyManager.channelKeyPath(aliceCommitments.params.localParams, aliceCommitments.params.channelConfig),
+            aliceCommitments.localCommitIndex
         )
 
         // alice didn't receive any update or sig
@@ -207,8 +207,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (bob4, _) = bob3.process(ChannelCommand.MessageReceived(revA))
         assertIs<LNChannel<Normal>>(bob4)
 
-        assertEquals(1, alice5.commitments.localNextHtlcId)
-        assertEquals(1, bob4.commitments.remoteNextHtlcId)
+        assertEquals(1, alice5.commitments.changes.localNextHtlcId)
+        assertEquals(1, bob4.commitments.changes.remoteNextHtlcId)
     }
 
     @Test
@@ -232,8 +232,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         }
 
         val (alice1, bob1) = disconnect(alice0, bob0)
-        val initA = Init(ByteVector(alice0.commitments.localParams.features.toByteArray()))
-        val initB = Init(ByteVector(bob0.commitments.localParams.features.toByteArray()))
+        val initA = Init(ByteVector(alice0.commitments.params.localParams.features.toByteArray()))
+        val initB = Init(ByteVector(bob0.commitments.params.localParams.features.toByteArray()))
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(initA, initB))
         assertIs<LNChannel<Syncing>>(alice2)
         val channelReestablishA = actionsAlice2.findOutgoingMessage<ChannelReestablish>()
@@ -266,8 +266,8 @@ class OfflineTestsCommon : LightningTestSuite() {
 
         assertIs<LNChannel<Normal>>(alice5)
         assertIs<LNChannel<Normal>>(bob5)
-        assertEquals(4, alice5.commitments.localCommit.index)
-        assertEquals(4, bob5.commitments.localCommit.index)
+        assertEquals(4, alice5.commitments.localCommitIndex)
+        assertEquals(4, bob5.commitments.localCommitIndex)
     }
 
     @Test
@@ -297,8 +297,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         // we manually replace alice's state with an older one
         val alice1 = aliceTmp1.copy(state = Offline(aliceOld.state))
 
-        val localInit = Init(ByteVector(alice.commitments.localParams.features.toByteArray()))
-        val remoteInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
+        val localInit = Init(ByteVector(alice.commitments.params.localParams.features.toByteArray()))
+        val remoteInit = Init(ByteVector(bob.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<LNChannel<Syncing>>(alice2)
@@ -337,8 +337,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice0, bob0) = TestsHelper.reachNormal(bobFeatures = TestConstants.Bob.nodeParams.features.remove(Feature.ChannelBackupClient))
         val (alice1, bob1) = disconnect(alice0, bob0)
 
-        val localInit = Init(ByteVector(alice0.commitments.localParams.features.toByteArray()))
-        val remoteInit = Init(ByteVector(bob0.commitments.localParams.features.toByteArray()))
+        val localInit = Init(ByteVector(alice0.commitments.params.localParams.features.toByteArray()))
+        val remoteInit = Init(ByteVector(bob0.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<LNChannel<Syncing>>(alice2)
@@ -391,8 +391,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         actions1.hasWatch<WatchSpent>()
         assertIs<LNChannel<Offline>>(alice1)
 
-        val localInit = Init(ByteVector(alice.commitments.localParams.features.toByteArray()))
-        val remoteInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
+        val localInit = Init(ByteVector(alice.commitments.params.localParams.features.toByteArray()))
+        val remoteInit = Init(ByteVector(bob.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<LNChannel<Syncing>>(alice2)
@@ -443,8 +443,8 @@ class OfflineTestsCommon : LightningTestSuite() {
 
         // Alice and Bob are disconnected.
         val (alice1, bob1) = disconnect(alice, bob)
-        val aliceInit = Init(ByteVector(alice.commitments.localParams.features.toByteArray()))
-        val bobInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
+        val aliceInit = Init(ByteVector(alice.commitments.params.localParams.features.toByteArray()))
+        val bobInit = Init(ByteVector(bob.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice) = alice1.process(ChannelCommand.Connected(aliceInit, bobInit))
         val (bob2, _) = bob1.process(ChannelCommand.Connected(bobInit, aliceInit))
@@ -467,10 +467,10 @@ class OfflineTestsCommon : LightningTestSuite() {
     @Test
     fun `wait for their channel reestablish when using channel backup`() {
         val (alice, bob) = TestsHelper.reachNormal()
-        assertTrue(bob.commitments.localParams.features.hasFeature(Feature.ChannelBackupClient))
+        assertTrue(bob.commitments.params.localParams.features.hasFeature(Feature.ChannelBackupClient))
         val (alice1, bob1) = disconnect(alice, bob)
-        val localInit = Init(ByteVector(alice.commitments.localParams.features.toByteArray()))
-        val remoteInit = Init(ByteVector(bob.commitments.localParams.features.toByteArray()))
+        val localInit = Init(ByteVector(alice.commitments.params.localParams.features.toByteArray()))
+        val remoteInit = Init(ByteVector(bob.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actions) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<LNChannel<Syncing>>(alice2)
@@ -487,8 +487,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(txSigsBob))
         assertIs<LNChannel<WaitForFundingConfirmed>>(alice1)
         val fundingTx = actionsAlice1.find<ChannelAction.Blockchain.PublishTx>().tx
-        assertEquals(fundingTx.hash, alice1.state.fundingTx.localSigs.txHash)
-        val (bob1, _) = bob.process(ChannelCommand.MessageReceived(alice1.state.fundingTx.localSigs))
+        assertEquals(fundingTx.hash, alice1.state.latestFundingTx.sharedTx.localSigs.txHash)
+        val (bob1, _) = bob.process(ChannelCommand.MessageReceived(alice1.state.latestFundingTx.sharedTx.localSigs))
         assertIs<LNChannel<WaitForFundingConfirmed>>(bob1)
         // Alice restarts:
         val (alice2, actionsAlice2) = LNChannel(alice1.ctx, WaitForInit).process(ChannelCommand.Restore(alice1.state))
@@ -507,7 +507,7 @@ class OfflineTestsCommon : LightningTestSuite() {
     @Test
     fun `recv BITCOIN_FUNDING_DEPTHOK`() {
         val (alice, bob, _) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs, alicePushAmount = 0.msat)
-        val fundingTx = alice.state.fundingTx.tx.buildUnsignedTx()
+        val fundingTx = alice.state.latestFundingTx.sharedTx.tx.buildUnsignedTx()
         val (alice1, bob1) = disconnect(alice, bob)
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.WatchReceived(WatchEventConfirmed(alice.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)))
         assertEquals(alice1, alice2)
@@ -523,13 +523,13 @@ class OfflineTestsCommon : LightningTestSuite() {
     fun `recv BITCOIN_FUNDING_DEPTHOK -- previous funding tx`() {
         val (alice, bob, txSigsBob, walletAlice) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs, alicePushAmount = 0.msat)
         val (alice1, bob1) = WaitForFundingConfirmedTestsCommon.rbf(alice, bob, txSigsBob, walletAlice)
-        val previousFundingTx = alice1.state.previousFundingTxs.first().first.signedTx!!
+        val previousFundingTx = alice1.state.previousFundingTxs.first().signedTx!!
         val (alice2, bob2) = disconnect(alice1, bob1)
         val (alice3, actionsAlice3) = alice2.process(ChannelCommand.WatchReceived(WatchEventConfirmed(alice.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, previousFundingTx)))
         assertIs<LNChannel<Offline>>(alice3)
         val aliceState3 = alice3.state.state
         assertIs<WaitForFundingConfirmed>(aliceState3)
-        assertEquals(aliceState3.commitments.fundingTxId, previousFundingTx.txid)
+        assertEquals(aliceState3.commitments.latest.fundingTxId, previousFundingTx.txid)
         assertTrue(aliceState3.previousFundingTxs.isEmpty())
         assertEquals(actionsAlice3.size, 1)
         assertEquals(actionsAlice3.hasWatch<WatchSpent>().txId, previousFundingTx.txid)
@@ -537,7 +537,7 @@ class OfflineTestsCommon : LightningTestSuite() {
         assertIs<LNChannel<Offline>>(bob3)
         val bobState3 = bob3.state.state
         assertIs<WaitForFundingConfirmed>(bobState3)
-        assertEquals(bobState3.commitments.fundingTxId, previousFundingTx.txid)
+        assertEquals(bobState3.commitments.latest.fundingTxId, previousFundingTx.txid)
         assertTrue(bobState3.previousFundingTxs.isEmpty())
         assertEquals(actionsBob3.size, 1)
         assertEquals(actionsBob3.hasWatch<WatchSpent>().txId, previousFundingTx.txid)
@@ -623,7 +623,7 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice, _) = TestsHelper.reachNormal()
         val (alice1, _) = alice.process(ChannelCommand.Disconnected)
         assertIs<LNChannel<Offline>>(alice1)
-        val commitTx = alice1.state.state.commitments.localCommit.publishableTxs.commitTx.tx
+        val commitTx = alice1.state.state.commitments.latest.localCommit.publishableTxs.commitTx.tx
         val (alice2, actions2) = alice1.process(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
         assertIs<LNChannel<Closing>>(alice2)
         actions2.hasTx(commitTx)
@@ -635,7 +635,7 @@ class OfflineTestsCommon : LightningTestSuite() {
         val bob = run {
             val (alice, bob) = TestsHelper.reachNormal()
             // alice publishes her commitment tx
-            val (bob1, _) = bob.process(ChannelCommand.WatchReceived(WatchEventSpent(bob.channelId, BITCOIN_FUNDING_SPENT, alice.commitments.localCommit.publishableTxs.commitTx.tx)))
+            val (bob1, _) = bob.process(ChannelCommand.WatchReceived(WatchEventSpent(bob.channelId, BITCOIN_FUNDING_SPENT, alice.commitments.latest.localCommit.publishableTxs.commitTx.tx)))
             assertIs<LNChannel<Closing>>(bob1)
             assertNull(bob1.state.closingTypeAlreadyKnown())
             bob1
@@ -646,7 +646,7 @@ class OfflineTestsCommon : LightningTestSuite() {
         assertIs<LNChannel<Closing>>(state1)
         assertEquals(4, actions.size)
         val watchSpent = actions.hasWatch<WatchSpent>()
-        assertEquals(bob.commitments.commitInput.outPoint.txid, watchSpent.txId)
+        assertEquals(bob.commitments.latest.commitInput.outPoint.txid, watchSpent.txId)
         val remoteCommitPublished = bob.state.remoteCommitPublished
         assertNotNull(remoteCommitPublished)
         val claimMainOutputTx = remoteCommitPublished.claimMainOutputTx

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
@@ -59,7 +59,7 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
             assertEquals(actionsAlice1.size, 5)
             assertTrue(actionsAlice1.hasOutgoingMessage<TxSignatures>().channelData.isEmpty())
             assertEquals(actionsAlice1.hasOutgoingMessage<ChannelReady>().alias, ShortChannelId.peerId(alice.staticParams.nodeParams.nodeId))
-            assertEquals(actionsAlice1.findWatch<WatchSpent>().txId, alice1.commitments.fundingTxId)
+            assertEquals(actionsAlice1.findWatch<WatchSpent>().txId, alice1.commitments.latest.fundingTxId)
             actionsAlice1.has<ChannelAction.Storage.StoreState>()
             assertEquals(ChannelEvents.Created(alice1.state), actionsAlice1.find<ChannelAction.EmitEvent>().event)
         }
@@ -69,7 +69,7 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
             assertEquals(actionsBob1.size, 6)
             assertFalse(actionsBob1.hasOutgoingMessage<TxSignatures>().channelData.isEmpty())
             assertEquals(actionsBob1.hasOutgoingMessage<ChannelReady>().alias, ShortChannelId.peerId(bob.staticParams.nodeParams.nodeId))
-            assertEquals(actionsBob1.findWatch<WatchSpent>().txId, bob1.commitments.fundingTxId)
+            assertEquals(actionsBob1.findWatch<WatchSpent>().txId, bob1.commitments.latest.fundingTxId)
             actionsBob1.has<ChannelAction.Storage.StoreState>()
             assertEquals(TestConstants.bobFundingAmount.toMilliSatoshi() + TestConstants.alicePushAmount - TestConstants.bobPushAmount, 200_000_000.msat)
             assertEquals(actionsBob1.find<ChannelAction.Storage.StoreIncomingAmount>().amount, 200_000_000.msat)

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -48,13 +48,13 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         actions = processResult.second
         assertTrue { actions.filterIsInstance<ChannelAction.Message.Send>().isEmpty() }
 
-        assertTrue { alice.commitments.localChanges.proposed.size == 1 }
-        assertTrue { alice.commitments.localChanges.signed.isEmpty() }
-        assertTrue { alice.commitments.localChanges.acked.isEmpty() }
+        assertTrue { alice.commitments.changes.localChanges.proposed.size == 1 }
+        assertTrue { alice.commitments.changes.localChanges.signed.isEmpty() }
+        assertTrue { alice.commitments.changes.localChanges.acked.isEmpty() }
 
-        assertTrue { bob.commitments.remoteChanges.proposed.size == 1 }
-        assertTrue { bob.commitments.remoteChanges.acked.isEmpty() }
-        assertTrue { bob.commitments.remoteChanges.signed.isEmpty() }
+        assertTrue { bob.commitments.changes.remoteChanges.proposed.size == 1 }
+        assertTrue { bob.commitments.changes.remoteChanges.acked.isEmpty() }
+        assertTrue { bob.commitments.changes.remoteChanges.signed.isEmpty() }
 
         // Step 2: alice ---> commitment_signed ---> bob
 
@@ -69,13 +69,13 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val bobRev = actions.findOutgoingMessage<RevokeAndAck>()
         val bobCmdSign = actions.findCommand<CMD_SIGN>()
 
-        assertTrue { alice.commitments.localChanges.proposed.isEmpty() }
-        assertTrue { alice.commitments.localChanges.signed.size == 1 }
-        assertTrue { alice.commitments.localChanges.acked.isEmpty() }
+        assertTrue { alice.commitments.changes.localChanges.proposed.isEmpty() }
+        assertTrue { alice.commitments.changes.localChanges.signed.size == 1 }
+        assertTrue { alice.commitments.changes.localChanges.acked.isEmpty() }
 
-        assertTrue { bob.commitments.remoteChanges.proposed.isEmpty() }
-        assertTrue { bob.commitments.remoteChanges.acked.size == 1 }
-        assertTrue { bob.commitments.remoteChanges.signed.isEmpty() }
+        assertTrue { bob.commitments.changes.remoteChanges.proposed.isEmpty() }
+        assertTrue { bob.commitments.changes.remoteChanges.acked.size == 1 }
+        assertTrue { bob.commitments.changes.remoteChanges.signed.isEmpty() }
 
         // Step 3: alice <--- revoke_and_ack <--- bob
 
@@ -84,13 +84,13 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         actions = processResult.second
         assertTrue { actions.filterIsInstance<ChannelAction.Message.Send>().isEmpty() }
 
-        assertTrue { alice.commitments.localChanges.proposed.isEmpty() }
-        assertTrue { alice.commitments.localChanges.signed.isEmpty() }
-        assertTrue { alice.commitments.localChanges.acked.size == 1 }
+        assertTrue { alice.commitments.changes.localChanges.proposed.isEmpty() }
+        assertTrue { alice.commitments.changes.localChanges.signed.isEmpty() }
+        assertTrue { alice.commitments.changes.localChanges.acked.size == 1 }
 
-        assertTrue { bob.commitments.remoteChanges.proposed.isEmpty() }
-        assertTrue { bob.commitments.remoteChanges.acked.size == 1 }
-        assertTrue { bob.commitments.remoteChanges.signed.isEmpty() }
+        assertTrue { bob.commitments.changes.remoteChanges.proposed.isEmpty() }
+        assertTrue { bob.commitments.changes.remoteChanges.acked.size == 1 }
+        assertTrue { bob.commitments.changes.remoteChanges.signed.isEmpty() }
 
         // Step 4: alice <--- commitment_signed <--- bob
 
@@ -104,13 +104,13 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         actions = processResult.second
         val aliceRev = actions.findOutgoingMessage<RevokeAndAck>()
 
-        assertTrue { alice.commitments.localChanges.proposed.isEmpty() }
-        assertTrue { alice.commitments.localChanges.signed.isEmpty() }
-        assertTrue { alice.commitments.localChanges.acked.isEmpty() }
+        assertTrue { alice.commitments.changes.localChanges.proposed.isEmpty() }
+        assertTrue { alice.commitments.changes.localChanges.signed.isEmpty() }
+        assertTrue { alice.commitments.changes.localChanges.acked.isEmpty() }
 
-        assertTrue { bob.commitments.remoteChanges.proposed.isEmpty() }
-        assertTrue { bob.commitments.remoteChanges.acked.isEmpty() }
-        assertTrue { bob.commitments.remoteChanges.signed.size == 1 }
+        assertTrue { bob.commitments.changes.remoteChanges.proposed.isEmpty() }
+        assertTrue { bob.commitments.changes.remoteChanges.acked.isEmpty() }
+        assertTrue { bob.commitments.changes.remoteChanges.signed.size == 1 }
 
         // Step 5: alice ---> revoke_and_ack ---> bob
 
@@ -120,13 +120,13 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertTrue { actions.filterIsInstance<ChannelAction.Message.Send>().isEmpty() }
         assertTrue { actions.filterIsInstance<ChannelAction.ProcessIncomingHtlc>().size == 1 }
 
-        assertTrue { alice.commitments.localChanges.proposed.isEmpty() }
-        assertTrue { alice.commitments.localChanges.signed.isEmpty() }
-        assertTrue { alice.commitments.localChanges.acked.isEmpty() }
+        assertTrue { alice.commitments.changes.localChanges.proposed.isEmpty() }
+        assertTrue { alice.commitments.changes.localChanges.signed.isEmpty() }
+        assertTrue { alice.commitments.changes.localChanges.acked.isEmpty() }
 
-        assertTrue { bob.commitments.remoteChanges.proposed.isEmpty() }
-        assertTrue { bob.commitments.remoteChanges.acked.isEmpty() }
-        assertTrue { bob.commitments.remoteChanges.signed.isEmpty() }
+        assertTrue { bob.commitments.changes.remoteChanges.proposed.isEmpty() }
+        assertTrue { bob.commitments.changes.remoteChanges.acked.isEmpty() }
+        assertTrue { bob.commitments.changes.remoteChanges.signed.isEmpty() }
     }
 
     @Test
@@ -190,10 +190,12 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(expectedFees, result2.received.fees)
 
         val (id1, id2) = result2.received.receivedWith.map { (it as IncomingPayment.ReceivedWith.NewChannel).id }
-        assertEquals(setOf(
-            makeReceivedWithNewChannel(payToOpenRequest1, uuid = id1),
-            makeReceivedWithNewChannel(payToOpenRequest2, uuid = id2)
-        ), result2.received.receivedWith)
+        assertEquals(
+            setOf(
+                makeReceivedWithNewChannel(payToOpenRequest1, uuid = id1),
+                makeReceivedWithNewChannel(payToOpenRequest2, uuid = id2)
+            ), result2.received.receivedWith
+        )
 
         checkDbPayment(result2.incomingPayment, paymentHandler.db)
     }
@@ -218,10 +220,12 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(expectedFees, result2.received.fees)
 
         val (id1, id2) = result2.received.receivedWith.map { (it as IncomingPayment.ReceivedWith.NewChannel).id }
-        assertEquals(setOf(
-            makeReceivedWithNewChannel(payToOpenRequest1, uuid = id1),
-            makeReceivedWithNewChannel(payToOpenRequest2, uuid = id2)
-        ), result2.received.receivedWith)
+        assertEquals(
+            setOf(
+                makeReceivedWithNewChannel(payToOpenRequest1, uuid = id1),
+                makeReceivedWithNewChannel(payToOpenRequest2, uuid = id2)
+            ), result2.received.receivedWith
+        )
 
         checkDbPayment(result2.incomingPayment, paymentHandler.db)
     }
@@ -1219,15 +1223,21 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val paymentHandler = IncomingPaymentHandler(TestConstants.Bob.nodeParams, TestConstants.Bob.walletParams, InMemoryPaymentsDb())
 
         // create incoming payment that has expired and not been paid
-        val expiredInvoice = paymentHandler.createInvoice(randomBytes32(), defaultAmount, Either.Left("expired"), listOf(), expirySeconds = 3600,
-            timestampSeconds = 1)
+        val expiredInvoice = paymentHandler.createInvoice(
+            randomBytes32(), defaultAmount, Either.Left("expired"), listOf(), expirySeconds = 3600,
+            timestampSeconds = 1
+        )
 
         // create incoming payment that has expired and been paid
         delay(100)
-        val paidInvoice = paymentHandler.createInvoice(defaultPreimage, defaultAmount, Either.Left("paid"), listOf(), expirySeconds = 3600,
-            timestampSeconds = 100)
-        paymentHandler.db.receivePayment(paidInvoice.paymentHash, receivedWith = setOf(IncomingPayment.ReceivedWith.NewChannel(id = UUID.randomUUID(), amount = 15_000_000.msat, serviceFee = 1_000_000.msat, channelId = null)),
-            receivedAt = 101) // simulate incoming payment being paid before it expired
+        val paidInvoice = paymentHandler.createInvoice(
+            defaultPreimage, defaultAmount, Either.Left("paid"), listOf(), expirySeconds = 3600,
+            timestampSeconds = 100
+        )
+        paymentHandler.db.receivePayment(
+            paidInvoice.paymentHash, receivedWith = setOf(IncomingPayment.ReceivedWith.NewChannel(id = UUID.randomUUID(), amount = 15_000_000.msat, serviceFee = 1_000_000.msat, channelId = null)),
+            receivedAt = 101
+        ) // simulate incoming payment being paid before it expired
 
         // create unexpired payment
         delay(100)

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/RouteCalculationTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/RouteCalculationTestsCommon.kt
@@ -27,10 +27,12 @@ class RouteCalculationTestsCommon : LightningTestSuite() {
 
     private fun makeChannel(channelId: ByteVector32, balance: MilliSatoshi, htlcMin: MilliSatoshi): Normal {
         val shortChannelId = ShortChannelId(Random.nextLong())
-        val reserve = defaultChannel.commitments.localChannelReserve
+        val reserve = defaultChannel.commitments.latest.localChannelReserve
         val commitments = defaultChannel.commitments.copy(
-            channelId = channelId,
-            remoteCommit = defaultChannel.commitments.remoteCommit.copy(spec = CommitmentSpec(setOf(), FeeratePerKw(0.sat), 50_000.msat, balance + ((Commitments.ANCHOR_AMOUNT * 2) + reserve).toMilliSatoshi()))
+            params = defaultChannel.commitments.params.copy(channelId = channelId),
+            active = defaultChannel.commitments.active.map {
+                it.copy(remoteCommit = it.remoteCommit.copy(spec = CommitmentSpec(setOf(), FeeratePerKw(0.sat), 50_000.msat, balance + ((Commitments.ANCHOR_AMOUNT * 2) + reserve).toMilliSatoshi())))
+            }
         )
         val channelUpdate = defaultChannel.state.channelUpdate.copy(htlcMinimumMsat = htlcMin)
         return defaultChannel.state.copy(shortChannelId = shortChannelId, commitments = commitments, channelUpdate = channelUpdate)

--- a/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationTestsCommon.kt
@@ -47,14 +47,14 @@ class StateSerializationTestsCommon : LightningTestSuite() {
         )
         val state = Serialization.deserialize(bin)
         assertIs<Normal>(state)
-        assertEquals(state.commitments.channelConfig, ChannelConfig.standard)
-        assertEquals(state.commitments.channelFeatures, ChannelFeatures(setOf(Feature.Wumbo, Feature.StaticRemoteKey, Feature.AnchorOutputs, Feature.ZeroReserveChannels, Feature.ZeroConfChannels)))
+        assertEquals(state.commitments.params.channelConfig, ChannelConfig.standard)
+        assertEquals(state.commitments.params.channelFeatures, ChannelFeatures(setOf(Feature.Wumbo, Feature.StaticRemoteKey, Feature.AnchorOutputs, Feature.ZeroReserveChannels, Feature.ZeroConfChannels)))
     }
 
     @Test
     fun `maximum number of HTLCs that is safe to use`() {
         val (alice, bob) = TestsHelper.reachNormal()
-        assertTrue(bob.commitments.localParams.features.hasFeature(Feature.ChannelBackupClient))
+        assertTrue(bob.commitments.params.localParams.features.hasFeature(Feature.ChannelBackupClient))
 
         tailrec fun addHtlcs(sender: LNChannel<Normal>, receiver: LNChannel<Normal>, amount: MilliSatoshi, count: Int): Pair<LNChannel<Normal>, LNChannel<Normal>> = if (count == 0) Pair(sender, receiver) else {
             val (p, _) = TestsHelper.addHtlc(amount, sender, receiver)

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
@@ -135,13 +135,13 @@ suspend fun CoroutineScope.newPeer(
         }
 
         val yourLastPerCommitmentSecret = state.commitments.remotePerCommitmentSecrets.lastIndex?.let { state.commitments.remotePerCommitmentSecrets.getHash(it) } ?: ByteVector32.Zeroes
-        val channelKeyPath = peer.nodeParams.keyManager.channelKeyPath(state.commitments.localParams, state.commitments.channelConfig)
-        val myCurrentPerCommitmentPoint = peer.nodeParams.keyManager.commitmentPoint(channelKeyPath, state.commitments.localCommit.index)
+        val channelKeyPath = peer.nodeParams.keyManager.channelKeyPath(state.commitments.params.localParams, state.commitments.params.channelConfig)
+        val myCurrentPerCommitmentPoint = peer.nodeParams.keyManager.commitmentPoint(channelKeyPath, state.commitments.localCommitIndex)
 
         val channelReestablish = ChannelReestablish(
             channelId = state.channelId,
-            nextLocalCommitmentNumber = state.commitments.localCommit.index + 1,
-            nextRemoteRevocationNumber = state.commitments.remoteCommit.index,
+            nextLocalCommitmentNumber = state.commitments.localCommitIndex + 1,
+            nextRemoteRevocationNumber = state.commitments.remoteCommitIndex,
             yourLastCommitmentSecret = PrivateKey(yourLastPerCommitmentSecret),
             myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint
         ).withChannelData(state.commitments.remoteChannelData)

--- a/src/commonTest/resources/nonreg/v2/Closing_0ba41d17/data.json
+++ b/src/commonTest/resources/nonreg/v2/Closing_0ba41d17/data.json
@@ -1,219 +1,236 @@
 {
     "type": "fr.acinq.lightning.channel.Closing",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 110000000,
-                        "paymentHash": "8402e76bc62b9de41e92cfd8375016737d985d5d73d4d3dfba46b855f8370b49",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 95000000,
-                        "paymentHash": "070fb40232bd54297d485a2303b042cbdd51011f34fd509f4bae3ee0c62f6fe4",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 705000000,
-                "toRemote": 90000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032905f010000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799018730100000000002200202228f1681cff3adf3524363fad7481c1aad6aa344b223cd97b4fb09a667f5e2db0ad01000000000022002028eee5bc7a7219b098d1f27ee035b83a6870d2be541097068097ab8a8d2568fba8a20a00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400473044022069b2ce78c6eb6728db4296f6a88b65af682c81dc613985ecf6c23d14cfad3b6602205af6b39cf883448ac1769495c029f230c18d1c4b70292bec6cafad220b74bb5801473044022043cd8250bf3125c454dbe9d7389a3000d6198e35ad82ddd767d2fb770d4e00000220740dd54ac489715d33c6730ee78ee3df4e00f875f67c93b005235d5d637334e40147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "9601ac0b3a2c26b11effb0690a37b4f86b10b144f1751ad6d64f5e58d40c78b8:3",
-                                "txOut": {
-                                    "amount": 95000,
-                                    "publicKeyScript": "00202228f1681cff3adf3524363fad7481c1aad6aa344b223cd97b4fb09a667f5e2d"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914e563f0bce1d82759c3702437ce10cf2d7545b5a288ac6851b27568"
-                            },
-                            "tx": "0200000001b8780cd4585e4fd6d61a75f144b1106bf8b4370a69b0ff1eb1262c3a0bac01960300000000010000000116660100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "6e4452d82c90fed66b3764557999d611cf78e5f32acac0af83839aa65f5ee66c33d859c48572a8f06228d226ca5cd80610d970d9abd0d50edf58186eade21d84",
-                        "remoteSig": "3dc75b272417d1deb5afabc3cdb5f9615f0e1a98b5e85bc661e3e2ef4a4346d84e587321dbf824e3d121ddbd0dc6098c062ab04b1879562b1c6f8ca6048e8edf"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "9601ac0b3a2c26b11effb0690a37b4f86b10b144f1751ad6d64f5e58d40c78b8:4",
-                                "txOut": {
-                                    "amount": 110000,
-                                    "publicKeyScript": "002028eee5bc7a7219b098d1f27ee035b83a6870d2be541097068097ab8a8d2568fb"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9141156a3cd8369ffb3b15e9151e98e1d039a674cfc88527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "0200000001b8780cd4585e4fd6d61a75f144b1106bf8b4370a69b0ff1eb1262c3a0bac019604000000000100000001e69f0100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
-                            "paymentHash": "8402e76bc62b9de41e92cfd8375016737d985d5d73d4d3dfba46b855f8370b49",
-                            "htlcId": 0
-                        },
-                        "localSig": "6c2c84ab6ddd5e0b576ddbd190b90a04f421c87cd7c0bf58f21b77014debcd36187e78df2604d1d3b90e7a8ebc547fed179c53e83b6030212cf0efb9f6f73afb",
-                        "remoteSig": "08d988b910001b302c708db95aabdd1b11a02a7d6c549b78715b2894070feec1557f5cd291b5559f866cc9f8352d17631f28eeb0764408f6f503442c636e3729"
-                    }
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 2,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 95000000,
-                        "paymentHash": "070fb40232bd54297d485a2303b042cbdd51011f34fd509f4bae3ee0c62f6fe4",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 110000000,
-                        "paymentHash": "8402e76bc62b9de41e92cfd8375016737d985d5d73d4d3dfba46b855f8370b49",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 90000000,
-                "toRemote": 705000000
-            },
-            "txid": "6552be7d50bfd1711e327a88449299c0cdac58c180f781d5a1d97908bbf5bf04",
-            "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
-        },
-        "localChanges": {
-            "proposed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 0,
-                    "paymentPreimage": "470394f1ea93ed652ed8fba12c00dcfe8212c4fd3295f7413f7a927e002ea4eb"
+                    "unknown": [
+                    ]
                 }
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+            },
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                    {
+                        "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "id": 0,
+                        "paymentPreimage": "470394f1ea93ed652ed8fba12c00dcfe8212c4fd3295f7413f7a927e002ea4eb"
+                    }
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 1,
+            "remoteNextHtlcId": 1
         },
-        "localNextHtlcId": 1,
-        "remoteNextHtlcId": 1,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 110000000,
+                                "paymentHash": "8402e76bc62b9de41e92cfd8375016737d985d5d73d4d3dfba46b855f8370b49",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 95000000,
+                                "paymentHash": "070fb40232bd54297d485a2303b042cbdd51011f34fd509f4bae3ee0c62f6fe4",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 705000000,
+                        "toRemote": 90000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032905f010000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799018730100000000002200202228f1681cff3adf3524363fad7481c1aad6aa344b223cd97b4fb09a667f5e2db0ad01000000000022002028eee5bc7a7219b098d1f27ee035b83a6870d2be541097068097ab8a8d2568fba8a20a00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400473044022069b2ce78c6eb6728db4296f6a88b65af682c81dc613985ecf6c23d14cfad3b6602205af6b39cf883448ac1769495c029f230c18d1c4b70292bec6cafad220b74bb5801473044022043cd8250bf3125c454dbe9d7389a3000d6198e35ad82ddd767d2fb770d4e00000220740dd54ac489715d33c6730ee78ee3df4e00f875f67c93b005235d5d637334e40147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "9601ac0b3a2c26b11effb0690a37b4f86b10b144f1751ad6d64f5e58d40c78b8:3",
+                                        "txOut": {
+                                            "amount": 95000,
+                                            "publicKeyScript": "00202228f1681cff3adf3524363fad7481c1aad6aa344b223cd97b4fb09a667f5e2d"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914e563f0bce1d82759c3702437ce10cf2d7545b5a288ac6851b27568"
+                                    },
+                                    "tx": "0200000001b8780cd4585e4fd6d61a75f144b1106bf8b4370a69b0ff1eb1262c3a0bac01960300000000010000000116660100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "6e4452d82c90fed66b3764557999d611cf78e5f32acac0af83839aa65f5ee66c33d859c48572a8f06228d226ca5cd80610d970d9abd0d50edf58186eade21d84",
+                                "remoteSig": "3dc75b272417d1deb5afabc3cdb5f9615f0e1a98b5e85bc661e3e2ef4a4346d84e587321dbf824e3d121ddbd0dc6098c062ab04b1879562b1c6f8ca6048e8edf"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "9601ac0b3a2c26b11effb0690a37b4f86b10b144f1751ad6d64f5e58d40c78b8:4",
+                                        "txOut": {
+                                            "amount": 110000,
+                                            "publicKeyScript": "002028eee5bc7a7219b098d1f27ee035b83a6870d2be541097068097ab8a8d2568fb"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9141156a3cd8369ffb3b15e9151e98e1d039a674cfc88527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "0200000001b8780cd4585e4fd6d61a75f144b1106bf8b4370a69b0ff1eb1262c3a0bac019604000000000100000001e69f0100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
+                                    "paymentHash": "8402e76bc62b9de41e92cfd8375016737d985d5d73d4d3dfba46b855f8370b49",
+                                    "htlcId": 0
+                                },
+                                "localSig": "6c2c84ab6ddd5e0b576ddbd190b90a04f421c87cd7c0bf58f21b77014debcd36187e78df2604d1d3b90e7a8ebc547fed179c53e83b6030212cf0efb9f6f73afb",
+                                "remoteSig": "08d988b910001b302c708db95aabdd1b11a02a7d6c549b78715b2894070feec1557f5cd291b5559f866cc9f8352d17631f28eeb0764408f6f503442c636e3729"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 2,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 95000000,
+                                "paymentHash": "070fb40232bd54297d485a2303b042cbdd51011f34fd509f4bae3ee0c62f6fe4",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 110000000,
+                                "paymentHash": "8402e76bc62b9de41e92cfd8375016737d985d5d73d4d3dfba46b855f8370b49",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 90000000,
+                        "toRemote": 705000000
+                    },
+                    "txid": "6552be7d50bfd1711e327a88449299c0cdac58c180f781d5a1d97908bbf5bf04",
+                    "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
             "0": "a63c8f54-772a-4912-9b2a-055f7f64ce56"
         },
@@ -221,24 +238,12 @@
             "left": null,
             "right": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "73267938ec3fb5ea5dc04e15eb163c30b5ff1ae4b68be8f1036418fdfaf595fb4090788cd267462f2f54005b0e18bd8741f363f4604e97033c5c69189518e80a2970316a58a96ffafff202df6313fef9ebf1e64a9425f6dc6b91bfcde58d82612f6275f3568df8adf20394169cae4e236304f2de2d5a1e576141ed2d5eab806b5e8abcd85c7d58c5353835f160dcb2f7d33aa447cffc64295a04f3503a339e926fb9ed0ea9355c01fa7b4064b72cc4b5b89b7b3f05710bf5cafc66e50bbd1085bdd0080990f4207a05332a92b64ad795ee61db4722936e2abd7a675b72a1a138ee4c8112e117caa529aaa879a7ccdc4a59c20fb8d6b1c4d5514aadf0f7a02a2a13d4db90209f6abc3a62eb1a027bde93065cdff27886d8009c3d1366c0c973c4cfccd993253900d625c776026f4d16ddcc425e264fc3e6224ede6cdecc577db5ff0d226c382a60f2e25e87eb495eb2ea107c26feb3fbe807b072e2de53d77187d76285f305d0462738cc4f013ff670b55cb88ea9dd30a75754ce7822bdebba1b5f89c598cdd1de5fb0d78f0c460979a509ee4b0760a2724ba822aa7a0bb2436387c4bf1e85aa0460abb36971a9e209f4349b2cbd1aa0093a22a3a9a358aa987c73b4f3a081b30abd76a5282b5579a26483fd3e7f0034e565baf7350d25143b3f3f83575a1e7669ff52ea23fcc58c762d544e19907c01e1d41874c3cc026f3275e2fb22fdff98a66b55f6ce0582eb3203cf0594e2b91fb921401fced7c3d8a48ab67de2f4112691071a306f2222d55264d0d4b73ce9d7f3c3002c53baf788b98a0ccf3c772f5276a83a1d755f1ec5539038374adfd39a5251302a464551372852755e9a8106412c86a8ccce6983e4b390c364d9445d63fe01d71a7f6714b182375f856deee803db882b7bf60aaf0db989b0e1d404306e6e6bf0ae6cc09b57126ce06c150cd89a03a6d33470febf74bc1508ac4825ea6b4289a323ba007004c4ed4d83167f6cffe70fb0ec45908d0e12699a55ecc648055272f57c4e84597a72448b57fc67b3f9d698e9bbdd2d6045c0abfcbcc04a611077d1840ce283f2f85d4312c8c30576f5ebf2629e8b6a35b486ea7f18561ccc2ced23f499b11d795168296574403822d320fca5c03ed5e98ae7851444ceac1766ef01902c4174e5d6b8b6e6816621e9a3909d81045060d330b3493ca3b580bc6401a37973f871ebf32d1aeb598f4aeb8d94e6484217344a78528d56a59d607318a66403d82bc43e7a5131b751e82dce1581846ef91de58a206e63302efa2caaa4699072e97d2cc5044abbabffdc48dc7a29851e14303e5bcd9063f71ce00d5bd841c831e3133d8425bbb7a5be701e7dbcca578a8162c204a75318c013b239dfdcbb16cf91c1ca05daec0bb8f8933594ca71b782c5eb644c70a5c02ff86bdd45e1d83045374cecbdf5dcb98da290bb5bc1559c8385abf3c055491bdd5a836efd6ab0c982c91725d632715527d5f6a0384b594015a4b2905fe7a1f8bbac9ee4fe0f21a820a30e02dd0143fdd17fdf997cebbd710cb6e21161f85e5875caac2e05ff4d6ed9dfb83f222e2d7cf6ee6eb164959a947e5dbfb23e8eb6086007fd45be398a55aac04f6e616fffe1178265b71781a792e960eb12661d7d20992b129b8fa6256162c2791807d526275ebf358a6e2afe64a9c5c4059aeeb3f9e1abd751df38f91857d7e6e187e6e6288bf7ff51ad29c41eb5e0338be2150d62a9e650dfce428603fa0853f13e53ee576047465ac208303db5e295f5594f932aebd7a28d593c3fb424bf00d6c2e057d4c28cd94a7b2a5d9b8154fda681e362a3b2a7f9296b0a858f89d4f89802952b1fc5ab3be0f2801f1dc353e0b44958356787841bdecb444797cbf7861863c2c75c34a6fbbd0e1c929e5bb3838a56e3dc45699354adcb89518f0c936e15fa0d35ac91bda263e808b1c62fe2eb79e623f4998fb4519234ba62f04651adf0a144e65b40c2d049f9e4b7cd7b760654c3b3bde806ddea2043798112cf413c6fe7a934016afacebdc69ef9cfcb42f65cbd940edda3d7e86db0f654df8e61626b8142e75a88c4454586f0a0f849f6d8cdce1b8e93137c3c63cee73535c12ab12306727f2530bf839b0924785b61ff95fda48126d4b95e1d16e63ae84f950f3ddfd2a3c1b86087fa605deab7adcdaa4d5e44f360817d17c42e6cb7d1cbcae6b92a1a29872acf228e07489b655cd4ce5650d5a0c4786fa6c9b7279493d1dae37146a9dcb087840dc3135c1a62fc0ce297a60c2254a2282180ea13338dd9e9d83a3976ae7632c4dff6abe29854469ec0c9f58216ca3eb56e8a271facf21570a9f1458f6e2dbd1bff2c0c24d5ee340cfdd08f5ea15ce9b764a014214573578d9cafdc3c925ca3fa6fd725aaf109bc2a67edef6f4ff33fde4f546fff607f06430d88a9e21865fa52195d6cc4e084e08ece1bbb88159357c9622663d2c9cf1669b08fba76bc3f39fabf4931ef78054736b2753413918fc00f41955d0e2761891f51c480d25179d7ac95d8415fe86961e127bfbbe55dde8ae85c6212e32645bad8f21a50e9f05256b1cf0a60504c79d3d172b20eeeb2410841c08fd8ef99c4c4260ffa489470b51044780a365655d9e171a399e23fbf4e94b9a610931a7dc4b323ae7b990e705e5568a637250fe70532f18c96595570762f9f149ac361839d59935a0ac655aecb43a6191e828b7aca27e98a1f8f68451e5d4ba456c685ec9886b610ed3786465266c59280d02f71c95cdac40fd61d575b422d73e4fbd15f503690b23e23580e2178bc5bdcea5390169c510b3f7de2dbbf79a3167b1fb6453803699151a3d3f551ee43fe41d67e06fa925bf587a4a2d299a4692a763ae7b2acdd6b432e76abbd91a482cce3895c647718e192a8159266afeb2f9d310a9ea0ee4e01b434bb3eab9b022882c5f196b2212d7e813c6c2e4af305c966dbd899224626dd9ad80627fdbb958bd471f7a9ba8eaebe0effda63d3c4b84b85557b0fdd80373f96b60d9bbdd664a7753154f640ba1f8eb1cbfe4212b7fc3ef9e44c93cd8210192b05b365d77cbe81fe004d2ed1fb3ae6587de8afc2710c93d7faca81490a3ae59b18ec2fc00cada9c718067a013f66aa67e1204cdfbcb9c9ceb405aaa8f625e6b435055f8c6d07e1e6ae8870cb1106b7c978ffd0f9417f481c79ebe51f0bf0dda3d30e0f944a1f037340b81308a0cf0b0a28502e805b285351144bf60f886a56d44d234cdbe589a01888b4fec9161d2900851dc44958fc5063e98e5f765c03ef208a13e5184b06385333e706e5dc63eb95f0c611b20907cc0211f2fa8f27ca8877bc9d0d6e92f8fc0d121c231351895d6e619d091bebb4e53af89036bf8fbdf8bd8126ea40f56703ca4d32d965b97cce5450bd7192e36caa9f54fb21a49cff86e6fa2f46c8230a2632f1219a8fab1187e9a7bce655c8f0973456f88d1f0653fb22b06f482fae5976056756584ccb08b9cba6fe8577304d0f9edfc96e03da97dd16877d15774de1613f3c6ab7e362e513c560a5750d47bfa2fb41bbecfa5989d7635038b5f4b8ea48fd2c2c13fd842f1ae199d5d382ec3f3824c66058f20da2feec3cb3854ecf357efc3b68d33ecc545271de838b12efe2669adf929504d4826d6eb2385483d86388f932013c07f8ecc66806c038b4a9f76ef0a942e4900289c3f212333bfda32ca493a77029e1c8cec4cc5f9e8b8e526853f7865408f352a5fc3ececab77f51fc177ebdb0bf19f03bfa3f1301d06bb8ae183f3ef51fee7a9d7ef797e517fcdc4abac56896a0279f3f84f093c1613107e5997c1268609cb34961e03f12e1160713960de286613b737bfd51531a980b14480ee7cdd8994f36cbf814bf7c5dc8638b8f52f00ae59ba86af9e836b4c3e4e78b38a2dc4bcff3cb0cb272a940fec253728f3d90c3fb2ce50c00f0357f5646ea2cc8a3b1feb4b7c25b093c59dcfa43aed3b8cf050b9d1edb5efcad35147dec5baadb0dc0caf38e01b7d89394908f50853fba05e173357c9ec63f0c17b4914b28c6be9bcff256ea628b2dd9a7a6bc72df034f979f3ffe2485941555786ea131b2f164ba79269e5b35807e90d4c4d73ca18aa5f8bd44c1f5545d4a0e334f3171aa5e08dca72660505c5d39082488ae64155510e54b3d999d15aae89cfae172733d0e13c9322f487c6e5f9bd76ee46477f7c460a20f3e1de49fb4a8b32087acea660959e2212690941dd02af8d19068dd53ba062e1d8baa47269d53ec801afff8cbb9caee4ed545f065359ba826c5987a3e73482f7a38615b427e47128ac7f54cc5b109fa8602ef8d0ece0e3f16714cc9498a6218c4e757e95f424ea64f970c43fec345d1cd02b809e1efb5522402a675661801b8e72b68e065b9d0b789963e1b8823fe8ada499abbd9a64b3b5f4b533a8d31df8412fb1b4b2b2b5ba6347edb7bcb33df9a850bd49e7fe7c1155ae97a53d4fdaa28cda7a4ec1d261052765be2b3e87205cb6ce843d2c8e95a2416fbeaedef809267d8cd72bc2bc19260bf9607450d6615026e6d15a70d5bd31c7b1c3811fc5fb2c1da6f2b080ae66acafbc13a81cd6ea41850b60933c80cc5fc88bc39e513fd7650f24857e90c386a7bb06f16790623c382f9b4c8100d4bc963750449f3989e3f24cd9edabd0ac395c715ac2b66c2529bbb48726d7c0b468c6aa7a6a206a4cea8d93568181c571de72ab6bc0bf066cedea7ae40a17dfc1890e2ff9318bb7d9ec60e0b60d61f9679b2b23c9a2f07c4a3784ca2713dd21e508ae47713666eb439bafb601fe8e0b677c03eca62680874f1b33bc04e3c7807c31eea06ab3759a7d0e1be3968e5dcb76d7f2885e1f4539e5b7968e1cbc2d6d7d519c757f401a17dac837b20cec445fd975e823cfdd28cfcc6284aae236c70423b4904eafabee1c7cd9e6d02069fbd912e3daf48985821fb66259ff0a42fdcb3c1d2f045975a9f154e5807224acd87c92d0c9d30205a500db9d1884e61ce835e88fda33bd4a6ceada13629515d46c278563afd549efd6a5513e89afb16f80a15f0e7ab518e7d18b65103f36534a94cd795d28247637762eb972422247e34fbf2fff1e775d540e025c2a59a3fabc412f988c908609604026ee63b82894aab9675430afc58c7ef9c857aefa94776194446cce84e67985e30c6232ecb82a3ad139dae0559f5c37b2a2c5c0e957bb947ff4bcfd86437ecdb033abc4baa558a81220e12"
         }
     },
-    "fundingTx": null,
     "waitingSinceBlock": 400000,
-    "alternativeCommitments": [
-    ],
     "localCommitPublished": {
         "commitTx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032905f010000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799018730100000000002200202228f1681cff3adf3524363fad7481c1aad6aa344b223cd97b4fb09a667f5e2db0ad01000000000022002028eee5bc7a7219b098d1f27ee035b83a6870d2be541097068097ab8a8d2568fba8a20a00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400473044022069b2ce78c6eb6728db4296f6a88b65af682c81dc613985ecf6c23d14cfad3b6602205af6b39cf883448ac1769495c029f230c18d1c4b70292bec6cafad220b74bb5801473044022043cd8250bf3125c454dbe9d7389a3000d6198e35ad82ddd767d2fb770d4e00000220740dd54ac489715d33c6730ee78ee3df4e00f875f67c93b005235d5d637334e40147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20",
         "claimMainDelayedOutputTx": {

--- a/src/commonTest/resources/nonreg/v2/Closing_0ed6ff68/data.json
+++ b/src/commonTest/resources/nonreg/v2/Closing_0ed6ff68/data.json
@@ -1,167 +1,172 @@
 {
     "type": "fr.acinq.lightning.channel.Closing",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
-            "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
+                    "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "0234ea3e3929ca115acc645d07c40eada7a98d86017614c3fa466d7e19760917e4"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
-    "fundingTx": null,
     "waitingSinceBlock": 400000,
-    "alternativeCommitments": [
-    ],
     "mutualClosePublished": [
         {
             "input": {

--- a/src/commonTest/resources/nonreg/v2/Closing_0efffae3/data.json
+++ b/src/commonTest/resources/nonreg/v2/Closing_0efffae3/data.json
@@ -1,170 +1,175 @@
 {
     "type": "fr.acinq.lightning.channel.Closing",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 5,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202bf8e35df3ccae49bcd2036ec55d8450741336530017d00f4f41dc44d69675b7040047304402202f27c14d4a412b64c8ca226b9a20c51068f6b939bad70d46dfc1600c39617552022066f267b145178f5a69d69fee8ae6930ded1d1dc96a746e79ea3302b7df989b6601483045022100e75f4f2e202db89d24d221c7c9329411a85876e00996499b5031c1ab094afdf3022044c7c948e25282f17396385eed0efca8d7a3226ce002fad2e48cca9afae5c43b0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedb99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 6,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51137bd5ff1caf7ee0f35541914637e19b0f4ce9373f1744044ae7b1064ecce3",
-            "remotePerCommitmentPoint": "03856c08523bf8c8def3044843a4ff90fbb1dee9f92d4ae82aaf3fb2688bfc3884"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 2,
+            "remoteNextHtlcId": 2
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 2,
-        "remoteNextHtlcId": 2,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 5,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202bf8e35df3ccae49bcd2036ec55d8450741336530017d00f4f41dc44d69675b7040047304402202f27c14d4a412b64c8ca226b9a20c51068f6b939bad70d46dfc1600c39617552022066f267b145178f5a69d69fee8ae6930ded1d1dc96a746e79ea3302b7df989b6601483045022100e75f4f2e202db89d24d221c7c9329411a85876e00996499b5031c1ab094afdf3022044c7c948e25282f17396385eed0efca8d7a3226ce002fad2e48cca9afae5c43b0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedb99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 6,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "txid": "51137bd5ff1caf7ee0f35541914637e19b0f4ce9373f1744044ae7b1064ecce3",
+                    "remotePerCommitmentPoint": "03856c08523bf8c8def3044843a4ff90fbb1dee9f92d4ae82aaf3fb2688bfc3884"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "0323e9618cf8548e5b78a14529e1c8df51895e47ae6026bf23f5f130299bbc92b0"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "af86858a35b5f1157fd7aaf673c32e67ca2d0ea39247b28f0807e32bcdb54d5248fe0dc200a4f126eba76515c03b4b8f7b66b5954d9614bf91ea309191db82c31e52b7b73bd0e1500e24e3357cd7ff6b67af31637a0359591abb1c6442c180e17fd25eed846e08e53821b9024a92423a6bfd1f50017a124565721665a6faf0042fe57c7c1fa69110c7c61e29aa7efd6600d54956ad0ac7242569bd12b5c76ce83e7616e2b5dc03a3e8323d870675723da9fccf6e7b6a9b51ede780737edaf10c3beb9c51cb32a9c28f11bed5bf19a37b81fb6553d322010bdd737c82405ab45e6b60b6b0c01d1a2099e05bf81ae3899efbf447919a99bacf31f4dfaaf1bc4fe266b7eb162215bf390bab1b86952a427ded6869bb2671c57200737170e667dd26eac1ac2be9ba5bad16575a681b04261c77a38fcc268b38b16fe6a1ac10c991aa4c603eaa7ecf3f2b2f48fa4de31ea44fdf4d7d4af605b02adb72822c96c334a15f5319e0f6f608310abaaf4ab56860d1584b6bcce7eea0f04dfe7da82937cb4df88ee4c1e82316b717f6aec4fc079633ae974a7cac797cdbd64608f37b904b98f9bcfeb4ee528089136a18ccde52f16fff46888b197d12e07a82545fdd8d6aa35326f2974c7e52920608f0b072e654536f2ca7c04b297756bbd1f6d14747dd7a5c020c9436bf6cee3f6f493c93d7c99332570ef7bd7f332b3c67550e75a3ac2030edb71e50574b446655f073722d83a0472a4ba051841d8a51645c24ce32f29b971a115d008d5d9861be104bebf869b1352aab99065094826f528d7546985a97535d7530d464e110d41903559912d86a125d3b91045928074f7e079deedf58afb0f1b26daa45f62a38989848d379c82f70543f102f647eba30211d57e1bf4072fe1bb4a285e7013a448de126368ff5c15a69c6fc59a9823548e0b629d8abdde62a3aea29c1dc3e99345193b076d3364e4afffc23557da48d03dd407efc18b6d13a353a2bed406ab9ec788bed9a2a09082ea5d60413a7bca50b07a78b01d5f8eee2d7109a6c8ff25c8f103cb5fa099ba373156352e279980a4c8d0561e4f2d5c11c113f18dff31d281f81820ee3a1e3021753ea891e2366ef0cd4c97fc870da0fb1eb0674a73bc4320085795f514102930b9975d385a9bb2dc9886296eb4efb2ff3dbda14803a1b4838899dda19f68554c9369db83e8ce22473cee3c94bfaad5e0743bc40c4f94d8e0de0946429e88a96aa7485bee65c7ec5053133700b699fb884ed7663f9a563c451f4f4e4a63dac66a90019704158ce8d419b22a62defe24872f4484c40c1d75eb63a4fd114b6b8d5ad20d222b13a0d39851ca35d9322be5b826a393072b376daeec127673b9c96dde60c1fe071d3f8b561ea397b32e199ce694c7f30358ae33fecd4509804650bba8c7ee106c2246adb89a8cc1077bb67b3140e2f544393f8e33e47768bac0e94e5a284150ec02ca22bd99cb5c746e4e72535b7cd22aba375bb7248f155a9e75fdb074fc7d4a54f6ec17b424cff1f96ba2f3d027fd4781a6f2053e85c69800c9cd321d6379b3051ac540370ca5e97d0f4a1c2a39da97ca9945b49e881bb612bf3c8c7112903f8c66edd837a22bf3a6bda66cb3f12bee916649ac06af4f1c9790a7af21bd3dcb5aae21755cad75c591417ad962310bcafede7d1ed307b13176709f8bb1f9c3fdf0809dbbb28dfaa2a26bd076d119a34976417c78a4973b98f9c153a4b4233520594ff81627c121e4526171f66838e0f00c58cc4253f0e24c9bb23f7ef43e91ce3c6300b65c8a5b84e67da9f0e5b29f3217e280db53a3168977ab9bcd98f04c94cc202e9ca839e1129dbbf318d5e621a573a3928c4786df99838ffbdc2482cac10d14510240f914833a0b4470831c14a84686ae1c0f12c935bd5d780f7b513096a1e4bb78efb03133668deeb4cb62621e5876e3005db805788d35fad046ec9043838ea036e65c282d87c5895ba322ecf443346f8f737fd2e5c0d5a2887a25ed9c1d0c53d989d6cf8679579c7361cde49870e0dd2b846a2ed8815a4e1213f73ef927cee4184631fd4d7d542d5ba639bcabb3d98b6d03ccb3a86b895925394bbe5d386d7395026457c950149228e5a5edbbd315ebafe822a37e16917518075c392eead699a38cfeaf5a08fe15c993a32d8b0c39a01661cde7d1c7d3de3f71e3342a40087b385475e40848ef45507b13ae05a7d492f9a0979d093facc04ebc63492e0c74cc72f30142a4039c1f66597ae6f63972028d8a718740ce237da4d8c3c09a824ac6fdc042bcc33fdc4f417c4f1d0f0823bddc6f71e6f72529ce3f3ba0f62e9edb26c2f042f7b21c9086d4a61b8424fb8dbbe831540d8db329c0f75d10f5e2bc4549ad44593ce2bf045d1d3e67fc59bf63dcf369327c1570bdad0cdcf98948515d27b0e2c25232955a4a603443ba332b7377938b920006a899e00c92827123883feb24161f5051beec48df36b608381224726ff5accf5f2c73aab9da3f9137dd5ca201a881bf35660d179f0fac7e5c69d1f4d0318a57b07b7a53d3ac5a568328080c47b12575cf07b1bdb047432e93c2f9029eb9d8fe51555698485eaaa6f74ff560601678985d7bbce969c204c7ebcfddd3d51c246e3639af4416e62efbc3ce9798cd9043d2d8ee00802140d60be622575288cc7cc1db082f50e148f7b778e95aa867df6bcb7bb542fdd7261859618e65d60270fa9cc37917e4a14f8e13c95c31671023e3848e8002e3fe25dff069078e3983240ba3ae99e212844310431af49aeb7b9328a2394115b642179e3859deb8aac311386a3571d53fd50e309ef6c5e044b78183ea450abbd92848505fe3226b1481b100e3474f12009157341e4c73a3438d105ec52b9f34ffbcab5ea5d3d65168d36a1f558bbe4fd255b950b20a78a97462ac8aea5b1acad474fdaa97d3f2b17c5b5353e48e79f64860f8e2b1a16d31f2ec3f596ccdc9eca8b0efdafac72704eee3add0a0be5e9a12a34a7f300cecab42464c929028fddf06146c9b918e8fc88316fe26155804657adcf3a4890e199c55603e3a86c0377386917fd39a58c72951a949a834ed99f707b350f2ec70651a5e4f4016f52b3a5b7e6633a95c7a606bffb65c8f764a30069d585d242761a4fef3a2fe6e88509ebdda0c2c064e35e58319e26583f7111fc6cad12b36f6671ea9460718b1c9abbfd8bb7c7a0ec6bbd66506bb14639ab41989deda3773e8f044f4ffb97e8cbdca5e73f847c218b527ed18faf2fae95c16d89f0389c8f02eb87f39d3be33cab5e39c0aa32cec82f067b36b16aca96cfd13117198bc463a5f39b55a3878147882d1257b0b8cfa9047038db1912f4b943db55ec490b019054b530e73056889489914df98308002175ed472501c86b74f598cf36640211b6483881d614da24872004c33ceb7f9c325f49363341028349376a6ee554820e01d60bde0cd822f70dc01a582edfb8784dfa03ead20c9aa235861333af90439980a40edcc056f0ad948725f494969bcd1cf9878aefef14e9952093a1467277ec9e4be3a9d18ce6131157959658a10d23f75831628e57d85bbfc8c90eb4b5b9803c6fdf8f10eef91647f4dc38367dbdc6caae7d064b04a4fd121642c6c995263d0eb4896fa4f66751b6c6efc57bde182f15abbe38ab5d55917d9f4f04c6c25f3179f816dd6ec47f89099d2fbc05417703b6007fa86d2ef108c983cc7c2f59f015e5469252bd58a1b14131f69a1385ebba1eb46bdd45b081f4ecaa147c780319c34c2a2e6dd281e6183ef4adddbe0e89fa9bb14e4e6e51b849916d1d7f1d6c7f89f0a8e090e5647206bfa94e0bf2242d606932b7033196cff04bbf7b91fa03037178c4042bdb1d4cbfe072136511bedd30c355ab733cb569a0e25254499ccab2ac447b584afcb01357282f28ac890165a99ef5a6979c036fd24afe7c06564ee5b47341d2c7e8d6bb99e6f04d04f2cd7a60dfeed7a95b47a3a0730744e7576ad92fa27be5ecbaa6ed07cacfa3d5f3bbead8e82a959573cfcef637dedac9ec54d98fc3aa7b51d56839cdcde74c5a7bf17f62e4ae0ca80f8d1443521f2d71253e190bb1cc0b0c0cded2a283f1399bde1c06fed0da92b1199db9a8dd52e20cc32ac84a9a6eb65d7d2ddf45687f6ce18c472f65fded8378e3f699277a754c75c7c94b242180cf018a09548a52206a8e8f0488c15a2d07c6e2a98622b265c6100a09a28c5dc66e3b0caaef29ae76a88e6cf1b8f155bdad84a747f5e2063041cd41b49912717b2e54f62b51afc82de929e9307c803aaa26dea29dc7f7c7d66cdddd6d4e6fe43a0aaeb1057fee4a52cf48ab8c81f7b76aaa16501003c0c28ea1d82d4322af24917b04f9927c01489218703213a6f2f369bbf0649040fdc3f2fb99db442b391c87a930e41d112d1b73f7476d5c10e0900811c78556e3316936f709560182306fcdacbee35d20dc62ff4a973359f62803a1aad02cff001be7f5be361766735b0d140ebf0ce1a34187459964ed98338d221b6f347937abc388a42e6031cc84fc8c00a99f33d83e4dd70ec5da629d5f7bc086c229331ccfda15c91291dd4128b9523d8f018dc637134739b9601b2d007830c8034106e2a6e4bc944c0e6d744f60bf38fc3fa702e3aa473dd15b5338485acf7e5d0b15ee95357de8224ef7fb47db1a268ed815512910a9a56430e04bb223ef5f9246f433bca6b046ffd20e2f55a26e41fa0da7f60ab90924afac4b827913dcb98d90304ec2f4c1f69fb1e25d47e622004b14932fa7176a43252c47f80e0ded5df71a3f2f8ff0961bf8d12273260c93a4f258d8cd89c8b55a3b20bf92670ecb4695ddfc6101a43f61f83ad029fbc1f7c9e91e5e51bc19d5f111efe98cd0b00a0a4603352fc69157f64ae04d02f0cf9bdbcd67616c3a718b2b6bc49922653e841f91bc4f3da3fdc3ec7a766f67f792997d2a83c00eff7ac9c17507c6c89a96cdca38fba3532163adeb253b7202abf192af8f71312d6a799ae36ba980c3e7bb2abad997df3b0986fbee7cc7de0a28887a9c58cfd96dc3f83413e60a1d784962071b2f20db112aac11126f41bd34c6c8b103d8d1b83c2bb8d8652e09ee8ec1aa4c1fbcd4e414da9eefa64a56d93c97573bbc6de1cd8c6e12fabb874175921259fc57ea31a5f25b40d259c09ccef8c5bf0b327bc814179924cc55f62f6fd51a396d86a94b4f58b5535e4859dfd2124791e25e69bb65e677"
         }
     },
-    "fundingTx": null,
     "waitingSinceBlock": 400000,
-    "alternativeCommitments": [
-    ],
     "revokedCommitPublished": [
         {
             "commitTx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080084a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da0325046000000000000220020290b762b514961d8ea3f1d0a0b7325c43daebfad3751211816c7bba59e607ccf204e0000000000002200201923dc9176a660d04e0744c51f5e04a3168985962079a6c5d9e2e763170878e1a8610000000000002200202956089b232f4af35587c10894e6e4351d029b0534fb01f7c3c90285a35d45ffb88800000000000022002058acb1c4d7241726756c7e09705500409991b84ce93c86d6ca4eceef76c98cd4d078020000000000220020adccc1c6aa5fb4707079451e579c5dc33c513f0d829346cefe8c80179e09d49ca8240b0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c0400473044022003a9fc09ecabbbc049b8dec3d3b92f092265f03b3d4842c0595de1b91b215be202206caebdbc0bfac0d93b3068a9a633268e7e8ccd5904971f8375e5b9b3ee64b3a501473044022045e9af4c12876dcc268d319687f1990ae8db9faace5e4281465bd5799e1a44f9022020c476373f17531c614eff980283fc8b3ace4e69f9e58debd891c0a3812211900147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aeda99dc20",

--- a/src/commonTest/resources/nonreg/v2/Closing_2fd2a3fa/data.json
+++ b/src/commonTest/resources/nonreg/v2/Closing_2fd2a3fa/data.json
@@ -1,312 +1,162 @@
 {
     "type": "fr.acinq.lightning.channel.Closing",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 10000000,
-                        "paymentHash": "d28cb22a6271c5710811d244e75a0d1ab476dc35db269a6c9d1d8da364224d47",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 12000000,
-                        "paymentHash": "a70d3a78c0aebb9a797a3be74f45f8a092c2a15c01a45b482f61b2ae560d0e6f",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 20000000,
-                        "paymentHash": "a7eefe6395b2fef677cdc493f4a6a21d57c0fc0bf96250c327d5b92f32d9b2d2",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 15000000,
-                        "paymentHash": "69414f76b2028ea1577739f22315fdbe7e55cde1d5290879c11180a4129c95ab",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 765000000,
-                "toRemote": 178000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-                    },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080084a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da0321027000000000000220020dcb30d6a2f2d4b21e5b65464e8254696ac36e858a51001f7b201cc8b5f9fd053e02e0000000000002200206f05b50d227c1925ee599a7b9e0542268b0eab9c09b44f4abd0a04cd8429ec54983a000000000000220020459e3a42f3cb4ee61f1bc037be0a0678a13ba76f81bcf8cb3c73405f29912fab204e0000000000002200200a26b988cc1f9a5e2be56a122b9409031c24ebb5aaacf58d84f9f8cb97d3291050b7020000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799050860b00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400483045022100cd5fde20faa1d444078842ae26b3b18e49d96204484963cb94e1b88aa720364d02202c33211d63ab514cdefae2683503790741a5cb0939be9a8252e41bb34dff36f701483045022100c25c87388e91e411355e9059292e858928b03c331fa6f8420a90cc8482237d5802207d6764430cc881811b8b5d48d6c3e64906458ee09ce55c61af58dfa57e598c400147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "5def32053e7f13610e4f8ada9cbfd6212f2aeb6d44cf85098586d9e1a7a8ef2d:2",
-                                "txOut": {
-                                    "amount": 10000,
-                                    "publicKeyScript": "0020dcb30d6a2f2d4b21e5b65464e8254696ac36e858a51001f7b201cc8b5f9fd053"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9143eaae3985730c9fa1e2c7a9973fa6c2dde566e2588527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "02000000012defa8a7e1d986850985cf446deb2a2f21d6bf9cda8a4f0e61137f3e0532ef5d0200000000010000000146190000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
-                            "paymentHash": "d28cb22a6271c5710811d244e75a0d1ab476dc35db269a6c9d1d8da364224d47",
-                            "htlcId": 0
-                        },
-                        "localSig": "2bfdc6c19d76f92c8ed4dd7342b67b395ce60c3b8860e19cbefcabc61d1e18d8243cc251c1f1372cbdcbfb7c1aa3a8112500685e8eb5fbd7f23787e9771c2761",
-                        "remoteSig": "771ab44a415de64e1ed488009d4d595ca38a2351510111795ec8bb868a7d128467432d124feea54f9028534ae6adc7c004df25162f3a92c50c981595241b3abc"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "5def32053e7f13610e4f8ada9cbfd6212f2aeb6d44cf85098586d9e1a7a8ef2d:3",
-                                "txOut": {
-                                    "amount": 12000,
-                                    "publicKeyScript": "00206f05b50d227c1925ee599a7b9e0542268b0eab9c09b44f4abd0a04cd8429ec54"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9145e40a45bfc495659019ffa2aeb7bf19ad857bb4988527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "02000000012defa8a7e1d986850985cf446deb2a2f21d6bf9cda8a4f0e61137f3e0532ef5d0300000000010000000116210000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
-                            "paymentHash": "a70d3a78c0aebb9a797a3be74f45f8a092c2a15c01a45b482f61b2ae560d0e6f",
-                            "htlcId": 1
-                        },
-                        "localSig": "1db6634af7b83589a82f042d7844c92427918fc14f5a07fd481cb5e7627494563edfa79579a297feda39d0c1dadf1e5474a8ed6dab3b09cd24d7e1bdce6fbfac",
-                        "remoteSig": "fc468edafeb689124f65503d2a5342174bc3e353c4660ac4c2a6db739a0d9aa964b6654b2e7e3bc1636862ae0711d1382009634dc597cba8f80de891bf8c8976"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "5def32053e7f13610e4f8ada9cbfd6212f2aeb6d44cf85098586d9e1a7a8ef2d:4",
-                                "txOut": {
-                                    "amount": 15000,
-                                    "publicKeyScript": "0020459e3a42f3cb4ee61f1bc037be0a0678a13ba76f81bcf8cb3c73405f29912fab"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a9149c58316bb601fd2f51936625aff0a885dd097f6088ac6851b27568"
-                            },
-                            "tx": "02000000012defa8a7e1d986850985cf446deb2a2f21d6bf9cda8a4f0e61137f3e0532ef5d04000000000100000001962d0000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 1
-                        },
-                        "localSig": "b67d1331000323ad99608f63bda251954d6e9db835de6b35cb1986692bca8d853218ef903983c7b715bb6782c9e970088942461acf0d9fa88f52e27966225604",
-                        "remoteSig": "08b9fe1bb40e54da35e2f3db2dfd177b4b17ce43a17fc2500b97ed6237bdaa45371000da3cd262057d7e604221ed01c94107933f31c168c21056994faebb57e7"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "5def32053e7f13610e4f8ada9cbfd6212f2aeb6d44cf85098586d9e1a7a8ef2d:5",
-                                "txOut": {
-                                    "amount": 20000,
-                                    "publicKeyScript": "00200a26b988cc1f9a5e2be56a122b9409031c24ebb5aaacf58d84f9f8cb97d32910"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a91406e01cab66017410c68d1dcb19e9ba6be598d48788ac6851b27568"
-                            },
-                            "tx": "02000000012defa8a7e1d986850985cf446deb2a2f21d6bf9cda8a4f0e61137f3e0532ef5d050000000001000000011e410000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "6a37e38305a929a5348626ab6e770e84e84b8ecd15252b0902850fc30882d81a0577b451be8a02637a03b7fe1fc5f581a547628d4672ccd235feaced0a2ff395",
-                        "remoteSig": "84050fd4025857a84b82b2f1dc8e9f8ba7f67bd8933409c33fe1869f5c821b6d07b962b5c72050d1c70108550aebee20c427fd6cd924ae85a7d069ec612e06fa"
-                    }
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 2,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 20000000,
-                        "paymentHash": "a7eefe6395b2fef677cdc493f4a6a21d57c0fc0bf96250c327d5b92f32d9b2d2",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 15000000,
-                        "paymentHash": "69414f76b2028ea1577739f22315fdbe7e55cde1d5290879c11180a4129c95ab",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 10000000,
-                        "paymentHash": "d28cb22a6271c5710811d244e75a0d1ab476dc35db269a6c9d1d8da364224d47",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 12000000,
-                        "paymentHash": "a70d3a78c0aebb9a797a3be74f45f8a092c2a15c01a45b482f61b2ae560d0e6f",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 178000000,
-                "toRemote": 765000000
-            },
-            "txid": "22753caa57b8ea006edfce1f75ed9be27612ee63ae3e50785ea12fab69263611",
-            "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
-        },
-        "localChanges": {
-            "proposed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 0,
-                    "paymentPreimage": "0a0b4fd37634872e99533be8219b7b69fad29b55f562427c198841fe448a3fa4"
-                },
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 1,
-                    "paymentPreimage": "c2e300bc51b0df81a16d4271a1bb291f5e46a52001de84d20dbe60572bfcbbab"
+                    "unknown": [
+                    ]
                 }
-            ],
-            "signed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 2,
-                    "amountMsat": 20000000,
-                    "paymentHash": "fd25b31fd47f9633be82bf51dacf048b9592b42ed1ffb3c9c2ddd37351697413",
-                    "cltvExpiry": 400144,
-                    "onionRoutingPacket": "<redacted>"
+            },
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
                 }
-            ],
-            "acked": [
-            ]
+            },
+            "channelFlags": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                    {
+                        "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "id": 0,
+                        "paymentPreimage": "0a0b4fd37634872e99533be8219b7b69fad29b55f562427c198841fe448a3fa4"
+                    },
+                    {
+                        "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "id": 1,
+                        "paymentPreimage": "c2e300bc51b0df81a16d4271a1bb291f5e46a52001de84d20dbe60572bfcbbab"
+                    }
+                ],
+                "signed": [
+                    {
+                        "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "id": 2,
+                        "amountMsat": 20000000,
+                        "paymentHash": "fd25b31fd47f9633be82bf51dacf048b9592b42ed1ffb3c9c2ddd37351697413",
+                        "cltvExpiry": 400144,
+                        "onionRoutingPacket": "<redacted>"
+                    }
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 3,
+            "remoteNextHtlcId": 2
         },
-        "localNextHtlcId": 3,
-        "remoteNextHtlcId": 2,
-        "payments": {
-            "0": "d6ad5565-c4cb-454a-a05f-398ed8d8127b",
-            "1": "cb0ca39b-c603-4952-a45b-70f119c594c3",
-            "2": "3a7ed472-a671-4ee4-9659-47818a48b3e3"
-        },
-        "remoteNextCommitInfo": {
-            "left": {
-                "nextRemoteCommit": {
-                    "index": 3,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 1,
                     "spec": {
                         "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 10000000,
+                                "paymentHash": "d28cb22a6271c5710811d244e75a0d1ab476dc35db269a6c9d1d8da364224d47",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 12000000,
+                                "paymentHash": "a70d3a78c0aebb9a797a3be74f45f8a092c2a15c01a45b482f61b2ae560d0e6f",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
                             {
                                 "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
                                 "id": 0,
@@ -322,12 +172,115 @@
                                 "paymentHash": "69414f76b2028ea1577739f22315fdbe7e55cde1d5290879c11180a4129c95ab",
                                 "cltvExpiry": 400144,
                                 "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 765000000,
+                        "toRemote": 178000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080084a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da0321027000000000000220020dcb30d6a2f2d4b21e5b65464e8254696ac36e858a51001f7b201cc8b5f9fd053e02e0000000000002200206f05b50d227c1925ee599a7b9e0542268b0eab9c09b44f4abd0a04cd8429ec54983a000000000000220020459e3a42f3cb4ee61f1bc037be0a0678a13ba76f81bcf8cb3c73405f29912fab204e0000000000002200200a26b988cc1f9a5e2be56a122b9409031c24ebb5aaacf58d84f9f8cb97d3291050b7020000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799050860b00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400483045022100cd5fde20faa1d444078842ae26b3b18e49d96204484963cb94e1b88aa720364d02202c33211d63ab514cdefae2683503790741a5cb0939be9a8252e41bb34dff36f701483045022100c25c87388e91e411355e9059292e858928b03c331fa6f8420a90cc8482237d5802207d6764430cc881811b8b5d48d6c3e64906458ee09ce55c61af58dfa57e598c400147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "5def32053e7f13610e4f8ada9cbfd6212f2aeb6d44cf85098586d9e1a7a8ef2d:2",
+                                        "txOut": {
+                                            "amount": 10000,
+                                            "publicKeyScript": "0020dcb30d6a2f2d4b21e5b65464e8254696ac36e858a51001f7b201cc8b5f9fd053"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9143eaae3985730c9fa1e2c7a9973fa6c2dde566e2588527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "02000000012defa8a7e1d986850985cf446deb2a2f21d6bf9cda8a4f0e61137f3e0532ef5d0200000000010000000146190000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
+                                    "paymentHash": "d28cb22a6271c5710811d244e75a0d1ab476dc35db269a6c9d1d8da364224d47",
+                                    "htlcId": 0
+                                },
+                                "localSig": "2bfdc6c19d76f92c8ed4dd7342b67b395ce60c3b8860e19cbefcabc61d1e18d8243cc251c1f1372cbdcbfb7c1aa3a8112500685e8eb5fbd7f23787e9771c2761",
+                                "remoteSig": "771ab44a415de64e1ed488009d4d595ca38a2351510111795ec8bb868a7d128467432d124feea54f9028534ae6adc7c004df25162f3a92c50c981595241b3abc"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "5def32053e7f13610e4f8ada9cbfd6212f2aeb6d44cf85098586d9e1a7a8ef2d:3",
+                                        "txOut": {
+                                            "amount": 12000,
+                                            "publicKeyScript": "00206f05b50d227c1925ee599a7b9e0542268b0eab9c09b44f4abd0a04cd8429ec54"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9145e40a45bfc495659019ffa2aeb7bf19ad857bb4988527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "02000000012defa8a7e1d986850985cf446deb2a2f21d6bf9cda8a4f0e61137f3e0532ef5d0300000000010000000116210000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
+                                    "paymentHash": "a70d3a78c0aebb9a797a3be74f45f8a092c2a15c01a45b482f61b2ae560d0e6f",
+                                    "htlcId": 1
+                                },
+                                "localSig": "1db6634af7b83589a82f042d7844c92427918fc14f5a07fd481cb5e7627494563edfa79579a297feda39d0c1dadf1e5474a8ed6dab3b09cd24d7e1bdce6fbfac",
+                                "remoteSig": "fc468edafeb689124f65503d2a5342174bc3e353c4660ac4c2a6db739a0d9aa964b6654b2e7e3bc1636862ae0711d1382009634dc597cba8f80de891bf8c8976"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "5def32053e7f13610e4f8ada9cbfd6212f2aeb6d44cf85098586d9e1a7a8ef2d:4",
+                                        "txOut": {
+                                            "amount": 15000,
+                                            "publicKeyScript": "0020459e3a42f3cb4ee61f1bc037be0a0678a13ba76f81bcf8cb3c73405f29912fab"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a9149c58316bb601fd2f51936625aff0a885dd097f6088ac6851b27568"
+                                    },
+                                    "tx": "02000000012defa8a7e1d986850985cf446deb2a2f21d6bf9cda8a4f0e61137f3e0532ef5d04000000000100000001962d0000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 1
+                                },
+                                "localSig": "b67d1331000323ad99608f63bda251954d6e9db835de6b35cb1986692bca8d853218ef903983c7b715bb6782c9e970088942461acf0d9fa88f52e27966225604",
+                                "remoteSig": "08b9fe1bb40e54da35e2f3db2dfd177b4b17ce43a17fc2500b97ed6237bdaa45371000da3cd262057d7e604221ed01c94107933f31c168c21056994faebb57e7"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "5def32053e7f13610e4f8ada9cbfd6212f2aeb6d44cf85098586d9e1a7a8ef2d:5",
+                                        "txOut": {
+                                            "amount": 20000,
+                                            "publicKeyScript": "00200a26b988cc1f9a5e2be56a122b9409031c24ebb5aaacf58d84f9f8cb97d32910"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a91406e01cab66017410c68d1dcb19e9ba6be598d48788ac6851b27568"
+                                    },
+                                    "tx": "02000000012defa8a7e1d986850985cf446deb2a2f21d6bf9cda8a4f0e61137f3e0532ef5d050000000001000000011e410000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "6a37e38305a929a5348626ab6e770e84e84b8ecd15252b0902850fc30882d81a0577b451be8a02637a03b7fe1fc5f581a547628d4672ccd235feaced0a2ff395",
+                                "remoteSig": "84050fd4025857a84b82b2f1dc8e9f8ba7f67bd8933409c33fe1869f5c821b6d07b962b5c72050d1c70108550aebee20c427fd6cd924ae85a7d069ec612e06fa"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 2,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 20000000,
+                                "paymentHash": "a7eefe6395b2fef677cdc493f4a6a21d57c0fc0bf96250c327d5b92f32d9b2d2",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
                             },
                             {
                                 "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                                "id": 2,
-                                "amountMsat": 20000000,
-                                "paymentHash": "fd25b31fd47f9633be82bf51dacf048b9592b42ed1ffb3c9c2ddd37351697413",
+                                "id": 1,
+                                "amountMsat": 15000000,
+                                "paymentHash": "69414f76b2028ea1577739f22315fdbe7e55cde1d5290879c11180a4129c95ab",
                                 "cltvExpiry": 400144,
                                 "onionRoutingPacket": "<redacted>"
                             }
@@ -352,44 +305,97 @@
                         ],
                         "feerate": 5000,
                         "toLocal": 178000000,
-                        "toRemote": 745000000
+                        "toRemote": 765000000
                     },
-                    "txid": "9269a688c278f4d86b79a545287703dd31e28f2099ad99f54a38f2292f8cc82c",
-                    "remotePerCommitmentPoint": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
+                    "txid": "22753caa57b8ea006edfce1f75ed9be27612ee63ae3e50785ea12fab69263611",
+                    "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
                 },
-                "sent": {
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "signature": "84ef9f5b45f000d2f7c87e40544c65ec97fcef4abc29046bbeeecc97ab28cce36d464c8bbea53b0e640c64d796c4c0d73f6bb8f3cfed13d5126c0e29035c71bf",
-                    "htlcSignatures": [
-                        "0337cc94c39b6749a5a21f629ed3b78373e4859cd4bcc48ec71ffdabb37049a403a333590962cecf60086d59eb9cf88fb0b46636377d27b834cee867dea40e9d",
-                        "7be9546168fdc1e6440491cf4086b0642badcea85f5144fa5156c526ec723bcb4791fbfcae5cb3d12ffa30f641046fe7411688d577da18a11a0a938ede92556e",
-                        "a81f03e68e8934681867f19e02a5af39bc05af7a32f38a4fa4ccb8d3e018d0e54995b229bad4cda7ec1592047fc9b1c2e6acc2b48628961c89c3a50854f584ad",
-                        "2762983e8939f33273c2bdcaac4d9437a9f8f748140b0a0c30ffd6fadf216f5c4f4d9531b1bc5e27b4ee6937465067c86c91b3cdf75a14b10556d84577e1c6f6",
-                        "b88daf0ff21e84739d7842fd4b2c645f63dcfa41bf75d967e906730404aa02ea49de08ab115779c2959a5169fac6038e77b79f92ff843ffaa7c5fac38fc49ee9"
-                    ]
-                },
+                "nextRemoteCommit": {
+                    "sig": {
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "signature": "84ef9f5b45f000d2f7c87e40544c65ec97fcef4abc29046bbeeecc97ab28cce36d464c8bbea53b0e640c64d796c4c0d73f6bb8f3cfed13d5126c0e29035c71bf",
+                        "htlcSignatures": [
+                            "0337cc94c39b6749a5a21f629ed3b78373e4859cd4bcc48ec71ffdabb37049a403a333590962cecf60086d59eb9cf88fb0b46636377d27b834cee867dea40e9d",
+                            "7be9546168fdc1e6440491cf4086b0642badcea85f5144fa5156c526ec723bcb4791fbfcae5cb3d12ffa30f641046fe7411688d577da18a11a0a938ede92556e",
+                            "a81f03e68e8934681867f19e02a5af39bc05af7a32f38a4fa4ccb8d3e018d0e54995b229bad4cda7ec1592047fc9b1c2e6acc2b48628961c89c3a50854f584ad",
+                            "2762983e8939f33273c2bdcaac4d9437a9f8f748140b0a0c30ffd6fadf216f5c4f4d9531b1bc5e27b4ee6937465067c86c91b3cdf75a14b10556d84577e1c6f6",
+                            "b88daf0ff21e84739d7842fd4b2c645f63dcfa41bf75d967e906730404aa02ea49de08ab115779c2959a5169fac6038e77b79f92ff843ffaa7c5fac38fc49ee9"
+                        ]
+                    },
+                    "commit": {
+                        "index": 3,
+                        "spec": {
+                            "htlcsIn": [
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 0,
+                                    "amountMsat": 20000000,
+                                    "paymentHash": "a7eefe6395b2fef677cdc493f4a6a21d57c0fc0bf96250c327d5b92f32d9b2d2",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                },
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 1,
+                                    "amountMsat": 15000000,
+                                    "paymentHash": "69414f76b2028ea1577739f22315fdbe7e55cde1d5290879c11180a4129c95ab",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                },
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 2,
+                                    "amountMsat": 20000000,
+                                    "paymentHash": "fd25b31fd47f9633be82bf51dacf048b9592b42ed1ffb3c9c2ddd37351697413",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                }
+                            ],
+                            "htlcsOut": [
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 0,
+                                    "amountMsat": 10000000,
+                                    "paymentHash": "d28cb22a6271c5710811d244e75a0d1ab476dc35db269a6c9d1d8da364224d47",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                },
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 1,
+                                    "amountMsat": 12000000,
+                                    "paymentHash": "a70d3a78c0aebb9a797a3be74f45f8a092c2a15c01a45b482f61b2ae560d0e6f",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                }
+                            ],
+                            "feerate": 5000,
+                            "toLocal": 178000000,
+                            "toRemote": 745000000
+                        },
+                        "txid": "9269a688c278f4d86b79a545287703dd31e28f2099ad99f54a38f2292f8cc82c",
+                        "remotePerCommitmentPoint": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
+                    }
+                }
+            }
+        ],
+        "payments": {
+            "0": "d6ad5565-c4cb-454a-a05f-398ed8d8127b",
+            "1": "cb0ca39b-c603-4952-a45b-70f119c594c3",
+            "2": "3a7ed472-a671-4ee4-9659-47818a48b3e3"
+        },
+        "remoteNextCommitInfo": {
+            "left": {
                 "sentAfterLocalCommitIndex": 1
             },
             "right": null
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "3ebc7e07fd1b8f9867602ebb7f28ca9e58ad885cc8f9fbd46d6763a170c3298e795f4d66cbd379de86e5ec4477eaf84b6b37fe10ad1ea371a9098007d7b0ce89e9d899f7c06af85bba8edaacd4b0979a78aa5eadb44a4796de8d7f4891cdbebdbf1c9e39225821fcde020711899cd535d5bc4c65c1883d9e242158d51097051cf5af8fee1844b2078e598dc8361e22351898e494963fadfd2bd4f7abab133043646172ef05949d4e34aa330ecffad25ab616ac4160b6811f77559c822f767d7249e91040b2123bbdd6f1d090f75e939ab89c35d2b0d0379f0c63bf9e45bdfcb87a0308b81e2301f213f7a785daf2da042a5ae048900026db6392d8468d3f060b83e2152d052f998559682bb7e41e0b8e453d1943392e1c3e2a15c92547901d41025b1581bf99c7ef254b0143f4f94f6ef72a08e8ba5a1f05b7130e33cebde1401013555611d24bc85d5a370568ca4d6c5c0abf36e1c9e0c79dfbc6c3954da9f6f9ef8292199582112d1b702976bb06a7042306c61a2766c69e913e7e40b21120a44c12db60a6b79fa94c5c9162d1db369b679babd2cfd8963c14b98fd314bafaf1fd45b4f88fda28d8039466b59f9cd9e1ed182ad9643d9611de15b3bfa4eab92aa0925c68745872fd4d23bc53a9fd5229604b431ff019757f8a6e96531b780001af81b14b6f8d11e138d323ba2aa0ea46fb4f7b06c9521943e56425199dfdcafccee05b2aad74f881f9e25073e7cc8709100d4ef1ac51b363ffbf2a3587337f13d3ec93711a93b273bc24dd0281f6ee53fd35336e39a99c5a01e337345bf72a6e9af8760d805a6bfaaacbe62772e06cd78b051f1bcb62d420e51dfdbbf860889f87191178a28408c6049cd94439d47ea25ee95e5a930970831e02200871ddfe525a334240236b5f5c8e2212ff3c1206f66e5610fbd8581d0fc4bf35939f6e643c627b298ac9e483b276c89e6fb0516d02b2680e9cd18122877a8df4d888e8323711ea433476d1e50ab83c65f6c7660a4b7679e55f9b7fbd06eced16cb56d4ba9b3ba2a49e8c3d7df98b34136bb9748799053c4ba112c29413a8c97ff599123bae383901f40b9016b4dcc930fbc9a9399d1cd98e8f711ab15fee118ba4d4f446adb97dfddddf1b4f50329aa8c76e1ff6fc66d6b780b7d36320bf6ca0265047cc0d9ed4f94939f57809792f99933587c7090b4a9946ca1e7cde98d95ce04ef40c1dd6511f477dff5ad3142e0eac2945e13d030fb25cb850ac47d35b3bb4f0be1c6edbff695e593ddba1b875942359a9f6d4ae8b1396a4f81aadbbad371c826d5e3a1cf0e6f0ba5cd2ab011f974de4e45dcdfd471721ce7ce6a26d09a22f78a7b9688a344d7fe75f5c9ad945b033e357079598b5fae7860957cf2fe53be7698efb4929418eaf5fc29ebd82fb97a19ee210340b85f2cea0c7281b3dd9b31115f18b41b6908e27a88540fcd176001e258022979ec18d269037b345fa6ba34bcad72af9559b95afb85429f58ceda03189b2baf28a8787c634b8c4b3779e05a045d98a22aca6b31fdc13d60aff2b0b11426a4d0376b1d1dd8b79f403123bbd92dc65b85aab7ca8e72555f390d149f4b0441aaece4eccace4a553c0587ff7cdb4e9b6be120de0b086f08928b0704575618d917ba7aac4e99f17f779f29c324c40cd99f52b73fd22b9baefd2b764c363250dbd151748067f390389a3f4fdb6cb7d5e03ec5170850a0a5254d5fc04a705f33c37b8414ca349e2c04429e6a816e1d1cf6a1eaa9125f34ea3eba3dab66a3bea64374b33ea50ed259edefc028e2c2aa0b2deb365b7cf6769fb13edc5cbf81cac1e9053c8fccc469c7f0ce783d636e8751fd5daad83048acaef83c09ecbb70e856e09ff42e5992d7c690cd855eb83ef00af41f8b22201dbedd0f22034b9b275a4936e1c8c9d5313e32bef3622eff2818726e179e514e5497ef8272263c0e5ede9a1932142d86217f395b64ef85ffbe267f2f369386c82dcbef705a63cb60b6b1466f9671263dace21063d7f9895eedcc627ec10f2b9974ea3c3b67ff6b88744ce015e124efabad9328e7949ac41cb509eb5319ab3c2299cdebc349be011ad152d44cb37577e1e3e3ae63ca0c9d295be661e7e518767a435a79ec995621c128cbffe9f45c2d0a32ca30d2ba0d548e1f0e09b2b34940f09401f14752da945fcb00e152d38feb5038bceee6c6bd9ea84be96262d611293b235a0b81f94d562364c08de25c7483a4b8613d0f88b44560d814fd8bca53fa2b97f099efd498d15f4d7ba9220689dd1717c3504ed3be2d57558c3fbab2d44556b3eecc09e2d5207b7da9f8e6713f3e2e05d71b705e7933ebf32718cf477c73318c691ee89c88fae55c90f3455326cc02c0ad35b7466ab72e61d1ccbc10cf4406d42b8c6adaf0c1539641d6718ed12b2c68200673768a281210edaed7205e282f723fbfdb7154c1cc3d0d0d8a8fad1c7e72478971f901b4e48265303abd3d6643c63cc5dca1b18e97755dca4ad96c7e46309be99e8ce527ee67213498ea5a8a6f24d26a170798b295d7d8b33d57d46410c45db148101468e34ae50703e8f07035fafdd96fc422994787ff3af23ca48068edcb423eaa21d5c84774bf8b39eb9eaa03f5207ec582184859f1d7cca53361f909b8f347940cf90c0a3f203ab43701b0a4908becf26ccaab822c0a288fead67f0e42bb6469320a7eed448e78275a5a43a84805abc18f0888bd1237fa52418a8cb54743437eb24d2662e211962165d4eb227a2d18473878b8cf3e13ea93021c8ec90ef7499cb6fc5fb4344c6eeccaf87b42d0d8e74b66d0061b75f18cc7849687550b1392abd36a4ec4ec8e6ec597c4b4221517f43611cee2158e2cc3809dc08ac517e676774479c9985680b95108be4ef1a9bbf691c3975bcc16a90b7bf02c8933dab05e33454e91256176e6021381e9b234a003877990488b0eb4894e650a558f48adc85907f7fb6c6a599540947ccc10c98ac8683b65d875811c1251092395bb39f7f7f14db38885122c6138fc9cd5f9968424efaa0fe836fb3365af5b8d567025752746deb64ff4b01f4a5cfe8fb6fde3bc7aa8b1e5ccd080fbab1d7fc1611d2c8a41f3fc045903b6a2d3e3867580b1b556c209bc31175a83c2d08e7956ed34e6d2cc27fd35b408b346046474167bfad3573e68b7ddc9cc43d9f2fba79bc32e9f744dfdc9dac599929f915bd66546c2d11c95d25b3c01f4ea32c43baa7bbcbcd74e814655548791be3e270925c6253634b0483d5e173871854c43469351195ddaaf979ccf27d2f66c2daec40d43c4ceac176cc288af03ba9ea22e455b3780976e856dc97375a2d221d75072f0a6a06fb6000a6665920b927c16bf1ab634025232e4b9367d508bdd820695ae42547ffcb259cedb6b08614a8888e689d4f1d67a761c46750476a0a2bd27c0727c522c8c18dd36a5327b416d44011b879d2ca123e5bb28158d214469e84d83e7fc17b36b653a88b0c24fea35fb093ce6dcc2dbeb21ec5b07c3564cd5c76327dd0cd7de00bc335fe2d381d7adb1611f21c761001595912776b0d234ae3c50048ce48ed8a09211991ba76ecbf6d6c5cb421c1ea0da50ea08bb60c4ede8c6e954568a854ce749bdce255ebe6bb42a5a82081cf86a888dfbe73d6a5d1b0b5cf72c5962cf668904349eead8c90d35fe65090e427e89d592f86ed789c5c0a89b2fb3d598f46b1d0cd20da0d68d2a516469ebaad5e720b58129518fd4563920230ac5cfb2324574d535fe3dc2a7fc5918d5a8618642f49a662bb47ae777d83985ff056c93129c9824b9d695ae5ea4ea7206ac9a81593509779225b6ed672bacc016a29256931364ac9df106abec4b1f5b873de86b754ee6d4a19d46e1a2688078a41f43d9bb442457542d20382e9a8b5380fb2b125dc7711de44ea6b52b386cddb6a88df25fa844b7a99c3d3f7024d1ef0f2af016d9bd8e227cd29d8de66982a229a05d50139e5f7c07efca97af92169175f1627b15da635177ec7fb3a2944ff0b22c0cf49fbcfa4c386d849411435e8ca216a07e09a544af117c2dda6aebd29e0c681ddf628c76875b3c2b8479d42bacb1c7d04aaed235d8d68ae96e07d47e900571e0491f59a274f3060dfa214d51e492c7cfc6ed2f6f031e7ac40f1cbc841f51961e00cd96dfc7f54237302cc21c5c5bf1b90d10743d1706781fa814dcb26cf153809c9ef03ace017949fd9abb8e0b90abc4dcd62dc9c9ee1960ef25aba359bb3e5f5dabc4f2a17b1f4f81b59b9db227adfd3adaec80e19565ff7f8edaafb4dbb6db1bebfb5c17897fc131d3e08dfd861b8a08fb5cbeb5e4a3a20b8761e79c783e9983e63527692ab97ff60ffc476d2bef1b13f66b9959e78843de25e0f829ab1ad814a67bb332d161ce3097c182d7f8cd5fcaaf4bb2ec626ea02826e2cf422731cf895d4c1f5d311d3c597e56be118c421c0593352b3deab77c88b718b32eb85aae3e2f017e97f391b5f5b1cc918d5149753735a2b51353dfb8b83be0169b79079d18dd806db4ca6be007def35573db4ff4c2c8dd904fe0c97462ed6b171dc0b1b53aacaefa79f4925d7946aff85c97886bae218d2a17a2dc666925bf81f694ac2cf6869b6878cf9d0c8b6e74e53d0a387040b585fa2462b517e63aafbb95c12ce892b12b3d73d5d97412e98d94728fb8aef96f3c31b1ee46cbccd202222bc28bde5dffee3ba83932ad8b20e1a3fc93a97ac059e8287a1686eee5ff5ac375becbf8f7e1d3c34cce14b2cfb12a35fde9a840802a0cd121fc4b544c4c94dd9fc2251749b4efd64f26aa3ba46fc9c39f66f4ec2e9a3de5d8c43341ddac0c2fed83d01a7d5356af924ae47169eb46676580270a1e4429624db6c630d2acb02260946082c45fcfd16fb6f618dfbbe1f0d14b804facf2bac2ae43f515c04d2cf4cc1103e6323037b6b0c74e5ab3e6cbeeaeb6fda9e9c21ced7db1d94aaedbaee4246555a4fbcc0ae6f0713d9100a1d04de3bed37cccf78af8bb427c89b113c52fc7032629fb37fe802d8c7e3961d5a7b6183be5475a5a53a1ef520895c284cfeafda109c23e0705d39d978b997868a3b91ef3930685b6e406f98ec9952c35bdb144b8e5a172367b4dd6428a69b4b1020bf4e4dee1413114807582a6347240ac26b374bb0b4edb9c29f0cd6d08c997df10558d97efb5b09a8648b0b0ffd367ed9a25af40e98a6f2a965ce0fcc138571a0c488273ba8fc935f16dd4a97f8"
         }
     },
-    "fundingTx": null,
     "waitingSinceBlock": 400000,
-    "alternativeCommitments": [
-    ],
     "nextRemoteCommitPublished": {
         "commitTx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080094a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032102700000000000022002035aa4e20460bedda8259e3e8177fa8411ccf6b5bd97495e8b24be8a926f41f04e02e000000000000220020b7432d935669b861b9e52afa2d907114a16a8f59183f9c9deca804564102a28c983a000000000000220020e73823f9a60b72c99746e99ddb4497d8a7413f40f0f82b51b28b4988208e0bbc204e00000000000022002046d508b9c29eeebaf3644440c7b7ca5eb51ee3e8017527b6c38c99f324d206fc204e0000000000002200204a034388d897e59aff4a04944803ed4248a6ce7c65d868f4b4318022be79e2c050b70200000000002200208c57ba9667b49d1f0fca9594b3f034b4df9269218a3725fe5995ae844f5c4fabd4340b0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040048304502210084ef9f5b45f000d2f7c87e40544c65ec97fcef4abc29046bbeeecc97ab28cce302206d464c8bbea53b0e640c64d796c4c0d73f6bb8f3cfed13d5126c0e29035c71bf0147304402207319270dd7bcc7141dae5b2221e74800adc377a38cb4ac2754dd1c5e568d84f902202e2cc92a2fd5775789cb4b4868466316b4235378d79c987231de0e35ab1d794e0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedd99dc20",
         "claimMainOutputTx": {

--- a/src/commonTest/resources/nonreg/v2/Closing_3bb07fb6/data.json
+++ b/src/commonTest/resources/nonreg/v2/Closing_3bb07fb6/data.json
@@ -1,219 +1,236 @@
 {
     "type": "fr.acinq.lightning.channel.Closing",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 110000000,
-                        "paymentHash": "c5be461cf5d852e51d0843a02669daa2c6bdb5936c50dd16a2eed74fb2695f2c",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 95000000,
-                        "paymentHash": "b3c444a354a0e80f8560756fb5e02aa1e8ea09eb8fefccbc2ffc778fbe1ea0fb",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 705000000,
-                "toRemote": 90000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032905f010000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a79901873010000000000220020b5abcef667acd30c1793157728653afaf2ea391a4039bc875b6ad468cc2f603ab0ad010000000000220020c24f3aaf87264753868abbf958e8e7dc70352378c068e4c47b02fefc0acd114fa8a20a00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173040047304402202aad97bec2048a0ccb1d0b1d38083d49b1de4ea238f29c60e9a181fc120df0cb02205ca4257086803c52b273570ba6475ccf8b7ac02616f58531575f9215388c9f6301483045022100c35d93b87bb3187e29e181821f4f718c3b6faf853159937093a4430e8db8d20302200ce7aec5b5560eee2b27de3d43686c6b0ba3de5d98a939c0c5a2ee06ad51c17d0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "735ca47f5592a678bb13ba5ef0c27b9acf0181dbeef2073f5668022077e05d38:3",
-                                "txOut": {
-                                    "amount": 95000,
-                                    "publicKeyScript": "0020b5abcef667acd30c1793157728653afaf2ea391a4039bc875b6ad468cc2f603a"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914f335537767c2b929f665f48046b4de72ae6e999e88ac6851b27568"
-                            },
-                            "tx": "0200000001385de077200268563f07f2eedb8101cf9a7bc2f05eba13bb78a692557fa45c730300000000010000000116660100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "3003b8f3d670387a33f4e443c5ad73480d15d36289a0c97a30cb188cc5c365e97d71373dd570ccad910648e1dcca5a9c814b824a4813ca1f283a9adbeef7f4b0",
-                        "remoteSig": "bbc0bb252d2e03dbfefaa3fc3d50cf7bc2fef26ad8a4f3efe2a00a1a356c74382c716ce5b8e6469bbca5cbf50e403c098ea389320ad8aed4d9bf4acce2058d4a"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "735ca47f5592a678bb13ba5ef0c27b9acf0181dbeef2073f5668022077e05d38:4",
-                                "txOut": {
-                                    "amount": 110000,
-                                    "publicKeyScript": "0020c24f3aaf87264753868abbf958e8e7dc70352378c068e4c47b02fefc0acd114f"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9140a2c4c072a7bbaf35ef47956a1f8e7c132af7f6f88527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "0200000001385de077200268563f07f2eedb8101cf9a7bc2f05eba13bb78a692557fa45c7304000000000100000001e69f0100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
-                            "paymentHash": "c5be461cf5d852e51d0843a02669daa2c6bdb5936c50dd16a2eed74fb2695f2c",
-                            "htlcId": 0
-                        },
-                        "localSig": "49dcb8f0605d4dcecd56a23e6821f0cf9cddfbfbfef92d018fbe996c7fa2908909a53e3c36da331164c5a3763ac4332708768bfcc6936cf64c5746254e18d6f6",
-                        "remoteSig": "19b2c53f5ae64336a2d6aa51500944fd3e4418be72efbc0529de32e3b1bec5e1315cc9cd535a243a6426bf482dca8cb983a8ac1441d1c7ff4c03c7194fe7c878"
-                    }
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 2,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 95000000,
-                        "paymentHash": "b3c444a354a0e80f8560756fb5e02aa1e8ea09eb8fefccbc2ffc778fbe1ea0fb",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 110000000,
-                        "paymentHash": "c5be461cf5d852e51d0843a02669daa2c6bdb5936c50dd16a2eed74fb2695f2c",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 90000000,
-                "toRemote": 705000000
-            },
-            "txid": "d4756e4280b3178aa6e35eb9937681a6dded4098af1f93d055c9a693686f922c",
-            "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
-        },
-        "localChanges": {
-            "proposed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 0,
-                    "paymentPreimage": "ece8429c09332ef2f819c5886b71cc500b21956b3faa6f3ab3f9005010c9655a"
+                    "unknown": [
+                    ]
                 }
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+            },
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                    {
+                        "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "id": 0,
+                        "paymentPreimage": "ece8429c09332ef2f819c5886b71cc500b21956b3faa6f3ab3f9005010c9655a"
+                    }
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 1,
+            "remoteNextHtlcId": 1
         },
-        "localNextHtlcId": 1,
-        "remoteNextHtlcId": 1,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 110000000,
+                                "paymentHash": "c5be461cf5d852e51d0843a02669daa2c6bdb5936c50dd16a2eed74fb2695f2c",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 95000000,
+                                "paymentHash": "b3c444a354a0e80f8560756fb5e02aa1e8ea09eb8fefccbc2ffc778fbe1ea0fb",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 705000000,
+                        "toRemote": 90000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032905f010000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a79901873010000000000220020b5abcef667acd30c1793157728653afaf2ea391a4039bc875b6ad468cc2f603ab0ad010000000000220020c24f3aaf87264753868abbf958e8e7dc70352378c068e4c47b02fefc0acd114fa8a20a00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173040047304402202aad97bec2048a0ccb1d0b1d38083d49b1de4ea238f29c60e9a181fc120df0cb02205ca4257086803c52b273570ba6475ccf8b7ac02616f58531575f9215388c9f6301483045022100c35d93b87bb3187e29e181821f4f718c3b6faf853159937093a4430e8db8d20302200ce7aec5b5560eee2b27de3d43686c6b0ba3de5d98a939c0c5a2ee06ad51c17d0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "735ca47f5592a678bb13ba5ef0c27b9acf0181dbeef2073f5668022077e05d38:3",
+                                        "txOut": {
+                                            "amount": 95000,
+                                            "publicKeyScript": "0020b5abcef667acd30c1793157728653afaf2ea391a4039bc875b6ad468cc2f603a"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914f335537767c2b929f665f48046b4de72ae6e999e88ac6851b27568"
+                                    },
+                                    "tx": "0200000001385de077200268563f07f2eedb8101cf9a7bc2f05eba13bb78a692557fa45c730300000000010000000116660100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "3003b8f3d670387a33f4e443c5ad73480d15d36289a0c97a30cb188cc5c365e97d71373dd570ccad910648e1dcca5a9c814b824a4813ca1f283a9adbeef7f4b0",
+                                "remoteSig": "bbc0bb252d2e03dbfefaa3fc3d50cf7bc2fef26ad8a4f3efe2a00a1a356c74382c716ce5b8e6469bbca5cbf50e403c098ea389320ad8aed4d9bf4acce2058d4a"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "735ca47f5592a678bb13ba5ef0c27b9acf0181dbeef2073f5668022077e05d38:4",
+                                        "txOut": {
+                                            "amount": 110000,
+                                            "publicKeyScript": "0020c24f3aaf87264753868abbf958e8e7dc70352378c068e4c47b02fefc0acd114f"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9140a2c4c072a7bbaf35ef47956a1f8e7c132af7f6f88527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "0200000001385de077200268563f07f2eedb8101cf9a7bc2f05eba13bb78a692557fa45c7304000000000100000001e69f0100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
+                                    "paymentHash": "c5be461cf5d852e51d0843a02669daa2c6bdb5936c50dd16a2eed74fb2695f2c",
+                                    "htlcId": 0
+                                },
+                                "localSig": "49dcb8f0605d4dcecd56a23e6821f0cf9cddfbfbfef92d018fbe996c7fa2908909a53e3c36da331164c5a3763ac4332708768bfcc6936cf64c5746254e18d6f6",
+                                "remoteSig": "19b2c53f5ae64336a2d6aa51500944fd3e4418be72efbc0529de32e3b1bec5e1315cc9cd535a243a6426bf482dca8cb983a8ac1441d1c7ff4c03c7194fe7c878"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 2,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 95000000,
+                                "paymentHash": "b3c444a354a0e80f8560756fb5e02aa1e8ea09eb8fefccbc2ffc778fbe1ea0fb",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 110000000,
+                                "paymentHash": "c5be461cf5d852e51d0843a02669daa2c6bdb5936c50dd16a2eed74fb2695f2c",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 90000000,
+                        "toRemote": 705000000
+                    },
+                    "txid": "d4756e4280b3178aa6e35eb9937681a6dded4098af1f93d055c9a693686f922c",
+                    "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
             "0": "c88282fa-5e7b-43d5-b72c-883708000c69"
         },
@@ -221,24 +238,12 @@
             "left": null,
             "right": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "e9be61fb16d68c464063d2c5d88736c677c9bd37b43da36ca6d66bb79d653b7b1b8ad94e7945bb46923d3ef877cceea88ce8af842c73ee0aff520db045a8b581ab19aee9837951dece8f1d6eff19f2375855135c8a517a4d6d2e9e6bccfcb4cdc90779c577b1a75cf4d9b6ff53a7b89978f5cc239c3b11bf999549151efd5f3c1a7d751276079f3eb3741b63d263b6dea7c9bc71380e88b6650f9008633f6bfeb0055932dc97f6d1fee22f24811a44cdd249c53495c2be7dbada65f67dacf95bd4812c4cb144de96459dc52612b82c8d5d57400f02a478e7411868d2ea375f27905c7c44f99f999cd4853c5d1222b8250861cd2bf18b15508e4fed4da0c9175fc56e6a79b4d386f33dc26d793cd696295bd1b7bc42d2a3ff5cecbcd59eca1861760886f762979a987d0d3b34716bf87cc7f6f5e11e894b8a69e24fe3940cb2d63431aef3994ccce6f9ab40cd1d1ca000d3d4cd261033e94458d61811b5b1d95ab485462f2c912258f134249f60eb20c66445e7f084907f787fe62053007afcf47dd225b90a8fa419cfbf94385046d6ab6932651f3d343091e41d463fd57c98383949421ab62f0ffbbea3809ecb7807703843525c29aca6265d5d156b1594e3dd6c05443303a9529429908c1a97476ffec7c1ed84f3f1ca523526c6baf7f6be3818d3f55ead9cd20062faabc6cb5d2f7653590e617cef291f46250805f9031f79bde194af796d942b67f91cce1b198d2fc44ca284fd9c56d1de1e97f8766648e7b116a2d8c0b7fc3e8d9b700d2a7376d053299a79fd70735d41d43d92421b3579063eb5cf96804e9593c598f461035f43a56a282402f0c1f10799b3c918cb93465ee33f2d153a55fc74e35ea989f4da7b8eaa27243a4f2c6e526620180b224abbaf42bb2e8d3da5600334385a3503b318e745a2e80ded0696808634c1f3bd4c1515d07dd943a31f005790a439f4737ec85be41b635a0a88f71c3333a5ef7ce68046cdc2c320ce4d55eff0f82b863ee7ee68c1a284b6bb5337330106e0845436f26d5c33f3bb63cd962100e7761399f575f2b88ef56f3b74c1f41a68badf476a3f9097c8f96a975fc16aaec9eccc5800b280c1aa73b5a2cbc036302ee374d703b963399af99872f8b15316a19915ff877c901110b253cd7bbf7c4c1caa6f5ddfe168e930e75a6547022b4931a134055183d2758689f6d2b94548718b6c870ee4748b0654a53bd68f52cd597798513e529283ead26adf043ae816f8eefc9de704bd30d612b0f421d1d7f600eb0500d5d67120ed87244c1cd07d130461aa057e6305be01dbdbc3c3aec4a8d1b188d20e2ba3493a77622f27f54652f028fc7c23694e4c1b3cbd77d5b2c362daed5b406ba5ceb9b674ce29a8a36871eb1ccecfede3f28be0e0f3bf74aef50ac240c07209e4a19aa79279c7a6d0ee04c15191292ed407775e48acfb8b47e12eedbdb94295007ad0b916fae7d4c06fb7e0beae95fa440027d35a9bc3568f0817e29674314a1397fde8f23f569a05bc231c1ab6d81dbf585e483e5f1e3a2331fd316f5232c03286caad7b3f2d8dab725c3248a6d1e092f0b95cc321c9d420d815fa78e552d4c0359a72b43068fcc195c3df93316f0a62f1844d405e510940b03c4f376b7e88059331249f97e7aea7d39397ea0947c771b18bc065f9c1b79617a340989080e5b3548493ef73670930c06bae8654eb2673f57271add34599728cddcf4a189a5ab0a10a439694e5afba886d046301756e7a155a30550a7e8bcec333efd81dfa0fd0724aad420961c94912ba8b2466d6500ace9aab7e78a31f6b8836766f788bc1be8cd6b337f49620d09c07e9519d41fa78d0d1e397cabbab03a7356c7bb271d2aa2e7c83f48527b393bcd03c18c558fd1dacfd9d2610ac779e5dd30fdf3b363480c45dc1d41fde4e2a988322525e48a756360ce7813f118fa5ae72367494d74198ac974793a9bdb5867bf5ba9be4d6df57e2ed27c85d3973a91fec28162fb2ed4b664582857e289cdafd850d8ff9071e51ca17e4f369aa5385de5579233c3ab7a1106a623272ba76ca95b53ff56054a28309419d46af37ffd0371516da829a0c6331bf1412d2c6fe3c0b467bdd16a4b74c8d5085a3af756cc8b4a6214ad7c3f3c16ab718d6bdc04812703e87c91cd19bb046d1a4053e72d5e5db028044f900edc6c780bc1dd9ac3240195ac765fd72b078248a2efffcbb6b2570633a84a8022ec1ca908f12c3990fe1667baac6a2e92d991c5538839b3614d42c642e414f0c319f9068f526bb8f46578c8cfccabbb2120ec4c6f85e618a37fa02e342011187d2074649caa3a56945ef64a64958e794fae707a9ad1d8db01be8fce080ffb14069e90afb800599867f7ffe3f3448ee35ef58519d1f537a4343f370997e5c1d6a5c24893ec2554fed73cbc205dc6a6c73142c8ecb78638edd9f9b78c35e6464c8daa73ad43ad0df80c06c9692281a522cbe9d72820f567944cf7cd98e79acf9da6ce8d2ec079cdd5a064ec378356a27160b974eb0c93f0a1eed874c6dd9c75133428bb048ea5133c1da0c2945e1dbcd1d22858550914b30510458cc45a9c518e7ee1ffddba061dae72a2f203105a14f55d8296b7969c5af6fac7d4eff9bb0c740c3840befebcc1285bf250ca009a40cbd5a07ddeaac43ebe1b3cd6a715e3540e0c589c5b1ba40638cbfa9660bd58522268c2c480bd8aefe4de0a0e23d828d7039197b5976fedecad3b1114fb56d9222111f430bc2fda7ccf415c15296fbd0142ff6da4bcbe1b2a922bd77f78a7616431e271968692ad63ca590d2b37de714c94ac00f2d7d2d017f0746d3604c35f445d186151305862a769aa67841fecf5c0569179191d3014a1977971d6f6af3155a562a66c7b7f3b0567b8fae708a401231f7fd240a458a0df3c64c3ed3b75ac2914252d5fe2078a6f73cf358e3cc63e1b8e2295f6a5421693cce2d2b75cf96ce9047bbcb6510fc493ae3dc7b351b6ea0d48fb9fc4608c43bc37ed6a2169be3821fd5e10cba97c6052329965a149007ea9c4a2b65b269acbe72373fa092b607a17a1b39e1df438459a179011a718eb6e60c2926ace34c8c9ff70d29f389de90ae6ec95a12fbc179bd4cd010e7f5fb4048db92c7168513f2a2ddc2e6047d9bedb25bd35caac540b4e7f22fcf0c8acd0b7bc97b4d719accf3126f06473d1a892c7c60ae989332abf4ed47785b63809db98b65c94556bbda9eff2dbd21fde24b24fdd6f30a1bf0cac372fac580a0aed482fa331ba4f8cde993bb8b3c85f960e9a98f4c0ee386cc520785ace7e26671640e1a6dbfbd2aa35e0f1eccd12a041bf2bce62d114048f2dc7109ebd182debe8ada5be4025993f31f208acf6acb8bd99050441ca57047898061f3fc2d0239535f6b990ae133e9723e0b95522078765352b37c3d3f24237ab003c42c33c211a968b38ed8f01ea3f5072af95a5cac8457299734ed6bafb14f5d76df8aeaf8f134b19a4a886e5fed2b17074a43f8e9657375c4fd285c36268532e9eb6609e110107539c61a86cbc59fb4594874d9eeeaa36f4f3326afb214dc408e6adf9fa7d161fcb2112f865052263b1a46d38caa6ee5084a3ab4dd00c54336a0131c344b59028cf7dcb6f5f8bd36482301585cce7996f86d30878050b12cd8813ffd5771211185d1349caa7b2c727921158ba9f3daa870708c1b8e0cb7d63089b7aff76ef473f42c981dd2f4566031299f5445e66eca2fac24430f6ad15b039567d2078831328f89854ae898e1b3357c5f747eda1847af70bf653448c9cb7bb4df8679a8a55911b049164a6526bb8bb727d0901b19dd7460d69710e1bd507a308f114afae0bc53d342e4428387b1bf40c4964ae8fc02f91744d99ef8f11e9cbeddb48fd9e4c7ee004dfb8dd02e03c7989cc9cef5822ae2564dab46d09b123390a6783033f244510852bb3daac5e6160ce87e23247b2c8ce2ab8f80f8801f2d8767d3b13b7fc831c8ccdad6b06dd93df07495e7b3bcab93f3948cd5a25221b4138dd648e5f92ddc1f4fb82aa7eb043b610c92ca1c6727a668591a21e24c8c9624101e63d5c3721ec5b1ac2a681940ca9852dd22f274c566693d911c81035327730f547cf5ddf4167c7c1a19accf53e874fbea5c377cb512eca084499c5619110e50108fe96b4803871b70947487e7d3c2d6cf2ffc5413f50e294e65efa98a893d4730cf7ebaf8316fa21e912f3a13122dbf4672f51d0f5b7e0c2e369a6195b7c7acd78a12c31eac9cfcb4b4292f9f3b6187b8bb9c09713daa4f7fd44a8136e65314c594c0578e5397f4d7b357e8c4525e62c445bbe8787187f663b8c965ca8dc285d5cd8fcdf4c6abb6077195bfc91d0111fc230a294d299ef6e6a92be63a1391d4a3f78115fbd62e4baf7f7ec6f44043b7ccfd19b7c91f18de11c97ff4fab4b107da0ee971546ad4b506217422f97a6680f3907c7658038e4136795bd34d4679372bf14ac98d871f0c70f488d6514320dcb94723ab8c40de45431f6b1396feefc87b2f444fe6419ca4e135d9243c1879dd46f17207176afa9eed87c31bc1822455b427e6190df6f1d3d8c38ace10e93e1695b1eef13b43a17b1aff27f723d203bcaf5b60762bacb24b6369f2e724895a06c05257a5ab644180e701df34bc0a5b188f849c623533106ac6f6ccea8661b9fe18b627394acd4d6380bc125d833920083257b0849843e00b0f719740738d08d08e77975fc2f5c900cd27c1c07a301f7dd23a34de19f18a0e58f98af08c305cce74285ccc1ae97ffe557a9a7428d4991825004a4bf388a1931725905472f0ae800679a4172441377e6c0916c0459a896b496c0db738fedeb557188e83ec9f20b1d8ea8adfb24127e65a174e3ed331a5bca2a2bd3e0bf967c073437070a5e24afcebaad9cfcfd2fa1bfa03e7707da8aa815d7d3b880460199507fa489330e62a678ff976f74a822d77265ded6e8a672fe141e41a856b02183444ee5708d62b4719d257c091762d9da8f07d5c69027710e9d672393a576c766fe4808932c4349cf0d80ee6479ee3ac64da259cf23b588456e7aa6de6857801f3c4d6ef1d631367e547d837560bd69af5cda7cb3592910a279361b039abba970e5aba31d1c3ada4a67fb400a56d8d697da736a8001bf5083103682ceccd6c360058bdefb41c85d02704812a2102016649399f8dc69db1b7930049ba43dcc6cd9ba208b19f0a1efa3b5a968f2b7f"
         }
     },
-    "fundingTx": null,
     "waitingSinceBlock": 400000,
-    "alternativeCommitments": [
-    ],
     "remoteCommitPublished": {
         "commitTx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032905f010000000000220020d0b9e19e805ad1211c8395712a4225729e443223fbb3444537b6c93f5fa36839187301000000000022002018f3224d69b1cc3fbb44bd3779eb2bb07c6c5dc9722fd99f9cd6da90c4f9bd45b0ad0100000000002200206c71102142c7c3090165e8d136f64fda559496481a26e89019fc7964812fdfada8a20a0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c04004730440220784da0cd9f8ec26ce8562955e4be1585ed1e1a2d5374f45dc1ce16f7ca7a663502202f1ab8222f0500c42b0f5d18e0beb3c321cce581f3ad6acc6a6b2a0bed81b20a01473044022001ab716f317e3f7faad7f3fbe85931ae091ac4d4377dd57f9ab3997172ea87d5022003296e024cd0183d506e35b7c53afa7927aa096792f8b148b4d14442f40c70c50147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedc99dc20",
         "claimMainOutputTx": {

--- a/src/commonTest/resources/nonreg/v2/Closing_8f1a524e/data.json
+++ b/src/commonTest/resources/nonreg/v2/Closing_8f1a524e/data.json
@@ -1,170 +1,175 @@
 {
     "type": "fr.acinq.lightning.channel.Closing",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
-            "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
+                    "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "56ac7d2006dabb7b7e26a032ac384ce15362f230e007a713e45ee0a514aef433db46a55d4650585517be36dc68babddf369cbfa743e9ad976640545119c378548729fd5750f0772ae26e1ac80a288f3baa7ae2416e9ea796403fe0b2111a919370021aba83cc9c3abd6671ddb7e2c54eaa64701b86d5b70ac2a44f723e399c449ff1b9ccb8e20481ea1ab6b9a752b38601fb202f4cf960cfdf3c77c91829747fbff494ab3701148abfb09bdee3bffe1bc46d157ae16e9d701764532db299530a3679b6ecce62fab88a75a8524b1b7484faf08b9347e1e3e92623286b98a27f8236f9d94831c489c9b66846d2e65b4c75a2850bf30b3268a3122589a58223265e5d62df74cf77ab3e781c3c1612142810b30c5e45775c70e6f17b3829688d69b5ed8769bd70018bc19de67fce65240ed94f1179087e74ca49212edd8d735f015a077e5cf6328d426d69e31898c0aafafe6d21b5784bf337508ba33a13c88a34a2d04e9f48e0f3ce7ad704524b9360adbf70d91b7900ccd2a53ce4da6f7b66226c860936f5549c7065f572e9e6debcec7560d5f2ec49bd257cd23a0da2dab7b72cc3118ee72826c15cc033bced6d35187d955019d1988549be9712ce4561ca1247497a6e60b506cb7f21dea80205fc66d2e13382998538a5c0dae806d18b8fce515a7538a881c5a12f67bc11e838b1154901f4fc84eb3165477f4bdf02dcf3d8ab42ba2ade55ee22cdf07bacf2b561cf05ebd3f8eca283c451ec09f0a8cd7b3ecbb83d17157e9830bb3d85d7143ebab10306544820b3811e89b7ce013d96db368bd9eff243e575dc10b2e7c576b9df66ad6c7379e6dda3423bde90a564d9995ade0a72842816996bbdbfaae0946ed2747c3247904fafae4bbe792bbba66ca29b1f9b0179a4093bb363dd3abbc6478441528b28daf1797d2d8fd3f200f0a6fdb8bfd4dfb02506bb16d4db103531d6f13d9c46613d4f03b84be135e19c4ede30717613efc50d6f28b6a36b5e61839ccd7a36a0d8ad6e81691f0772cff88f0e800bb9539e71ea3f1a52f281a9ba7c469fa917dbc75d8b7dc9e702c6a70d5d46b453804771adb6bc8cf85476ac31657776e674b632358f1e49ac1a9a4934736830224a136d76be62cf925af87746be07ef128b11a06d798ac7780843d46a2a5d3dd12eac27ef1af0a12581ec423df8be05aa0473b7cc30e55cf77d7255d1b2f9d0223e3dea9912552aee6fc1c9d3266d69266d40c8b85730e1a4327c956a51e06705e8b3f47463ab4bac168253ae55583523ed4220d97908932efc57616b4977e2418f26eb1077a4320386abf788ff8456bf044f5b95821520f8985f734a97dbcd5ad21d66d1b870a73f5bba1c4f382d369a3c8ebff86ce0b7fa29cd589053f1fbdc1fc392ccac7d548f11326ccc22cf641b7f10afa5d79c1b2015b768bda455fe573bd15001259a9ef3a0c47e3e4937065a4712d2d8d49c989bd59e3d8c130913fef431d954fd34b09947d40dce38a6301602ef65bcd1d874ae23bde4436cd0c0c2d8c671f0f73b42ee20fe083de4ce2380b4a33568eee72b82e6bf157dcee288091f9ffcc0837ae75ab3aba9eb7e081a5e491239a19e778dca132b958ee845a8de97876721766507191e74dd6b5ed4c08ba9b9547525fc0b809c46a4a7dc529df6f9b33f27905f355043c31f4a32cf2d1f7086a6af0455fc424da920ec2906a7464823b9f8bab0d693c8ea8a55317df43e6c6bda79015814558da1fc2c92ed6c80863544788dac519f418349a7707d59a1dcd160ea4867a562dd04c780c954d3e43bff6c8186eb4b80359ed267e216c96b0ef3d57fd3d39a99cc7e034afd2d3f6c62cfcdea85eec1f2ef1f2fc5f272a6117034b6c8b5085a1d02892d942b952a17fef041d4082296a0fc800497b86760d89b7eaf03a90c5482fe5304fe81fd4bda06a8a333a03a819b3341ab9335f12dcdb8fbdb27c235d80ee0d41844c564f9c84de48c198064a9111d236e6c3e60f36e3c656216c191097f17b285fba088391f5b65a430e92eeaae792b243fe05c88887bc9d52480bc63628e5a1e4821a977e1411dd22d343aca4aebe1b9b6efd23197bb3701fcbbbab1d5f2f426b85601c5ff37d79377f41dd8ebd16af52ae50ed0b45d4db319b1d6789cd2b6c3fa2e1ba2abb2a00d1267e0fe7467aa2be5a76af028c15f9ce9f5edb31c1aea177795ee1ccee5b667bac787f6115659a264fd5be27cd77e4eab64c4ac30a57eec78bcf3b13a0119ea60a0e8953d2f955c10295a5b0ffe4e653042deed40473a143e6201a1f64052f0d6edaa5796a4956e477745b0e00805f4cf4e0e3300ce338d8f27e8bd6c3fb626222f3e09ce38ac076bb49726e31aa4e48372f3638e7ddb66451496387e4a8c9d0ed3268f368455c3a055e70edb94bcf7961a51c740c9e1de1cbbc70c189dd48c1208a86b0fc85264659597bcd3c0980c87146446d6d2edee022b91573f8f734d2d8e21b6b1b78873c39ec34dad9b90d9b6214c33dec5dc087c108c9c8a70de64b6e5cb794cc35f581af2416831968d0021ce6e7d56e4880c34481e99cc6ac41a36619fc0de2628196f4d6f4b10ac82ff810302bab14cd58b6c10143a758f93a4bc99893d6d0a6391c5a4cd9c90ca2ce6e8310d4293305548a618cd0a5d4477dbb7911ce5bf92fc8810d549cb440ff9d5607811ecc5a0e878b780c51814fda3826dc4f108f63ac9e2a74cc0a375a5be4c9eed9dc836dfd3761f966f58a6eb60ca6d8102d34d5640cab6c253b7fbb6a17e0eece493f2541dbb9c43b6ea618deecb816cc5af8ad9b1914d445d622656cbfe9e5e22aa341412fdfb0b59b6baee4c56a9fe1ae146e47e7d3aa3f9b2eec7492e6ec1d01eb9ecdf1c9488c3c8a02b5582e145256cc6df17bd3947e4528941e358a83bc32802a047d7c3564e8c8f4f3869a5d66a34421efdc67dde9cafc5fbe685be01d0c420f764d3a7f027225d9b3ac980a7b3af4536b7bf89abbce5d9a4474f461240097ec5d81e21d969a41065b3818b7936231d28f208b066c272641d011c2412e0ecff7115feeca6bf137068a0da8d88360e9741fd1c9147208355b0eb466dc00b48e1845868834dcdc21d2719eea5e0f40df5e04dbb45a87ef473212f0ffd2ea97f82487938a25893eb834ca6b9c27b1910c9e3a4fa57d7c453e25bb9a193d3b71df314f93f10b7ee2dbc0498e16dff70aa79cb61c2b22cf471014f4046f71358ed17082dd0a797c8e4a624bf79d774ef1892232c7f2fb8cb9958b3912d120e84adab1f4f9c943311212f9f006870741dd47d109fde5de7f3973aad517bafb3b83c9249c7283e5e8b977488068e6f7a90418b87824b55abb62e045d3605cfe8271339a0e6d5090629d33882c9339533ec4ae2436d6e0fd48e853c56d68744cec5b5acb0c3246c301d5dbc96db9f8bc38adb66fb9e5d8712f3f6761abaaea03a57a57a9dd8c4fdab4969770fd3f3afe8545e7f12152d01eada01133a0578391a2ff9a57d828dbfeb558cfba31dafdba1b629dd497352b8f92d630aa20ce9e95d416f5d65ce95efec6bc62fa3822127b19285e9a3420a48227bac6dcda6d3531ce57f401250cf581fa8bba6f1c23fc3269d6b01a347369225619a784f08f9a84b03a2b2d44874fe943712811555898f4812f4c9cb622dc2a9cd49996d086d6a7df33eb0436746ff3180d408e19aea960f4beb0ca12170549e874c23fdf27654fd870708bde5ff98f26d26defdfdf5d2dab2e29db10d53579a6913a1ea31c49d0bc6aaca7ec0babff6e5c251d72198adbd5b1192c33d756ecd4fe4b1e35a2d43dcd4a3ed292cb4a26b236d986d83cca36b4e31ed3d1cb1409b3dff0f437b2b3897300cb8de1672e6b878a7bfff9dd75e01e16b6bff56d06b392c0349cd85b99de6cfffdf9e93c3ecb2f688d3b2b7442dd257b0893572cfbf348b2f28989eba7b8579384884b0352a77207af3d5c18d9acb09f944e6881d9deb9a1a9248c4b9f74f341982122777e95da9667cd0f1f09dcad04de4899aa0cc6bd2ee428ef3a4224c37e911c202328262192ec8180d0cd8329e569caf9bfb515819872e65066433b92ec6ee289f278e8fde4eba02a6c09e695643ff3f439687dbb3a20e7cc4d99ccc54727bc19f831ff28efb29717036dbf78465ca8b63e2d1154d6629b4f4c576bd967f9a5cc554862728fd2a7bd7ac9c1f9b628b3542acf023013baf6a8002feb051e2d2ac8ca66c97d428026cea6e428aa72d96b7ef53bb185360a3ac0f079e9e9d11f51829262eb18b1682d48bfc5024e65fd7af0f94f5b940c5e7b2760ff841def1506855cf85e679cb904dcf829687aede7fb70840e9ad6d9b7ad7b27ffb6def8a840f40d11f794bde4bbced2b5b63fc2c263461ade7f02fee63a4e0907a7f1b44a0e3656c8e4ccc6f00731972e9b1337dbe72d70fe715b93ee4e106ca3c330356a5983e74dec3a5e75d20b5e5fad7e51f28ce38f966bf83a44bb83a6a9ec694a2d61d71f536f6bb3da3c787f2c763cc2045067d56d2600aa0f4f24bfaf43b37fb8fece78d91ec511fcce7680bbda8684cdb0e9a619cd9888321bbd3d60ebec5ce4787b9ce687ffcd136db1f2a2877143c7dcb17bcbbdc7c8b5e3850097e7a12691211b4e607361a4834bf6f8f73575c3009a0dc6f2fc257c23404fc293933e3b1c31d0975968da2d4e54ac082289ab76c725f38913d0480cb61c6bff80b3f30b25662a39459619417d820cd25b34265bea62809d9e52b57a7e1c604ee4390e39d6185f6391dbd46f514dd6af3978de827adf594da0f0d430a5f9e216a003f128533bf40377b5c0c5bcd391f77c9e3e9aed8994a514c21ab5e38ca0176c8427d742e66db449d5657a05266d96f4fa3f2adefcafed21bc955c9b26cffe1f98e3a17b002387c14eddd1cc3ddda603e1076669bd0d6eda1079c9fc976437cd999c37b655ae612587c74b7cd00ae658e54572818be38c62f9c2ac0c97cae81c4eddfe4940ba79a545e54b0cfb439b81336e7d8f191b5885d19138c3d57badcaec8a1320715304bccd54c7f04a0577a80f0c600a92719982844f27130cee8932577e5b237c8432fcbf80e0c1dc97e5ae31a9eb4027964465cbf531cc9ebe8fd1750d681bfb1590265801bf7c8bbb876b17daa008876961fc7db1a7e4d896075248d845035817e1aafa68ce8f4a6cb1f344d11056ecbe423f3df6b2c9d22db72f9cb35860c096d3c6a960012420b4133c6b567"
         }
     },
-    "fundingTx": null,
     "waitingSinceBlock": 400000,
-    "alternativeCommitments": [
-    ],
     "mutualCloseProposed": [
         {
             "input": {

--- a/src/commonTest/resources/nonreg/v2/Closing_ef682e2e/data.json
+++ b/src/commonTest/resources/nonreg/v2/Closing_ef682e2e/data.json
@@ -1,227 +1,244 @@
 {
     "type": "fr.acinq.lightning.channel.Closing",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 3,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 250000000,
-                        "paymentHash": "edaff8f0e5117e83b2570b5f9d7115631df9c3de0f680c041d9cdfc087b4b51e",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
                     },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 100000000,
-                        "paymentHash": "a4459f57dc69d1342cd3c880a5bdb880ccea97be95587d5c6e87234f209e1ecd",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 2,
-                        "amountMsat": 10000,
-                        "paymentHash": "90792e276988a51c9382702617df7e340cf7f0299c3eb58fda1b3a493ebcb395",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 449990000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032a086010000000000220020ff5d65b735c30cb217486f62f8d590e56b6c27192299584ea87dbaa4452ef679400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799090d00300000000002200204ce05fb81556eaf7911d606ec23f598ea0e05d43e722c78010e1788774bc8fa686be06000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb320400483045022100a277bf52a6558d90135e0691ac9a66a9cd8b1717367e675f7d9551b251ab37f502206bc0aa48c04c085b3bb27d2fab0a83e75eed1898d81269bea19e48bd182864f301473044022060fc42daff3f531f27399b6c8cea7753f7e327f5dca6ce3e1cf11ba7bc695da102206373ebcc82fb07f2157bdb8399abf19563f6fd202ba86ade0bceb7693093ef0b0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedd99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "007ffe03e47cb696972af3e747c5f0ff813953d1d127b844aa8e66d4eedd6d48:2",
-                                "txOut": {
-                                    "amount": 100000,
-                                    "publicKeyScript": "0020ff5d65b735c30cb217486f62f8d590e56b6c27192299584ea87dbaa4452ef679"
-                                },
-                                "redeemScript": "76a914c58f2d84aa3dcc020f248d3a0f0095ce66e3b7ad8763ac672102486e1f94c3b4e63555b63bea6e7ae60e550b2275dab745118ca8dfbb634604967c820120876475527c2103aef82904d176eefc9f86b138b86f4f411ed4778f341321bdfb021f5cdff7dd8752ae67a91412bb12f52c0bcac1a16e576e3e9c28d6032de7c888ac6851b27568"
-                            },
-                            "tx": "0200000001486dddeed4668eaa44b827d1d1533981fff0c547e7f32a9796b67ce403fe7f00020000000001000000019e7901000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb32101b0600",
-                            "htlcId": 1
-                        },
-                        "localSig": "5e865cf9ae0fc879ceb90e3144f2273fee1806f47b0d4949cac5e4621daaed681944f26ba277941c0619c98553dd9c7cba7be07beb9c867edf7fad1ec1602465",
-                        "remoteSig": "a392c69c1f762942710dae08a686916a493b9b1589216a57f9a4b459305cbad423289a8fa364ec92848ffa5288b8a0e3b2d56bd6fc4cb223bef73fbd90a38b29"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "007ffe03e47cb696972af3e747c5f0ff813953d1d127b844aa8e66d4eedd6d48:4",
-                                "txOut": {
-                                    "amount": 250000,
-                                    "publicKeyScript": "00204ce05fb81556eaf7911d606ec23f598ea0e05d43e722c78010e1788774bc8fa6"
-                                },
-                                "redeemScript": "76a914c58f2d84aa3dcc020f248d3a0f0095ce66e3b7ad8763ac672102486e1f94c3b4e63555b63bea6e7ae60e550b2275dab745118ca8dfbb634604967c820120876475527c2103aef82904d176eefc9f86b138b86f4f411ed4778f341321bdfb021f5cdff7dd8752ae67a914a8f988eded2363756daabbaa863a2f4c0453d67c88ac6851b27568"
-                            },
-                            "tx": "0200000001486dddeed4668eaa44b827d1d1533981fff0c547e7f32a9796b67ce403fe7f00040000000001000000018ec303000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb32101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "db5a218afb52ce77c6484b4fcdf98a45fc8fe12476b2f34d4b776e024fe973456952aeb623f3c8b7915c2b772be6b29855edfc5f829e9f5c42aff2678d796ea0",
-                        "remoteSig": "55f5fe760f30e659a8c8b6c62b2ec9dc806a2e30e0615af16bb93e3e6c0d543b2e2103e0b1a65e12ee8c18b658d3bb0b5a3c1c7e35845a5f1976a2abe2de1a81"
-                    }
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 3,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 250000000,
-                        "paymentHash": "edaff8f0e5117e83b2570b5f9d7115631df9c3de0f680c041d9cdfc087b4b51e",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 100000000,
-                        "paymentHash": "a4459f57dc69d1342cd3c880a5bdb880ccea97be95587d5c6e87234f209e1ecd",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 2,
-                        "amountMsat": 10000,
-                        "paymentHash": "90792e276988a51c9382702617df7e340cf7f0299c3eb58fda1b3a493ebcb395",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 449990000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "01871396b3a2d43dd3067377ee9e84da84da3b3d1cb8b4cd140543cbbd8f6a7b",
-            "remotePerCommitmentPoint": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 3,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 3,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 3,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 250000000,
+                                "paymentHash": "edaff8f0e5117e83b2570b5f9d7115631df9c3de0f680c041d9cdfc087b4b51e",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 100000000,
+                                "paymentHash": "a4459f57dc69d1342cd3c880a5bdb880ccea97be95587d5c6e87234f209e1ecd",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 2,
+                                "amountMsat": 10000,
+                                "paymentHash": "90792e276988a51c9382702617df7e340cf7f0299c3eb58fda1b3a493ebcb395",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 449990000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032a086010000000000220020ff5d65b735c30cb217486f62f8d590e56b6c27192299584ea87dbaa4452ef679400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799090d00300000000002200204ce05fb81556eaf7911d606ec23f598ea0e05d43e722c78010e1788774bc8fa686be06000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb320400483045022100a277bf52a6558d90135e0691ac9a66a9cd8b1717367e675f7d9551b251ab37f502206bc0aa48c04c085b3bb27d2fab0a83e75eed1898d81269bea19e48bd182864f301473044022060fc42daff3f531f27399b6c8cea7753f7e327f5dca6ce3e1cf11ba7bc695da102206373ebcc82fb07f2157bdb8399abf19563f6fd202ba86ade0bceb7693093ef0b0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedd99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "007ffe03e47cb696972af3e747c5f0ff813953d1d127b844aa8e66d4eedd6d48:2",
+                                        "txOut": {
+                                            "amount": 100000,
+                                            "publicKeyScript": "0020ff5d65b735c30cb217486f62f8d590e56b6c27192299584ea87dbaa4452ef679"
+                                        },
+                                        "redeemScript": "76a914c58f2d84aa3dcc020f248d3a0f0095ce66e3b7ad8763ac672102486e1f94c3b4e63555b63bea6e7ae60e550b2275dab745118ca8dfbb634604967c820120876475527c2103aef82904d176eefc9f86b138b86f4f411ed4778f341321bdfb021f5cdff7dd8752ae67a91412bb12f52c0bcac1a16e576e3e9c28d6032de7c888ac6851b27568"
+                                    },
+                                    "tx": "0200000001486dddeed4668eaa44b827d1d1533981fff0c547e7f32a9796b67ce403fe7f00020000000001000000019e7901000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb32101b0600",
+                                    "htlcId": 1
+                                },
+                                "localSig": "5e865cf9ae0fc879ceb90e3144f2273fee1806f47b0d4949cac5e4621daaed681944f26ba277941c0619c98553dd9c7cba7be07beb9c867edf7fad1ec1602465",
+                                "remoteSig": "a392c69c1f762942710dae08a686916a493b9b1589216a57f9a4b459305cbad423289a8fa364ec92848ffa5288b8a0e3b2d56bd6fc4cb223bef73fbd90a38b29"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "007ffe03e47cb696972af3e747c5f0ff813953d1d127b844aa8e66d4eedd6d48:4",
+                                        "txOut": {
+                                            "amount": 250000,
+                                            "publicKeyScript": "00204ce05fb81556eaf7911d606ec23f598ea0e05d43e722c78010e1788774bc8fa6"
+                                        },
+                                        "redeemScript": "76a914c58f2d84aa3dcc020f248d3a0f0095ce66e3b7ad8763ac672102486e1f94c3b4e63555b63bea6e7ae60e550b2275dab745118ca8dfbb634604967c820120876475527c2103aef82904d176eefc9f86b138b86f4f411ed4778f341321bdfb021f5cdff7dd8752ae67a914a8f988eded2363756daabbaa863a2f4c0453d67c88ac6851b27568"
+                                    },
+                                    "tx": "0200000001486dddeed4668eaa44b827d1d1533981fff0c547e7f32a9796b67ce403fe7f00040000000001000000018ec303000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb32101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "db5a218afb52ce77c6484b4fcdf98a45fc8fe12476b2f34d4b776e024fe973456952aeb623f3c8b7915c2b772be6b29855edfc5f829e9f5c42aff2678d796ea0",
+                                "remoteSig": "55f5fe760f30e659a8c8b6c62b2ec9dc806a2e30e0615af16bb93e3e6c0d543b2e2103e0b1a65e12ee8c18b658d3bb0b5a3c1c7e35845a5f1976a2abe2de1a81"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 3,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 250000000,
+                                "paymentHash": "edaff8f0e5117e83b2570b5f9d7115631df9c3de0f680c041d9cdfc087b4b51e",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 100000000,
+                                "paymentHash": "a4459f57dc69d1342cd3c880a5bdb880ccea97be95587d5c6e87234f209e1ecd",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 2,
+                                "amountMsat": 10000,
+                                "paymentHash": "90792e276988a51c9382702617df7e340cf7f0299c3eb58fda1b3a493ebcb395",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 449990000
+                    },
+                    "txid": "01871396b3a2d43dd3067377ee9e84da84da3b3d1cb8b4cd140543cbbd8f6a7b",
+                    "remotePerCommitmentPoint": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
             "0": "d4f57ab7-0de9-4440-9aea-debd7c80496c",
             "1": "bbac2fe3-1c00-4426-804f-24fd754236ef",
@@ -231,21 +248,9 @@
             "left": null,
             "right": "036e46c0c33872871f0509fda1b455136e44b797452c86c79134b70a86a3d9abc3"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
-    "fundingTx": null,
     "waitingSinceBlock": 400000,
-    "alternativeCommitments": [
-    ],
     "futureRemoteCommitPublished": {
         "commitTx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da0323ec5060000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c7a640800000000002200209dc2944c1a6ba1328557dee83915131119ee24d8ab416687d6f6a3f30b8a12d00400483045022100cfa7dba6b4171a0dfaa35964875d987870cb6d33878869f5c547921a9e00c99502204e8454e9c95935ee346b233d11866907b0618378502efdd420fa48b5734edb74014830450221008e9f9d70a9261ca88a634210e7ef89001ad02471602fac212a622f8d0231dc2602206eb7fc5d5006f1d383a66846c503c81f97dbdf22ba0e44c09c6b5bdd87d1ad460147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aed899dc20",
         "claimMainOutputTx": {

--- a/src/commonTest/resources/nonreg/v2/Negotiating_c8d15808/data.json
+++ b/src/commonTest/resources/nonreg/v2/Negotiating_c8d15808/data.json
@@ -1,162 +1,170 @@
 {
     "type": "fr.acinq.lightning.channel.Negotiating",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
-            "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
+                    "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "localShutdown": {
         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",

--- a/src/commonTest/resources/nonreg/v2/Negotiating_d9b4cd96/data.json
+++ b/src/commonTest/resources/nonreg/v2/Negotiating_d9b4cd96/data.json
@@ -1,162 +1,170 @@
 {
     "type": "fr.acinq.lightning.channel.Negotiating",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
-            "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
+                    "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "0234ea3e3929ca115acc645d07c40eada7a98d86017614c3fa466d7e19760917e4"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "localShutdown": {
         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",

--- a/src/commonTest/resources/nonreg/v2/Negotiating_ee10091c/data.json
+++ b/src/commonTest/resources/nonreg/v2/Negotiating_ee10091c/data.json
@@ -1,162 +1,170 @@
 {
     "type": "fr.acinq.lightning.channel.Negotiating",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
-            "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
+                    "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "0234ea3e3929ca115acc645d07c40eada7a98d86017614c3fa466d7e19760917e4"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "localShutdown": {
         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",

--- a/src/commonTest/resources/nonreg/v2/Negotiating_f52b19b8/data.json
+++ b/src/commonTest/resources/nonreg/v2/Negotiating_f52b19b8/data.json
@@ -1,162 +1,170 @@
 {
     "type": "fr.acinq.lightning.channel.Negotiating",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
-            "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
+                    "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "8c0ca0219d38704b18133d3e9c6f2fff5fcba2fa4d7ddca7cd38361c62d91123930e013d96e802c4ef5e6c9cb1f101aa956ff6fd3375a525dd9a1483c4e39135fc8d732b2109b7965a03f4acb1a4b0c3e9de40ec5d0b075f0b9a6d7ee71f6fba369ba60c5de117d04338216a29a4034ab7a3fe6b162d2fffd8d8ffb1a1e120aba163590a45add7b0cb61a56acd91fa206fadece0959b20d127e7b64ee0a2dfd945bcd9b31cade08fb9dc778e101f6de98b23d805c82415b48f72bad94058c651a9bf017a75c518d7cd8975e2ee114691aab5c05c5178273744408ecbdb20119eb638019cabb65baf2f379bdabeba39fab76c027b7ef802c5561cc9d80675621aef1cc1a60d27ede5b54c40a92e71ea7579376480583bd18be60875b4789f59197c4647eb0581a6b777d0e0cbef26166cd73a501a39133f9f7d529b8cd7a67356c9509f0d0254edb193434b72e34235adddec1bb43ad0605fe92651d3f68499a96e788aed0d641e15a166eb45c181d3a71f87bd92fbd3a309026534da87120a24c8b0a87ec13bd4eae6954085b8d1b3a0b1316f8602974a2949d0daf65b915ed77c78a67d78c49d1538a2365e50da0931237df3ea18613f3dedc1ed6d73686528b7fba8a84270a88d715879630e7bf2bcfcbc26e3d02ea691aa23f7cb9db872933aed347c86068f422111c22f2d91a509792304771274dd8c34dbd645bc319ef17ebacdc42dcba613105bab6e0f520869dcab50e7591fe803a4dc1301997af79983481b803b71800d3f552ea3401dfb93e9019c4e566d7112aab6169f05e0017f522776942a2b26114fa11969daf6a761933d1650a75f1d645943e85bb0be8338721bd43671c5e6d18052420dcbff9c28ed02888e8e5bb89bbd45f3d043887289ab36bc311621a62e5c874cc333e28cc275cc4242f4e524c0ddb9f5ea9199eedb0668f21048b11f486c5ba712d5edcbea80e85148e4a51a3a1c84842ed7db02b88c121d0426335183ee62e6a20ceb1040a658e769fc261e27eafed669d7c6bd8bb58111325a8e5c1faf44ed32ceb1791a8b1d2a482a6353beb4e7a4bded388408c1bbb72823e846a16a5e65612d412dbf9a0d6c21545fb965f3d43f4e16b9a1daa885433a4dbcb45cf25e5cf8e43bfadc4c6663061fee3894da75582ed83201a1e171271c638057a9c3d8faed7036c4f7e2a6bb45ab87f102803f4b9d0ebfe6342740c5082367dc5257652edb933f96a90113775e738bcd22e97730596f3d1631bf0ef05d96c8579f1f6a503631dc79c8238cdfd1e6ba4ebdbc1a6884f455f1048d66d275fa4deeff73bea7f6611e100f7e7ec94276fb85b8fb1f47cb08b2e09e97e744f64c0733e8f9e340f2e6e2d75adf7693692de5f4360aa5f666707db1488ad6be41312689ae6e8d6f7f1113c757f9aeb690a3545493c6a26b6f01926efd9da9747d444c11d60f3da935de3007c8bf7538e696663c8aa98b1b58881f666ba00d7c619747d385e59e3f5885d6a4d1ddc70df9ca2d6c871cb6143647a194bd4ada7baf8f3421faa74dd7e18ee66d57e9281f9235e749a09ccca9b15e0a5bcc2bc49ee8aa7d9b9321e173863d40e3625412f1d0bd115e9dc07fa3addc5e6df48e3464c09b06c2fc02929fafb6b848f17e0d0f234c27280412754f651763caaa55fbf90e911b2bb64a69b1d2c79b4430bbde2f07630e635f7937d827686bcb622f287049c607944af8a3aacceaf74a7d709fecd909d99722486654d097c63781ac283347ab4f37d8d9d15f5638ae3f2780930752a8d1c19f25b904e59837464680b57901d7d09dd029bc3d0201d0929616ba5e7c7d967618678885c05da4abb1df78cbf3def8a5c7c1497a78266a62670471da7eeb65c1127275b9f534e4162bd33f4d77036a0823b0f53fb33bb6ff41f419379e4b21723feaa0d627a693625af1b1030a5436bb487fc4b8f8dda4bf513a58d44637df3901751f006e560cd8e53bf46e1512b7c449a79638bb14624af9b1409bcf301d32d4dcbf9078f2efdf356af11cdcee29fff984134de2003898cb60117ada37c2c20c963bfd337cb2c9c70b78efa746b6137fe70140aae2c7cb30697e54a5baa2a5ab4188b7ac8f4910a53f195537965e5229a41511c0a02b046a2f7b92acb0dfea2c2ab34209c04f5b92296fc4214c2644536ccf9495a79da81a53688f86a2b070f727b39e0dfa1d379c4bbaebe0d9f0c907fa90cb43383dbb033bb859e4dcb43efbcc388f1a235eb40979ef295a3bc1099aa0cf9788f776fca622dd8589079d20fd2c265e3b4d6812588ad226dfb61efb00eac0536409cb9b51d46a838dc347b8c1b9c521204f3cf99157e892ccad0a046a6c8bffebb810ef374cd7bd31d390706d53f983ade51bc920c5fbe8625fed4b34304207964e8ad12bd78c4b4590ed4d224e7f8b366bf1af81e0000b9a2543ac84a57a64d04d8be82e7888974dc4bfdc64772402952f0e0b42d4857aa7081c54f93313c74b5a5abe10615086458815ed93d226a80528383d9336dc21f8d5d40ec40c1cd954be32d8a31c777a96eef4e36bd9acedaa1fe1d806a73623e31c19992c741018f876da5b88dc8c3fffa82363273cf10952444f53308d2e6f40f52cff30b68c7dc38b56763aef19c29bb742bdf5d7b60b59a7c50075a258c9a8ab3ebb04eb7080555b5a114fb9e7ce9760f819a72217fd52b27c7beabb14a2ab837e73dbe64e31fae6b1051bb50df8d7866d38de6b119eb37bc7036f8896c096efd3b453cb9658eb72431cecb54a9c487e52ee32416a08784fae535df25a2518244d19abb78e3cc8485b5c89123c0f1cb5eca8ad96c95c6539ea14440e5d9f299bd8bba6259481b7b0401b3b5b26d0e755c996da5f9668ddc76ab96c61f83233e24b3fa6b27114799f3ac0d17951883cb1cdad6ab72384a1f821d9ffffb728aa288d6aaacb93558bfba2ec59e67fc67ecf278eb11ac844894f67aa4bc4799da7bd39644096fe737b81d6adc69dbc06f4a153b5b6c3e57e544fec36deeffdc9e24a194a8e1abed5a361f5131c38d6e0cf05b86886a217283c865aca2919a6d46886ece53bd43cc5af069619fb12c812f92c007df3b504c66e7f10a593fdd8d3c4e6a8c743ced232732ad438a667df097bac7566de7fdc85225845545b189d85a83b18d4053f3c6fc2105fbba0e254c2a5c753b97d1791045630527672f82eadeaec0db03c3f880377de04e1b7cbf09fbf87c04def97cd8dee544581e877788f21b7567a955dfd7a06a816dc7ac11529400acb16abf4e7730f16c3312ac43a84b62e9aed266134ef2ee0db3bf2aedbc12f838eec6d0f1427defe77bdb650aa5398dd4989b94b9236a70e68d48c2e4f5bab36312fd1f1e4593cd9995878fd6a2b12515c0d41c9f0aeaac69fb77a013d8d4704ab4a173574d595edc90882c1bf947e9fdbe0ab1d680e3b4ec6e497cdd6a8e00e8dc9bca52066997d1c973ba27aadbe36876f1011dc11d6835acbbe5c7cfd6c3204b2a44dbf89b9715fd4797cf4200a4ca858705f624a1b48d75e166a1cb0c68e8dc0c994d69e199835e9f62f9b24167f28781f2f35ea1149f53bbda63bcb27b74f0e3e4704026e84e873306de2300488e9a182d2e85e46ac04b89c94277bc1f883a7047f62d117e45055bba398612091e9fcd4bbdd0d15e4b41c97898d9acdf904aa6cf144ef62ef7dd26f755c2fe353ed5eff1aef005ab99b7e355111a9ba5c5d03874914526e0356bc78f09543d6419e87be1df37d34393b12f87c676f49556a6ae5c91c194bbecf27936a91f3688a501c2ccb9a32fea57e195d3b0e0fd0b4640840400ec086678ee67ba0bd774de3c111979708409207e4d4bd1dce2321b77ccc71127be8318fe92e6ec730a47112bd069c9cad37361f693d07a90b0a37e5875938b06d6370d1f1c1c280bfd83fc5e2d0b803e467eacfd37c48ca37721193859cd499653f5dfd78c26e4b181e82b5005cac0e9bd55fb2850dd4c70cc1e3fe5c81167336f36839fce30f245061191282585ff911c9e4af395ad4cf77b6e4f17d389ae8fbd61a3a3a4e73ccae0716507afa7ac4d0f2349c3aa56f47b6aa78806d7c20b50e125ee329921ffe96f8123d3e4be8be89b2318b6e016c385728b7a02f7dbb14552e2863453c33e3854047e6d8f84fe9f56c9200962025182d418580a294a0d09e9740e187e3be88236f62542b56bf08f72a859ae8a809e78a90e86b9b2cde799f9cca6049d5f49e97365744bede14be8cf680175cca275444e37327ea04d624faed898e0fc7751f1ac7d6241d93472c2d6ee8925fedc9169539799701174a81d3d6e00a9ac9647286d08b6c982c6baf86810d1e9f91c581f0c755273009389019bcb68a7ffbb4f0bc7de1ec45004c93f1a04a8c4cb60490654f616250c14bb54e9fe1fa1ad866830451afe98559d3e0e85073c2950d181feeb935c6cb69962a644ba8736535c11e7a9efbc17e9669b1c232985e9c5eaad29618ad9f461f1438d8c35c691d3d3bf80642a11f57cbf19ec1a7e63b2289d7c0e178052b6b344267d99e018c3f724f44ac465097ddea64d35e36c78736cfe6488991c4469d25b132db3560744e418be6ef3452ab5a73f66205e1ba67944cf1a556e60b037fb9ec6579f8638be744e075e0fc99722bcfc40efaf603c00e16b714ada2b7390cf2e9867df6c5961d96cb63298037df5f20e69b3b4bd2d2a24f68c48e02538fc1b2723fff9b52f18012d2024c40bfefb202b6292065b2cafb67aa1539e9d8b96ca039cc08e232fbb44cb46d7ce5017b14cd7f4e4e1675c2bd0b8d74958ac3c1232134d91dd02d701eef4ab953237b548f289f7e9ff902e7b39c40226596037271dd3296865618fd62a0abe228adb4286217b6049d157bd3a91b8997730fb29f0b086c9a0cd56f7f0ad198eedf098c86371570db86a7e2e972d58c8baee2e9e7aa34534e3f11e210d21ab8bb9de9517910e67d24881c8d2a72baa26b440bcdba17aa1c0d3448e3b78c62ad09bdf8a686af48107386c8a2fe1e8b575f9be0780a642305e9e9147f93fbc71447780dda6bc865d3412e5aecf0e842603bf65f059c9a3c3515ed949152e68d386415aaad1e8048be59bef3e4bab26d9cdc15a81a84f51dad584db81558c2c12c0728b0a028ea4729b6f032585d45feae6bc12e237febab2bef1117c366380078d163de200e03fa31640e9e927737f2679c8104f74b7ac4d36e32bd4a7d84632a2cf95e161fb3b5fa81321d5afe02467f059d13f440a03592a3f2b2ee93f667e2ed66559ef53cd734bed10b16062d6581be18e4717cf8837443653a5ffe6da47a73883210b7129bd1543b745f5ada684a84003f8955ae9150126f22397d5e38c814899b67"
         }

--- a/src/commonTest/resources/nonreg/v2/Normal_748a735b/data.json
+++ b/src/commonTest/resources/nonreg/v2/Normal_748a735b/data.json
@@ -1,161 +1,169 @@
 {
     "type": "fr.acinq.lightning.channel.Normal",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 4,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 840000000,
-                "toRemote": 160000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da0320071020000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990b8b80c00000000002200205079bfdf0d2b5e13578de7bd639aba698df8785dbbe1a40907add319c71494f704004830450221008a0e5f22c602c0a8518a624bf145aa91b59c14b6e091d21788a579425236558002206b86a5048942a76e5fa3aaae2501c69cfbf0ca712aaa059a4b5d59ccaf8b48a301483045022100ecbd1de0aa98cfb38c3dd8ead1ea17ac5b33abf2d69e56bbd52b0d1f796f9ad702207041efe3996e9a41d00ca924a79c5d734ccc289a3370ea71f6408906adf2a4c60147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aeda99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 4,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 160000000,
-                "toRemote": 840000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "94ff78d40fb22d0279aea0c68546aa6bfbb0581aec4e481a923b542b067c19cf",
-            "remotePerCommitmentPoint": "036e46c0c33872871f0509fda1b455136e44b797452c86c79134b70a86a3d9abc3"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 2
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 2,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 4,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 840000000,
+                        "toRemote": 160000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da0320071020000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990b8b80c00000000002200205079bfdf0d2b5e13578de7bd639aba698df8785dbbe1a40907add319c71494f704004830450221008a0e5f22c602c0a8518a624bf145aa91b59c14b6e091d21788a579425236558002206b86a5048942a76e5fa3aaae2501c69cfbf0ca712aaa059a4b5d59ccaf8b48a301483045022100ecbd1de0aa98cfb38c3dd8ead1ea17ac5b33abf2d69e56bbd52b0d1f796f9ad702207041efe3996e9a41d00ca924a79c5d734ccc289a3370ea71f6408906adf2a4c60147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aeda99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 4,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 160000000,
+                        "toRemote": 840000000
+                    },
+                    "txid": "94ff78d40fb22d0279aea0c68546aa6bfbb0581aec4e481a923b542b067c19cf",
+                    "remotePerCommitmentPoint": "036e46c0c33872871f0509fda1b455136e44b797452c86c79134b70a86a3d9abc3"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "03fc9e0ff6fbb2af495d07b96f42c88d4bbc89ea4d75714eb660d9408db65ccde3"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "shortChannelId": "400144x1x0",
     "buried": false,

--- a/src/commonTest/resources/nonreg/v2/Normal_e2253ddd/data.json
+++ b/src/commonTest/resources/nonreg/v2/Normal_e2253ddd/data.json
@@ -1,92 +1,105 @@
 {
     "type": "fr.acinq.lightning.channel.Normal",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
                 ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
                     {
+                        "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
                         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
                         "id": 0,
                         "amountMsat": 300000,
@@ -95,6 +108,7 @@
                         "onionRoutingPacket": "<redacted>"
                     },
                     {
+                        "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
                         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
                         "id": 1,
                         "amountMsat": 50000000,
@@ -103,6 +117,7 @@
                         "onionRoutingPacket": "<redacted>"
                     },
                     {
+                        "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
                         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
                         "id": 2,
                         "amountMsat": 4000000,
@@ -111,203 +126,205 @@
                         "onionRoutingPacket": "<redacted>"
                     }
                 ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 50000000,
-                        "paymentHash": "f73e3549be28dea0a905affb32a94f935eb5df20a4366f564d851f5a3da6b562",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 8000000,
-                        "paymentHash": "0e0a51de262852c8cd55c92d2f4befa0fc6e584d0328af533ed6f4e1362fc3db",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 2,
-                        "amountMsat": 1000000,
-                        "paymentHash": "fb22254abd9621229fe6971c0627beddb01569817f701dbf31f5fe0a32714a1e",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 3,
-                        "amountMsat": 500000,
-                        "paymentHash": "b654bd9eccb1a84213b6880dcbbed7a53278ca5c48092dd360805886049c16db",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 740500000,
-                "toRemote": 145700000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-                    },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080074a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032401f0000000000002200206520f0c1ce76af1efb00c648cbb90fd645c162b0f5e4b2b750967644352f71dd50c30000000000002200202a9429e3863a2ef776e475172706053ac34fd5e459a9a2a108797a49614f0ace50c30000000000002200206f9fef6a1c60ac312c4889117dccbb62809ca95476afcf1faa89071109ff4c662439020000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990f8290b00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17304004830450221008669f29b67dc5ed41573e218bea0e5bec8195144d064b9f94505208f7986c80102205b1c6714872bce2128b7601cc6d9efe5bd4e1f1215529467ee0e0b310f6eae5b014830450221008065c3eef26d7f1ce10533458d34871d8ae1f1097569b089c4ce87274efda9b6022071f088e2488d6c81e01e3d0b3491f2a5637a99f727d38f0a23f477e23605e9870147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "9cc4da8281ede5c3eb2f4d06752524a2b4483e61931deb8c88bdf9120a925534:2",
-                                "txOut": {
-                                    "amount": 8000,
-                                    "publicKeyScript": "00206520f0c1ce76af1efb00c648cbb90fd645c162b0f5e4b2b750967644352f71dd"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a91465f865edf5b4b3dd8a9ed58605115e43513cc93a88ac6851b27568"
-                            },
-                            "tx": "02000000013455920a12f9bd888ceb1d93613e48b4a2242575064d2febc3e5ed8182dac49c020000000001000000013e120000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 1
-                        },
-                        "localSig": "74bba8e50d5ed3e335f12f4447ee37149528fbd1122402ce861cb9f721c77a844c03ba7902e70d0ce10264611a005aef5c9beeb850bdac18cef097e35fef3b9f",
-                        "remoteSig": "4f6dd32b93928582f463dfcad55e7fa88b2d64ae5dfbae145a863e796e064f125cc447909812ec3227533a6bcde6f6bb1634a7a276cabd4df8f2b49c7108097f"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "9cc4da8281ede5c3eb2f4d06752524a2b4483e61931deb8c88bdf9120a925534:3",
-                                "txOut": {
-                                    "amount": 50000,
-                                    "publicKeyScript": "00202a9429e3863a2ef776e475172706053ac34fd5e459a9a2a108797a49614f0ace"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a914e53b2faa6ce43549d6e8685a8b7e3bc459ebf64c88527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "02000000013455920a12f9bd888ceb1d93613e48b4a2242575064d2febc3e5ed8182dac49c0300000000010000000186b50000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
-                            "paymentHash": "31ee886646d6c55841f87b3978f6eb92eb7a3e3532ffa0207aad5a6c25dd6559",
-                            "htlcId": 1
-                        },
-                        "localSig": "0ca57059edcd8dede992661dd33a3ea0f202e65e36f1db90ee2799d22364db942177bd5855c27cbdf46eb92d40274b2d55e1f1f79cd8efdfb9d6619ea26d8936",
-                        "remoteSig": "68f36e3658a730868bd2d4e41a06b7dc0a531ab3af0abe6e7e992e338a809a2e11207db9a81559761b1a70888a34c168382c57e4056950a6465064d75b622f6b"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "9cc4da8281ede5c3eb2f4d06752524a2b4483e61931deb8c88bdf9120a925534:4",
-                                "txOut": {
-                                    "amount": 50000,
-                                    "publicKeyScript": "00206f9fef6a1c60ac312c4889117dccbb62809ca95476afcf1faa89071109ff4c66"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914a70d7cbdf2a845a86d8e9d024af809a7bae69dc388ac6851b27568"
-                            },
-                            "tx": "02000000013455920a12f9bd888ceb1d93613e48b4a2242575064d2febc3e5ed8182dac49c040000000001000000014eb60000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "4e65c9ae5f8cb18152abde6672cb59a05c037404234d0b97e061e2d3694ecba1330d0731679b8aca9f54074e4ec76b81d693f320f960efac7d00f65f95469587",
-                        "remoteSig": "1e8a60f305efbde315e67e296656f1ae28cccae9ea28b2c65316be8e1f2ea8af59411e0fff1f7634622e7d21fbd8650201911caf0744e24ac0ca4c2d315e3c12"
-                    }
+                "signed": [
                 ]
-            }
-        },
-        "remoteCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 50000000,
-                        "paymentHash": "f73e3549be28dea0a905affb32a94f935eb5df20a4366f564d851f5a3da6b562",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 8000000,
-                        "paymentHash": "0e0a51de262852c8cd55c92d2f4befa0fc6e584d0328af533ed6f4e1362fc3db",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 2,
-                        "amountMsat": 1000000,
-                        "paymentHash": "fb22254abd9621229fe6971c0627beddb01569817f701dbf31f5fe0a32714a1e",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 3,
-                        "amountMsat": 500000,
-                        "paymentHash": "b654bd9eccb1a84213b6880dcbbed7a53278ca5c48092dd360805886049c16db",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 740500000
             },
-            "txid": "b90aa4d67ddfca7b850711aa8f69c2b0309f7e36113360c6e42ff12f5824bfd6",
-            "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
+            "localNextHtlcId": 4,
+            "remoteNextHtlcId": 3
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
-        },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 0,
-                    "amountMsat": 300000,
-                    "paymentHash": "6b61226257ee70b198904c0ec5177495e856438051efba7baebcdc528782967d",
-                    "cltvExpiry": 400144,
-                    "onionRoutingPacket": "<redacted>"
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
                 },
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 1,
-                    "amountMsat": 50000000,
-                    "paymentHash": "31ee886646d6c55841f87b3978f6eb92eb7a3e3532ffa0207aad5a6c25dd6559",
-                    "cltvExpiry": 400144,
-                    "onionRoutingPacket": "<redacted>"
+                "remoteFundingStatus": {
+                    "status": "locked"
                 },
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 2,
-                    "amountMsat": 4000000,
-                    "paymentHash": "dfe0669321cf183422618fcd3f27bc2c7aa736c66d2c47ea5047f907890723d7",
-                    "cltvExpiry": 400144,
-                    "onionRoutingPacket": "<redacted>"
-                }
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 4,
-        "remoteNextHtlcId": 3,
+                "localCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 300000,
+                                "paymentHash": "6b61226257ee70b198904c0ec5177495e856438051efba7baebcdc528782967d",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 50000000,
+                                "paymentHash": "31ee886646d6c55841f87b3978f6eb92eb7a3e3532ffa0207aad5a6c25dd6559",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 2,
+                                "amountMsat": 4000000,
+                                "paymentHash": "dfe0669321cf183422618fcd3f27bc2c7aa736c66d2c47ea5047f907890723d7",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 50000000,
+                                "paymentHash": "f73e3549be28dea0a905affb32a94f935eb5df20a4366f564d851f5a3da6b562",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 8000000,
+                                "paymentHash": "0e0a51de262852c8cd55c92d2f4befa0fc6e584d0328af533ed6f4e1362fc3db",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 2,
+                                "amountMsat": 1000000,
+                                "paymentHash": "fb22254abd9621229fe6971c0627beddb01569817f701dbf31f5fe0a32714a1e",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 3,
+                                "amountMsat": 500000,
+                                "paymentHash": "b654bd9eccb1a84213b6880dcbbed7a53278ca5c48092dd360805886049c16db",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 740500000,
+                        "toRemote": 145700000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080074a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032401f0000000000002200206520f0c1ce76af1efb00c648cbb90fd645c162b0f5e4b2b750967644352f71dd50c30000000000002200202a9429e3863a2ef776e475172706053ac34fd5e459a9a2a108797a49614f0ace50c30000000000002200206f9fef6a1c60ac312c4889117dccbb62809ca95476afcf1faa89071109ff4c662439020000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990f8290b00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17304004830450221008669f29b67dc5ed41573e218bea0e5bec8195144d064b9f94505208f7986c80102205b1c6714872bce2128b7601cc6d9efe5bd4e1f1215529467ee0e0b310f6eae5b014830450221008065c3eef26d7f1ce10533458d34871d8ae1f1097569b089c4ce87274efda9b6022071f088e2488d6c81e01e3d0b3491f2a5637a99f727d38f0a23f477e23605e9870147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "9cc4da8281ede5c3eb2f4d06752524a2b4483e61931deb8c88bdf9120a925534:2",
+                                        "txOut": {
+                                            "amount": 8000,
+                                            "publicKeyScript": "00206520f0c1ce76af1efb00c648cbb90fd645c162b0f5e4b2b750967644352f71dd"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a91465f865edf5b4b3dd8a9ed58605115e43513cc93a88ac6851b27568"
+                                    },
+                                    "tx": "02000000013455920a12f9bd888ceb1d93613e48b4a2242575064d2febc3e5ed8182dac49c020000000001000000013e120000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 1
+                                },
+                                "localSig": "74bba8e50d5ed3e335f12f4447ee37149528fbd1122402ce861cb9f721c77a844c03ba7902e70d0ce10264611a005aef5c9beeb850bdac18cef097e35fef3b9f",
+                                "remoteSig": "4f6dd32b93928582f463dfcad55e7fa88b2d64ae5dfbae145a863e796e064f125cc447909812ec3227533a6bcde6f6bb1634a7a276cabd4df8f2b49c7108097f"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "9cc4da8281ede5c3eb2f4d06752524a2b4483e61931deb8c88bdf9120a925534:3",
+                                        "txOut": {
+                                            "amount": 50000,
+                                            "publicKeyScript": "00202a9429e3863a2ef776e475172706053ac34fd5e459a9a2a108797a49614f0ace"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a914e53b2faa6ce43549d6e8685a8b7e3bc459ebf64c88527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "02000000013455920a12f9bd888ceb1d93613e48b4a2242575064d2febc3e5ed8182dac49c0300000000010000000186b50000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
+                                    "paymentHash": "31ee886646d6c55841f87b3978f6eb92eb7a3e3532ffa0207aad5a6c25dd6559",
+                                    "htlcId": 1
+                                },
+                                "localSig": "0ca57059edcd8dede992661dd33a3ea0f202e65e36f1db90ee2799d22364db942177bd5855c27cbdf46eb92d40274b2d55e1f1f79cd8efdfb9d6619ea26d8936",
+                                "remoteSig": "68f36e3658a730868bd2d4e41a06b7dc0a531ab3af0abe6e7e992e338a809a2e11207db9a81559761b1a70888a34c168382c57e4056950a6465064d75b622f6b"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "9cc4da8281ede5c3eb2f4d06752524a2b4483e61931deb8c88bdf9120a925534:4",
+                                        "txOut": {
+                                            "amount": 50000,
+                                            "publicKeyScript": "00206f9fef6a1c60ac312c4889117dccbb62809ca95476afcf1faa89071109ff4c66"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914a70d7cbdf2a845a86d8e9d024af809a7bae69dc388ac6851b27568"
+                                    },
+                                    "tx": "02000000013455920a12f9bd888ceb1d93613e48b4a2242575064d2febc3e5ed8182dac49c040000000001000000014eb60000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "4e65c9ae5f8cb18152abde6672cb59a05c037404234d0b97e061e2d3694ecba1330d0731679b8aca9f54074e4ec76b81d693f320f960efac7d00f65f95469587",
+                                "remoteSig": "1e8a60f305efbde315e67e296656f1ae28cccae9ea28b2c65316be8e1f2ea8af59411e0fff1f7634622e7d21fbd8650201911caf0744e24ac0ca4c2d315e3c12"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 50000000,
+                                "paymentHash": "f73e3549be28dea0a905affb32a94f935eb5df20a4366f564d851f5a3da6b562",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 8000000,
+                                "paymentHash": "0e0a51de262852c8cd55c92d2f4befa0fc6e584d0328af533ed6f4e1362fc3db",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 2,
+                                "amountMsat": 1000000,
+                                "paymentHash": "fb22254abd9621229fe6971c0627beddb01569817f701dbf31f5fe0a32714a1e",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 3,
+                                "amountMsat": 500000,
+                                "paymentHash": "b654bd9eccb1a84213b6880dcbbed7a53278ca5c48092dd360805886049c16db",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 740500000
+                    },
+                    "txid": "b90aa4d67ddfca7b850711aa8f69c2b0309f7e36113360c6e42ff12f5824bfd6",
+                    "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
             "0": "fc04440c-9db0-4d12-98bc-ab3197ddd10a",
             "1": "cc5751b1-6c0a-4828-a26c-6a6e57fd4eaa",
@@ -318,16 +335,7 @@
             "left": null,
             "right": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "8feea322d066d4e3cd8858cfaf6ec9de1c51418af54140ebc5a99a4dc10fb098d7e97d0a0c44ac8a1e0de44f53f02a9b5a759cc4a1aae91391d80f459e4d5cc45c26f7eaa41871a4b083f7a8ee67b69157d517137d936b86b50f13cec26f136f79f1f9725b9d270fb455124ee2a7623a69f1610586351ffa281ab3de26a996e5047bdf09370e8672d1f7ad361f4e685a1270c9e4c10fc9d6ea3d0b3d83801f09880aa7716e7a3ddc7b5bddba5f7b818d714de9088ed769980564461394a6374b72fe347ac22a63143fd71ba51e4e4af6f9d51b4d8fa3f7627ad8d406672f016a1d94ac8152b34eb59b9e142e14ea553541440207fc268ee367ecbe7fe0053420fc28204c27db6ef42a29395e28625e3ec2a253d73d3a77a6cd847857fd20502e00d217653b994a8496f4b783842e36e68309985e4f8a06b33f13ae7ef12955495bbd48b127306e24f351f5021207f887e52efd3433eddf237606f92bf26a38c9480a2b2a95169a2e8a1d4fd575638bfda643d77609a08b4e083f1471d64e2e4337350942dff807db3530e4d96b00e33c95530506c743bcb5fd2248ce62c7dd0506fec42f21a4dc7153e06601075da0667f8d8de527758636c1140f2e5da640832111c1cd9efd4eb2b81d3c2a03e764fcffd9a5feddac08a9a734f895999203b16776baba5e52d367f45058762c510426270cea4ae89af0f88ee98ecd7b7f99092159071fce312f853a9e8ef78181fc312a4aeafc99d1fca74241330e0673fb9af4a3931a4fe54ec046b25a687cc85aa96b0f1193ff7d1d8d5b6a1f5ad2ca3ffebfa0dfa11418561189a32a323d171ddd233fa24de895ac21732de40927a71d12b552bd9095d9eb5d51ce62e6cb1859e697669fbd3e6d348ee52173a1de0a58abb4637011df5580b5a25e0f713f02255e9a7bc289b4cef8c3e1c98bdbace8770703ee0fe8e612cc3e82a696573ec930d94ab9ef7486d9788f1caedacbdcac7423a66d9074f65555080389a00b0c9c38ed41801062140d11701f997f7d31287e27420072ca52b46c5c98aa0b7a8ceb97f40c921049551d201e71d1ec40a9b479dc7814cdfaf894e8ac5aea35a86de722abf8948a48115d76ce411147f86d6f7013498acf884b4a0bb918df6856151e355c9969b0ffce04d62e96e308d35ad31f0ca0a1b3f8b4e9eaa4e94a7038d2e705c1fa759f4eba475dd3cc9c5843e19b5ad1c068633fe86d6e27b6c758ae4c4a40176a4af1f9bf7f358238128ecbca99eb231bd2eebc48a117b115d983811f032b22a93cf92ff8b09b8467821e8b14b16825b743bcfe6a7cf75e28661f5e35014370079e1f17abe62f23f396c3c1cf42992046a3a08d916d4ee61df67d732df0b3ae3060c4011d5dbe59f80c8f7470a3803b0d0d756ac1891d76aae887e2462407ce5b2402968845d9fda3fffcc325f46ff5857beed116d766f1580a2d9c3ca30d907df050daf8751df72be14d01fe4e48132bc3a386a4962949088d2e3fe34d344be3b64f99503c9d02117bfd4424631828043da39d5c4b8516c38bb2a5adf44cf7ccc0618b167053d45d187a88b4ace66086d5c25912aae249b3648da2734285dc05f87e4f1aa11d4aa120d1129467953388e7036f41a95d4d30d872a120979ef6293186cc0e5cf9c33f04d98a32cc6f7f131ef452ceeaf05349bac43a455e88e1e5229c6cdcabb0dff4e14a7e039ef83bb43d04057a00a20b34f144981c87d0eb5b165f62313acda8ef24b4ec87599a61d7ec83275f3bc948d93684182d4c27cb52b301400e4ae7770b0c53e1f93a12e526279f65f42e5258072350e463d73dbbd2773417e28ee30250ff2009eab8d5413ff284190549a92bc5359ea32ce3a1a33e6530de5f0522eedf1f6f21fe26b830fd12be3be35874ef167b7503987c71af02c33eeac46dc7da0e4892907a5134a5d84db4450d50e0c8d4aca999e7248432177a62229558e2043fd0a2b9a9634562e75bfc5fdf2e489310adbeedbdf6f02e9a0c7edc0c008e5e232c938260bb65c156bba17b6e500b97f2f7d5df5879d8e062af132ebd3afdb0054007e91049824a9d61f1d23d9f1025df017e6b9703482d23159bc73f4882ae43fab47b6ed8020d2d5be8c137669e9f7695f5890dad5008b734f7dd46885cd5412403c3d5043140b6ee1d3cbe444b77bd4c830161c37bc22580f349f99a25861ae30924567e27e5f438087619224073d95de422406b236fbe9ff13c4fe199bde6b6b1028ba891e2ef921996af01e2ea4ac389b9d7670a25a7b614786b6c18a863a56a35f86aa2f00ce785d5a2454f4c6cb6d0bdad70c8b4eacd3e129dbbe600effbbed0157f23cbf401254a6cbdbe4c6bd1d2e799ba3627fefca8b01eb4757ca0b92ab8138dacb3aa292f010332e6d64f5a71974e5d3685d23708b644476383fd61a091292766fc83f5c497734535e56355579a90cfcbec0e3422d68c3c63875a9931af3e9b2fdaa6746df659ad4dfa596f8a6881703a8a918157a204f7b21c81fdfb7195455bea4018d6f74a39ab8ac4530a7bbb3add963ed9161e04c5fafe9b93299acec3f9c6006f428a2eba8c9f9abe16ea45f5926188ff026a645bad92fb67c0b48d15f79a3cbb5fe7efd46f72b2c3d91904716c841e4daa39fcf6e070958b29745b8a6bd1aaa56d15f20604038a32b004b11d8af1fa13969aacb0dc131f2e33922845ffb41f5daa6436050891e86e67f7c76f46412de8907e687554e44f08c840730a926129ab3f2a4aa3a7800e18b4438d16c1e3debaa227a826df5c4e0a8ff22fbb8363fdaf3b48e2be0490dde382c491d32407d66043785f8a8184baea18c28b4b80903a9d5efb98018300c3ad849f2c432075a677874f74fc27d24b684b775c741afb98eaf7af851b9327c12f5606f0db1be5d8bc5412bbc0dd32b1ed775c6a72de4a3f3959eab60359591ccab4baa85d9f667a232d164d2232edbcd32108816b5c0cfd7cee1e4d7127cae44b69f9d53b2394be83f7bd670618a4ee936eeae98b9d1ab47dae58791285085d1781acff37bf291970862c8af1d2fe12790cc963a6c7f3e81442976a1784c8f69b3f571be717490e7d84945ef8589e684358d3c885ab03282ea2f1d32bc455d0e85544c845a4447c360b4192afa56406fcee9242f6fdca24b78590db51e23924d97728d054ee27838f5f5501eddf29c7e87881c88e5cdcbde75cf1a60d0b5dd4be93b7bab8b85199d047d99e78ed7f38ac930742d34bb97647c4692d9bd2e8fddd0b4eeec1482bcd823f3d4ef9fb995a3c0585d86e0e87fa265708e48594d428e2b71f25094f10b5ff262cafa1c2efbfd13a0e69933e3cc76bc4b7ba30f7f07762390e8df3afb9e79315f018011c39faa6fae56c4404da01bdb8c62eaf63549444a153495ecc4d74a57be34e605cc5751d8e66072786d314616b6519a76beebdcbc42e730172450282dddac8b3b1cdeeecdbb6e558efb17da91a47f8cad09e50120ce6cab38544c9e31fcc24ed93afb73625140c7711f07f76078aa7b0b456e548b2f2aef829e3a60717c941d4e0115bdd934f5e4197e1688323e941e48b0b8d0dd8f9f5728c7f0b12db3d6011660f770cb43af8e40a1d1faf5b7bf95be996ddad7a4e2145c35b13185f0ba2b4b8e87b3ed6238c9615c8751e55d1d190a9ac1df0c80d3d985e18a6c0727e613989092a8c03319349e16aae3fc68d887fa05c9cf062143c416939e02fb7a46c559793aa78706f6b1a546988fa6d23067f6b84cec84678bc1afab65b7194cdb09eaf1be84d5020d048664f56b4d22c424af6058bb3bbe9b3a5fd9d96faa5b32adba90f04e86b4ea44e942bacf764becc490c8e5d772ec83b66faf646aa3373db4c30048de42787deb0a0abb59c54263620735499a44ba91eeb3228fc302e566995c1fecfdd12f7d275ae41801b9bf017fef5ea3cd2b89bb53a55951a9c2b2b793b87e40c059e573b66b1f1ba6545d2a49296aeaed26f4a1b20af094578ac8f1e47ee97c2f3bea13e813361368121f3304d125df7cd7163a8513ce0eaa55b1bc9e8454b4bc015e910d5b645d0c8d99e933efc9c57d21a481f03919bb38a8f763011ee75fb149d7be22ebe9863dfe6088ec3325f49b936a1e33a580e65ee66dc099a961bb991f1192ef008f7c3b0d2e3934efbd6ffe2abe5219adac1dba7e39592909fc727f4d0ecf73ad23151eacec893a48bfd6540a731ee89a8439a1c3017f7c215da4f216d32cd9b46161b311a677aa8cff37253ec0e922ff6663e75f79200fc2dd676782b2b0326251711e2a62d98580bf5c25a2834bdbaddc58dc0d8a7f1a0eae6efdaa9ec1316b48a18ed3418574b6c565a2272b3f95902df9907a611b90b2e99f77326fa0e9539d9da8f02dbb4a5d1f3840edb4f6ce23d1cd7baa9377c989a2946fdbf114c44012abc828871b5e5a2574a2ca3ed41d08bf90b0c55c3b79760ea7a4faa6ffc9a6dc644a812c7a003859b9911e22ecb9dbeabdc21008d95b226154024834b885534f6af8d6c599ed664d7c6253311d6debba2e3062db5d4f884adf2c08ee4dd3541cbfa0dfed8cdb8f87aa7083eaec22ee5f8d4984e24d9afd9f6859d1a5b6c2e0a255126abc3bab846d78a4263da1c8f436e08ccb66240da88a27e712faf128b780e62816523544b7a1f6faf9b31ae02505a04ba8897428c636028481249fd9f8642cec85a9244e98c35036f59f02c348b224a159ac15fd65032ed7eb17b0206ec4ca452eb10a8a710b82f84dc18ae033480f8c4252c9ab6a4e9b12e77c14800ad7bec8f24c3499fffb70a585eb0787563e11f4ec14ad6c205e800c08dd5444e0b6dc7e9c8e7a7c54ab4bdce78be0dfb12b9cf30b293775aac78a48c0c78b3588456541fc0b58e487c5559a70a39ba06c7511286595c3ccb32e53b1e8a1afeb49b144e311ba2fa1f8ff4fec02c50ce8bb2efcfafe506ea963185d72f1608460185492ac409a4a95ae1ea82ea318f0e4edeabb223b1c2b3486d582ffd482323566f0c15cc8bbab3b6bbec54cb35b0f12098103176022e08ff07e664e54ecb5f85155e19b02e91840d506fee36df7ab28c86d4a6b0c067898dfa579f6d357242761124c3a8f58b2a399922f1d6b60ff549e3b45e9a9734ef1c7501d07b5d1fd1fd63dc662b0da3d1a9bb5c5c584039891795ed02d4b69aca515299a2ab8938ca9c8a2d38a98a63f1dd1e9c073558deef9c015d30d77ef7830f9324"
         }

--- a/src/commonTest/resources/nonreg/v2/Normal_ff248f8d/data.json
+++ b/src/commonTest/resources/nonreg/v2/Normal_ff248f8d/data.json
@@ -1,162 +1,170 @@
 {
     "type": "fr.acinq.lightning.channel.Normal",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
-            "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
+                    "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "0234ea3e3929ca115acc645d07c40eada7a98d86017614c3fa466d7e19760917e4"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "shortChannelId": "400144x1x0",
     "buried": false,

--- a/src/commonTest/resources/nonreg/v2/Normal_ff4a71b6/data.json
+++ b/src/commonTest/resources/nonreg/v2/Normal_ff4a71b6/data.json
@@ -1,92 +1,107 @@
 {
     "type": "fr.acinq.lightning.channel.Normal",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
                 ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
                     {
+                        "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
                         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
                         "id": 0,
                         "amountMsat": 4640000,
@@ -95,6 +110,7 @@
                         "onionRoutingPacket": "<redacted>"
                     },
                     {
+                        "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
                         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
                         "id": 1,
                         "amountMsat": 4340000,
@@ -102,171 +118,133 @@
                         "cltvExpiry": 400144,
                         "onionRoutingPacket": "<redacted>"
                     }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 4540000,
-                        "paymentHash": "954b05bac0091518574fbae7eb52457ff537cb6b88b7ee1f98147dab5a8abc63",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 4550000,
-                        "paymentHash": "7fbd08c3ac7021f5ca8295d759231b7ce2452face5f11c1d14dbbe7035e36aaa",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 790910000,
-                "toRemote": 191020000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-                    },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080074a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032bc110000000000002200208bf1a46fa0bd7ca44eda0c5df968544c280859a29a527641afac57c27bf7003fc611000000000000220020de61d4f9864b11e111190b9d11f62ebf7476d517a7bba5b0a5b0f80f4e54eb1f20120000000000002200207805c9f22468069984db4db780b44c97593e4fee2c8ee32114f1c9b4a6d70fe42cea020000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990e2ee0b00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400483045022100da0c7b59463b6a4284147a3b027c48627364bbc2640e212182fcb516124a527302202177fb27546d43967a07e90666a6433f0ceeeff9d464b8ce2ef974aea294271a014830450221008c9af1f2b41e06cb6713f33b488ee65ec8b28db0505ad6d57f25fa10ef89ceb00220688569c56bcc9027b8302cfdd2daa6b1f1a2c537ff5c7b68787ab4b0ad7ecdee0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "2ba9027cf8e58bb8298b03b361336d6453ebc9c03135afc8741c0871b167d491:2",
-                                "txOut": {
-                                    "amount": 4540,
-                                    "publicKeyScript": "00208bf1a46fa0bd7ca44eda0c5df968544c280859a29a527641afac57c27bf7003f"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914e3343ec0997580d5b583bb2025e77adaf760c37a88ac6851b27568"
-                            },
-                            "tx": "020000000191d467b171081c74c8af3531c0c9eb53646d3361b3038b29b88be5f87c02a92b02000000000100000001ba040000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "24f317d01b079986c85a1fdaaac8d7c9fc069285ef6c00afc68cbdbc39e1fa232ea6e020f29d1401374f24c1e0fda672a747774884a6bfc39a5822da0db9b0f4",
-                        "remoteSig": "d9c3afcf4a2f4f55d7250e246160809488c95964ee30daafb70d168b065cdb8a609292b9737f7e327588a5d0d6dc80fc9f14e0659853b0c0fd636979a1fdcb7d"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "2ba9027cf8e58bb8298b03b361336d6453ebc9c03135afc8741c0871b167d491:3",
-                                "txOut": {
-                                    "amount": 4550,
-                                    "publicKeyScript": "0020de61d4f9864b11e111190b9d11f62ebf7476d517a7bba5b0a5b0f80f4e54eb1f"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914bf3a02ed662f79cdd5fef9658003fec6a8d8eff288ac6851b27568"
-                            },
-                            "tx": "020000000191d467b171081c74c8af3531c0c9eb53646d3361b3038b29b88be5f87c02a92b03000000000100000001c4040000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 1
-                        },
-                        "localSig": "779952b88b9f4a4bc16fe15f68444bba160065dce2d79ba7ba42b36b7db061482cc29992803323c676d885c4622de762bf1554951bc2eb9e669208b92f7ae3da",
-                        "remoteSig": "a114cdabf6695b1f2e17d01c7c948ea83e0a3d1001ef69d83d5e41eddccf9c7e2500498ab1787039cafec7fa5815d53ffe37c4e94456d1f8b5d03aa0bf56342c"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "2ba9027cf8e58bb8298b03b361336d6453ebc9c03135afc8741c0871b167d491:4",
-                                "txOut": {
-                                    "amount": 4640,
-                                    "publicKeyScript": "00207805c9f22468069984db4db780b44c97593e4fee2c8ee32114f1c9b4a6d70fe4"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a914562c7aee508993870ab9ed39c9ea6d072b5cb78888527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "020000000191d467b171081c74c8af3531c0c9eb53646d3361b3038b29b88be5f87c02a92b0400000000010000000156040000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
-                            "paymentHash": "21cfd1bdff21a6254dd36cfd62e00733b834ec648cb36b59c10ef6172e78389e",
-                            "htlcId": 0
-                        },
-                        "localSig": "d2216ff0af9cbcccaa86e4b11b5a46d8036fcccee8956e5fc92234a9dc9f46a6642f882bb195e04bf7de06b86781c864c1ae976dda2fe13004c9b9bbbfb16fe6",
-                        "remoteSig": "9f5d72d734e17f3bb86673b895921de22d04ca5e1e16fabb5cebec97bffa22dc634f8d7170c34e389ba2da99b707ebda7509fbdacdae90edb75b67d82bd8a6c0"
-                    }
                 ]
-            }
-        },
-        "remoteCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 4540000,
-                        "paymentHash": "954b05bac0091518574fbae7eb52457ff537cb6b88b7ee1f98147dab5a8abc63",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 4550000,
-                        "paymentHash": "7fbd08c3ac7021f5ca8295d759231b7ce2452face5f11c1d14dbbe7035e36aaa",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 790910000
             },
-            "txid": "ab5641cfc9de5225bd6b32206cc83500169ac53c4d1d3d22a94e9a52a75a549e",
-            "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
+            "localNextHtlcId": 2,
+            "remoteNextHtlcId": 2
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
-        },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 0,
-                    "amountMsat": 4640000,
-                    "paymentHash": "21cfd1bdff21a6254dd36cfd62e00733b834ec648cb36b59c10ef6172e78389e",
-                    "cltvExpiry": 400144,
-                    "onionRoutingPacket": "<redacted>"
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
                 },
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 1,
-                    "amountMsat": 4340000,
-                    "paymentHash": "6da74844b47a2823a6e64f45f0963e230ca49f179d36bca71c2adca8a83b042a",
-                    "cltvExpiry": 400144,
-                    "onionRoutingPacket": "<redacted>"
-                }
-            ]
-        },
-        "localNextHtlcId": 2,
-        "remoteNextHtlcId": 2,
-        "payments": {
-            "0": "7e780474-04b9-41db-94b9-7ef99349408f",
-            "1": "683c4687-c4b7-4cb1-ac82-6808f57f4409"
-        },
-        "remoteNextCommitInfo": {
-            "left": {
-                "nextRemoteCommit": {
-                    "index": 2,
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 4640000,
+                                "paymentHash": "21cfd1bdff21a6254dd36cfd62e00733b834ec648cb36b59c10ef6172e78389e",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 4340000,
+                                "paymentHash": "6da74844b47a2823a6e64f45f0963e230ca49f179d36bca71c2adca8a83b042a",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 4540000,
+                                "paymentHash": "954b05bac0091518574fbae7eb52457ff537cb6b88b7ee1f98147dab5a8abc63",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 4550000,
+                                "paymentHash": "7fbd08c3ac7021f5ca8295d759231b7ce2452face5f11c1d14dbbe7035e36aaa",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 790910000,
+                        "toRemote": 191020000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080074a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032bc110000000000002200208bf1a46fa0bd7ca44eda0c5df968544c280859a29a527641afac57c27bf7003fc611000000000000220020de61d4f9864b11e111190b9d11f62ebf7476d517a7bba5b0a5b0f80f4e54eb1f20120000000000002200207805c9f22468069984db4db780b44c97593e4fee2c8ee32114f1c9b4a6d70fe42cea020000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990e2ee0b00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400483045022100da0c7b59463b6a4284147a3b027c48627364bbc2640e212182fcb516124a527302202177fb27546d43967a07e90666a6433f0ceeeff9d464b8ce2ef974aea294271a014830450221008c9af1f2b41e06cb6713f33b488ee65ec8b28db0505ad6d57f25fa10ef89ceb00220688569c56bcc9027b8302cfdd2daa6b1f1a2c537ff5c7b68787ab4b0ad7ecdee0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "2ba9027cf8e58bb8298b03b361336d6453ebc9c03135afc8741c0871b167d491:2",
+                                        "txOut": {
+                                            "amount": 4540,
+                                            "publicKeyScript": "00208bf1a46fa0bd7ca44eda0c5df968544c280859a29a527641afac57c27bf7003f"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914e3343ec0997580d5b583bb2025e77adaf760c37a88ac6851b27568"
+                                    },
+                                    "tx": "020000000191d467b171081c74c8af3531c0c9eb53646d3361b3038b29b88be5f87c02a92b02000000000100000001ba040000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "24f317d01b079986c85a1fdaaac8d7c9fc069285ef6c00afc68cbdbc39e1fa232ea6e020f29d1401374f24c1e0fda672a747774884a6bfc39a5822da0db9b0f4",
+                                "remoteSig": "d9c3afcf4a2f4f55d7250e246160809488c95964ee30daafb70d168b065cdb8a609292b9737f7e327588a5d0d6dc80fc9f14e0659853b0c0fd636979a1fdcb7d"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "2ba9027cf8e58bb8298b03b361336d6453ebc9c03135afc8741c0871b167d491:3",
+                                        "txOut": {
+                                            "amount": 4550,
+                                            "publicKeyScript": "0020de61d4f9864b11e111190b9d11f62ebf7476d517a7bba5b0a5b0f80f4e54eb1f"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914bf3a02ed662f79cdd5fef9658003fec6a8d8eff288ac6851b27568"
+                                    },
+                                    "tx": "020000000191d467b171081c74c8af3531c0c9eb53646d3361b3038b29b88be5f87c02a92b03000000000100000001c4040000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 1
+                                },
+                                "localSig": "779952b88b9f4a4bc16fe15f68444bba160065dce2d79ba7ba42b36b7db061482cc29992803323c676d885c4622de762bf1554951bc2eb9e669208b92f7ae3da",
+                                "remoteSig": "a114cdabf6695b1f2e17d01c7c948ea83e0a3d1001ef69d83d5e41eddccf9c7e2500498ab1787039cafec7fa5815d53ffe37c4e94456d1f8b5d03aa0bf56342c"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "2ba9027cf8e58bb8298b03b361336d6453ebc9c03135afc8741c0871b167d491:4",
+                                        "txOut": {
+                                            "amount": 4640,
+                                            "publicKeyScript": "00207805c9f22468069984db4db780b44c97593e4fee2c8ee32114f1c9b4a6d70fe4"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a914562c7aee508993870ab9ed39c9ea6d072b5cb78888527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "020000000191d467b171081c74c8af3531c0c9eb53646d3361b3038b29b88be5f87c02a92b0400000000010000000156040000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
+                                    "paymentHash": "21cfd1bdff21a6254dd36cfd62e00733b834ec648cb36b59c10ef6172e78389e",
+                                    "htlcId": 0
+                                },
+                                "localSig": "d2216ff0af9cbcccaa86e4b11b5a46d8036fcccee8956e5fc92234a9dc9f46a6642f882bb195e04bf7de06b86781c864c1ae976dda2fe13004c9b9bbbfb16fe6",
+                                "remoteSig": "9f5d72d734e17f3bb86673b895921de22d04ca5e1e16fabb5cebec97bffa22dc634f8d7170c34e389ba2da99b707ebda7509fbdacdae90edb75b67d82bd8a6c0"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 1,
                     "spec": {
                         "htlcsIn": [
                             {
@@ -287,54 +265,85 @@
                             }
                         ],
                         "htlcsOut": [
-                            {
-                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                                "id": 0,
-                                "amountMsat": 4640000,
-                                "paymentHash": "21cfd1bdff21a6254dd36cfd62e00733b834ec648cb36b59c10ef6172e78389e",
-                                "cltvExpiry": 400144,
-                                "onionRoutingPacket": "<redacted>"
-                            },
-                            {
-                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                                "id": 1,
-                                "amountMsat": 4340000,
-                                "paymentHash": "6da74844b47a2823a6e64f45f0963e230ca49f179d36bca71c2adca8a83b042a",
-                                "cltvExpiry": 400144,
-                                "onionRoutingPacket": "<redacted>"
-                            }
                         ],
                         "feerate": 5000,
-                        "toLocal": 191020000,
+                        "toLocal": 200000000,
                         "toRemote": 790910000
                     },
-                    "txid": "70a92b624690358d74df2d65c94d784f896a18648288dd1b10c54a9fc6c0401d",
-                    "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
+                    "txid": "ab5641cfc9de5225bd6b32206cc83500169ac53c4d1d3d22a94e9a52a75a549e",
+                    "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
                 },
-                "sent": {
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "signature": "d0dc87687f989fa9d9cb00875bbd7e29cc076219898281c2ad05225abec90f610fd09a46f9e3b6618c26d0159573000bb15cf9e36e99e6a42f9029f55358984b",
-                    "htlcSignatures": [
-                        "b73f21dececcaf374e766088ac1769a547b96ffa8fb7d8ec885b5c65be7ae1242beee07cbd9f7b2924b6a7ea41ca624209723f981a9624f118a51d639227feaa",
-                        "137ed5daa06fc8b58c0f5bd37dbea2e11183082dac805a75f449343f5d21cd8935e99f3f035585622d97cfceaf9e136e8e3596c8e4e7ce2a91f94893c0aa4846",
-                        "38e3c64a9188825a0814f574ea237d27373eb499dd9ca575361795e314868eab431d035f74a183d3219eae0a321affaff9ef652bf15539007a8101b8044d9822",
-                        "a547db99506cd969cd115cc455362365f784fb4b6e15b8a619ed19b45797a8a92c8e7e03f2503eab4be97c6867abff2615fc897d3f9d5d15d1d88dcd68e38ac6"
-                    ]
-                },
+                "nextRemoteCommit": {
+                    "sig": {
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "signature": "d0dc87687f989fa9d9cb00875bbd7e29cc076219898281c2ad05225abec90f610fd09a46f9e3b6618c26d0159573000bb15cf9e36e99e6a42f9029f55358984b",
+                        "htlcSignatures": [
+                            "b73f21dececcaf374e766088ac1769a547b96ffa8fb7d8ec885b5c65be7ae1242beee07cbd9f7b2924b6a7ea41ca624209723f981a9624f118a51d639227feaa",
+                            "137ed5daa06fc8b58c0f5bd37dbea2e11183082dac805a75f449343f5d21cd8935e99f3f035585622d97cfceaf9e136e8e3596c8e4e7ce2a91f94893c0aa4846",
+                            "38e3c64a9188825a0814f574ea237d27373eb499dd9ca575361795e314868eab431d035f74a183d3219eae0a321affaff9ef652bf15539007a8101b8044d9822",
+                            "a547db99506cd969cd115cc455362365f784fb4b6e15b8a619ed19b45797a8a92c8e7e03f2503eab4be97c6867abff2615fc897d3f9d5d15d1d88dcd68e38ac6"
+                        ]
+                    },
+                    "commit": {
+                        "index": 2,
+                        "spec": {
+                            "htlcsIn": [
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 0,
+                                    "amountMsat": 4540000,
+                                    "paymentHash": "954b05bac0091518574fbae7eb52457ff537cb6b88b7ee1f98147dab5a8abc63",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                },
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 1,
+                                    "amountMsat": 4550000,
+                                    "paymentHash": "7fbd08c3ac7021f5ca8295d759231b7ce2452face5f11c1d14dbbe7035e36aaa",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                }
+                            ],
+                            "htlcsOut": [
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 0,
+                                    "amountMsat": 4640000,
+                                    "paymentHash": "21cfd1bdff21a6254dd36cfd62e00733b834ec648cb36b59c10ef6172e78389e",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                },
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 1,
+                                    "amountMsat": 4340000,
+                                    "paymentHash": "6da74844b47a2823a6e64f45f0963e230ca49f179d36bca71c2adca8a83b042a",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                }
+                            ],
+                            "feerate": 5000,
+                            "toLocal": 191020000,
+                            "toRemote": 790910000
+                        },
+                        "txid": "70a92b624690358d74df2d65c94d784f896a18648288dd1b10c54a9fc6c0401d",
+                        "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
+                    }
+                }
+            }
+        ],
+        "payments": {
+            "0": "7e780474-04b9-41db-94b9-7ef99349408f",
+            "1": "683c4687-c4b7-4cb1-ac82-6808f57f4409"
+        },
+        "remoteNextCommitInfo": {
+            "left": {
                 "sentAfterLocalCommitIndex": 1
             },
             "right": null
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "0604e2cc07a6a6f4f76baeaccce8d3571d9112b8cda1132fb4ce96614c8a6f31a237323899890ed65aa1f1f2d2ee3bcda264a60e93e06cc953ed00b33827a7663ac10c9967dd1ef5f9eac23859aad530f8535ec69622a3fdf433b0d69377f8af8eb22a32948bbc5fc4bba70c6d517d75d548fda5beaccd19bf60c16a8c52893912ac862db63cc5e977f6aa2f3833765f81fbd4dba5462f74ba0b3ee2ea5582f2c503b897a8c703f03fddde1b12203bc42f8dfee976ab3471de4deeff10231ba47cd11cabdb3b7396d4b7259ee60d8bb4b0bfa017de4899aa8ad1c656acdf24a67c5a4d33e15a27953aa618d721ab518612b2a38ef287c3161e559ec3647ff979fd56e124b13a5f7330df250be2497f2a004658606018b74281b63e2c8c22215662e1d44a23cc9b62e232753a9b61f6d8c1c5af016e58708098b02746ff3aaaab58f7c5ff26044b927d206930967acdc32771e9f7a2f655f9dae0b88bf5545b427b0d9336b902fab7344fcc35df9300142889dac9084e9d3a92f1107d28dc09e20a368a367a3af68b1bac6768920aa5a1f63658a3a1caf1eb26de6bd4e1c3df88f5e48e4951fc1e0af7a9feff9c6f879ebcaf886e45130db3149d13c291731dc87a6c575efa46290a02815cbbbea2050c10438e7191d8c8ddfde36358c3f2d9b0f713c1c82992a1bbd15d592c88eb2a8a255d7ed8fc36e6e5a6233eeba6f625974f8faffa2d02c8a478cc8dd1aef5122ed7fb72354df5f62c6133fa83127da0093d26a29812514a048b65ab77a5253114cf9d2b218fa2678f18f54665f653fb35e17cdbd0e15a0a8b0e6bdc950c8f50f902c096ac74e6d02c21d0fff6fd39702802e451a854f4dce094296830de2b9570c3a9eca23dfb41640eb650c73ae9fa0d8c73a073a5fa4663f2d8329f0b46c9ea7fcc8deac9d55d49923aa48c5de0fa4f9fa2c970581ff0737f4fbba3c44da799a65611ab2af8df807654a71c6a70354fe43ce51490b8f9c240a548f819e8059a9691360fc4627c9ac17ba7707d20d01bd1f4829d499faefcbc2cfc602f8ea730c2372e5604608ac255cf261750b5a8427752f29b3a9e7d850cff8bf5171d9a3bf354c66e27203397c89cbed10746fcd4d12c7b4cd248162de87b90cbaf571b4d4f8b460b33a16fc52a1487264e5208252bdbb21b7f1645af46097e2aac9f2eee194bc72bda0124a8d92b33173e23bdbdb1495a506235953a203c0f98371b8d44067664007bdc87a7f567ac8b79f20ab398d727f5ec1dee7beadad010aca6aa9de0aaedc581e136c0cba641d0206d036603554baaf6d03f5ca647c5f019cebf49f81b380126735c76c7e519fdffb0337896f8ee46b437d8fbf29957d05514851a8fc9e15c54a3990db96dc2c55f04eb4bca0e72a17c24598bb2268a9ada03fb606fb9c1de5217df32bd729a06044417672e7547367af426eade1b00b7037bb6324f3b79a0fbd12476596bc70f79ea67de0c63e8450904482107c33d5559d1a1404370b8dc78ae9f739780f3caef407d8d59d46873897f2cedd1a6b9e8c39afd68f1cb65180b791a1a5412ada4c0434becb6089344a97fc754ab0bb675dcad2a6a3b4a405a60d152372bded8a3f1e6c26fd1eb10f4969c3d42a4d6c724711c020a3377ab749aad2163150f4954091b71e806536d9dd41298f359db8ef41f834353b9abe9d8c7456c5f1cf1fd78a0ce3134a5e8e809ba084428c384e856eaaf19cfff5f89e1da7f89cc1dfb87391beba81f99f64a8d691689971a59bddfb6362b0a71c97592f983a024987f25fe471e477ad640657b15350e042201a441fa07da7826d13798158243e9e8bd30de9e5e0e6c913277e1312f9dba0e7c3201659431bb2f894127b7e1a2d7802e8ddd449c20ac366acc91aab037e2bbf2864d6ec13226ecec4aedbf75e8c0306cf36d9652bb7177cee6542ea2e2e69fcdbf6670204e8b87859c7e34aa602dc1322997480936342eff46e820a37a07acf46b291652f17e5f06c950f37a4fbcab553e77bf20926b2af9163984f59dc424c3bb3cfcf6333ab7b362b8243ab86565b9aa2de6bdda1693b6bb139fc45fa1a7eadffad1202551afec9954174e40f1c2fc20bb3c5c9fcf19b79e4776e9c30134c1d9c935ca617101914bd5906c9af159849a69c7f623e457f2353bc6cc89ed11c047298b5d7736a8a2e3796790a4e512fe90e33628b97f4506c24bdb63f7b327abdd9cf8a3c71eb079b09ddc3d23d8977ecdb45a687fb755e6ed821a3c7f7adfa37676c66877e4c00c09e2ab8f465985fd79869d0c41a00ab493e45271998506c984eac915b07fd50324259b85de1443e186ff3635beb76be2743effffa62c4165d15d853b2667b76438ae17d8417c0c8c92e960d972ec1d60e7a922b49c659dc60443c589e20c5e94a5bfff81bb088e68b609594d7632d0656984150c34df7e02aece15b4ffcde19f788abcf795a75b0aaf565e8e9ae0efbe544f210213775586d3b4db383be0940068ae9f2a6f4f586a39132a64e53b5e344bafcdd33b6908de068f991fb8595a9606c7a34305406038f7820d91acdd209d02bfbb91f6a772112a84754541dc0c6b2d9f9e209bc6835646846ef4923173036d52352f6ebb456794c4653eea97a54a8b9f674c7083f73d622f8f76757311987bb4fd1c12942ddc019e3a2e3119093b2cc514191e5ecc18e91958fb69badba63ba3f5bd17ef10366b909aa133f578a080123aea1160ca4390e3290440b6bf6dfedcd1f849639711bf088db0a67c93ed5871343678a4bcd2cbdd6dede5943184103b21b583caa7fe0606672a4412e675b11a9f2f2c1acdbc5008d104de031c9a7169bb2b70221449b64b0ff1b1922143e3a43280011875377c8a92a24f4bd2fec3cbd0e4239e67e4cee4aac0606a90064ec7d926c69dc873f40804bff7fc1f8fff4d094b2e9450835e5ced8dff6af1e231aa49fd908bc91d09f4521c4676e73874602076e24c305ca4050db485f4207b6704e86de980dce1ca90ab42b5971667faf7519ed95631a1cb5d6a907df6d7177ccc6a55fec25591b310ace50c7146839a5dd6fd1dfbccd514a17391661d5960d8376249c4a249338bdba4028c4b0431b4814ae55c36b66eb243e21f7c0fd483a9b461fa305875997d2ce727c3f7955ce0f05ef85ee6aaca942a70b73fbd9ced11b28147005730107a4ea0152a43cb80b75da653656f680e453b6858e9fa27f64a747dbec4dfc9a90d14d178f0f6f32ba6a39deecb981c84f4994db22a8bfd925f4a92a95e6b31b161a681be21760a5f7fad811afae4da168864e8eb3ff8798b6ac3a96051abb79436b14727888cc49f8ca100064a1cc83654dd218bd58f3f777bc4b7b73bbc687bb9d8076484990a2272b54efc1a041ba57b6ed4d62a16885cd9b087dae57120e4954936a4ad0a9e5da75a21fd058c503d264f8d63e50a3c4affc90f1bbebfbbad750cbfa52ee8e89aef826af4dc0ad49b03accda524f0c4307dc545eabd1db4acba25190cf30a8b03f640f2ea89cb239ab6c250241ca31e16d17cb560508243a2116dd0c16d76784f511eb5435f0466b49d2bfa004c3651b0152bc5507e64f5a41cdd1d0da5a21b2d51cb4110c5f5de61b743c34740e620618c3bf426964250271005ed3fceab7e4e6f554d4d65588c6b39ad857e267a319c779e2f9b8ccb749597d2e8cd000f2b2266543f2755022ac5ce31011543f6e7d31ce4a3a862d4d8e55f895005a8ce766f00c40e79279d221d084584b5060e40966586d8a091d6721929ac125360c9298d9c094db3c7be23d72fd17ead90cb33f0444f1c6e2a5ab77223e446ecb5d95b238cb72594f25524c07df22a50118160a954d66c91ddef25dd7364cf7f799ac941109f84f2a53d846c25ccc46b58ea6848c1dacedbb8bb7f7a1db1194c331c2db1e7e49d23422184ac3d1803815b64158b8bbd32d92e79c5dbc49b9500d568db25fa7729a1ecb6c3a88f574aec6202098ab89e2cf685e446cf28559fa7cce28a8545f298b14e74ed7039408dff99d7366ee966b1a5f67af3841cb4e112c870e29e56cfc9cab340117602d9dd104effd72bf424fb91ea770f5b65749bb90bf6521ef365c07325cee76df867d53450549976739870572bf40b4f70008387a3376071702b984805c721b83a7b6f30249855242e289e18c302c6331fbc1664befd25fd0c4c3b1e2e5e1a9cc4c7ad693a0fec5ad98fa391a8610ffd65fceb0318225b2fc3fa990a340ba4018fedafcf9b29445a5fe12169f87bb174c9ab4a697adbfc9f890682c3da79c61c83e9bb4eb362b9b79c8f051b0a69b2057eed7d6e8809bf458701e97d052c85469113f5b156bc93a27abdc3cffae7a3bbd075f38f17d4f98afe7847d91f420b913cee1743433b5e31328a10bb95fcffb8651e3fc2246306cc575f95b3237e821cf9f2e82470d0c09809d2506fe53ec00efa984b2fb31bcc1bdaf86ccbe8f1bd5b42fd9c7e7a4b0aca3d40bbbb5911e45edf53980efb6368de25b46c88c1b168dabcb436a19ef31da31432fa5068aba62f255596bb159fc3a266be4a2a839b2e8552c7c41b357890ae4eceb84722f2f737e44171eafd88fab05bda5dc147d13cb1c6c9f4cc0377d34d1025a0c5de10f02de8c2e11066af97ae4973a1dfeccacaa13cea263ab7455b1a4e886c0f50d095095591fb4b07ce981c8fe5dd80712c42b8efde5fe42f988d3956b94e0a41a1bad7119412ebd27405c0b19fd92d0174ae74bbb204aca06b0150b5a06c9a822bdd03d11959e0f213a66b395a7d11eee53f74fbad37de86874ea0c6e372296caaec1bb50de1586192b1b469968896c4124c39837553134f66c0b8a7d2c0708861f4706801c0b41ae10bb18e2df354ffb0fcc88390155e93a4e5ad221be8751feb7136283ff55efa559bcfe6a06e69ff33b9c949e1f06d3d84eaa6b64615d75d0f36d924a65e79920e1864d2b4993df333ccc3f3e5fad84e860f9fb0e0173bc57621e4b2b7ced1488453a62e81ac8e1452b13ed69cf82e2938e10927c6981697e6dc856244ca40f00daae5a1118ee177d41fa59ef06cc465c05d1bd24695f48f8efdb59c90788cabf3522dfbd5b61b9967e1d82182ca748e2b3fe6cea05fb948ce561379b64f87e1e43050b823ca7951eec02e0325405115d52b5b8d5f4a015e3e95753ca6dd9c0258cd389f16af5e89be5f20c0bfca119b9aece1f66f2346f7e7"
         }

--- a/src/commonTest/resources/nonreg/v2/Normal_ffd9f5db/data.json
+++ b/src/commonTest/resources/nonreg/v2/Normal_ffd9f5db/data.json
@@ -1,189 +1,198 @@
 {
     "type": "fr.acinq.lightning.channel.Normal",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
-            "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
-        },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateFee",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "feeratePerKw": 6000
+                    "unknown": [
+                    ]
                 }
-            ],
-            "acked": [
-            ]
+            },
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                    {
+                        "type": "fr.acinq.lightning.wire.UpdateFee",
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "feeratePerKw": 6000
+                    }
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
-        "payments": {
-        },
-        "remoteNextCommitInfo": {
-            "left": {
-                "nextRemoteCommit": {
-                    "index": 1,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
                     "spec": {
                         "htlcsIn": [
                         ],
                         "htlcsOut": [
                         ],
-                        "feerate": 6000,
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
                         "toLocal": 200000000,
                         "toRemote": 800000000
                     },
-                    "txid": "339f36873e0cf27e7cd975000f8216b8eb1f9f96e7deb32704271650e5464457",
-                    "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
+                    "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
+                    "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
                 },
-                "sent": {
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "signature": "264a5ee8dfd9bd8302af0a7a71821b1cdb434421da261fcc8beddb72a851cf1832ad6cb93ab09b8d6b704d9e7eff9c3ce1570e2ef2c6794007f735d3dc50ca8b",
-                    "htlcSignatures": [
-                    ]
-                },
+                "nextRemoteCommit": {
+                    "sig": {
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "signature": "264a5ee8dfd9bd8302af0a7a71821b1cdb434421da261fcc8beddb72a851cf1832ad6cb93ab09b8d6b704d9e7eff9c3ce1570e2ef2c6794007f735d3dc50ca8b",
+                        "htlcSignatures": [
+                        ]
+                    },
+                    "commit": {
+                        "index": 1,
+                        "spec": {
+                            "htlcsIn": [
+                            ],
+                            "htlcsOut": [
+                            ],
+                            "feerate": 6000,
+                            "toLocal": 200000000,
+                            "toRemote": 800000000
+                        },
+                        "txid": "339f36873e0cf27e7cd975000f8216b8eb1f9f96e7deb32704271650e5464457",
+                        "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
+                    }
+                }
+            }
+        ],
+        "payments": {
+        },
+        "remoteNextCommitInfo": {
+            "left": {
                 "sentAfterLocalCommitIndex": 0
             },
             "right": null
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "0d40bf80015515b5aa86918d9d8dd94b681522e06253416b445e66d9ff3e96831482e5829e016432fa02608c05619f28a8bc1d17c3f13424c42ab614b18a5c8c5392d29bfc8073f433bd66d371b11bfbdd5b003e56e7811fd5c32868547a0d95ca390da17c0f169ba5dbbcab700144bcff9d56a2ca71cf894b735477a4ddfef30d9fa6940dfed01957da58f0bcab920d9192bac1e0d5ac38327b954341d2265f1aa4de1234ce4c2e610ea04afca4c384831976fac7b4d62c7bbe829556e67f067e045f6b04d2337eaa3053104b06a34f766aa6946c143fddd17329418e2f91b0d9e2e81a68f5f230a718137bdaa12031cd7a4e197a16dec4f1bad013abd256f5e109172e2f88e66f38663e1bc1e04a78eafca9aa992f0301e34754d8e0c50e012d1d19b8e619ffbd8e0a43752b9bd2200e6b47b3e2a8d0a1bc9fbf7cebc6160c9647c1fe7884e819c3b0c0baba752681b82d7a5fd74c35f8ceaf5f9cb68d0a47c85ca3f5a3c5627e13bc88b8087819da84424caf28871ef802e5dc2523369b55086449435d9229cda7769750c179024400d22dc0311dd63b93e227844f247e7ae7699201a2435f3fb6ae38314c6eb68536de5626e497389a8b2e08aa169676f1ed98984a21618483638e5621701697a0305c520bf9df86641316981a97ee1475acbc0749ce49b8c718611e208aec624ee65b261f4a381634a58da51bc2bfdeb4b54819c87b384c7d544da98525ff98fc9e82bb92df5fb325ea3b0fe73b480e85f4d8a51e37e94fda0a574d9a85dc4639982b7ac2e7420c674721361ab3e51ef4455b9f59933d2bc04836a232a7a53de0719aa121f58e6d14fe3b71f2178115581a45fc4cea15593f7fb4cf0dfbf85fb9355830d6fbe64a5d5ccebe9b10ddddfb88317be57869db944a16d724eb5b658bba3560f2df7757dc6b582859da5ab579f5d0d7d43999d9930d6f2377eff51da6122d9a2bca213fc9368a0ba9253df32ed6cfd45d4dbf72574496d5295323c18a263bf90fcefbb7b9c9b5579604cfab39bbf6982a098f27de5dacca003bc1fe54b6d1aa63fc269994720a31b887909e60b0846c2cc75b9e65ed616493b8a09b873c50e2a60cf50678a2030ed5b4ab5d54886b6bd90830a00579e1b03955ee2caeb889a8b470a969c6e8a2cfe57a33bcaafcbb02e5166347916b3dacb3ff43f348e57e1bef9351c17213ef7499b11d2a8e50d1dcff53268fab218fb8b9c4d2cbb8579cf5641a54020c9ed9e58b3ff55c1cd9cc4da8e8aa2b234e6d5df538b2de5431c32fb6c177bf5f3f85ef0031005e24e14701ebd5e1fd9e76861bcff3cd2b80c3c7ed25d07ce8d74f0b049a064705ff366d17625d1dc0619f430ef375ed587d42d4ac0e936cae6920cc637756d0272df2709f1964868446eec86e946815ee132c458ac0344a425375ac68b793f5b60a8428f0421b87e4a4e55c44e4df67a2e8c6ace566b524470f6ce44f29df8891dc5de19c43d65f82336eb8200b86750952f5e39af5de6fbc8543bca005ff6e77ab6f64252038edb272d892508ccb761843be09b3b8d90b7487bedb92550c6d12b0e1289275452643ef99614b19faa0c54437f171fc12586d13395aaac9cb556d4daba90468c2955d143a8d294b0944c47a46b56b89dadfa05f355e008a768c2546c7f0e33be9980e1428e36c0c856199dab9c2739fe912f468baff12db809cfbe50e4029eb4e17e7cb3ffa1ef6d1aba9b472613c362efd7ba63306dec48f44423b7f15ee2658b2f51dd410ded6251ed9892b98a3a6bc36fe2023f538aba18548a17b812f22183837b830ba5ad6f4516fd091ba9c387eebd00377eaf1df5633b4c6e572f1a859d0b56d077b159629b5dce2d9c26ff185d3426f0c2759a27ad2fca6436992b823839a22ae6a1891f243e72abec715af0af733ddb8408c134117d64e3b2c7e417df9d5cb5158d91cc6994cee7ce048b41b4623169235e29bdce3d2d775a745da5698467bbe646aed844fc0490cf13a8e144525a949ddb06fffbf86d0135f37ce9e6654ff2ed02eae6652d9f6393a38b1dd815203c9d65f5aa238adb89ce6a378d0be9d9c0eb87fb540e5a23a7bc790e725a4cb1705c5b71cd11e2c21a39b929ead9372f200e8a44c38174cbb4e9f3de0b25b714aa085890f334e24fead287804b0ecbb1202ea1052311f5a30a0a282332435f2c8e9188dfbe3b35ffd1d39daeb3849f5077ee31093e3e69e788f5ec615968a42b4ebc27ef9ba81f6aad18792ca043bcafa5dcf7413aa5397373e3910982e83bc40a574c932ccff521e9f208e950bc103d2677628205977ebc0fdfddebc1025f3266669913157ecfa70439682904df36f651112285a4960a001ccacbca9c2f9e0b048cb515af8a8b12a7024666c0100ff457b09d4e5ca50921c24ddf27ef5bca9989c08ba146c06f77bd91f63d6b44fb77101e3301e42038e2a9bd5bff636a22faad6de75fbaacef183331534d61bcc5827ef0ffc13f08057a3c3d99beb946aa8ccf8b661d16f28cc9cd9d0465d00caf55850f9ea721d2396c7678a298869802ce96d24e14d534ac0d29d03d70d4c2b65bb80c9715fa02646e2f2a41c9eddbfde55c0146f552fcdce0eaa47bf1a3737ee20095256a6498bb50091ca1774a39cc5887069a346b2c6d25395cf07ac2de53027db764cddd41ea4e607cc67d0623d730cbf79e47a3d880d74c878a7e157bc90498f4dd4a8dd578e8288a9bdfbf75079c952e9cd1cbc7083c8714a4ccf8aa87bd202cedd66aecc6e1768074b09797aafa09b801b3216d13299da908e2b9e76a943ac9d893766298a140d128beef78d077fe973e736a4b89dc9df434a591916674f25f7156bce775a5dd3f9fdf77efd6ac59bdd6eb540cafef4ef011a4eb2933465b21eeef8affed5e7a308a670155750c21c824eadb287b90e8fe7bcca8bdd50a324f3a7cf922ae53144167c645cb77259e00ccd8dfe69c68e76d0b437019da1997533ce6c93916d2d2d0acacaf295da3bf5d4f93aa4eee07367617cb19dce82cd8b1fbef60e5bc95fed7fb1ac02b9540d91941e1a663f014c07902eacfe94a9d11b9d4ac8d7e9fa269e5cb43d4dc31672249b0f5e2d7867213527075c21df3a69732615e9e797c8a11b1ef1875cce770094b8a9bc3daa58ab03bda624ea0d1dbb9d02ab0848be47f005f0d4a7c86c71aff69953d6af5e63c23e390c3dc61666c1f6fa2644f58cba07d70b0844485d5ca847843780497389c01d4d882e235368dad945ad4705ad14642756c7c1bbe30292bcc417a56283eaf47e1abf752d6d913692b8241e8d6a9b992277e0efcfe7dbb49144c6a184ee13be8128e961f71859533b8c5941e6d19e29f73154918684f428171b78330b7337e194fbb504660999e53bfc3124a71f5c9494c1b0ea9ede867f9fb87cef135795dad1dac116c28a6742eb64cf9de27a07f9864977ee9aa579f175299bba9837dcab6d2eb7918dc68d243128f19890d2697c92ddabd78980b32a11867a08bc8510dbdc8c5682b8d37436fc3401b2c712ea15b23e35c3a26e33d9f7ae73b7e81d61c1a486524a4ebd7c97200f15f8d4d12694ad209b8d5489fcfebc632871a7b0b3147ff0eabdad941ae9c7f4a3223182d57e8dd3510f0e430ec662655e32092c126ac284102a2397968f66436463e55205485bca96dae57da6230a60865c391e49d2b527e7b1508f3752302a6dbb9e3604d67cc8d9d1b71117d0e3cc0eea998f50f61cbd42522e08a63daacfaedeb7b0ba56b984c0184a9bae7b5adc588caa830d5a693a699f62f0017d0fb404d8e656e0b378700d3a2f43c2b25efb73457bd2de729a17653e580a9e3ae5e7f5b09fefe65c3fb3838e53245045876d32f8b4e0ba438b56db5c8cfc2e866dcf90b81825413dd945d0c6e7ba67352afa4e225f852c6bca9796649caa64e72a53903b0b3645672c38eb3c7a4d84f2bf805b6500098610441df24ad3a3d60d0cc9a69b185c7e2572d9e402641a3a3cf03d23089874052a3c1702b5686bb931ccb974b7003568334ebea35dbe15b95eaa3e9a0346d56651c5199496b8977919753ffb0f836142003b1e1712a023f1de756f477747237158a01be15478c980c678197b36456efdc01192fbf1b88b46bedd92656a98a8ae008e3e795d627f44803f150ac135f08ad4d966af6c10b1782e2ce95b34d185777ab3df3572028889ca6d2f1bf6c63e26f6ddb2f207b3d59d2c2a5b537a4fcb2e206fda70cbadf8c7195c4652404ae6775d026a604e3e2021dc11a7cefd0c43cf0738e90ed311bb633a032e2d8aeaf88d30e78b0e1377e7422e66118df460de5e887b257db20b20eb9d0975e8254763e87046d3e6252cb20b0afdd2b0baacdba0474776473789efc65d32d3d0ec1945717079aea8de188569965151d57f724648bee71d0407c008e9ce3114646993fdb16245b131bd6d4d657686742ae64efdcbc8eb084518cb9460c1ad24188d3b17ad9996b56caa3cc0d6eb8e5417442405fa94a5f46e1af36edb365170a433c2d5c6daa39930b14e1c893919a057ce7c1bd28d5351a4ba44b195e3d1d022b2faf651b0d6d27dd1526db910c5ee66f7a0636c27116411875daa1b1ec2b009a6bcc1fc1087a8f257ccb1a30193d18b368ef099ea6811118e2304cd894ad741e2d411b18fb39f0dc0f1573922b76f2f3dfe2a1ada1d9f68fff6cb49baf4ce6073404a89710f5127a23a4bacbee24477799ce39e313423e32d4cbebdc8a800fa0226644794c586ea286a9e137d9990cb9e4515bc3b57ed80fdf3f21e3044847be0671f9e53e8f44c45bc667fc05c35d6c7c99aa70f08ea1839b50393c8a205fc4ddc30529d9df5243a4119c9dc57b656fbf7109dd7e56268c1245e89975acc4f180a6663ef51e586bc6220b08377d64440a4e21c3c2b26985a0f5a8aef251ccbb1f71e3f1fb25a3facc83dcdeb9d0f9144a6ac12a4d7657cf04e933420239d1729f284e2c1b3783cf08cce2a9391292f03c8f1af295b72f0be0c8642e4a37c1f81ccb32b2cd1ef210546af165f47e28b01e616a1b33cbb6ac16e8bd06d4e8a41a14b238ff4ddc6e6c9cc4ac6b716616916af845b6b6e225ee2e751a542c0fa82da127f0796ba460c53069a1ce2a720f238e498d5ecc63d56014c7386d8ab4abd5fb6c02b1ba5df24962cf0b95cd6a99fcb42e2cf54a9ceef85355861010ee9442ad7ed30a7370c243d0e76fbb9"
         }

--- a/src/commonTest/resources/nonreg/v2/ShuttingDown_c321b947/data.json
+++ b/src/commonTest/resources/nonreg/v2/ShuttingDown_c321b947/data.json
@@ -1,212 +1,229 @@
 {
     "type": "fr.acinq.lightning.channel.ShuttingDown",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 300000000,
-                        "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 200000000,
-                        "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 300000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d0300000000002200200d94818c9b1a70b689daa5af63b6c6737ea40a9de55839819bf0421217d68d80400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990a0740400000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173e093040000000000220020c9b6634f8ea3a3789e96570513e9bc701395ea27477c07e80931a2ab9bbb549c0400483045022100fd4910f0944d529ec90d2d5f2587f28d7036fccdbff3dc215f8f418dea8bb3b20220723b0c27c7e719588b7375ffd76f8246074c8d126c77c829c03f18e66a12b498014830450221009faae1d00f87d980fd620db27a06a27cca8cc0b2269611124d0dab3a5c28076e02206dce7336d5c38377f54b6b92af7db4f38b43e12afa94301fce129b19e5892e690147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "24237f2dafcc072f634bc4ffc74b34157a827567ed32e8adc85bf72b54b9a07a:2",
-                                "txOut": {
-                                    "amount": 200000,
-                                    "publicKeyScript": "00200d94818c9b1a70b689daa5af63b6c6737ea40a9de55839819bf0421217d68d80"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a9148f93e0f27c3c23aca8fb53a150df1bc2fd6a69d788ac6851b27568"
-                            },
-                            "tx": "02000000017aa0b9542bf75bc8ade832ed6775827a15344bc7ffc44b632f07ccaf2d7f2324020000000001000000013e000300000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 1
-                        },
-                        "localSig": "c880a09b595628130f63f97406bc588dc11ac2b914c28c105cb5bf3c40007a2a7473756cabb4ac0a0e5b5c8d30ea91b87b6f1e0e1ac741df10c8863bf79f568f",
-                        "remoteSig": "226e43ad5f13f16b82eb841eb528756ea8a9ab4e12659c4992eaec016e67b81d74e32adb0e4c54ad1030e82d30e75c3ae4d4abec73ec9295fc24cf6301f00c33"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "24237f2dafcc072f634bc4ffc74b34157a827567ed32e8adc85bf72b54b9a07a:5",
-                                "txOut": {
-                                    "amount": 300000,
-                                    "publicKeyScript": "0020c9b6634f8ea3a3789e96570513e9bc701395ea27477c07e80931a2ab9bbb549c"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a9145108735b412dc599563a3cda98629158bd4c649188ac6851b27568"
-                            },
-                            "tx": "02000000017aa0b9542bf75bc8ade832ed6775827a15344bc7ffc44b632f07ccaf2d7f232405000000000100000001de860400000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "ae0a956ce019ca635f347205cc792036606d626b07620e329d84835a09fe24ce3d9996c28bef74f8ceea15e088103b2c096156e43c104cb7eaa60cd237b89f3b",
-                        "remoteSig": "cb127029d3c26886560adaee978ab3f8742b995dda61b6e84f2a7d1496485a23197239a180246f0a27ba6f10abc9ed1e92119991646073194d8f5b12ff747bb7"
-                    }
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 300000000,
-                        "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 200000000,
-                        "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 300000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "86441d0d05c27ecef1fd4bd850172890c8cee07eb0aedb272034eb36f93221be",
-            "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 2,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 2,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 300000000,
+                                "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 200000000,
+                                "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 300000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d0300000000002200200d94818c9b1a70b689daa5af63b6c6737ea40a9de55839819bf0421217d68d80400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990a0740400000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173e093040000000000220020c9b6634f8ea3a3789e96570513e9bc701395ea27477c07e80931a2ab9bbb549c0400483045022100fd4910f0944d529ec90d2d5f2587f28d7036fccdbff3dc215f8f418dea8bb3b20220723b0c27c7e719588b7375ffd76f8246074c8d126c77c829c03f18e66a12b498014830450221009faae1d00f87d980fd620db27a06a27cca8cc0b2269611124d0dab3a5c28076e02206dce7336d5c38377f54b6b92af7db4f38b43e12afa94301fce129b19e5892e690147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "24237f2dafcc072f634bc4ffc74b34157a827567ed32e8adc85bf72b54b9a07a:2",
+                                        "txOut": {
+                                            "amount": 200000,
+                                            "publicKeyScript": "00200d94818c9b1a70b689daa5af63b6c6737ea40a9de55839819bf0421217d68d80"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a9148f93e0f27c3c23aca8fb53a150df1bc2fd6a69d788ac6851b27568"
+                                    },
+                                    "tx": "02000000017aa0b9542bf75bc8ade832ed6775827a15344bc7ffc44b632f07ccaf2d7f2324020000000001000000013e000300000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 1
+                                },
+                                "localSig": "c880a09b595628130f63f97406bc588dc11ac2b914c28c105cb5bf3c40007a2a7473756cabb4ac0a0e5b5c8d30ea91b87b6f1e0e1ac741df10c8863bf79f568f",
+                                "remoteSig": "226e43ad5f13f16b82eb841eb528756ea8a9ab4e12659c4992eaec016e67b81d74e32adb0e4c54ad1030e82d30e75c3ae4d4abec73ec9295fc24cf6301f00c33"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "24237f2dafcc072f634bc4ffc74b34157a827567ed32e8adc85bf72b54b9a07a:5",
+                                        "txOut": {
+                                            "amount": 300000,
+                                            "publicKeyScript": "0020c9b6634f8ea3a3789e96570513e9bc701395ea27477c07e80931a2ab9bbb549c"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a9145108735b412dc599563a3cda98629158bd4c649188ac6851b27568"
+                                    },
+                                    "tx": "02000000017aa0b9542bf75bc8ade832ed6775827a15344bc7ffc44b632f07ccaf2d7f232405000000000100000001de860400000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "ae0a956ce019ca635f347205cc792036606d626b07620e329d84835a09fe24ce3d9996c28bef74f8ceea15e088103b2c096156e43c104cb7eaa60cd237b89f3b",
+                                "remoteSig": "cb127029d3c26886560adaee978ab3f8742b995dda61b6e84f2a7d1496485a23197239a180246f0a27ba6f10abc9ed1e92119991646073194d8f5b12ff747bb7"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 300000000,
+                                "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 200000000,
+                                "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 300000000
+                    },
+                    "txid": "86441d0d05c27ecef1fd4bd850172890c8cee07eb0aedb272034eb36f93221be",
+                    "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
             "0": "7df1b9cf-c6fa-4fe2-bcb3-ca42ee8a5d25",
             "1": "0be929fc-3824-48c2-8247-927bc54b2611"
@@ -215,16 +232,7 @@
             "left": null,
             "right": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "efbff61a8ce1624a44a273370dabef3744c5a740f2d42d643d17b01c8c13c22d2ee1a38bde2d57cc45f50101c4c38828585275ccdf87eb272674b855549c3d48be0e7d2b6bb086918c72eaf2fe3c801d86dc3e25a6b86c4a2c3904d6c7528db5d643d2afd583afe9ad466a5f192b126215229753a975763b8e074ff7856da46867fa80e35b8f8b92b3a1a34b0f7a4dbde0c60366fb531d0f2d50fdfd432d04b1f55c86ce4ee5c0a740a847c71d9159e2b0d5c33386291424d744704385fc6b6c4de7aef575cd65d17f5960fdfd845ff8ba33c49e7bea33d113d28c82d8befe4670a464da366c58ee4f57e64dc1c1644614b6e12c63c59f2f6c216341abdd6f5cdf8977bfb925f52eb897d646675ab74ef73c78d975b143ec6973bb2481f59ce93cc7d059da222fb41f5e7e6fca2565509ba4a3e87597a83f196b72ee1953c71c93d447e2285f4c86889edb77bb82a9223b5d52573b8f9b225da629a5e512a3b2f8e684d7cd9375fa39962261f6791e424865a7ff39823d69d9b75e7bdec047bc77a6bf55983b582666f3edfdfe5c8b89409abdafccdb9d2dd6786d9b1f5993159fa195a24355508cc05b8a6bd4619ad027071c9382e02f1bf465c9a654829c473febc3110e3bab8a5d97ff37ac7d1afb5097b32f86bbd995be219513f3eaf3f9740f8f8da12ae66ff76831397e84c969742ab10770d997916b6bf61dc8b5448cfa262934d02724fe11a0cffbceee11e346761fa376c3f180c9bfb515f8747a122ded534e352fa885e4e410b2cb712857a58ecce8c2a6208f9bcabae27a5ab74fd9165a94d17770a8ef8952ba7fbe1c672aba15dcf4495889e99704e038a510a640570411d49318a4f3cdf091a3b208c4eeb348ec321506f3e5769a7f428016f4d452c5a6839fb4aacb65535accbb8cc7b1be80c941d57125d192942fd6135abb4f2d3a38471e0553ad764ba1c2c6861210840af3aeec5b767b6608754007f6353252b52f836b86f58be05c6d18774bda6b77b6781bd1340e07d87ea2d39c73bce8f14aa5833e8d07d22dfe0d0bc80b140e6d4b88377d9c6175c8cade12a863370ec5549bf18caf637be6cc6a18ac4a237979f2741878bc32bb14fe12bc1f23c967d7c6bb58e775310540d836a6d64c3253b8c65a8e3166f4287186d351b883ada22edff2e94802c1dbbe96e59ca21fad15ab754edad008c86d11dec0531bc60c95ba808f1ec6b2ed6284a089dcd7d556acfba7cca45688fb2c80f482f7d200735be022212a65956cf9f1dec388859b90bd7238b66f10cc33423f6b91a13cfeea9a26353f9ec44b0ec3381c50cc9407b1365e2293c300262bca19b4a386533bc02b5ea97207827dfcb58eeabd88bdfe9a1faa7d215137e70ae1446f953898c12b183336368dfad068186e21b826f715d04bfbb5fef7a450e9c4a9bbbf0f80c36cb37217d78f6556037b48ef406f2885a6906a3495bd1ca6ecaab0591c67fd06d5b23b4e7c4b085032414c246e49a3974956fd35278a18fcff71d784c69b733c0f5b8927df627e91ab75334d6c6dfff84c04d7678b069d52567eb842672f78958bc5f825cb3a5dde7f9903ccc79ab30e0f8b29b86ea7e26cc6beb22397da2742806692ea6fb4ac7e6e11fc816d88dd7d7e37ac482a023c0db4d3c782944697e0e4d8ca053ac5c7aba29e592a9b094e331ad6a8f09ad455f4ed86c135c75db443eff081bb039bfbb9a2c79f93944f84cd74bb0ebace4145dcac8f34b1b5efcad6e832d2a243aedc79604f942599f3b8bce92547006acd3b7e597fd7e37bc3ba3105d2afeb92a72fe7042a873e2f3a24c151f498986311c76630f58a06b57dd18f4be04d5cef8bb71a59f2b1e82fc915bcde7dccf844bbd657a463686ed6690e072f794ece3a5d66eee2541f9cf68be5f1d5c60f67aad450f560c080bb43c2ba0cc36f0b5792e5e6ed143c38ad59e9216fa33dc9bbba208c7ddad20d2f572977c83126232043812ac2d45f92283461626343dc90aa02d9e61aeaea79ffe9b94fa2a6bd217cae098248423ca24c27dbcb9116f19ac9b8c79158f95ae631f7374ba2621f9c6588dfebf25b3b1c4593640d3edbc41d69764cf727f16c82cfed5916538a893f965385ac4ae32f3ec6f723217994beb68dd344e62e5f240d27973fdb668c7587b35b92511f024d552c2cb7588203bd2b5c9f51ebf2db7675e5f241bfb3959fdbe8ee5eb86106303f2069da20e28dbc48bedce9f42d4ef17b5f830604efebab73635c9b15edc329d5dc250f780c62b0532baf08bb0c1860ce7e3b07fd2d259d9e4dec7b7d64903c787147b9ca85cb13f1acb0189cd13b1f481dd139d2be646afc94db164554cc22262745ecb0c4ae59d8ba90da5b2aeac35277a5f9fc02fc9970ef7f630f0dd084dd32a8be25a94197441388285334ba5426f1eddd1dac35c17979ad0a8a5e50bd18aae24a0bf1c4d29d16c336c48dd7289564d0e85de3cdb7b055fdba2c09f181bf29d85e9fb7fd4f1ca503e35b297716f0a0606521c0aa934aae4a8259a00c45ce1332ff998c9ccc499c858a6c2db465c981370427bb595122a20d6a491b2888f85488a2ca5cdff32163c5d68300107462f0e094f3e55c31cc619f71562985c124bfb29de4ba8e7e1d845802be099bacad8748063c7df520591cae9f056723c3d8b47b07e014a679e81b51a6aff5a958baceeb9cbc97a20ceb52852ea7a0c80fdf6462d08c7dd1d9131648df378306cde261d42cf5f85b15d0c0a14ef5316d5d7fcc6f37761f810c2ee460c936dce16e3da7a60dc175766edcaa32720b123c698e46befd7fd1b2cb1779a220db6dec482c35841cd1a84cf6306a82bc26691ec50ebb314d1e05491222d88adb43a1ba48cf1bb46940ca4a025b8bb6f2219dedf99c414e489e7ff43faa159399c1aa5cb8910ec8ff35801bd9606a1d7e1a057e2d8380657a96e171b09fe51d1fb6eb7d8111b16cadd856ee5f829965b7acec5acc8500e64cd38713e2d23e4727fec677e47fe9dde3b4bc5afb147c482587423b33659b17fc80bb8a9a7770d31eb4d8f8c4c1ec49a37ea59e0572c94f3cc8f0535c8b29c06598a7d88923e281af37ba8e405c4ef3b3fb23134833270516ef9fa0cf7494a6d44587d6517db69cda4208f9709029999d6b3b4eef613abc6f9bd22c7901feb1601a2b069e0ffd48ea55c613253a6ada53d0549cdf42051d89fdc108c7825742a08a0d940cd78d8266d39e00d2ecfff35a227ddbdeb657f0fb3c401510a6ed313778eeec99b43e2ce70f39e581c171fcb6c76758f3b28ee43d39dff5f7fb31111921d909455ed07c3038c5002cfae21f9629135d1449d69b094b4097e889f5639d9a912f03ef8d04632b2e4ccdb4cac9c56851f4f1058919ac8062d9114a3fdb893f1a023209eef1141af7fb1aa2f469e639ceea1e9230d98796da426ddf2eb91d893bd4f47e251869a7a345cd8be2350db12edfed4a8252bda54906a631c7828f8af0611100dd29458c02e5a491dbbff319b8814e7e39a9fdf36d3933aa01e249ab0162136ddd8f7c584b9be7445d1e9690db06e59446aa5469c6abad3ede543c871dbb3ef11f5a5bbefbb0794fb4929751520f0a62986636f79ab38c87f8f18fe5ed6df384dbe0fb37ec199eb80b4ae63e4117931a82ab41d3a46367fc5b5611087f956ac2cf0f573d69f484289d2134f4fa01d28a08ef1d5655756ad447eab3a7e2b60959b43ea82a894a2e70809bd9834059d2404cfc174dd3370a55234a7131b4a53f1de3d1726739e4cf266446bbadc380fb66ea6c3468fb2e6789ae6214e6cd90982c4fc2eb55bd501e3502b65410e252281944f9c62500e55da3440f985463aa9d0229b5280e9d09271e2fd142f0f4fd2ff9b736618055a1395e0418c0927f6376211b5b6426166bd6cda9109437cfcf81009562c7f2b2f766369d71ac72c3d1bebf4343b698a33d2bee82e6a465fc33f61a3e92ff3d6d3b22648f87df4208170142f1e734890215a991f8a6ad80e4ae1fff2e9b366c7958c39be8fe2cc25c8617135a5351e1f460d59f5242ac6bf6b775c5fd4a1cf3bc417a21af653e83dfda481a1fe4e4fc0b8ff227c32e7c26c791a19b01539f113f98517167fb7ad9e560dbd4044a62630b80948b80a18b28cc5bf57c2c9b0d256292dc5dc5111804537f08333e2058fcca3b9ea34f5a1a812cc778e632df90c4fb9c577e1b05ab2f5600ba09f36b34118cca8f3ac84188c55a7cd27081a67c94e7790066ad1fc7835cefcf571188733b4fbdbe697711eecbbea278479d72ca21fcd62e4024978ab5ecdacf5985f4e6959e7714c80a493a62a7626b913171257b4a7bfe57f826f4e40de4b01f251d830bcb62f200774bf0881f493ae1e73a412c29308e8d6bfafff5bfb925b3e7d4e7e20a1203e71da5cd5c6320943590cc3ec89ec53dae9605292fb57373aff3c805d058ac2b0c82f668f9d0137c717c00359949921cba3be8570511d9bb47265e547a6ab75e0f85aabca1c84483c75549751da39773419a089e488f95a9bc214741c59299a0b0226eac0fc34698c228675b107ab644a46fbdf7f96bb578a2458afc92f29ded5052105fd6a29c4a0889d7c9abcd09fb53e817e99961286347eba150becdd1c2e591c0885e2e756cb79e4d4acc1f855e215c0f2995b45cbda23dcc67270f9b4e0bf7bb49217ab0b2ac6589a936613c7828d6ac46f7858b4010b33a0625d6220fc8f3994d5cb39609a67c018b120fa0dbed73d2809688dc80976c24b9124281af8f9b1b4c51c1218dcbc3bd9a0b9e729b949562804b30b1e39a654d63daf00a51f02041bacba7a383d0b448e99472a5dcfc9a0736a8c635b6d6285452453a15a26dfbb18c2ceb7da40d33000e04a43471104fb52ab3ed374c2e5e3a603b9266fb32f55e2f7c388e56bbc82082dc2d132429144764031fefb24fe165c0572d3a4d8f30ed4ef9e14b3ed4ef3e12a66b7bd555955e07ba435dfe71de41eb7d656b2e7bc32ace12ffa8385b9b617c233ea4ab018f9d7f794ce070b01e94bc5ab1a511aafbe07bd2b95f8582c776643e2326a1f75ebf4f52d893219cdaeb33236c99b058278e34a0b8f78309af14f067eee7aa2e63a6c2adf0afc2f166b5b02ccf1f03db25b8f260dc26f3e9dac99096ce0864e5d13ad743c2a41209a8716445ac51205a99ea73c380321e636f37f47a97dc5e8ec58d7db1f54293eaab386e28726cf223efdae502cba2ecff73ab69a4d467133ad7ea0b22b0e6f4526c6da4759b82ceabd9c5e5c95949d7bd6badaa776c70dabda5ab64c6659bd21ee459a957a39f40108e4f9c0d19861b211f48003870a0f514d524d2599a4515290cc79deab43a71de4e263c2af4e88eb04325b5bba5f632bf15f735ca8d87effea35d4fee2630f282e30fce610200c759acf4bd8f92057d7266511631571d126bc325897f137ea5c0ea91d388511010380aaf89a0b2addf90408e83baa35f837daee3ac9d9196de28a367e59e33cadfcd6c2df85debdb40f1f41e163e6db85c8dd624de74cc94f8d304fd69b1f51d5117fa98834db5aa8a2458f8c2b7a44082e87a82a352d5811c93551cf0cbda8b356035dfd21408822095fec8b910aea02b1600c5c477700877aaec59303b8931de823a99e981ab0d25449c0bbd65ee388d6ff091fcfb192c0b1e8870463bffe7fbfca3c7621c809ec1167f3174ce34f41b2090e8eb945f9c48dc2b3e9600c638b32e98e6adc46f01bb8d0925e79c8403d6e517c6b704d54f64553fca562f232e8b018c048f7accf14a791a36e15ffd2463e215a7bb291f6a4f082d108cf2d12c488f43c35d1c13553949979e72a57881d7f693d748ab16d6b4a0ed03193e90493c59f5e4a2fafcaa6bb7fda644a17056a01e1e287ddf3de25e7a6a1c868672ec59963201669987d142348ac0c9837970395b3fe22476a192c8057bfc521c142d196d41e45e1a3a4a797ae68e15238b086100d50b5b9cea598f802dea865bed1eee8c5e5abc5da24372395deeaa9b980919c886f9fd5225a7aaa02999bd4a02a559243eb66cc1ab12c4a257e17ce1495151a5a2197a1a047d24f8d800043d6dcc99db1728808b5778783ba17b62aab3a0a872d090c414aba7c855086e9aba12f212c3e10007d041269a84701eeb9a4caa454d73bd43b19f71efc159bbd6a80f082ea5494a5d937cd6fdf05dae74231e630c838b80a1434dcc7e0f009a0eb84a9798aadb3fc73bcced1961994267ea349de055537847b72f316527da2dc2dcc79133cc5533aa8a533024804e3848ed3bbe652dec75ac43bd2345a0fd4adc0a9e3831506f6adb53b9acb4f925b9b37804ebbbc37ca7332295dc7f66829ad3fecde19452a1e569e2daf69b8801ca860c8da723b422adf2ca5efc07916783849c259216f2ee8c73669f76c26e979720b856381ded90ec404b99046632d35d00f8a0316226c7cfce5b005f907c05275f2aef478a0d0d2e03c5961c2f431268d118e86ba1f98d77575893d5ae5be7b793a8af1261bd1cda715861db80487c965d57d1766e6fb9f149b4f9c61e3610c01dfa1d9108a0a219bbb867049c6e45f83a57438656f5ba2b1cb61997858236d11c51ac7bc5ef324bd8fb0834ed045686b205e5a9f985bbe1a96f16e1d368b49e1868bfec950073d488010272938a766aac169bf0456bee6278b173e108a8f92329218b88562130b6e40c342c56c9a13c0a521faa25051bd1c172ae206c13340dd21eec67944afe3d700e5d304cb3cc470270ea13dc9439af82e5c9fd83d796301ebb3c00dc48fa7d4bbcf424d64ee0bf1e99ccac07620936b8f4e65468bc51534802e9d2834bbbf90a011339bdb54a52927468b8d166c85f6296040859df2fadba6a0a4f2f18d27db98efed66c2bbb764ebc9306afc3fb4ab20bc65389f04a64b6610520d329e58badaa25f7a6475624450af5858cefa9c8ff61845e3b6a7d3d44ceba47c882a5e06bd230cb98a192e92a78bd47e2442be74727b6514a7ad2140a94069b463fd6f6ce39e03b691a23f6b84f5351ea0a0a160fe59236718c82825c1d077d23f084b22e4fba6ba5f1a54f19d5d206102678a93637085857009d35c423f4c328efbf77a7a95050b5e4383621d75b4c84a67ddb6df01f53dfd2e06827b76b4de0144f265270dee16f7cdb2633354feae7256362fae4b9357023ea4b9d163a6852d4f09adcebaa17b6b2595bfe4567cc9bfc2d070ce388337af87a37676389b85ff6815349f0d046ce79988b0fefce1b6e23ef3a729d7ee1624892aeaa70f52b67e1053e91fd0a40d314d47143551a14e1c034906fed2b7af0ce05e61e2cd4221468847edf4ee473511495875d551093f9ecb53e4dda439d8f1d63af925282fe71480564fd0a85c695c67b6b8344de310b0619301023c825ec0a151f5d4b6df427e62e41930b602db488836b08f4b1148658bd81d87a55aa349a9c05e35202306cd393f6e4222b23a2afdc0718753f3423afd5874e3e4bcf7f3f5a56c956cd62ebe8a877a583648115f819f70afc4ce885ba44d7731441407a0e8d8a43fb1324e89fa4e19f2b5ee776a6b0472132db1b39b585d2de6d93dafe9ff02e5e6685a77fe433d4897b633413e94e15fcffb6718136f7c132fa6df37075570bd04be1ba159a0b075efe860fb47bc43bc8da8089c37a50b52637ae2adb270c2242cca82f3cac8fea2fae9363b6f969cfbaf088361e27c6d9b2bfc2538f74b7a28a8391c68296e38be2d4b4173e9eeffd8d6157987a46aec7e7c6395dccde74f6850ab247158a623ecb27c38443463a3ab374357e94736b7ac9f0ae83248cb1d77a2472f1550a6ab093f400eb4f39ca2f467f0cc88e8e0ee6a39c55c6396320c2af43485835f8b015ba47af5b101742d66c0198e364d7546626f7dbf08b594bae52ba5748950b6a8b9fd168915c92116fe896c7d88e6931cc93cc4078266598644d564e547f2d668dc71be1056e51391eb0e59a65389db4b0ad83288cc22ec68cc166510d1d495191eff11fbc8d69a60764fa1d62b0b900c4779d09c5096414f9457bbdc5fb2004766aea576e374b33b259581c6adc68f4393d46d53fef3882841790cf75b40241d20823c8bdb6c3501d66a1aff1fc906be0aa8106241c023ca4738b66390852e16bee9e041bdfa1dc5de8b21c113e82278abe9a86158f9523c1a840507d50aa79bee2a3eded7f78782b2981e835caaf396122fad8466b27320acae5f8d0c8ee73c2a990d0f7dfc00d6e85c154a1c26543276ec271b72eb95375fee11955642a584c94546975c8c258214715b131b28d0718dbd53ad72e1e03ada412fe1e5ede62060dc223fb6368d1f5856ede5d6f2f74470b14cb5bba51dfb711a9687314c795808e84eab928527da5bda701e3f14faa451df38400a0e322ea6f155efc05b1c5b8af190efe5c82924967fbd0bef054e77a9a97fa463b71277ab54c135cb06d4712a2426d390adc6336ae3a4e6d2068c44bd6d919059cd011f9d36adab4caafb08416795c38c2a8c34a4631bfdf218e57b6740a6acbc8a8a3b081dab4a44e748fbec1787ec451ce53d13cde20e389c2d2c06470bd786f436d693efa320f9d4166d01615597657b3eaaf8ae932b1125f9abdb0025f442bd553a4afdd9e0cc018157361adb9b49f739dccc0598bc63fb6ab7d0bc01ce1b9d8707aa45b48ccb11730165c4d7839fd95215f38985a1c969b64e990c8309a5e963406923ac92b6ae092eabb5ffba671d3229882fc03e12deac82d0f16b2f1d259ffa628a21556898ec578e8e26152a4cae4a9ff07dc3fa49435990329dbb131e942b77ab3acb5a0ed8de88b742c854441b2deeced59dc6827ff8eb7510b16d9375a54ac75d58f364dde4bd8aa596b0bc4caff53f94b6fb2295371ef7782205f38f897437a8dcdbc015ab5d1cfa2917d7f412d506c9803a2c40416d1b8338f3cb7254f4a379bb7fde18066f677cb8961015f4d452af876ecc211c272da4a7088396106d8769caa5adef56bdc117295505324afb803f49a8fbbf5e7e30a900270e11d2f93102ced92fe18b711416c9d5a17401e36fc5e6e059b21d8de123c5d9bbaeaf59495eb665b30a98f90d5ff43c51913e8896fd7262f89d5e40029cbca4c73a52a795e1a12f684c88ca96b73daf355da8a622e4bfa39ab12368feff9a1536a2bd380039c5f3b38f5b3d69c07535b872fd056fe83d0a90ac3aa4ebb99570583a652442e5b42b09374ffae9287dccb55dffd48397d5dfe0b1a94ba8751243fbf3a03c50ea5010b641ce6d2897f77f506f050f88d0f1e1dc96b81a578677cc2c7ccd7eae1afc3e28ff5d6ffa60020451701caef692ef4d1ba5a4d80fe99bcedfa490c92c5b6c8d0ba2553ef1ce3118bbeb3908ce42871bfc2fc71051ce2ae878b0a05bb42c95268808a2dc5755e4161e429ac36e09c5c2805a4dccfab353a0d3e3b8206381a8d2201429a77b17aec506f4d778c7ca055862820af054f17780b3ad60c778f0dbdae22a9d76bd264e7aee9ce38d2ab00b29fcab4590acb843aaab249807fef5b83b7a7014048b915695cf00af8c4d770b3ead87514293804c463ccca63fb6bded300e10a95a159bd4c01003c0c4ebb7102c1d7eef139729c2827da4b60cca622ba7d78808f5df5148a6b87a240bec20630272691e18e708cd402a16402520b6a1a765732a01db8278c5b47f68fb2ae96ccd3e3d3dac1102c1fd944c6a7f8d0f3d9ae64f7c8f479ce0c1d55aac30080ce835d0d1b477fbf0b439a898befc0b5a13c10e80f449fd1314bb83771593a4744399aa961293336b8108918a74bc466960455408e66292499b9e40a24735a50f86eb90a6505c7408da63f94fe4e2cd8ffb896947300342244235fc49d30ece993a6de06bc88e84acc6d021ae746edd68df29b250bde1205bf3eb173454f31e0cfdf78db6478f2e5074e5626315ef909a13e1f6b8f95260da1e57c98c2daf3e695990cd52238cdf2d1ed0264e2eeebe6372b4eb3c87a92631747a37e87c69a5bc643a5fc60a543324417e577cf8d7847aaf8e4d3d951f97bbeb97cd005930cbcb74f893ca282ec61ed0737b3bb9608f6a2784237a563a34432113eb9de5cb88f061f240e7f67453a50f66e8dfefe7d981e67546b5df00b423b9606b7e1a832a9f2d4f2653bbe05a3f4d79b1ed4f71c5a7036127e733c48888fa747d2467bf18115ea078bbb134ce2a4ecb891ebfb07c37676c01577c234b67c0726322057056750b0c6b712a8172088bababefa810569add845ffe99d45fe375a214affa994db9514059a01b046e1a38b2bdde56fc1943e1aa60d7f7337adf55541a6582eec2b00265a4472b1f2e5ba3694ff357f5f9973c276e0c427fa816654b181a3abb3569c0bfce6d97f8aec83de0c41f6e1497adf8419f80fe9fc4b2c2f4f30f77ebb86fdae9ec05d41129be8db80388e200450727d9c5b150f18338826f5bcfdafc5fe3f313c6276f494bb39b0b7a6ce473097b948120695d127579f37b222ad4d318d161e0f3b29ce84638cd9f439cf1abc1b06b9214a86ce2a000b3e38f2abe7c4105cd68b50b33dc2a0fccd37eb40f1098a8dff86edf4353b53fc368ab670d54ff909961242fa9cbba7a976d7f8e0a3ce886800b896819aca98f50d6cc94f73cf9999c9ec6b61a92bf16e6c77f1b0dfa3cf6a85222f4262e33032e842b2f1377d74f7b09010fa0009bb11f705e1674d83f6a9df8210a2a7245727f1d112301c77d1656a7c0b97f9d1495dca1da73c48ed400c6261fda02cfe1db9659d0183b418198a6d8b17135611d34362fac2527315479f6495906b013b8b28d1b8fbb4cb4077f8a25bb379219e34ab551fe7ccbc407be82090dfa61300bab698c8e8bca888e489438304274e8646570fc866dcb2a2fe86b3e4304ece8f18fab58eb86507a0874dbf9a1181540ff91470e690634f537659d32f6f96d2f17608eeeb8c34f56cf7467b95322b3e6c571ff036c1802fb55ab9b054800d08d502377cfe1d4e546a2ae60b7d44656b5c1ea225417b733cf53f14aa83b3498abb6c45aea86a9e59bfa1260f085a424e1d3e39cefe034b18439278bee9c1436812605463108d99282381ada76ebe76425808a364946c1d959e1605f8d7e924854ef05e5dd77513f47b24bb192566365fb2e1b7a1e3f28c0cb0c30726aa296d722aedeb1752e81503756d4988434100dd7c46bf7651ff9fef9d8412dba285500c652eedfb4a168c38a403170be48dfa498bfc1f66e467dc69fc90f7ad896120981e8eafd38187bbd84d46e62836998baee57bb4cd82d95455871b23ed6ab3b792806eaa0083adccc9e5736bd47b85a766e4f2f9574b77758fec1f053ef5d9b603ad4ffa2c3c40a9764553c5db9ab29636f482875bcbbd423d39060e9a3376a4d24b47f91a83c240f919ef53a09e072fd6558d74490c56116df1ac26c2b197da9eb3260a7b182daa77474c050a2b0d7abe2334a258a9f6f0e559f1ad135f777b9cde5cda5bb953c285aa76c04d1fde1b27b8bfc17fa25fa6fe8587eb0f1e9bc8f815fb2f85acb841544a678ba49582152f1c4af1032a319679280d3e17ad743c08a952ba92c4fdce1c484239272cb0421e34df73bebcc864e38c74aa7cffa786d3275f17b006bb91a4d39f5c2901cf6cbcccf1f7b4878b77ffc24dd3c27d4faed7265c68aa95947e7f0a10178a06833363ae54639ccc797073d757032d704718f5a498a748673befdb9a33621eb37e99c6d142889b01aeb2b0c117af960909789036b04a01a957304fe0be5488e71b6f37918940d85519a901b40719aac88a9b405d90ef5f027ad478fe21a28624636963b38d72b36550f54761ba0bae137a118bce4593000aabff2d288ff08b8032c76ac8b63def8197fa9a75bec93d8d19694903b47cd79286e375dcc6421bc4da56f20052f470f685dac895af8ea05d35c53346afb199c15e1d2dea52c9785814e24d21c8dba9366ee6eff0138cc35c3530433a71e20ce71a7748ae0186e4d18e405a1e6555b6623665b4fe7d1c38f0f3d2e80a10072f7aedb96d49e686ac58d699842784ee185bb0f96f085da7b764d72485203711409ac7479c00718bed7c08d1eb4054a0ed6d0e3c28a14985cea98b66af3208c7c4b483756e4ccab186c6bedcf7b2e1924458944a0a658b24c4f9ee8710b7af726728ef9e53d5fd7ce535571d75686d25b750e61b115d57cf8e86524816caff558cd62a918521a0dd7f98d13069ad8751ff418e88fdad06f99999c9fdc171df667dfaaf5b6e17bec7cbb4106ed40e96240c39a6c90737f277704e73a8b951234cb1392db1fb551da8e711b93da62a1ae3431dc0a40996c79c4827dd05ce5643fc30a8bb517d6b61fdcd67dd6c0fd52a712915c166c138e71c9fab65ad35e72f4f533278d5aae11f0a94542e63d386dae83db2e7a41cb271205a9b39413650b2f00cf5e8eb198ac961d0b989f2e603fa53a6c9b3294c190a78ee6b7944d7d08f58ab954cf4f4168ed14895d274be5a3507930b38470c661f557310007f7de8d875624bdabe83c7f5d0b22036b1abcbe8b2429a9db97a3d2fd9d13d9fc7741996ecfc0b8f733d830d12b8411ab2d52d0b5aa9650e15cab4b2572ace0c1a9299087cb99abb6342c102ae2e48e5a104a5582cea7d34665893769c8d0543c2d66585b8c5def9792c5309a22917bae1f49ffb58a27c84c3775b8fda3fe40ba763ea96bfa49afae918607b9c46813d369f328dfba3c679090cfaacf0df547f00b1d30524cce32c34f574b092f6d44f1ab107de9bddd3ef8988b6b9d813ea4004d894d82ec05d59dd6c05f7b63b86a82dce911aa18b9c6b01d56a596bd83d1f22899be1fa22bfeb6ac98b86d6ea7ee5603203d158b3288f732bfd899456aa821b54234bd6af8086c9787d2ba7c49e45a90b461348595e9a54ace1602a34b87b5b00da2b1730fcc5a1b36274da196242be0c32d3bcba94a18661b2d191f42f4034d3f1495cead7f40f9b14d4b7ec6a62087ad1bef83d54bb22bd889c96da383624da870bb1b7b09de1370b2eed0d4848f1856f64df9a844190bde0fd83b1f346f1457325030de529ae2b5e1878acc9c6bfe01cc7bf484d4b5148e32cab8f43dee253d6722ef89df26e0df397a6ba90e3fead6905c972d7a8a4df2edff4f10c383e23f0c2571cc8c731d2a07c6e13819984e87cfa1d326ff69ba57cd0297a66a501bf7d950a78a6f643472793c5029c660aed1b9bbf4188b1a6d80c4d31ea18351a8d9a274c75bea91a7ad7fcb55c51cdaa830c10c956f8a81d39f8004ad44b3fee4cad68cebeae8a333df4a6e2804c7c253664ad862ee7d1a3a0db886cebbc60245d92897b3829e6f04083d2c4e0133f6498c88f3a61255eff59113625b17c815ab4da1c28981334c093a8f8fab2932075cc5378a1b1d598f6aa71de43e18717bbbf8eb410732ba09c1b3c2982f727ed32e8439b7e6c2924142f030cba2b948fbe126b9f608d1fe855f7d4966cde6faa61dcc7859217b8fab06a63fa0ad39c354d733c454c1c6d14043bca5f5c32f63332b89afd5d63748117d58a9ea73d093a6bc1569dbe7bd5aa69fd5c94e90ecbbd2cb6cf08320cb3c28fdd7038e4db260ef0b605076ed1d63560dd153bc4b2d1781df002c8c7d47b5f11ce45b7671c5e5afe027401df68b2793e5fd0f1bb9a84c1b25b1a695d0a1d35b54e76c9878e3665b89f9a88c5f2b5cf2b65450c401bd7a173c0e6e8654e90bb75ecfd4ab578deb17bbf2995bafb92a5874f6b100020ef7b8d3ab5290268d3751798c4bd5a8bafb452c054df7a3cd248c5ff7cb79a767a566297ac88671843a78f13f306d7aeeff57c52267a5b43a614d97b0d8e4b51c546f17a6737bf0c5b89f59146d82a8ead21759412fb84e998e9f5acedfde5f9bac97c868288b9f2d2e2a5616f5739898d412cd80a72b8057e65fc53cbd7ce788bd183d798f0497d9792abb84efb5ff6683b9cc4cf39b3197c4cf351d25a76ebb4a7fe58d3ed0cb174b02b301ecfdc56897586cd174d1a986d9b0fdeb5cc6114353d16ca3a46277a4aa5e2fd52d79264801916efc88bc7eec2909b6031b50ed566dcfa3319a7cb079c5b0ba643be2ae24d46d9cffa65f6ff952bdff2ab99aa84247e8bdefcef6950cbd6e05d2bdb87c70f07480550eb001a496f552ee281a2238f713ea3c583c75bc8b69fc64788b9cd5bde5c8970eafec7999ed71c6b11956a34b91349b961a82a1fded7c55158ac3da0b68cc79021c0a9bb203100ba1b28196e05012c33458f064f7cb889cdc80f7d32cc3ebd7e3492db2b52b23771dbc6a9a3ae1644ee5f1e2ba058df6e91d72b19b5086a95c134aa2d7b1255fe7eb8722d38d5878381ddb26b2996f9cc07d2791ba9938f0166cc9693088aa6972c7c88cf6428fb1fe66371e39428638df9c618bda09db016cc559390fe14f993fb509370a97c01715bbdd7fa0815d0c9cbe86ecf4c6668326d0efbedf863d5af542982ae44c0f7e3eb9aa4756fc4246b75df570af4907835a8adf08f3dfad6da772477090bcfeb0085665e57f6ae8011cb75a63b180cd2bb1d106f82c6ec3bdd97fd6f62877e6c4e5562ccff0bbb371caac3bd865904de528abb1f6a20773a3a64b59ac26fc8383fa591140e8fb3b6c13026a5ee37f040b8cff299bc8ad40041b306ab7ddf289e309925ff75ceaa53aae79bf162080a6a842051f7f6863fe5617c7215ffdda1946152a401312f5373640d0331a44018b2165c098ca6291182ca6f397efb781591a8ef6be2128e3e4d52228541871734042571c8c8424a8ecae50c8b727672e0c25a8bbb48d827e525513321d66a14bbde4f66ab9ff7ebd23a9297ed2c7d9c47c4990691669db24fe8d863eab17bb6d4f1d5b44b3b9588e5c6a0fd870554872b634f0a03642b9c1699bbc0fd78c79ffe7b73c21efe501a62d957d79e0a03d893832bfd188444ccf6b322c2e1bf4ba89c31627a0e90703363d4d02364a78d7cbc7e110914ee302c01e03a206291bd8379ffc41dfda6127c377676f8cc5f1d47547934f20333563c7b0d4afe1b557a99036b42a2557843e2c3ad0752a5447c4b2a918d8a150e1cc8e4573a8c4110a288a77fc2529f7d6053e09d9360b73b607b3d2905f75ab8f49565072de7d12cf0e24405299e589f3d6ba402e3d16a23d40ef7461a881a1e790e4ab7638cd56f9049a92d72f3d8912ac24618c8ecbdecae4c8b133c1a518a265b79adacf654c126f98bdf23bfa5b0b0130ab9a24f70b80d70747e150ee1b58edc7de7e1c000dfdfa0dfe63df050543dce1f28e9ff397b4f60727ea65b511fa65b9ffc4a7b96fa0ae3130f6b4d0bb340555c21ab5c60eea34a75215bf9c8d071fe8639c36e1f2b9c0e9fa8f5b179d4d887a4e0a184459af0b057b4a1c5afa70f0c79c067f426d24352927832c14f606564030879087962459216ff5aed064c78879f76aea1de30af5a1d0de1142e168917f7a5c8e179ae0c415963604508042333cd037733c9984a170d4079fb1b76364ac42ad49ea0402c876b48aab7d8c410cc8271e4a1de945e5ce40704589adf565d1bd4a77eaf61700b4ebf69eaccdc00da81c8ce7c50c4b461f03c25422c80d8aec6d57037119f18e863744a2d3a02aa866ecd0e19ded38d02f3e626cda9ccab94f759cd8ddae7847d0a1d6dc5b8f4c9fe6afecc63ff2b4c4a18f4a09181ccd50a7b76f8ef5e706aa726dcad6703b22483af3d77bec186361e361ab5bd77aa6bfaf15eb1e547e642c0fd7da114a124eb5a86f4f3b02c52160e57fe2ca7e2d62a7174622aa12f1de33f719e7831d1f2f463f16b1d4a6f5489f613347b91686f09cc17a4d8f8a756e0a51bc5c4112f0d0aa44e3e233c61b75fa9dcf333477771cdf9d150fbbc8475e2f0f529aca49783ef90d5139cc61658f5798b860fa6875bb9ac3f634db387f814fa9064a475074d5d6b"
         }

--- a/src/commonTest/resources/nonreg/v2/ShuttingDown_f89ecd50/data.json
+++ b/src/commonTest/resources/nonreg/v2/ShuttingDown_f89ecd50/data.json
@@ -1,230 +1,218 @@
 {
     "type": "fr.acinq.lightning.channel.ShuttingDown",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 300000000,
-                        "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 200000000,
-                        "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 300000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-                    },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020c69b2c7f0223bcc7777e7029c6aae25110a0eb82c3a1ccc5daf47230d08a34d0400d030000000000220020cbfc18dfba5112418175b4d4683d6fb064a77a230e2190fd50344d3290d6d4b2a074040000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40ce09304000000000022002039c8ad7d16980a6cea19c49477e44f93844c2fac06d07dcd2ad37e27d4f75071040047304402205c2b83ac40b26a2a671114830a8a6cce3c2cd9eaea2fc92004689ee58eb70ef40220082ebc49b5f6a0355fa371516f8d633da496fde6cfe4ee440aa3e41b51905ff601483045022100fa8aa60f854006c44c33fa4a4a77edf207b936704806cbd56631114cf9018040022065b9d1ae8b03f2e8a5bc552ae3ad79ce008fbc95aee2672525e45e6dfd43674f0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "86441d0d05c27ecef1fd4bd850172890c8cee07eb0aedb272034eb36f93221be:3",
-                                "txOut": {
-                                    "amount": 200000,
-                                    "publicKeyScript": "0020cbfc18dfba5112418175b4d4683d6fb064a77a230e2190fd50344d3290d6d4b2"
-                                },
-                                "redeemScript": "76a914aef8f6925558b0a595971422e2bcca65b0116cef8763ac672102f846a96b1afc033efdaf605745a9ca6824d773b8d459f0d86e9a9ee5aacdd3557c8201208763a9148f93e0f27c3c23aca8fb53a150df1bc2fd6a69d788527c21032311a586e1653dd5e9b165302c08e9e3468bfbdd676f33775b8322c16e28616652ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "0200000001be2132f936eb342027dbaeb07ee0cec890281750d84bfdf1ce7ec2050d1d44860300000000010000000176ff020000000000220020c69b2c7f0223bcc7777e7029c6aae25110a0eb82c3a1ccc5daf47230d08a34d000000000",
-                            "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
-                            "htlcId": 1
-                        },
-                        "localSig": "3a48052a0a6d3f08cd7282532ab677841d58185b4841f7cb5ce2fa7f5fa9508e0ba1c6faab996456d1b42ad928baa8dd77ba8b96ee9f77188c56d9fd0cba46ff",
-                        "remoteSig": "276855a968c96fe4ffd255fec0061e69e72d1f311b41c95616425c36da118ff27f8664a70a0379e4dbe3c47a953c9a5b1535f90c8539a205664b7d64cb2bf928"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "86441d0d05c27ecef1fd4bd850172890c8cee07eb0aedb272034eb36f93221be:5",
-                                "txOut": {
-                                    "amount": 300000,
-                                    "publicKeyScript": "002039c8ad7d16980a6cea19c49477e44f93844c2fac06d07dcd2ad37e27d4f75071"
-                                },
-                                "redeemScript": "76a914aef8f6925558b0a595971422e2bcca65b0116cef8763ac672102f846a96b1afc033efdaf605745a9ca6824d773b8d459f0d86e9a9ee5aacdd3557c8201208763a9145108735b412dc599563a3cda98629158bd4c649188527c21032311a586e1653dd5e9b165302c08e9e3468bfbdd676f33775b8322c16e28616652ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "0200000001be2132f936eb342027dbaeb07ee0cec890281750d84bfdf1ce7ec2050d1d4486050000000001000000011686040000000000220020c69b2c7f0223bcc7777e7029c6aae25110a0eb82c3a1ccc5daf47230d08a34d000000000",
-                            "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
-                            "htlcId": 0
-                        },
-                        "localSig": "c8e46340d683b21b765bc27db5c3fffa3742d6f131a22a9d131781e13d218d7932b4c3c79b4a30a2e5b6079e0e8ead81bb5528eb4ee2c7c502cae01f789bf552",
-                        "remoteSig": "0d0a30d748b1953bcd6c1c4a24d681089de79146cdc098578ffd4cca4ae92fd94c0c3e2c72c9619f2dec8d9a4a8fa91d7546c3095e20d9a1329e0d74bff533f4"
-                    }
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 300000000,
-                        "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 200000000,
-                        "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 300000000,
-                "toRemote": 200000000
-            },
-            "txid": "24237f2dafcc072f634bc4ffc74b34157a827567ed32e8adc85bf72b54b9a07a",
-            "remotePerCommitmentPoint": "0234ea3e3929ca115acc645d07c40eada7a98d86017614c3fa466d7e19760917e4"
-        },
-        "localChanges": {
-            "proposed": [
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
             ],
-            "signed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 0,
-                    "paymentPreimage": "2afc28d3ad7a8a83426769f6765edbcd9e320335a2e4200df95f54f22472fe3d"
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional"
+                    },
+                    "unknown": [
+                    ]
                 }
-            ],
-            "acked": [
-            ]
+            },
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                    {
+                        "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "id": 0,
+                        "paymentPreimage": "2afc28d3ad7a8a83426769f6765edbcd9e320335a2e4200df95f54f22472fe3d"
+                    }
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 2
         },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 2,
-        "payments": {
-        },
-        "remoteNextCommitInfo": {
-            "left": {
-                "nextRemoteCommit": {
-                    "index": 2,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 300000000,
+                                "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 200000000,
+                                "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 300000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020c69b2c7f0223bcc7777e7029c6aae25110a0eb82c3a1ccc5daf47230d08a34d0400d030000000000220020cbfc18dfba5112418175b4d4683d6fb064a77a230e2190fd50344d3290d6d4b2a074040000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40ce09304000000000022002039c8ad7d16980a6cea19c49477e44f93844c2fac06d07dcd2ad37e27d4f75071040047304402205c2b83ac40b26a2a671114830a8a6cce3c2cd9eaea2fc92004689ee58eb70ef40220082ebc49b5f6a0355fa371516f8d633da496fde6cfe4ee440aa3e41b51905ff601483045022100fa8aa60f854006c44c33fa4a4a77edf207b936704806cbd56631114cf9018040022065b9d1ae8b03f2e8a5bc552ae3ad79ce008fbc95aee2672525e45e6dfd43674f0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "86441d0d05c27ecef1fd4bd850172890c8cee07eb0aedb272034eb36f93221be:3",
+                                        "txOut": {
+                                            "amount": 200000,
+                                            "publicKeyScript": "0020cbfc18dfba5112418175b4d4683d6fb064a77a230e2190fd50344d3290d6d4b2"
+                                        },
+                                        "redeemScript": "76a914aef8f6925558b0a595971422e2bcca65b0116cef8763ac672102f846a96b1afc033efdaf605745a9ca6824d773b8d459f0d86e9a9ee5aacdd3557c8201208763a9148f93e0f27c3c23aca8fb53a150df1bc2fd6a69d788527c21032311a586e1653dd5e9b165302c08e9e3468bfbdd676f33775b8322c16e28616652ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "0200000001be2132f936eb342027dbaeb07ee0cec890281750d84bfdf1ce7ec2050d1d44860300000000010000000176ff020000000000220020c69b2c7f0223bcc7777e7029c6aae25110a0eb82c3a1ccc5daf47230d08a34d000000000",
+                                    "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
+                                    "htlcId": 1
+                                },
+                                "localSig": "3a48052a0a6d3f08cd7282532ab677841d58185b4841f7cb5ce2fa7f5fa9508e0ba1c6faab996456d1b42ad928baa8dd77ba8b96ee9f77188c56d9fd0cba46ff",
+                                "remoteSig": "276855a968c96fe4ffd255fec0061e69e72d1f311b41c95616425c36da118ff27f8664a70a0379e4dbe3c47a953c9a5b1535f90c8539a205664b7d64cb2bf928"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "86441d0d05c27ecef1fd4bd850172890c8cee07eb0aedb272034eb36f93221be:5",
+                                        "txOut": {
+                                            "amount": 300000,
+                                            "publicKeyScript": "002039c8ad7d16980a6cea19c49477e44f93844c2fac06d07dcd2ad37e27d4f75071"
+                                        },
+                                        "redeemScript": "76a914aef8f6925558b0a595971422e2bcca65b0116cef8763ac672102f846a96b1afc033efdaf605745a9ca6824d773b8d459f0d86e9a9ee5aacdd3557c8201208763a9145108735b412dc599563a3cda98629158bd4c649188527c21032311a586e1653dd5e9b165302c08e9e3468bfbdd676f33775b8322c16e28616652ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "0200000001be2132f936eb342027dbaeb07ee0cec890281750d84bfdf1ce7ec2050d1d4486050000000001000000011686040000000000220020c69b2c7f0223bcc7777e7029c6aae25110a0eb82c3a1ccc5daf47230d08a34d000000000",
+                                    "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
+                                    "htlcId": 0
+                                },
+                                "localSig": "c8e46340d683b21b765bc27db5c3fffa3742d6f131a22a9d131781e13d218d7932b4c3c79b4a30a2e5b6079e0e8ead81bb5528eb4ee2c7c502cae01f789bf552",
+                                "remoteSig": "0d0a30d748b1953bcd6c1c4a24d681089de79146cdc098578ffd4cca4ae92fd94c0c3e2c72c9619f2dec8d9a4a8fa91d7546c3095e20d9a1329e0d74bff533f4"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 1,
                     "spec": {
                         "htlcsIn": [
                         ],
                         "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 300000000,
+                                "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
                             {
                                 "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
                                 "id": 1,
@@ -236,32 +224,53 @@
                         ],
                         "feerate": 5000,
                         "toLocal": 300000000,
-                        "toRemote": 500000000
+                        "toRemote": 200000000
                     },
-                    "txid": "9cc11d9e60703e915ff4d2f7c4844685161e46042af4a0a42312f18abf8d0cdd",
-                    "remotePerCommitmentPoint": "03574dea18e57e2450dc92c992e7d6b8f966251f6e8d202bb737a4e28d45feb3c4"
+                    "txid": "24237f2dafcc072f634bc4ffc74b34157a827567ed32e8adc85bf72b54b9a07a",
+                    "remotePerCommitmentPoint": "0234ea3e3929ca115acc645d07c40eada7a98d86017614c3fa466d7e19760917e4"
                 },
-                "sent": {
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "signature": "76471ff891395937899d320fe60649024ff8a3fc5c849da066c246f8f5011c46775610a8b9483c8b8cc0e542326265590c56a3496245bbdc37724ba9c516f449",
-                    "htlcSignatures": [
-                        "c81afe7a07d66af6c99b38151f167f74672b15434282b46c625396f99fdde972667386e57cb1c4d1d473e098cb2fdefbab4497cf845d02c6e9da8de7f287e24b"
-                    ]
-                },
+                "nextRemoteCommit": {
+                    "sig": {
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "signature": "76471ff891395937899d320fe60649024ff8a3fc5c849da066c246f8f5011c46775610a8b9483c8b8cc0e542326265590c56a3496245bbdc37724ba9c516f449",
+                        "htlcSignatures": [
+                            "c81afe7a07d66af6c99b38151f167f74672b15434282b46c625396f99fdde972667386e57cb1c4d1d473e098cb2fdefbab4497cf845d02c6e9da8de7f287e24b"
+                        ]
+                    },
+                    "commit": {
+                        "index": 2,
+                        "spec": {
+                            "htlcsIn": [
+                            ],
+                            "htlcsOut": [
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 1,
+                                    "amountMsat": 200000000,
+                                    "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                }
+                            ],
+                            "feerate": 5000,
+                            "toLocal": 300000000,
+                            "toRemote": 500000000
+                        },
+                        "txid": "9cc11d9e60703e915ff4d2f7c4844685161e46042af4a0a42312f18abf8d0cdd",
+                        "remotePerCommitmentPoint": "03574dea18e57e2450dc92c992e7d6b8f966251f6e8d202bb737a4e28d45feb3c4"
+                    }
+                }
+            }
+        ],
+        "payments": {
+        },
+        "remoteNextCommitInfo": {
+            "left": {
                 "sentAfterLocalCommitIndex": 1
             },
             "right": null
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "localShutdown": {
         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",

--- a/src/commonTest/resources/nonreg/v2/WaitForFundingConfirmed_f7421b49/data.json
+++ b/src/commonTest/resources/nonreg/v2/WaitForFundingConfirmed_f7421b49/data.json
@@ -1,162 +1,170 @@
 {
     "type": "fr.acinq.lightning.channel.LegacyWaitForFundingConfirmed",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
-            "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
+                    "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "0322de78372f8cc69c1bb97cce09072d84a4daf9cc77715ee429fb5153f2a292f2"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "fundingTx": null,
     "waitingSinceBlock": 0,

--- a/src/commonTest/resources/nonreg/v2/WaitForFundingConfirmed_fe3c5978/data.json
+++ b/src/commonTest/resources/nonreg/v2/WaitForFundingConfirmed_fe3c5978/data.json
@@ -1,163 +1,171 @@
 {
     "type": "fr.acinq.lightning.channel.LegacyWaitForFundingConfirmed",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "zero_conf_channels": "Mandatory"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "zero_conf_channels": "Mandatory"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
-            "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
+                    "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "0354950a7fbbf53329f8a3f912cbc734d94134da30555ed28470ceab5daea6fba9"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "fundingTx": null,
     "waitingSinceBlock": 0,

--- a/src/commonTest/resources/nonreg/v2/WaitForFundingConfirmed_ff74dd33/data.json
+++ b/src/commonTest/resources/nonreg/v2/WaitForFundingConfirmed_ff74dd33/data.json
@@ -1,162 +1,170 @@
 {
     "type": "fr.acinq.lightning.channel.LegacyWaitForFundingConfirmed",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
-            "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
+                    "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "03bd8a174751163f38af0abc6c513d98f05d66080e67061cadf5e2b11b665579d9"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "2f7edc2aaf19044090c45b2fff7f644ccc3a8e46dfa833ffbbbec0053851644d3dc2178a3b9f9f1c97748d2819eabb3fc4bb1247292e313b0110f410ff68ed4ddc9a72b18eceed357436dff3a175cb7a5382fec74a47854cdde1f40413737b3bfd8a30ddf78e762b86622ee24d71e559b1db503b9c45225c787dcaebc78e0d0a203ed894c9d09211ee782603d1cb60a2b7a1d189028373676e687cf152472742defc9983ee1062d93724018d7b57ce2a0c87a8719a9c26d64d7b89255fd4e09c564b209dbf4234bd94fdee819216ce2688fb28c177b643b1ed1592a91612b03b75fc7628444f8f4b167e0621008feee70afe1424eff8f6fab0229efc4b2222b635d695d5b907ab1d775be189433dbd58a63deadb2efade687a06b6167c32aebe41b8166ec32ec8969f3d5b5bc560e5fbd9c4dac4453397373c1144dc51f8382a785bd71efe8e89fd727f7b8a0272623638c72e654e9c6a4327da3c9dfda6d54ffe3dd688efeaf49b38d0db45bb2104b27ae8fc150605856eb2fce77a17e55a302f2aca121b69380b7deef05d152fab0e846260a6c8acb7e296603b22cb912e10722b0e119802f220d900f26885f51fc244c1c2d699f18b8037c023ca95b31e12503040d15f889c0633cd501d527f28ba1c5a03738ab02e2dc25f48942e96006b8f3468225692d9726417453afee08a436de7470810a839025847a9d634d20adeeb444dbf410a451fad2fea468a585fe7c66f79da1371f1a29a0fd9da0efa2252f5e6befe9e6a9005fe04f03a05eb5fc083b213dbe249aafdd98f09b0ca71417749a373d07187a33d92530123ea05a459455873fdf0dc1179f8989cb5d85402755078705e7810a08a3c94332a9e9c0234f5a157164cf56642195c3255cf671d2ca12485b5828f4f7d31d2f23389565b40b8db54bec68c42a2d67a8d942f49ad563ec8ca6bd379920acfb21cd385f3589f8c0b2fd2b8d59d38cb026916d19a1302573abb7a1e5bb516445ebf75f5ed0a0d2d405189723d0c378082820e780929427604a1ee362e4734de3a056ee8b10a1bd2ee88b265256011f2a827b262be69396673060043d2551d8c7c4d8e4193f64373e4884c6ee221cbbca1a020d700468b579d416d931b504a6645e0368efea75a6e791f7e63ee86a69505fe829dcea4f4be3a50fb7ad812c62e0bf68e4233587a7bee34a354e9582b9b985d8dbda8eae1be3e1b2e35f31cdb8306d627e599490486f295b0e216377fd82c4500b8e2885385de2f021222a72d8481361c7fba8364d0b7bc62ea8d46748bf13ebbd91a2db97d7e17aaa621edb3b7a715c9d62c6a8a3becd1d938065883752a504da9c50b7363a415e2c0c7e925a57070113f626cac667dea80e83060cb0b9db82eaa77ef9a12759bae777dc3de68ee725719d105af1adf4f93092f96bbd12a51aa7b7ccc44209fe33e1dcc90f58e2fcd6e2ec561d03522a9e835f1780d92e7e93bc557ab138d8abe679842203e65255130ab4db1556e35ced5b2f2b99574538b54c516f0dc42a73207de9213ca99ef633d925405f883d32e05f910b972f79738c4897fd2154ce20d2d1f0fe03fbb247b30e1c3a8cb1da396fda7699cab8472e2f296cbf30a6d1e87855814fa3df7ba4dec87b8d7f5a1b24302a47c7f33460835c912379169e49353159619b5f09cbe050e08334d61bce620e83e4cf496c4953cc86ef8e84f114b62c579ec51aa6305cb056e69b6230ce109ec13b5529b72e9eac965fd7c4a4d3e4be02e21074e59b6c07b3b3c65a3e2f1e3458da0a0cbef6b69ae54464ba06e675f5718e5b28e4e1b2542f87d8d970cf04cd200a36f08cbc4b17a99d41aadd58e562d591077e603b1bc6433551bcd5b2a87e9454aa191d102412529037aceb1ab86819c4766c1b56dc6953264f2d6caa016f1a2d582363fa4c7c49e742cceb9b3a4fc38dadc2263c296c886402e05102b42cc316aff8cb73e8fd4ed72df93789730664a62ceb3ed950ae4a2a6caac8b45dbe055fc764722f80bc3bd8494cde1367b34c1aef3765a53c70cab60287fc2f2ed1253758dd5b30993ad968dd87641a269ce72a99e9d19378417cd5522e207bdde7948bfc70507d6ad14c3f25d3723ac3203e3dff6fd6e970f4e450daf267e4fa8f1e2decf36efaab9f9a6d4e0874f2400eba70d728ccda9948d8fc6f9ea09323322c3365e31f494fb8a953273acc78b5021633e913ae8a0a028e33abe87eada41847a2e4bd0b8e28e19f6cddef7adb16dd72b0f51e7a21e699d880e97c96c4a13f568d1fc4537af36a7fd04e36c084bfa7fcfcd85b1507d26315d795385cc7c9ead66349bc264c691442eab3d0dda64cec7684663a1d81fe86753fc2b40f9a17759c4992a51631e7a6e755b324d5f6b9ffd09e121e68522b782b485c85da6edb92dbb06e2ca35edd208c9245bea83b1586154a21939ab9c4f4e9a51a39ce34d1684e929467cb3461784591ed50a309dba95ac3d2d6febfb62b0ec7ed327d550f9522c2a80684b002b75d1c3e738c1f4a0e04f528f08e69336c676eec9581c8c218212bd64a6eb8c88f12bb01bf18b81066aabf6a66eb69ffe01187163ecaa1a73fe363341b977e24c4f696c7d525c1f4509655cad80a1f9edf08534e7109081eec230356023bd5b8f0576d563e49a91b63605ab84ab9e0c53232a50039b0aac128ddee708c770fe14adc52d009507f638b294d1d4564386784da0296aaf69487d34d969a4968060394be2faa0ac7e6e07183693ae3809b0822c6c6f26b5cdc3333a65cef83fba26b4cc9b44b11ed9b0b48e3b6b401c83772cb2607872584c3aa0047cd97c224a2a52b8115c6a40dd943eb4eb8407d0bb66b665c514923da85252649a075180dcad10e8dacac2710ee8760cae7185c1cebdedd278fab47a11fd32817a5e67841cd8a4761d5ff290862dafa987b7044171a53d4d881aa49717186ddd6834363d3e99df011a28af4d7513d038076c7c88ed1419eaccce33cc7ff76af9504e52553ac606e395ef337b09b37f8cab53353af8e813204adeb34f98361c579e7ddedd835be38859b4a9f128938c31365e9711f4b1bc7263692bf3b69e57668db47d8a925fb473a929c8ba3c6168944cef96bacd91ab699c85d9c09e5b9342d69d79cfe3ee91c21a07758add7e1fe26ad3a82ad2937919b5b678357208a3200ce5f76a4d2780a0c7478cb21041cf0d38db5542904a05c1b5794cec0f66a0775d9f396cd10fd362500cedaeadee2326566fc3a6525ea2edd6b4d876e206bbfa06e46ad2e648faa9dc7ae726c5d9854646ca956da0a33008dd2e5d9310a3834d42234745ecb5fec6255884cfaebb79d096a8a26fff606b2c6636b942ee45f7045738de3f3b0a5f5b509ebd40752c62c99dbeec314c7f06fc278b97245e96bb8eed207220afb4abc6e3e4c81441a14955c925d044613fab63e64d63dd0ce9864ffbf1a5529837445557b261877161b32b92e62c8692b2f666bfbb2b1b475fcc2fcf5f66e5b282023a313d6cb7ffd24639df67ba083db7508064a74970959801de5f653a447c95cd0bdafc2f8224ab4278178028c2275709939208d21170716ee5e3d42e9965fc2e584486b1cb5fbabd2cb23de0546ab8d3817b62f4f0043a7903170424cd0da5ac37dbea30e4457b66e8641b1a5297b00f2c93195219ccfa872db4aa17d628b889c15c746a4d95a8e779c504519b34ac3edc7c9b08dd140de7f818c7dc8de4963f6514fd6317f678bbe058622104fca2232ae32a9fab82106d080daa8e7c040a2d958686b34923ee05d75f684bec64b829c1072c04057bc3992b44cf631ddbd5897c8902cf54d094a8986db85ed67ac989ac0509af123c95a9200a3418ae5200643d37b74675ea17b8dd9a334450dfa4f1d50c294bc1bab463c2acaaadbebcc36ba4510788fa2c2e5b7f7b02f3b7df3126e7f8100d9a913040bcb2b738de6687d46cb4df92f4c952b78c65b23d9aaeead083654141c1bea00e9de6b4033cf33b8ea5506abef3197b2aa687b436998cd0f10509638385b204ea0b14c9d76fc4ea64e50b261b3255364ef09cfaa52698f275c248b1dd4bc38096db272b28afc8fe5dbe96f683c75d594a576341b6baf7d91fe610dff3fe1f10481fa46fe1ab60405ce8e2b3195a3f8f3584a5719e9e837289d8aad48a9486dfb23c8704a1ebba550432d0193a9eaa7e47f520a5859bd9e6c590d36147a2a96658338c96243b535bff2a61bb20a0ef932ffe12866c1d82dd37f3526622b2d908de6682aa5aa133757168a80a589e68689f7e2db0c4957064a148d87911b4fd0c7a53ee3cc85f98b09c82430108e03a984149421f281b15ccbb8b03b38fdd808e17b3d87ac04f84be7b4d349d5fef01ce3618ce60a465589349d0f3a6a65a6060a72bcf4e238d058ef66e37f007efb74114fadb75b91ab05c255e31bed4db4eca0493ac05e30ccd97fb2251bba8f75782115069f032961936de1f8b8b61784218756775e3b7a58c2c2b1d49eaf643b4b8a532dc14b7b17073ffdf8d7a68b7b52c1dd01951363a8dd25158ca49a489abc196b41323e8466c979c933478bca5e8ef0c7bbdfb00914bdfc2e508f92e0c3ad08b0d4c39b242c222a63261bf9ee07c04587eb7488e2092de8a8e400b2e5333c971f6fdc371c7984f2bd09e2d1ebf044dfbad9024f36801494d51819f79a851328f3bd8a18579dd0a1d58875716a3390fba8c0b02af6847676c5467337331365c477dde935216a8ad6cdf4bca2408035fab3a2db43ed13d3c10149369283ad1c6cf80cbb569cbe8c427ce5aaed912a6a21a0d51caf81888a063be329cb74a40ac0933530be2e048de543c8e28f5b85d98c1c803cd5ffc53a15980df9307ed250d5f6839eec69a914a557b229a3f0c5d1917c906103685fcb2de8e0782d67fbb5a9fc3a9e99495c5fa588f93e5b54e7a5ded9f55b1670031d095a0bd0fee384a7f5d539c3aeb6a3b2fcb59dff0abfc0da0afdf36345f82a7d6bd629274d9991ed0291b60ce09eae8603a72ff6204eb190ba10790b05be027417606751c57a68de165b899180dc6d1359451c2eebf9d212c706878f75dda39e6b8f96347ac5cd36b3e2fad6300d29b5b65b60e47d51b96bc2facbbac95a6bc95bff3e5747f91f8eb549de44e9db4af4ca210102fbab9fa341b2d8ad56ba1650e4d016c56767cad66718fc62cce46670d80a8c25a5d544a21a931bf136d47"
         }

--- a/src/commonTest/resources/nonreg/v2/WaitForFundingLocked_f3437082/data.json
+++ b/src/commonTest/resources/nonreg/v2/WaitForFundingLocked_f3437082/data.json
@@ -1,162 +1,170 @@
 {
     "type": "fr.acinq.lightning.channel.LegacyWaitForFundingLocked",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
-            "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
+                    "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "03bb831ea93a1d0d2540af20196552beabb0c5e385e6b358516d3c40ccde7723b1"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "shortChannelId": "400000x42x0",
     "lastSent": {

--- a/src/commonTest/resources/nonreg/v2/WaitForRemotePublishFutureCommitment_ae47fde9/data.json
+++ b/src/commonTest/resources/nonreg/v2/WaitForRemotePublishFutureCommitment_ae47fde9/data.json
@@ -1,161 +1,169 @@
 {
     "type": "fr.acinq.lightning.channel.WaitForRemotePublishFutureCommitment",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
-            "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
+                    "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "remoteChannelReestablish": {
         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",

--- a/src/commonTest/resources/nonreg/v2/WaitForRemotePublishFutureCommitment_d803549f/data.json
+++ b/src/commonTest/resources/nonreg/v2/WaitForRemotePublishFutureCommitment_d803549f/data.json
@@ -1,227 +1,244 @@
 {
     "type": "fr.acinq.lightning.channel.WaitForRemotePublishFutureCommitment",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_support_large_channel",
-            "option_static_remotekey",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 3,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 250000000,
-                        "paymentHash": "edaff8f0e5117e83b2570b5f9d7115631df9c3de0f680c041d9cdfc087b4b51e",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_support_large_channel",
+                "option_static_remotekey",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
                     },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 100000000,
-                        "paymentHash": "a4459f57dc69d1342cd3c880a5bdb880ccea97be95587d5c6e87234f209e1ecd",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 2,
-                        "amountMsat": 10000,
-                        "paymentHash": "90792e276988a51c9382702617df7e340cf7f0299c3eb58fda1b3a493ebcb395",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 449990000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032a086010000000000220020ff5d65b735c30cb217486f62f8d590e56b6c27192299584ea87dbaa4452ef679400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799090d00300000000002200204ce05fb81556eaf7911d606ec23f598ea0e05d43e722c78010e1788774bc8fa686be06000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb320400483045022100a277bf52a6558d90135e0691ac9a66a9cd8b1717367e675f7d9551b251ab37f502206bc0aa48c04c085b3bb27d2fab0a83e75eed1898d81269bea19e48bd182864f301473044022060fc42daff3f531f27399b6c8cea7753f7e327f5dca6ce3e1cf11ba7bc695da102206373ebcc82fb07f2157bdb8399abf19563f6fd202ba86ade0bceb7693093ef0b0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedd99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "007ffe03e47cb696972af3e747c5f0ff813953d1d127b844aa8e66d4eedd6d48:2",
-                                "txOut": {
-                                    "amount": 100000,
-                                    "publicKeyScript": "0020ff5d65b735c30cb217486f62f8d590e56b6c27192299584ea87dbaa4452ef679"
-                                },
-                                "redeemScript": "76a914c58f2d84aa3dcc020f248d3a0f0095ce66e3b7ad8763ac672102486e1f94c3b4e63555b63bea6e7ae60e550b2275dab745118ca8dfbb634604967c820120876475527c2103aef82904d176eefc9f86b138b86f4f411ed4778f341321bdfb021f5cdff7dd8752ae67a91412bb12f52c0bcac1a16e576e3e9c28d6032de7c888ac6851b27568"
-                            },
-                            "tx": "0200000001486dddeed4668eaa44b827d1d1533981fff0c547e7f32a9796b67ce403fe7f00020000000001000000019e7901000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb32101b0600",
-                            "htlcId": 1
-                        },
-                        "localSig": "5e865cf9ae0fc879ceb90e3144f2273fee1806f47b0d4949cac5e4621daaed681944f26ba277941c0619c98553dd9c7cba7be07beb9c867edf7fad1ec1602465",
-                        "remoteSig": "a392c69c1f762942710dae08a686916a493b9b1589216a57f9a4b459305cbad423289a8fa364ec92848ffa5288b8a0e3b2d56bd6fc4cb223bef73fbd90a38b29"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "007ffe03e47cb696972af3e747c5f0ff813953d1d127b844aa8e66d4eedd6d48:4",
-                                "txOut": {
-                                    "amount": 250000,
-                                    "publicKeyScript": "00204ce05fb81556eaf7911d606ec23f598ea0e05d43e722c78010e1788774bc8fa6"
-                                },
-                                "redeemScript": "76a914c58f2d84aa3dcc020f248d3a0f0095ce66e3b7ad8763ac672102486e1f94c3b4e63555b63bea6e7ae60e550b2275dab745118ca8dfbb634604967c820120876475527c2103aef82904d176eefc9f86b138b86f4f411ed4778f341321bdfb021f5cdff7dd8752ae67a914a8f988eded2363756daabbaa863a2f4c0453d67c88ac6851b27568"
-                            },
-                            "tx": "0200000001486dddeed4668eaa44b827d1d1533981fff0c547e7f32a9796b67ce403fe7f00040000000001000000018ec303000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb32101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "db5a218afb52ce77c6484b4fcdf98a45fc8fe12476b2f34d4b776e024fe973456952aeb623f3c8b7915c2b772be6b29855edfc5f829e9f5c42aff2678d796ea0",
-                        "remoteSig": "55f5fe760f30e659a8c8b6c62b2ec9dc806a2e30e0615af16bb93e3e6c0d543b2e2103e0b1a65e12ee8c18b658d3bb0b5a3c1c7e35845a5f1976a2abe2de1a81"
-                    }
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 3,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 250000000,
-                        "paymentHash": "edaff8f0e5117e83b2570b5f9d7115631df9c3de0f680c041d9cdfc087b4b51e",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 100000000,
-                        "paymentHash": "a4459f57dc69d1342cd3c880a5bdb880ccea97be95587d5c6e87234f209e1ecd",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 2,
-                        "amountMsat": 10000,
-                        "paymentHash": "90792e276988a51c9382702617df7e340cf7f0299c3eb58fda1b3a493ebcb395",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 449990000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "01871396b3a2d43dd3067377ee9e84da84da3b3d1cb8b4cd140543cbbd8f6a7b",
-            "remotePerCommitmentPoint": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 3,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 3,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 3,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 250000000,
+                                "paymentHash": "edaff8f0e5117e83b2570b5f9d7115631df9c3de0f680c041d9cdfc087b4b51e",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 100000000,
+                                "paymentHash": "a4459f57dc69d1342cd3c880a5bdb880ccea97be95587d5c6e87234f209e1ecd",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 2,
+                                "amountMsat": 10000,
+                                "paymentHash": "90792e276988a51c9382702617df7e340cf7f0299c3eb58fda1b3a493ebcb395",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 449990000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032a086010000000000220020ff5d65b735c30cb217486f62f8d590e56b6c27192299584ea87dbaa4452ef679400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799090d00300000000002200204ce05fb81556eaf7911d606ec23f598ea0e05d43e722c78010e1788774bc8fa686be06000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb320400483045022100a277bf52a6558d90135e0691ac9a66a9cd8b1717367e675f7d9551b251ab37f502206bc0aa48c04c085b3bb27d2fab0a83e75eed1898d81269bea19e48bd182864f301473044022060fc42daff3f531f27399b6c8cea7753f7e327f5dca6ce3e1cf11ba7bc695da102206373ebcc82fb07f2157bdb8399abf19563f6fd202ba86ade0bceb7693093ef0b0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedd99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "007ffe03e47cb696972af3e747c5f0ff813953d1d127b844aa8e66d4eedd6d48:2",
+                                        "txOut": {
+                                            "amount": 100000,
+                                            "publicKeyScript": "0020ff5d65b735c30cb217486f62f8d590e56b6c27192299584ea87dbaa4452ef679"
+                                        },
+                                        "redeemScript": "76a914c58f2d84aa3dcc020f248d3a0f0095ce66e3b7ad8763ac672102486e1f94c3b4e63555b63bea6e7ae60e550b2275dab745118ca8dfbb634604967c820120876475527c2103aef82904d176eefc9f86b138b86f4f411ed4778f341321bdfb021f5cdff7dd8752ae67a91412bb12f52c0bcac1a16e576e3e9c28d6032de7c888ac6851b27568"
+                                    },
+                                    "tx": "0200000001486dddeed4668eaa44b827d1d1533981fff0c547e7f32a9796b67ce403fe7f00020000000001000000019e7901000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb32101b0600",
+                                    "htlcId": 1
+                                },
+                                "localSig": "5e865cf9ae0fc879ceb90e3144f2273fee1806f47b0d4949cac5e4621daaed681944f26ba277941c0619c98553dd9c7cba7be07beb9c867edf7fad1ec1602465",
+                                "remoteSig": "a392c69c1f762942710dae08a686916a493b9b1589216a57f9a4b459305cbad423289a8fa364ec92848ffa5288b8a0e3b2d56bd6fc4cb223bef73fbd90a38b29"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "007ffe03e47cb696972af3e747c5f0ff813953d1d127b844aa8e66d4eedd6d48:4",
+                                        "txOut": {
+                                            "amount": 250000,
+                                            "publicKeyScript": "00204ce05fb81556eaf7911d606ec23f598ea0e05d43e722c78010e1788774bc8fa6"
+                                        },
+                                        "redeemScript": "76a914c58f2d84aa3dcc020f248d3a0f0095ce66e3b7ad8763ac672102486e1f94c3b4e63555b63bea6e7ae60e550b2275dab745118ca8dfbb634604967c820120876475527c2103aef82904d176eefc9f86b138b86f4f411ed4778f341321bdfb021f5cdff7dd8752ae67a914a8f988eded2363756daabbaa863a2f4c0453d67c88ac6851b27568"
+                                    },
+                                    "tx": "0200000001486dddeed4668eaa44b827d1d1533981fff0c547e7f32a9796b67ce403fe7f00040000000001000000018ec303000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb32101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "db5a218afb52ce77c6484b4fcdf98a45fc8fe12476b2f34d4b776e024fe973456952aeb623f3c8b7915c2b772be6b29855edfc5f829e9f5c42aff2678d796ea0",
+                                "remoteSig": "55f5fe760f30e659a8c8b6c62b2ec9dc806a2e30e0615af16bb93e3e6c0d543b2e2103e0b1a65e12ee8c18b658d3bb0b5a3c1c7e35845a5f1976a2abe2de1a81"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 3,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 250000000,
+                                "paymentHash": "edaff8f0e5117e83b2570b5f9d7115631df9c3de0f680c041d9cdfc087b4b51e",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 100000000,
+                                "paymentHash": "a4459f57dc69d1342cd3c880a5bdb880ccea97be95587d5c6e87234f209e1ecd",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 2,
+                                "amountMsat": 10000,
+                                "paymentHash": "90792e276988a51c9382702617df7e340cf7f0299c3eb58fda1b3a493ebcb395",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 449990000
+                    },
+                    "txid": "01871396b3a2d43dd3067377ee9e84da84da3b3d1cb8b4cd140543cbbd8f6a7b",
+                    "remotePerCommitmentPoint": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
             "0": "d4f57ab7-0de9-4440-9aea-debd7c80496c",
             "1": "bbac2fe3-1c00-4426-804f-24fd754236ef",
@@ -231,16 +248,7 @@
             "left": null,
             "right": "036e46c0c33872871f0509fda1b455136e44b797452c86c79134b70a86a3d9abc3"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "remoteChannelReestablish": {
         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",

--- a/src/commonTest/resources/nonreg/v3/Closing_029bf8f3/data.json
+++ b/src/commonTest/resources/nonreg/v3/Closing_029bf8f3/data.json
@@ -1,315 +1,268 @@
 {
     "type": "fr.acinq.lightning.channel.Closing",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 50000000,
-                        "paymentHash": "6d7f885fa7349eadb6ee7917f76e2d5be5375a53908f9412251844652029fb83",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 55000000,
-                        "paymentHash": "740ff4fdd9e09ecaf72246957c47c2bf3f4df277ae1a167edee9ac6779f52cef",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 250000000,
-                        "paymentHash": "f46652d1941b2aee27d8bfe5f4c934fe6b6bab4eff3c20390ec6572c18ba807b",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 100000000,
-                        "paymentHash": "19b16e9994f802d2e02a327e5e167006f76616bbb0bf9edb93240399eee69637",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 2,
-                        "amountMsat": 10000,
-                        "paymentHash": "88bf41d772fae54153d0e1ef7d08bfae6bc157e01a37339c4f97985f8dae8d43",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 449990000,
-                "toRemote": 95000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-                    },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080084a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da03250c30000000000002200200a56c86dc2e94046c61370f8e91b9cf2b8ceeb1e5597b8b3ea2191ac32076835d8d600000000000022002074e2cfb625e3787193fbb4f26dbd7739c5484c4455fc53c71bb2bce84b476ff71873010000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990a0860100000000002200205d9ebea209786542771331647e3bfbe27d502165721f79d5fa7c650fc0f4f82190d00300000000002200204d3d669bcc3a84c7fddb2b53587dc6e478a73ddc56fc6d741b8d8101275738ecceb70600000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400483045022100b93cbfbaef80225e26044222ba5a5bcf0835be8f7ca65e72216e3920faeffd3002202066354a81bbc965915dc5982207805e73baea30784905e921fafaa3fb3a2e8501483045022100f5e63ea5bbf6f9a73a5a2ee48f5aef9562321f94e5863a9048e2ad37b37c813b0220682d540a528d769741cae70b70b570dc6dac987b2ff7afa7ef429f66a9940d0d0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "7372fda43b27856d434c954465abbff64d4f9967d1f76fe3f140281fa19d690f:2",
-                                "txOut": {
-                                    "amount": 50000,
-                                    "publicKeyScript": "00200a56c86dc2e94046c61370f8e91b9cf2b8ceeb1e5597b8b3ea2191ac32076835"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9148ae4a6eb50d67f9380f44bde85467e5c9f7806f988527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "02000000010f699da11f2840f1e36ff7d167994f4df6bfab6544954c436d85273ba4fd72730200000000010000000186b50000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
-                            "paymentHash": "6d7f885fa7349eadb6ee7917f76e2d5be5375a53908f9412251844652029fb83",
-                            "htlcId": 0
-                        },
-                        "localSig": "9f68f26d23a9815202a8de58c3cd74d28f2e792e938a32c180c30dc95f561a921537ced22d434d129135d919ebe4a7e5a6b185abe6706f209f2ddb42ebcc16ff",
-                        "remoteSig": "0c07663f04a9d7c8f0365ba313aed68be3576119190d2ec497c112cf149611373506b12a40e85825349d92f9627d0c7d192cdb6a5b54d733143a9085b6e15383"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "7372fda43b27856d434c954465abbff64d4f9967d1f76fe3f140281fa19d690f:3",
-                                "txOut": {
-                                    "amount": 55000,
-                                    "publicKeyScript": "002074e2cfb625e3787193fbb4f26dbd7739c5484c4455fc53c71bb2bce84b476ff7"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9142bd4ed0a2ca74a654fbca59c835108a740fb7d4c88527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "02000000010f699da11f2840f1e36ff7d167994f4df6bfab6544954c436d85273ba4fd7273030000000001000000010ec90000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
-                            "paymentHash": "740ff4fdd9e09ecaf72246957c47c2bf3f4df277ae1a167edee9ac6779f52cef",
-                            "htlcId": 1
-                        },
-                        "localSig": "33e51eb795a5c12732b1cca6a6424cc5426bd9f16d17cdddcb4808c4fcbde9a12a4a963bf5d87518b244035d6ce21d5bdbc027dde903cd3ac8de6e3653ba609f",
-                        "remoteSig": "a1041fa5030e25f7260b8935199b3c895a1327f42933f61c7b7b8b960cf1b21e5e6355c1076b8344215c78036f0258678d8f0ea06aa681f12a707691d4b733e7"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "7372fda43b27856d434c954465abbff64d4f9967d1f76fe3f140281fa19d690f:5",
-                                "txOut": {
-                                    "amount": 100000,
-                                    "publicKeyScript": "00205d9ebea209786542771331647e3bfbe27d502165721f79d5fa7c650fc0f4f821"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914480a81e9dea741d5e4b0603e53617e3e9363e38588ac6851b27568"
-                            },
-                            "tx": "02000000010f699da11f2840f1e36ff7d167994f4df6bfab6544954c436d85273ba4fd7273050000000001000000019e790100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 1
-                        },
-                        "localSig": "7691922eb89a947ba9b19bfc83610cdeddf6b323a3ca6c57542b0da7dfd4bf8c0d7af8b3fef0468e435fbb5993f2f13560a7082b9c4631b148493eb94e351269",
-                        "remoteSig": "f5d715d948cbe6a99a203e194a2ad1947475562b160e53f404bd1e6fc91a94c16d66409805e56b31f35fa6006eebe530a7e63f11af0176244b2a290817b10508"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "7372fda43b27856d434c954465abbff64d4f9967d1f76fe3f140281fa19d690f:6",
-                                "txOut": {
-                                    "amount": 250000,
-                                    "publicKeyScript": "00204d3d669bcc3a84c7fddb2b53587dc6e478a73ddc56fc6d741b8d8101275738ec"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914f91b7d27cebfd9aaea7b3c5a8ff29d6b3fe733b188ac6851b27568"
-                            },
-                            "tx": "02000000010f699da11f2840f1e36ff7d167994f4df6bfab6544954c436d85273ba4fd7273060000000001000000018ec30300000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "8be08f09f14bf4fc93d932154940e568784110b62386d9fc893a4872461019ec54cdcb59b985e7dc8588ee564e0a7a948126e14f30291477a8eb5a6b3167b528",
-                        "remoteSig": "b1828ea2bd1cb006845f9077318105f2289c7d158bfd6906f8bdbed62d56f013005f909afd64eff871f8407ff47e420347c05c0b72bb383c58d77c6c7920cb7b"
-                    }
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 2,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 250000000,
-                        "paymentHash": "f46652d1941b2aee27d8bfe5f4c934fe6b6bab4eff3c20390ec6572c18ba807b",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 100000000,
-                        "paymentHash": "19b16e9994f802d2e02a327e5e167006f76616bbb0bf9edb93240399eee69637",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 2,
-                        "amountMsat": 10000,
-                        "paymentHash": "88bf41d772fae54153d0e1ef7d08bfae6bc157e01a37339c4f97985f8dae8d43",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 50000000,
-                        "paymentHash": "6d7f885fa7349eadb6ee7917f76e2d5be5375a53908f9412251844652029fb83",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 55000000,
-                        "paymentHash": "740ff4fdd9e09ecaf72246957c47c2bf3f4df277ae1a167edee9ac6779f52cef",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 95000000,
-                "toRemote": 449990000
-            },
-            "txid": "7eadcb16addad348b3259b016c106db14aa01d95050740beef7d75c046768566",
-            "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
-        },
-        "localChanges": {
-            "proposed": [
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
             ],
-            "signed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 0,
-                    "paymentPreimage": "96abc2a3f0ed17d9ec5cddc3f67e76d94d500daccc0ca85407b2ca6caf515bba"
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
+                    },
+                    "unknown": [
+                    ]
                 }
-            ],
-            "acked": [
-            ]
-        },
-        "remoteChanges": {
-            "proposed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 1,
-                    "paymentPreimage": "53c9ce2b799dcafac3fdd3123faecd8e2995202c39911f7f26ca016e5acabe3f"
+            },
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
                 }
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
+            },
+            "channelFlags": 0
         },
-        "localNextHtlcId": 3,
-        "remoteNextHtlcId": 2,
-        "payments": {
-            "0": "63bcda18-e368-4b94-8f92-f584b22f5f39",
-            "1": "10a0c73e-8c05-4825-a46a-98166a75e9d9",
-            "2": "1ec9b64b-519c-444d-a034-4e10d2db9d1f"
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                    {
+                        "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "id": 0,
+                        "paymentPreimage": "96abc2a3f0ed17d9ec5cddc3f67e76d94d500daccc0ca85407b2ca6caf515bba"
+                    }
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                    {
+                        "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "id": 1,
+                        "paymentPreimage": "53c9ce2b799dcafac3fdd3123faecd8e2995202c39911f7f26ca016e5acabe3f"
+                    }
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 3,
+            "remoteNextHtlcId": 2
         },
-        "remoteNextCommitInfo": {
-            "left": {
-                "nextRemoteCommit": {
-                    "index": 3,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 50000000,
+                                "paymentHash": "6d7f885fa7349eadb6ee7917f76e2d5be5375a53908f9412251844652029fb83",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 55000000,
+                                "paymentHash": "740ff4fdd9e09ecaf72246957c47c2bf3f4df277ae1a167edee9ac6779f52cef",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 250000000,
+                                "paymentHash": "f46652d1941b2aee27d8bfe5f4c934fe6b6bab4eff3c20390ec6572c18ba807b",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 100000000,
+                                "paymentHash": "19b16e9994f802d2e02a327e5e167006f76616bbb0bf9edb93240399eee69637",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 2,
+                                "amountMsat": 10000,
+                                "paymentHash": "88bf41d772fae54153d0e1ef7d08bfae6bc157e01a37339c4f97985f8dae8d43",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 449990000,
+                        "toRemote": 95000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080084a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da03250c30000000000002200200a56c86dc2e94046c61370f8e91b9cf2b8ceeb1e5597b8b3ea2191ac32076835d8d600000000000022002074e2cfb625e3787193fbb4f26dbd7739c5484c4455fc53c71bb2bce84b476ff71873010000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990a0860100000000002200205d9ebea209786542771331647e3bfbe27d502165721f79d5fa7c650fc0f4f82190d00300000000002200204d3d669bcc3a84c7fddb2b53587dc6e478a73ddc56fc6d741b8d8101275738ecceb70600000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400483045022100b93cbfbaef80225e26044222ba5a5bcf0835be8f7ca65e72216e3920faeffd3002202066354a81bbc965915dc5982207805e73baea30784905e921fafaa3fb3a2e8501483045022100f5e63ea5bbf6f9a73a5a2ee48f5aef9562321f94e5863a9048e2ad37b37c813b0220682d540a528d769741cae70b70b570dc6dac987b2ff7afa7ef429f66a9940d0d0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "7372fda43b27856d434c954465abbff64d4f9967d1f76fe3f140281fa19d690f:2",
+                                        "txOut": {
+                                            "amount": 50000,
+                                            "publicKeyScript": "00200a56c86dc2e94046c61370f8e91b9cf2b8ceeb1e5597b8b3ea2191ac32076835"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9148ae4a6eb50d67f9380f44bde85467e5c9f7806f988527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "02000000010f699da11f2840f1e36ff7d167994f4df6bfab6544954c436d85273ba4fd72730200000000010000000186b50000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
+                                    "paymentHash": "6d7f885fa7349eadb6ee7917f76e2d5be5375a53908f9412251844652029fb83",
+                                    "htlcId": 0
+                                },
+                                "localSig": "9f68f26d23a9815202a8de58c3cd74d28f2e792e938a32c180c30dc95f561a921537ced22d434d129135d919ebe4a7e5a6b185abe6706f209f2ddb42ebcc16ff",
+                                "remoteSig": "0c07663f04a9d7c8f0365ba313aed68be3576119190d2ec497c112cf149611373506b12a40e85825349d92f9627d0c7d192cdb6a5b54d733143a9085b6e15383"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "7372fda43b27856d434c954465abbff64d4f9967d1f76fe3f140281fa19d690f:3",
+                                        "txOut": {
+                                            "amount": 55000,
+                                            "publicKeyScript": "002074e2cfb625e3787193fbb4f26dbd7739c5484c4455fc53c71bb2bce84b476ff7"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9142bd4ed0a2ca74a654fbca59c835108a740fb7d4c88527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "02000000010f699da11f2840f1e36ff7d167994f4df6bfab6544954c436d85273ba4fd7273030000000001000000010ec90000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
+                                    "paymentHash": "740ff4fdd9e09ecaf72246957c47c2bf3f4df277ae1a167edee9ac6779f52cef",
+                                    "htlcId": 1
+                                },
+                                "localSig": "33e51eb795a5c12732b1cca6a6424cc5426bd9f16d17cdddcb4808c4fcbde9a12a4a963bf5d87518b244035d6ce21d5bdbc027dde903cd3ac8de6e3653ba609f",
+                                "remoteSig": "a1041fa5030e25f7260b8935199b3c895a1327f42933f61c7b7b8b960cf1b21e5e6355c1076b8344215c78036f0258678d8f0ea06aa681f12a707691d4b733e7"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "7372fda43b27856d434c954465abbff64d4f9967d1f76fe3f140281fa19d690f:5",
+                                        "txOut": {
+                                            "amount": 100000,
+                                            "publicKeyScript": "00205d9ebea209786542771331647e3bfbe27d502165721f79d5fa7c650fc0f4f821"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914480a81e9dea741d5e4b0603e53617e3e9363e38588ac6851b27568"
+                                    },
+                                    "tx": "02000000010f699da11f2840f1e36ff7d167994f4df6bfab6544954c436d85273ba4fd7273050000000001000000019e790100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 1
+                                },
+                                "localSig": "7691922eb89a947ba9b19bfc83610cdeddf6b323a3ca6c57542b0da7dfd4bf8c0d7af8b3fef0468e435fbb5993f2f13560a7082b9c4631b148493eb94e351269",
+                                "remoteSig": "f5d715d948cbe6a99a203e194a2ad1947475562b160e53f404bd1e6fc91a94c16d66409805e56b31f35fa6006eebe530a7e63f11af0176244b2a290817b10508"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "7372fda43b27856d434c954465abbff64d4f9967d1f76fe3f140281fa19d690f:6",
+                                        "txOut": {
+                                            "amount": 250000,
+                                            "publicKeyScript": "00204d3d669bcc3a84c7fddb2b53587dc6e478a73ddc56fc6d741b8d8101275738ec"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914f91b7d27cebfd9aaea7b3c5a8ff29d6b3fe733b188ac6851b27568"
+                                    },
+                                    "tx": "02000000010f699da11f2840f1e36ff7d167994f4df6bfab6544954c436d85273ba4fd7273060000000001000000018ec30300000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "8be08f09f14bf4fc93d932154940e568784110b62386d9fc893a4872461019ec54cdcb59b985e7dc8588ee564e0a7a948126e14f30291477a8eb5a6b3167b528",
+                                "remoteSig": "b1828ea2bd1cb006845f9077318105f2289c7d158bfd6906f8bdbed62d56f013005f909afd64eff871f8407ff47e420347c05c0b72bb383c58d77c6c7920cb7b"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 2,
                     "spec": {
                         "htlcsIn": [
                             {
@@ -340,6 +293,14 @@
                         "htlcsOut": [
                             {
                                 "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 50000000,
+                                "paymentHash": "6d7f885fa7349eadb6ee7917f76e2d5be5375a53908f9412251844652029fb83",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
                                 "id": 1,
                                 "amountMsat": 55000000,
                                 "paymentHash": "740ff4fdd9e09ecaf72246957c47c2bf3f4df277ae1a167edee9ac6779f52cef",
@@ -349,42 +310,87 @@
                         ],
                         "feerate": 5000,
                         "toLocal": 95000000,
-                        "toRemote": 499990000
+                        "toRemote": 449990000
                     },
-                    "txid": "6fa734b6dd68a4ec5374924405d3f359c29c31df3e5775afc33b8cab86302be3",
-                    "remotePerCommitmentPoint": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
+                    "txid": "7eadcb16addad348b3259b016c106db14aa01d95050740beef7d75c046768566",
+                    "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
                 },
-                "sent": {
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "signature": "9b6dc8c4c7cdf17421cdc9922c2d8783ce34dc3d55af4cb1f1a7f3f5ed8477275ef25fc7db687fc6278128058905c4f4379880772702361e4106e63c974c6133",
-                    "htlcSignatures": [
-                        "fab06d0caff3cb9b51f6a74957abc54c7a8e595d16cd6a2ee89805b01964ea120ea6a57d24c5c48f98a00571126c682a61ddc936eecfda506baf9433a8ef07c2",
-                        "2112123ef29e32e85f51b59c896a3872f67c81a0becdb50ae942f928406b54a7424599b0572e4a126b50f53b9ccf1d15f1e164a483276428059ce1610c127be0",
-                        "2393c0379bb6f4f50b7bd8213243ceb45d8f2aaf14cc3026f7b9089e2e0901d73fb202cff46b6a998892a3df480576dc107c6518c3ab90da25872f5f2565b403"
-                    ]
-                },
+                "nextRemoteCommit": {
+                    "sig": {
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "signature": "9b6dc8c4c7cdf17421cdc9922c2d8783ce34dc3d55af4cb1f1a7f3f5ed8477275ef25fc7db687fc6278128058905c4f4379880772702361e4106e63c974c6133",
+                        "htlcSignatures": [
+                            "fab06d0caff3cb9b51f6a74957abc54c7a8e595d16cd6a2ee89805b01964ea120ea6a57d24c5c48f98a00571126c682a61ddc936eecfda506baf9433a8ef07c2",
+                            "2112123ef29e32e85f51b59c896a3872f67c81a0becdb50ae942f928406b54a7424599b0572e4a126b50f53b9ccf1d15f1e164a483276428059ce1610c127be0",
+                            "2393c0379bb6f4f50b7bd8213243ceb45d8f2aaf14cc3026f7b9089e2e0901d73fb202cff46b6a998892a3df480576dc107c6518c3ab90da25872f5f2565b403"
+                        ]
+                    },
+                    "commit": {
+                        "index": 3,
+                        "spec": {
+                            "htlcsIn": [
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 0,
+                                    "amountMsat": 250000000,
+                                    "paymentHash": "f46652d1941b2aee27d8bfe5f4c934fe6b6bab4eff3c20390ec6572c18ba807b",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                },
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 1,
+                                    "amountMsat": 100000000,
+                                    "paymentHash": "19b16e9994f802d2e02a327e5e167006f76616bbb0bf9edb93240399eee69637",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                },
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 2,
+                                    "amountMsat": 10000,
+                                    "paymentHash": "88bf41d772fae54153d0e1ef7d08bfae6bc157e01a37339c4f97985f8dae8d43",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                }
+                            ],
+                            "htlcsOut": [
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 1,
+                                    "amountMsat": 55000000,
+                                    "paymentHash": "740ff4fdd9e09ecaf72246957c47c2bf3f4df277ae1a167edee9ac6779f52cef",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                }
+                            ],
+                            "feerate": 5000,
+                            "toLocal": 95000000,
+                            "toRemote": 499990000
+                        },
+                        "txid": "6fa734b6dd68a4ec5374924405d3f359c29c31df3e5775afc33b8cab86302be3",
+                        "remotePerCommitmentPoint": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
+                    }
+                }
+            }
+        ],
+        "payments": {
+            "0": "63bcda18-e368-4b94-8f92-f584b22f5f39",
+            "1": "10a0c73e-8c05-4825-a46a-98166a75e9d9",
+            "2": "1ec9b64b-519c-444d-a034-4e10d2db9d1f"
+        },
+        "remoteNextCommitInfo": {
+            "left": {
                 "sentAfterLocalCommitIndex": 1
             },
             "right": null
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "5de29f41beb1139cca140898918fb6077c10e5db556b67e3ab11ff05a7e0bef6b791df640f9f31ab4ee849395b56e16e1976edca2c2eca4f6f66069a1e18d579c98326c82f2e77e0437e7cdb99089d354d6cd76415b8bb14bd620555823e323c432be7fb622906602a934faaf5ab1cdad769f3574b06403dc7597c9baaeb0e53fc45e3a46162cd52493dd132299aaf7e830917afa2b3d9a325e1e578a8aacf882c7908295ca70171bea5db44a33e1264206373bd1143f377c9e8b8de3b027e983f30d828036e51e5ce52f19e6d93ec4d9e0647731507a42fb60cbb8ac83f663eedd061e5bb29b800e0ff08d49f8763de1aed441b6929113c66be86cd279ac79bcffe601e7da19a2d712d4189f1091dec7cd5f1041f520adad3b8ec3c2b16f3dfc8298120c5b7d9c17354a2de753a19f8a36c4379822fb524a093ac0a3996c5fd5e01ebf1e972a47eccd1554f79d8cf8574739dc38550bd5b5fe04a42e83410720cba5b04056b2c5d9b526df45c312eb6aae05a6be8890b2aa197dfdb7a00c468ffbd6ca8bbd006d29d9505e4e6dec28996caaf39f9d3789f859ddf1ece60b8a78679d4118ba9a127a12b7306fb823f531cd84d24f71c3a0ed9b43f580ea81910467929f11ebef56d09191783879d0aaf5302e3759cf060f28e3c5483e3fa0ae182e4ef9c40810d399d5037f8b91f7e0fac9da2dcd3395312bef360b208590ff13aacc9a838be6d59488d8de5041fbc9f3a4a8a0727d6b2fc8442ff7a02f1710c81b7460080a9beb0b51e5d39972c1d1827c9882a9dd744ee4e078fcf7ad2a5b231a65415d310341974bdeb83843723c9b3fcbf34812ebfda9a4eadc053c2e0f1fcefbfb10939506cbd7e858b09a9cf5dd2e99581bc1a41ddb6893f7efb91fa6c172bf01b205c3ea33d941202a243de56645ade023685ffc19dde4a0608658b50389cf111900eba9e4980d67b7ca2e3fb8f13e0253af6544ad5e6cae12b8a9c93d49d1adef5292be29d58d14b3dea5df958ec501828191dbb5ee075af3c659cdc7f34ac8ff130dffdbb12bce477c988933bf018e83a5f693ae6ffdf8bf97727c5d911f7b2c88ce231e96647c9f9c01c962e860793ebd5e7deb7d29085931747552532a1ae835db46ea588896c79331054f14dabb945fc76edb345f0f93447cdf922d39bbe0b030bc89f719fb3fcf21c0bab9e44e51be2fdfa70fbf69b20a12ecc6137db90fe01bf1b6faf0ce4b02306983d0fbba896c4a39437164d47313c7a30f0cf928c1c8d1faafea9e953b94dc0ce6348805a834c631baf154d98a966dce358dbd2258abe48e93ab5f03d6c59c971aa2730416f877348fbf28820beaef96ff1d5228f7a3a9d9436e5adc6ef0e6462e3291f60937b1a0d6d729c59affae939e7cd5d7c7a349df84f1d6410aef2b4081967d3e2697b973bda1acce8603eebf8b7f43b46c2112bf3d5bc83685126ba472ccaf489b93d5622fde316e113517d7d50550713a959a1648f71693b5a7036e9ec41832ec43f838fe83bc610163e2f4361884c5d5b1ae6907f8a4c6f9aafc6ff5b0d989c66881e373ac85a75964889255eecf2d67dd3d3748f2d723e4d149b9743ad4e11b59a9f0adb2cd816431dcda3ee458f99de9ef8669003c3ab75408380a24e09082462429cb5ae2c07a30206145bb6aa783b45311b35e62cfe298ca275a1fccda142201d8e5d779184be788afe0c93b393d8710fa7fbc08cc2034e1b2a1cbe9058b5bfc655e410e5f63c1398c773407a2b17faa6c6b966598ca175fc7968ad303ab6aea1e0d57486564203a9de95d9aab8ba7a2b70598c5d9f4ea89ef10d26ccbb0901e0d72c18534901762abb4928d5b6ad157a064381d26965061030439634c8b6429d02e002b1a00f55c1bc47a20ba8166540fc5cdde8e569287c44db5ef527eee068c87654e6290e92dbc00034ce5e3408f5db4ab6d7036eaba86b56c8c86220cd34b446adb93b74f074200e577d22962f5f2caf5075abff968a61084ddee8463d71672e9e2078d04b534993e469b96a0984668041832471484e0b25c88de65dd414f851e379a08456e00e686d92d7f0a63901362d25c61f19e40e130f3311518f6c11fe9d18acba3a4fac5a7c242ecb043080b4b9a953ea8f242ef9423bf3bce69878b7750e8fe2acbdb9deab755cc7d038a052c847b3ae508fb60c9d74158c806bf02f268264d21bf73f6a02a277bce491062a25928f571f779890dc984463a31a72023ea0da0e8e3ae393c59e1432baf63e1bcd837fc18f67b7ea68211e8ee2a276b0f462df10bc6b840427371cbdd0990936e365ed6a362f940b8a6aa7b6c0658212b9b618ece4a5089170038815e7329eef1f1e5a2d2bb7cc6d13bb6e162d365feb2bfab706b521ece4a267a1aca9067cff6492933565b8a41a3bd4b31d449930cabe8b488f7184e57dbbdcc6fe24aa69c409375d1d27c7610aa39145c89182d23ea816dbcc8a0abe4c05c2c6e128a0bf216e2e8ea667fdbc502cce53acad05aac86f2689856e32494a458a8f64aed60297575e8e12875bb2812f6f8cc2dbb07e97b2d6fc5a4600f9ae1da3b40265b98be1b2fc3495cf70ef1ad51aee16d5b3be9408e1951fbb35464de45ac208c57710d47aef3aa9f2f7bf214d24b397babbb1bb4c13c233bf61be791d6c15f31405d45167b96998fc2a2cb89d034643cacda0252fb160c33a47dd45977b7f17a61a069836dbfbbf3207521762be50c3e46de2a98232b9d6bffca30325e527085671caa20af4ea79a576a86b5b3ed3941e1bbc7bf820754310b996dd96fa151dc8f3675500a99960c40a180f706d0180fb157d2ca15869a7c505f95e44cf95ed3f999b7452e89a3fa33396967130418366400a0ebe394a41d5790e2b08563535625dcb9d1e5a6ec46d131a31ba4fbc69c59eb00e65ebbdc7fae12b243b91723c93eedbefd05a3ea81a3b2957a4afcf4e9b45302652433646dae8d10e0bc2f5b353e80c3f4a336baf9eeb8c60635a805dcb420a8e6e31358ef4e20be65fba2dcbded2c8db7d62b3a32347dbdf324e198311460702c719728ae9fadf2652d5f95e1436bb64cfd6d2edb0757b3767abe07b393afc7fb7466a43db5801ff100ad006f531aa8848a8dd80d6b91836dbb53ff62c2d8f0452f97676f4af0881dffd397ebf51157529c3fd7107599170bb9fb0b6a8934748a21f9dc33d8e9ee6e52724773e93ac544036878f169a434fbfaea049a5fa693e0649b41bb54728b4ed901065dd8f5db51c7f4cb2c312f24befe1701dcc80e406f1d914776724b9ece0fad8af9a173efccd883704b16ca89e7228f32a2ee4bae5f97d75d1d332d884e460b478bd9f7d46d460492dcd9bf62b47732587e1363dbdb420d2cbe5731509270415f9f800ada8cc7f83ee51114994b7e5a1852e7bc147c6ae74956647d961a96a793cb90a83fa6d85c3b72bb85fc45e76bc4fef8ed0d6d5b475a8f69c82ea0ed28162a8c852591f34d14ab48b40e93e3ec72831dd42a874d38e8b6d11d2dabc5f22703218d5749fe1ae9776efa1afecccaf1ada81102bd26d2807e93b063fc774b1d4b3925b927392beebfcbaff94a377677f7d1800e95c68886316e564bb344f9bf75c32b10bee07a7c7e686a5d21c678a58946c6896f55815eb8f0b8e5bcd50d10a3e76b64ec5cc32bd3abf82e21b3c36017724e0275d5be23f9c6dba732bda122773b06d6360df3c9932cc1a1eea5257fbdd37dd12564ebed5a6c33a2453e24d09d6581afde56fcd3487899eb1f918b99e70250a73114eece82371f246ed00c7b9afde7da71826779e668831a309c3f4043513d7cbb25a609bcbd827f3603298c474bc61d7bbe681fc45e764d5c7697929bbb00a3cfc7d383524d1ac0c5f9ee6a233c376b00dfd730509f566f6fb13118d5785d3ae666f21517c1d465d702f4c9d0acfc4c909cb4c3c3773828faba15c8d736d537ac6c44af035cbc25f347a205e86bd83093641eade1fed91b2ba753732ab7c7bf55056e3262f777444150dd122d695d75ee05eee65b40e1ea78d453b9fd58471cd6ca6b38765d3b0b8006681e1962b5034ef51a6d1c0838da6f74518df614a98a16c4478e9466a24a1a1ffcf93af22dba9315adfb024fd2890859aa61a69f7de14956fa8b51f5b0ea107f190bcb3604f20a78cefa7a8fe877062d91d1312850c2892cd829a8857f11b17ce88cfb76106e0668d29e42f22f3bc63013196caa2940b8e7d8d109d5a9bd0bdf6df7540a2edef34996012181d52313804e40c0c9a1a47657bc199f6612256a3d8ce7f27d9e42d0325af9666143c12579072c518a3a25e8097fd38d5412cc6474588f7c9cd97331709a0f7f94961c41ea410af13c2727ea3d029905daad8f4ffedffb2dfe082c9efeb72c01d251bd88f75c10e739864900ec458db01661da7593c119a95470861fb997d6c0afd403d4ee6e608f5a4eeedf4e975fa30728d100f1b5737087995414f6d02a90c4220ab07ebe3680d6afdd5dd4ee5e4b526888f0e7c6253d7e75e38ee23bc47e9eea25fd2b0bca2c62ceb7bcd4021a1ec0ebcc75bc53340e65dbca291cc384048f61d9a8f1a62a05e78bda566eb79f0ef5d71df46793d964c2c425e7674263103d4e4ad768d2fc1bad4d74e3af4ceb36e5efe569cabbf216bee722cf6386e372c0e6f464fb51f29077bd751aee5e24900bc7869a82a137c21ff126ca0489e579db4f9ab39d0f405377119eaa78f4324b65219bd042cbc987faaabcdc6ff9487e20089de0b9fb661c1e50992d09c67c1fbbe1f726efbf8af66211c452d0cc060534dec4b5344b55889095c8afd050fc082ab59b91174aa32b65f498bb65f8446f0a91498d2db4924339fccc5be3ac63a74c7e931343aa433e276442882b8b2a78b38ac8a29433f101ea0ef829725764bc7ab630b18e5b33d85fd7d83e94bf5a01da79737cc3c11750ee438b20c6fce9ba024c6c3523279ab25c7ce7b8f73f0cbc7b3335fc497a4e4186d29361f6a711e2d7e6ca87039173d4f0432ed2787dd4c239b7f5757d0596c31c24bb7d1165f02ad90c3b363ffb85c6f423438fa748f0bc0c7efb00848f30444808fee9f9373e48a99c20b5cae11c039c908889e424c953e8f22e97d0068dc7474b4c8bc2ec98b73c50fe9302185ae6fbaaaab19ee2519e94202619b7a8bcadcbf250c2f6f60f8c0c1c416c750b78de71bf3109179cf815a2d0ebe3de600544ec38f"
         }
     },
-    "fundingTx": null,
     "waitingSinceBlock": 400000,
-    "alternativeCommitments": [
-    ],
     "nextRemoteCommitPublished": {
         "commitTx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080074a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032d8d600000000000022002087cce86185b16389811a4dbb2516fded6c23a30745eb1a6e34a61eb4eb10501818730100000000002200208c57ba9667b49d1f0fca9594b3f034b4df9269218a3725fe5995ae844f5c4faba086010000000000220020ac7cc695a72ece2b540ef241a0befb12d85a3480f0de4a6c4d6469c42d64b64990d00300000000002200200b3d269935bf5376248fa97dce2ea8106caff5b854f88f29f171e5f33a7043637a7e070000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c04004830450221009b6dc8c4c7cdf17421cdc9922c2d8783ce34dc3d55af4cb1f1a7f3f5ed84772702205ef25fc7db687fc6278128058905c4f4379880772702361e4106e63c974c613301483045022100f1798723f9f5b236f5e9e258a72671b1d6709316dcb13e8ce845b72855508f3602207dfc7b3796a03fbba00f359b3c8d6cd8d6454fad7139a8366a0cafdf66d2cdf60147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedd99dc20",
         "claimMainOutputTx": {

--- a/src/commonTest/resources/nonreg/v3/Closing_0ba41d17/data.json
+++ b/src/commonTest/resources/nonreg/v3/Closing_0ba41d17/data.json
@@ -1,217 +1,234 @@
 {
     "type": "fr.acinq.lightning.channel.Closing",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 110000000,
-                        "paymentHash": "8402e76bc62b9de41e92cfd8375016737d985d5d73d4d3dfba46b855f8370b49",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 95000000,
-                        "paymentHash": "070fb40232bd54297d485a2303b042cbdd51011f34fd509f4bae3ee0c62f6fe4",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 705000000,
-                "toRemote": 90000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032905f010000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799018730100000000002200202228f1681cff3adf3524363fad7481c1aad6aa344b223cd97b4fb09a667f5e2db0ad01000000000022002028eee5bc7a7219b098d1f27ee035b83a6870d2be541097068097ab8a8d2568fba8a20a00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400473044022069b2ce78c6eb6728db4296f6a88b65af682c81dc613985ecf6c23d14cfad3b6602205af6b39cf883448ac1769495c029f230c18d1c4b70292bec6cafad220b74bb5801473044022043cd8250bf3125c454dbe9d7389a3000d6198e35ad82ddd767d2fb770d4e00000220740dd54ac489715d33c6730ee78ee3df4e00f875f67c93b005235d5d637334e40147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "9601ac0b3a2c26b11effb0690a37b4f86b10b144f1751ad6d64f5e58d40c78b8:3",
-                                "txOut": {
-                                    "amount": 95000,
-                                    "publicKeyScript": "00202228f1681cff3adf3524363fad7481c1aad6aa344b223cd97b4fb09a667f5e2d"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914e563f0bce1d82759c3702437ce10cf2d7545b5a288ac6851b27568"
-                            },
-                            "tx": "0200000001b8780cd4585e4fd6d61a75f144b1106bf8b4370a69b0ff1eb1262c3a0bac01960300000000010000000116660100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "6e4452d82c90fed66b3764557999d611cf78e5f32acac0af83839aa65f5ee66c33d859c48572a8f06228d226ca5cd80610d970d9abd0d50edf58186eade21d84",
-                        "remoteSig": "3dc75b272417d1deb5afabc3cdb5f9615f0e1a98b5e85bc661e3e2ef4a4346d84e587321dbf824e3d121ddbd0dc6098c062ab04b1879562b1c6f8ca6048e8edf"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "9601ac0b3a2c26b11effb0690a37b4f86b10b144f1751ad6d64f5e58d40c78b8:4",
-                                "txOut": {
-                                    "amount": 110000,
-                                    "publicKeyScript": "002028eee5bc7a7219b098d1f27ee035b83a6870d2be541097068097ab8a8d2568fb"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9141156a3cd8369ffb3b15e9151e98e1d039a674cfc88527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "0200000001b8780cd4585e4fd6d61a75f144b1106bf8b4370a69b0ff1eb1262c3a0bac019604000000000100000001e69f0100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
-                            "paymentHash": "8402e76bc62b9de41e92cfd8375016737d985d5d73d4d3dfba46b855f8370b49",
-                            "htlcId": 0
-                        },
-                        "localSig": "6c2c84ab6ddd5e0b576ddbd190b90a04f421c87cd7c0bf58f21b77014debcd36187e78df2604d1d3b90e7a8ebc547fed179c53e83b6030212cf0efb9f6f73afb",
-                        "remoteSig": "08d988b910001b302c708db95aabdd1b11a02a7d6c549b78715b2894070feec1557f5cd291b5559f866cc9f8352d17631f28eeb0764408f6f503442c636e3729"
-                    }
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 2,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 95000000,
-                        "paymentHash": "070fb40232bd54297d485a2303b042cbdd51011f34fd509f4bae3ee0c62f6fe4",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 110000000,
-                        "paymentHash": "8402e76bc62b9de41e92cfd8375016737d985d5d73d4d3dfba46b855f8370b49",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 90000000,
-                "toRemote": 705000000
-            },
-            "txid": "6552be7d50bfd1711e327a88449299c0cdac58c180f781d5a1d97908bbf5bf04",
-            "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
-        },
-        "localChanges": {
-            "proposed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 0,
-                    "paymentPreimage": "470394f1ea93ed652ed8fba12c00dcfe8212c4fd3295f7413f7a927e002ea4eb"
+                    "unknown": [
+                    ]
                 }
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+            },
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                    {
+                        "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "id": 0,
+                        "paymentPreimage": "470394f1ea93ed652ed8fba12c00dcfe8212c4fd3295f7413f7a927e002ea4eb"
+                    }
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 1,
+            "remoteNextHtlcId": 1
         },
-        "localNextHtlcId": 1,
-        "remoteNextHtlcId": 1,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 110000000,
+                                "paymentHash": "8402e76bc62b9de41e92cfd8375016737d985d5d73d4d3dfba46b855f8370b49",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 95000000,
+                                "paymentHash": "070fb40232bd54297d485a2303b042cbdd51011f34fd509f4bae3ee0c62f6fe4",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 705000000,
+                        "toRemote": 90000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032905f010000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799018730100000000002200202228f1681cff3adf3524363fad7481c1aad6aa344b223cd97b4fb09a667f5e2db0ad01000000000022002028eee5bc7a7219b098d1f27ee035b83a6870d2be541097068097ab8a8d2568fba8a20a00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400473044022069b2ce78c6eb6728db4296f6a88b65af682c81dc613985ecf6c23d14cfad3b6602205af6b39cf883448ac1769495c029f230c18d1c4b70292bec6cafad220b74bb5801473044022043cd8250bf3125c454dbe9d7389a3000d6198e35ad82ddd767d2fb770d4e00000220740dd54ac489715d33c6730ee78ee3df4e00f875f67c93b005235d5d637334e40147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "9601ac0b3a2c26b11effb0690a37b4f86b10b144f1751ad6d64f5e58d40c78b8:3",
+                                        "txOut": {
+                                            "amount": 95000,
+                                            "publicKeyScript": "00202228f1681cff3adf3524363fad7481c1aad6aa344b223cd97b4fb09a667f5e2d"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914e563f0bce1d82759c3702437ce10cf2d7545b5a288ac6851b27568"
+                                    },
+                                    "tx": "0200000001b8780cd4585e4fd6d61a75f144b1106bf8b4370a69b0ff1eb1262c3a0bac01960300000000010000000116660100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "6e4452d82c90fed66b3764557999d611cf78e5f32acac0af83839aa65f5ee66c33d859c48572a8f06228d226ca5cd80610d970d9abd0d50edf58186eade21d84",
+                                "remoteSig": "3dc75b272417d1deb5afabc3cdb5f9615f0e1a98b5e85bc661e3e2ef4a4346d84e587321dbf824e3d121ddbd0dc6098c062ab04b1879562b1c6f8ca6048e8edf"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "9601ac0b3a2c26b11effb0690a37b4f86b10b144f1751ad6d64f5e58d40c78b8:4",
+                                        "txOut": {
+                                            "amount": 110000,
+                                            "publicKeyScript": "002028eee5bc7a7219b098d1f27ee035b83a6870d2be541097068097ab8a8d2568fb"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9141156a3cd8369ffb3b15e9151e98e1d039a674cfc88527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "0200000001b8780cd4585e4fd6d61a75f144b1106bf8b4370a69b0ff1eb1262c3a0bac019604000000000100000001e69f0100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
+                                    "paymentHash": "8402e76bc62b9de41e92cfd8375016737d985d5d73d4d3dfba46b855f8370b49",
+                                    "htlcId": 0
+                                },
+                                "localSig": "6c2c84ab6ddd5e0b576ddbd190b90a04f421c87cd7c0bf58f21b77014debcd36187e78df2604d1d3b90e7a8ebc547fed179c53e83b6030212cf0efb9f6f73afb",
+                                "remoteSig": "08d988b910001b302c708db95aabdd1b11a02a7d6c549b78715b2894070feec1557f5cd291b5559f866cc9f8352d17631f28eeb0764408f6f503442c636e3729"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 2,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 95000000,
+                                "paymentHash": "070fb40232bd54297d485a2303b042cbdd51011f34fd509f4bae3ee0c62f6fe4",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 110000000,
+                                "paymentHash": "8402e76bc62b9de41e92cfd8375016737d985d5d73d4d3dfba46b855f8370b49",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 90000000,
+                        "toRemote": 705000000
+                    },
+                    "txid": "6552be7d50bfd1711e327a88449299c0cdac58c180f781d5a1d97908bbf5bf04",
+                    "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
             "0": "a63c8f54-772a-4912-9b2a-055f7f64ce56"
         },
@@ -219,24 +236,12 @@
             "left": null,
             "right": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "73267938ec3fb5ea5dc04e15eb163c30b5ff1ae4b68be8f1036418fdfaf595fb4090788cd267462f2f54005b0e18bd8741f363f4604e97033c5c69189518e80a2970316a58a96ffafff202df6313fef9ebf1e64a9425f6dc6b91bfcde58d82612f6275f3568df8adf20394169cae4e236304f2de2d5a1e576141ed2d5eab806b5e8abcd85c7d58c5353835f160dcb2f7d33aa447cffc64295a04f3503a339e926fb9ed0ea9355c01fa7b4064b72cc4b5b89b7b3f05710bf5cafc66e50bbd1085bdd0080990f4207a05332a92b64ad795ee61db4722936e2abd7a675b72a1a138ee4c8112e117caa529aaa879a7ccdc4a59c20fb8d6b1c4d5514aadf0f7a02a2a13d4db90209f6abc3a62eb1a027bde93065cdff27886d8009c3d1366c0c973c4cfccd993253900d625c776026f4d16ddcc425e264fc3e6224ede6cdecc577db5ff0d226c382a60f2e25e87eb495eb2ea107c26feb3fbe807b072e2de53d77187d76285f305d0462738cc4f013ff670b55cb88ea9dd30a75754ce7822bdebba1b5f89c598cdd1de5fb0d78f0c460979a509ee4b0760a2724ba822aa7a0bb2436387c4bf1e85aa0460abb36971a9e209f4349b2cbd1aa0093a22a3a9a358aa987c73b4f3a081b30abd76a5282b5579a26483fd3e7f0034e565baf7350d25143b3f3f83575a1e7669ff52ea23fcc58c762d544e19907c01e1d41874c3cc026f3275e2fb22fdff98a66b55f6ce0582eb3203cf0594e2b91fb921401fced7c3d8a48ab67de2f4112691071a306f2222d55264d0d4b73ce9d7f3c3002c53baf788b98a0ccf3c772f5276a83a1d755f1ec5539038374adfd39a5251302a464551372852755e9a8106412c86a8ccce6983e4b390c364d9445d63fe01d71a7f6714b182375f856deee803db882b7bf60aaf0db989b0e1d404306e6e6bf0ae6cc09b57126ce06c150cd89a03a6d33470febf74bc1508ac4825ea6b4289a323ba007004c4ed4d83167f6cffe70fb0ec45908d0e12699a55ecc648055272f57c4e84597a72448b57fc67b3f9d698e9bbdd2d6045c0abfcbcc04a611077d1840ce283f2f85d4312c8c30576f5ebf2629e8b6a35b486ea7f18561ccc2ced23f499b11d795168296574403822d320fca5c03ed5e98ae7851444ceac1766ef01902c4174e5d6b8b6e6816621e9a3909d81045060d330b3493ca3b580bc6401a37973f871ebf32d1aeb598f4aeb8d94e6484217344a78528d56a59d607318a66403d82bc43e7a5131b751e82dce1581846ef91de58a206e63302efa2caaa4699072e97d2cc5044abbabffdc48dc7a29851e14303e5bcd9063f71ce00d5bd841c831e3133d8425bbb7a5be701e7dbcca578a8162c204a75318c013b239dfdcbb16cf91c1ca05daec0bb8f8933594ca71b782c5eb644c70a5c02ff86bdd45e1d83045374cecbdf5dcb98da290bb5bc1559c8385abf3c055491bdd5a836efd6ab0c982c91725d632715527d5f6a0384b594015a4b2905fe7a1f8bbac9ee4fe0f21a820a30e02dd0143fdd17fdf997cebbd710cb6e21161f85e5875caac2e05ff4d6ed9dfb83f222e2d7cf6ee6eb164959a947e5dbfb23e8eb6086007fd45be398a55aac04f6e616fffe1178265b71781a792e960eb12661d7d20992b129b8fa6256162c2791807d526275ebf358a6e2afe64a9c5c4059aeeb3f9e1abd751df38f91857d7e6e187e6e6288bf7ff51ad29c41eb5e0338be2150d62a9e650dfce428603fa0853f13e53ee576047465ac208303db5e295f5594f932aebd7a28d593c3fb424bf00d6c2e057d4c28cd94a7b2a5d9b8154fda681e362a3b2a7f9296b0a858f89d4f89802952b1fc5ab3be0f2801f1dc353e0b44958356787841bdecb444797cbf7861863c2c75c34a6fbbd0e1c929e5bb3838a56e3dc45699354adcb89518f0c936e15fa0d35ac91bda263e808b1c62fe2eb79e623f4998fb4519234ba62f04651adf0a144e65b40c2d049f9e4b7cd7b760654c3b3bde806ddea2043798112cf413c6fe7a934016afacebdc69ef9cfcb42f65cbd940edda3d7e86db0f654df8e61626b8142e75a88c4454586f0a0f849f6d8cdce1b8e93137c3c63cee73535c12ab12306727f2530bf839b0924785b61ff95fda48126d4b95e1d16e63ae84f950f3ddfd2a3c1b86087fa605deab7adcdaa4d5e44f360817d17c42e6cb7d1cbcae6b92a1a29872acf228e07489b655cd4ce5650d5a0c4786fa6c9b7279493d1dae37146a9dcb087840dc3135c1a62fc0ce297a60c2254a2282180ea13338dd9e9d83a3976ae7632c4dff6abe29854469ec0c9f58216ca3eb56e8a271facf21570a9f1458f6e2dbd1bff2c0c24d5ee340cfdd08f5ea15ce9b764a014214573578d9cafdc3c925ca3fa6fd725aaf109bc2a67edef6f4ff33fde4f546fff607f06430d88a9e21865fa52195d6cc4e084e08ece1bbb88159357c9622663d2c9cf1669b08fba76bc3f39fabf4931ef78054736b2753413918fc00f41955d0e2761891f51c480d25179d7ac95d8415fe86961e127bfbbe55dde8ae85c6212e32645bad8f21a50e9f05256b1cf0a60504c79d3d172b20eeeb2410841c08fd8ef99c4c4260ffa489470b51044780a365655d9e171a399e23fbf4e94b9a610931a7dc4b323ae7b990e705e5568a637250fe70532f18c96595570762f9f149ac361839d59935a0ac655aecb43a6191e828b7aca27e98a1f8f68451e5d4ba456c685ec9886b610ed3786465266c59280d02f71c95cdac40fd61d575b422d73e4fbd15f503690b23e23580e2178bc5bdcea5390169c510b3f7de2dbbf79a3167b1fb6453803699151a3d3f551ee43fe41d67e06fa925bf587a4a2d299a4692a763ae7b2acdd6b432e76abbd91a482cce3895c647718e192a8159266afeb2f9d310a9ea0ee4e01b434bb3eab9b022882c5f196b2212d7e813c6c2e4af305c966dbd899224626dd9ad80627fdbb958bd471f7a9ba8eaebe0effda63d3c4b84b85557b0fdd80373f96b60d9bbdd664a7753154f640ba1f8eb1cbfe4212b7fc3ef9e44c93cd8210192b05b365d77cbe81fe004d2ed1fb3ae6587de8afc2710c93d7faca81490a3ae59b18ec2fc00cada9c718067a013f66aa67e1204cdfbcb9c9ceb405aaa8f625e6b435055f8c6d07e1e6ae8870cb1106b7c978ffd0f9417f481c79ebe51f0bf0dda3d30e0f944a1f037340b81308a0cf0b0a28502e805b285351144bf60f886a56d44d234cdbe589a01888b4fec9161d2900851dc44958fc5063e98e5f765c03ef208a13e5184b06385333e706e5dc63eb95f0c611b20907cc0211f2fa8f27ca8877bc9d0d6e92f8fc0d121c231351895d6e619d091bebb4e53af89036bf8fbdf8bd8126ea40f56703ca4d32d965b97cce5450bd7192e36caa9f54fb21a49cff86e6fa2f46c8230a2632f1219a8fab1187e9a7bce655c8f0973456f88d1f0653fb22b06f482fae5976056756584ccb08b9cba6fe8577304d0f9edfc96e03da97dd16877d15774de1613f3c6ab7e362e513c560a5750d47bfa2fb41bbecfa5989d7635038b5f4b8ea48fd2c2c13fd842f1ae199d5d382ec3f3824c66058f20da2feec3cb3854ecf357efc3b68d33ecc545271de838b12efe2669adf929504d4826d6eb2385483d86388f932013c07f8ecc66806c038b4a9f76ef0a942e4900289c3f212333bfda32ca493a77029e1c8cec4cc5f9e8b8e526853f7865408f352a5fc3ececab77f51fc177ebdb0bf19f03bfa3f1301d06bb8ae183f3ef51fee7a9d7ef797e517fcdc4abac56896a0279f3f84f093c1613107e5997c1268609cb34961e03f12e1160713960de286613b737bfd51531a980b14480ee7cdd8994f36cbf814bf7c5dc8638b8f52f00ae59ba86af9e836b4c3e4e78b38a2dc4bcff3cb0cb272a940fec253728f3d90c3fb2ce50c00f0357f5646ea2cc8a3b1feb4b7c25b093c59dcfa43aed3b8cf050b9d1edb5efcad35147dec5baadb0dc0caf38e01b7d89394908f50853fba05e173357c9ec63f0c17b4914b28c6be9bcff256ea628b2dd9a7a6bc72df034f979f3ffe2485941555786ea131b2f164ba79269e5b35807e90d4c4d73ca18aa5f8bd44c1f5545d4a0e334f3171aa5e08dca72660505c5d39082488ae64155510e54b3d999d15aae89cfae172733d0e13c9322f487c6e5f9bd76ee46477f7c460a20f3e1de49fb4a8b32087acea660959e2212690941dd02af8d19068dd53ba062e1d8baa47269d53ec801afff8cbb9caee4ed545f065359ba826c5987a3e73482f7a38615b427e47128ac7f54cc5b109fa8602ef8d0ece0e3f16714cc9498a6218c4e757e95f424ea64f970c43fec345d1cd02b809e1efb5522402a675661801b8e72b68e065b9d0b789963e1b8823fe8ada499abbd9a64b3b5f4b533a8d31df8412fb1b4b2b2b5ba6347edb7bcb33df9a850bd49e7fe7c1155ae97a53d4fdaa28cda7a4ec1d261052765be2b3e87205cb6ce843d2c8e95a2416fbeaedef809267d8cd72bc2bc19260bf9607450d6615026e6d15a70d5bd31c7b1c3811fc5fb2c1da6f2b080ae66acafbc13a81cd6ea41850b60933c80cc5fc88bc39e513fd7650f24857e90c386a7bb06f16790623c382f9b4c8100d4bc963750449f3989e3f24cd9edabd0ac395c715ac2b66c2529bbb48726d7c0b468c6aa7a6a206a4cea8d93568181c571de72ab6bc0bf066cedea7ae40a17dfc1890e2ff9318bb7d9ec60e0b60d61f9679b2b23c9a2f07c4a3784ca2713dd21e508ae47713666eb439bafb601fe8e0b677c03eca62680874f1b33bc04e3c7807c31eea06ab3759a7d0e1be3968e5dcb76d7f2885e1f4539e5b7968e1cbc2d6d7d519c757f401a17dac837b20cec445fd975e823cfdd28cfcc6284aae236c70423b4904eafabee1c7cd9e6d02069fbd912e3daf48985821fb66259ff0a42fdcb3c1d2f045975a9f154e5807224acd87c92d0c9d30205a500db9d1884e61ce835e88fda33bd4a6ceada13629515d46c278563afd549efd6a5513e89afb16f80a15f0e7ab518e7d18b65103f36534a94cd795d28247637762eb972422247e34fbf2fff1e775d540e025c2a59a3fabc412f988c908609604026ee63b82894aab9675430afc58c7ef9c857aefa94776194446cce84e67985e30c6232ecb82a3ad139dae0559f5c37b2a2c5c0e957bb947ff4bcfd86437ecdb033abc4baa558a81220e12"
         }
     },
-    "fundingTx": null,
     "waitingSinceBlock": 400000,
-    "alternativeCommitments": [
-    ],
     "localCommitPublished": {
         "commitTx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032905f010000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799018730100000000002200202228f1681cff3adf3524363fad7481c1aad6aa344b223cd97b4fb09a667f5e2db0ad01000000000022002028eee5bc7a7219b098d1f27ee035b83a6870d2be541097068097ab8a8d2568fba8a20a00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400473044022069b2ce78c6eb6728db4296f6a88b65af682c81dc613985ecf6c23d14cfad3b6602205af6b39cf883448ac1769495c029f230c18d1c4b70292bec6cafad220b74bb5801473044022043cd8250bf3125c454dbe9d7389a3000d6198e35ad82ddd767d2fb770d4e00000220740dd54ac489715d33c6730ee78ee3df4e00f875f67c93b005235d5d637334e40147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20",
         "claimMainDelayedOutputTx": {

--- a/src/commonTest/resources/nonreg/v3/Closing_0ed6ff68/data.json
+++ b/src/commonTest/resources/nonreg/v3/Closing_0ed6ff68/data.json
@@ -1,165 +1,170 @@
 {
     "type": "fr.acinq.lightning.channel.Closing",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
-            "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
+                    "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "0234ea3e3929ca115acc645d07c40eada7a98d86017614c3fa466d7e19760917e4"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
-    "fundingTx": null,
     "waitingSinceBlock": 400000,
-    "alternativeCommitments": [
-    ],
     "mutualClosePublished": [
         {
             "input": {

--- a/src/commonTest/resources/nonreg/v3/Closing_0efffae3/data.json
+++ b/src/commonTest/resources/nonreg/v3/Closing_0efffae3/data.json
@@ -1,168 +1,173 @@
 {
     "type": "fr.acinq.lightning.channel.Closing",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 5,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202bf8e35df3ccae49bcd2036ec55d8450741336530017d00f4f41dc44d69675b7040047304402202f27c14d4a412b64c8ca226b9a20c51068f6b939bad70d46dfc1600c39617552022066f267b145178f5a69d69fee8ae6930ded1d1dc96a746e79ea3302b7df989b6601483045022100e75f4f2e202db89d24d221c7c9329411a85876e00996499b5031c1ab094afdf3022044c7c948e25282f17396385eed0efca8d7a3226ce002fad2e48cca9afae5c43b0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedb99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 6,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51137bd5ff1caf7ee0f35541914637e19b0f4ce9373f1744044ae7b1064ecce3",
-            "remotePerCommitmentPoint": "03856c08523bf8c8def3044843a4ff90fbb1dee9f92d4ae82aaf3fb2688bfc3884"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 2,
+            "remoteNextHtlcId": 2
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 2,
-        "remoteNextHtlcId": 2,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 5,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202bf8e35df3ccae49bcd2036ec55d8450741336530017d00f4f41dc44d69675b7040047304402202f27c14d4a412b64c8ca226b9a20c51068f6b939bad70d46dfc1600c39617552022066f267b145178f5a69d69fee8ae6930ded1d1dc96a746e79ea3302b7df989b6601483045022100e75f4f2e202db89d24d221c7c9329411a85876e00996499b5031c1ab094afdf3022044c7c948e25282f17396385eed0efca8d7a3226ce002fad2e48cca9afae5c43b0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedb99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 6,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "txid": "51137bd5ff1caf7ee0f35541914637e19b0f4ce9373f1744044ae7b1064ecce3",
+                    "remotePerCommitmentPoint": "03856c08523bf8c8def3044843a4ff90fbb1dee9f92d4ae82aaf3fb2688bfc3884"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "0323e9618cf8548e5b78a14529e1c8df51895e47ae6026bf23f5f130299bbc92b0"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "af86858a35b5f1157fd7aaf673c32e67ca2d0ea39247b28f0807e32bcdb54d5248fe0dc200a4f126eba76515c03b4b8f7b66b5954d9614bf91ea309191db82c31e52b7b73bd0e1500e24e3357cd7ff6b67af31637a0359591abb1c6442c180e17fd25eed846e08e53821b9024a92423a6bfd1f50017a124565721665a6faf0042fe57c7c1fa69110c7c61e29aa7efd6600d54956ad0ac7242569bd12b5c76ce83e7616e2b5dc03a3e8323d870675723da9fccf6e7b6a9b51ede780737edaf10c3beb9c51cb32a9c28f11bed5bf19a37b81fb6553d322010bdd737c82405ab45e6b60b6b0c01d1a2099e05bf81ae3899efbf447919a99bacf31f4dfaaf1bc4fe266b7eb162215bf390bab1b86952a427ded6869bb2671c57200737170e667dd26eac1ac2be9ba5bad16575a681b04261c77a38fcc268b38b16fe6a1ac10c991aa4c603eaa7ecf3f2b2f48fa4de31ea44fdf4d7d4af605b02adb72822c96c334a15f5319e0f6f608310abaaf4ab56860d1584b6bcce7eea0f04dfe7da82937cb4df88ee4c1e82316b717f6aec4fc079633ae974a7cac797cdbd64608f37b904b98f9bcfeb4ee528089136a18ccde52f16fff46888b197d12e07a82545fdd8d6aa35326f2974c7e52920608f0b072e654536f2ca7c04b297756bbd1f6d14747dd7a5c020c9436bf6cee3f6f493c93d7c99332570ef7bd7f332b3c67550e75a3ac2030edb71e50574b446655f073722d83a0472a4ba051841d8a51645c24ce32f29b971a115d008d5d9861be104bebf869b1352aab99065094826f528d7546985a97535d7530d464e110d41903559912d86a125d3b91045928074f7e079deedf58afb0f1b26daa45f62a38989848d379c82f70543f102f647eba30211d57e1bf4072fe1bb4a285e7013a448de126368ff5c15a69c6fc59a9823548e0b629d8abdde62a3aea29c1dc3e99345193b076d3364e4afffc23557da48d03dd407efc18b6d13a353a2bed406ab9ec788bed9a2a09082ea5d60413a7bca50b07a78b01d5f8eee2d7109a6c8ff25c8f103cb5fa099ba373156352e279980a4c8d0561e4f2d5c11c113f18dff31d281f81820ee3a1e3021753ea891e2366ef0cd4c97fc870da0fb1eb0674a73bc4320085795f514102930b9975d385a9bb2dc9886296eb4efb2ff3dbda14803a1b4838899dda19f68554c9369db83e8ce22473cee3c94bfaad5e0743bc40c4f94d8e0de0946429e88a96aa7485bee65c7ec5053133700b699fb884ed7663f9a563c451f4f4e4a63dac66a90019704158ce8d419b22a62defe24872f4484c40c1d75eb63a4fd114b6b8d5ad20d222b13a0d39851ca35d9322be5b826a393072b376daeec127673b9c96dde60c1fe071d3f8b561ea397b32e199ce694c7f30358ae33fecd4509804650bba8c7ee106c2246adb89a8cc1077bb67b3140e2f544393f8e33e47768bac0e94e5a284150ec02ca22bd99cb5c746e4e72535b7cd22aba375bb7248f155a9e75fdb074fc7d4a54f6ec17b424cff1f96ba2f3d027fd4781a6f2053e85c69800c9cd321d6379b3051ac540370ca5e97d0f4a1c2a39da97ca9945b49e881bb612bf3c8c7112903f8c66edd837a22bf3a6bda66cb3f12bee916649ac06af4f1c9790a7af21bd3dcb5aae21755cad75c591417ad962310bcafede7d1ed307b13176709f8bb1f9c3fdf0809dbbb28dfaa2a26bd076d119a34976417c78a4973b98f9c153a4b4233520594ff81627c121e4526171f66838e0f00c58cc4253f0e24c9bb23f7ef43e91ce3c6300b65c8a5b84e67da9f0e5b29f3217e280db53a3168977ab9bcd98f04c94cc202e9ca839e1129dbbf318d5e621a573a3928c4786df99838ffbdc2482cac10d14510240f914833a0b4470831c14a84686ae1c0f12c935bd5d780f7b513096a1e4bb78efb03133668deeb4cb62621e5876e3005db805788d35fad046ec9043838ea036e65c282d87c5895ba322ecf443346f8f737fd2e5c0d5a2887a25ed9c1d0c53d989d6cf8679579c7361cde49870e0dd2b846a2ed8815a4e1213f73ef927cee4184631fd4d7d542d5ba639bcabb3d98b6d03ccb3a86b895925394bbe5d386d7395026457c950149228e5a5edbbd315ebafe822a37e16917518075c392eead699a38cfeaf5a08fe15c993a32d8b0c39a01661cde7d1c7d3de3f71e3342a40087b385475e40848ef45507b13ae05a7d492f9a0979d093facc04ebc63492e0c74cc72f30142a4039c1f66597ae6f63972028d8a718740ce237da4d8c3c09a824ac6fdc042bcc33fdc4f417c4f1d0f0823bddc6f71e6f72529ce3f3ba0f62e9edb26c2f042f7b21c9086d4a61b8424fb8dbbe831540d8db329c0f75d10f5e2bc4549ad44593ce2bf045d1d3e67fc59bf63dcf369327c1570bdad0cdcf98948515d27b0e2c25232955a4a603443ba332b7377938b920006a899e00c92827123883feb24161f5051beec48df36b608381224726ff5accf5f2c73aab9da3f9137dd5ca201a881bf35660d179f0fac7e5c69d1f4d0318a57b07b7a53d3ac5a568328080c47b12575cf07b1bdb047432e93c2f9029eb9d8fe51555698485eaaa6f74ff560601678985d7bbce969c204c7ebcfddd3d51c246e3639af4416e62efbc3ce9798cd9043d2d8ee00802140d60be622575288cc7cc1db082f50e148f7b778e95aa867df6bcb7bb542fdd7261859618e65d60270fa9cc37917e4a14f8e13c95c31671023e3848e8002e3fe25dff069078e3983240ba3ae99e212844310431af49aeb7b9328a2394115b642179e3859deb8aac311386a3571d53fd50e309ef6c5e044b78183ea450abbd92848505fe3226b1481b100e3474f12009157341e4c73a3438d105ec52b9f34ffbcab5ea5d3d65168d36a1f558bbe4fd255b950b20a78a97462ac8aea5b1acad474fdaa97d3f2b17c5b5353e48e79f64860f8e2b1a16d31f2ec3f596ccdc9eca8b0efdafac72704eee3add0a0be5e9a12a34a7f300cecab42464c929028fddf06146c9b918e8fc88316fe26155804657adcf3a4890e199c55603e3a86c0377386917fd39a58c72951a949a834ed99f707b350f2ec70651a5e4f4016f52b3a5b7e6633a95c7a606bffb65c8f764a30069d585d242761a4fef3a2fe6e88509ebdda0c2c064e35e58319e26583f7111fc6cad12b36f6671ea9460718b1c9abbfd8bb7c7a0ec6bbd66506bb14639ab41989deda3773e8f044f4ffb97e8cbdca5e73f847c218b527ed18faf2fae95c16d89f0389c8f02eb87f39d3be33cab5e39c0aa32cec82f067b36b16aca96cfd13117198bc463a5f39b55a3878147882d1257b0b8cfa9047038db1912f4b943db55ec490b019054b530e73056889489914df98308002175ed472501c86b74f598cf36640211b6483881d614da24872004c33ceb7f9c325f49363341028349376a6ee554820e01d60bde0cd822f70dc01a582edfb8784dfa03ead20c9aa235861333af90439980a40edcc056f0ad948725f494969bcd1cf9878aefef14e9952093a1467277ec9e4be3a9d18ce6131157959658a10d23f75831628e57d85bbfc8c90eb4b5b9803c6fdf8f10eef91647f4dc38367dbdc6caae7d064b04a4fd121642c6c995263d0eb4896fa4f66751b6c6efc57bde182f15abbe38ab5d55917d9f4f04c6c25f3179f816dd6ec47f89099d2fbc05417703b6007fa86d2ef108c983cc7c2f59f015e5469252bd58a1b14131f69a1385ebba1eb46bdd45b081f4ecaa147c780319c34c2a2e6dd281e6183ef4adddbe0e89fa9bb14e4e6e51b849916d1d7f1d6c7f89f0a8e090e5647206bfa94e0bf2242d606932b7033196cff04bbf7b91fa03037178c4042bdb1d4cbfe072136511bedd30c355ab733cb569a0e25254499ccab2ac447b584afcb01357282f28ac890165a99ef5a6979c036fd24afe7c06564ee5b47341d2c7e8d6bb99e6f04d04f2cd7a60dfeed7a95b47a3a0730744e7576ad92fa27be5ecbaa6ed07cacfa3d5f3bbead8e82a959573cfcef637dedac9ec54d98fc3aa7b51d56839cdcde74c5a7bf17f62e4ae0ca80f8d1443521f2d71253e190bb1cc0b0c0cded2a283f1399bde1c06fed0da92b1199db9a8dd52e20cc32ac84a9a6eb65d7d2ddf45687f6ce18c472f65fded8378e3f699277a754c75c7c94b242180cf018a09548a52206a8e8f0488c15a2d07c6e2a98622b265c6100a09a28c5dc66e3b0caaef29ae76a88e6cf1b8f155bdad84a747f5e2063041cd41b49912717b2e54f62b51afc82de929e9307c803aaa26dea29dc7f7c7d66cdddd6d4e6fe43a0aaeb1057fee4a52cf48ab8c81f7b76aaa16501003c0c28ea1d82d4322af24917b04f9927c01489218703213a6f2f369bbf0649040fdc3f2fb99db442b391c87a930e41d112d1b73f7476d5c10e0900811c78556e3316936f709560182306fcdacbee35d20dc62ff4a973359f62803a1aad02cff001be7f5be361766735b0d140ebf0ce1a34187459964ed98338d221b6f347937abc388a42e6031cc84fc8c00a99f33d83e4dd70ec5da629d5f7bc086c229331ccfda15c91291dd4128b9523d8f018dc637134739b9601b2d007830c8034106e2a6e4bc944c0e6d744f60bf38fc3fa702e3aa473dd15b5338485acf7e5d0b15ee95357de8224ef7fb47db1a268ed815512910a9a56430e04bb223ef5f9246f433bca6b046ffd20e2f55a26e41fa0da7f60ab90924afac4b827913dcb98d90304ec2f4c1f69fb1e25d47e622004b14932fa7176a43252c47f80e0ded5df71a3f2f8ff0961bf8d12273260c93a4f258d8cd89c8b55a3b20bf92670ecb4695ddfc6101a43f61f83ad029fbc1f7c9e91e5e51bc19d5f111efe98cd0b00a0a4603352fc69157f64ae04d02f0cf9bdbcd67616c3a718b2b6bc49922653e841f91bc4f3da3fdc3ec7a766f67f792997d2a83c00eff7ac9c17507c6c89a96cdca38fba3532163adeb253b7202abf192af8f71312d6a799ae36ba980c3e7bb2abad997df3b0986fbee7cc7de0a28887a9c58cfd96dc3f83413e60a1d784962071b2f20db112aac11126f41bd34c6c8b103d8d1b83c2bb8d8652e09ee8ec1aa4c1fbcd4e414da9eefa64a56d93c97573bbc6de1cd8c6e12fabb874175921259fc57ea31a5f25b40d259c09ccef8c5bf0b327bc814179924cc55f62f6fd51a396d86a94b4f58b5535e4859dfd2124791e25e69bb65e677"
         }
     },
-    "fundingTx": null,
     "waitingSinceBlock": 400000,
-    "alternativeCommitments": [
-    ],
     "revokedCommitPublished": [
         {
             "commitTx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080084a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da0325046000000000000220020290b762b514961d8ea3f1d0a0b7325c43daebfad3751211816c7bba59e607ccf204e0000000000002200201923dc9176a660d04e0744c51f5e04a3168985962079a6c5d9e2e763170878e1a8610000000000002200202956089b232f4af35587c10894e6e4351d029b0534fb01f7c3c90285a35d45ffb88800000000000022002058acb1c4d7241726756c7e09705500409991b84ce93c86d6ca4eceef76c98cd4d078020000000000220020adccc1c6aa5fb4707079451e579c5dc33c513f0d829346cefe8c80179e09d49ca8240b0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c0400473044022003a9fc09ecabbbc049b8dec3d3b92f092265f03b3d4842c0595de1b91b215be202206caebdbc0bfac0d93b3068a9a633268e7e8ccd5904971f8375e5b9b3ee64b3a501473044022045e9af4c12876dcc268d319687f1990ae8db9faace5e4281465bd5799e1a44f9022020c476373f17531c614eff980283fc8b3ace4e69f9e58debd891c0a3812211900147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aeda99dc20",

--- a/src/commonTest/resources/nonreg/v3/Closing_ebbd24bc/data.json
+++ b/src/commonTest/resources/nonreg/v3/Closing_ebbd24bc/data.json
@@ -1,217 +1,234 @@
 {
     "type": "fr.acinq.lightning.channel.Closing",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 110000000,
-                        "paymentHash": "c5be461cf5d852e51d0843a02669daa2c6bdb5936c50dd16a2eed74fb2695f2c",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 95000000,
-                        "paymentHash": "b3c444a354a0e80f8560756fb5e02aa1e8ea09eb8fefccbc2ffc778fbe1ea0fb",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 705000000,
-                "toRemote": 90000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032905f010000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a79901873010000000000220020b5abcef667acd30c1793157728653afaf2ea391a4039bc875b6ad468cc2f603ab0ad010000000000220020c24f3aaf87264753868abbf958e8e7dc70352378c068e4c47b02fefc0acd114fa8a20a00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173040047304402202aad97bec2048a0ccb1d0b1d38083d49b1de4ea238f29c60e9a181fc120df0cb02205ca4257086803c52b273570ba6475ccf8b7ac02616f58531575f9215388c9f6301483045022100c35d93b87bb3187e29e181821f4f718c3b6faf853159937093a4430e8db8d20302200ce7aec5b5560eee2b27de3d43686c6b0ba3de5d98a939c0c5a2ee06ad51c17d0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "735ca47f5592a678bb13ba5ef0c27b9acf0181dbeef2073f5668022077e05d38:3",
-                                "txOut": {
-                                    "amount": 95000,
-                                    "publicKeyScript": "0020b5abcef667acd30c1793157728653afaf2ea391a4039bc875b6ad468cc2f603a"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914f335537767c2b929f665f48046b4de72ae6e999e88ac6851b27568"
-                            },
-                            "tx": "0200000001385de077200268563f07f2eedb8101cf9a7bc2f05eba13bb78a692557fa45c730300000000010000000116660100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "3003b8f3d670387a33f4e443c5ad73480d15d36289a0c97a30cb188cc5c365e97d71373dd570ccad910648e1dcca5a9c814b824a4813ca1f283a9adbeef7f4b0",
-                        "remoteSig": "bbc0bb252d2e03dbfefaa3fc3d50cf7bc2fef26ad8a4f3efe2a00a1a356c74382c716ce5b8e6469bbca5cbf50e403c098ea389320ad8aed4d9bf4acce2058d4a"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "735ca47f5592a678bb13ba5ef0c27b9acf0181dbeef2073f5668022077e05d38:4",
-                                "txOut": {
-                                    "amount": 110000,
-                                    "publicKeyScript": "0020c24f3aaf87264753868abbf958e8e7dc70352378c068e4c47b02fefc0acd114f"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9140a2c4c072a7bbaf35ef47956a1f8e7c132af7f6f88527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "0200000001385de077200268563f07f2eedb8101cf9a7bc2f05eba13bb78a692557fa45c7304000000000100000001e69f0100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
-                            "paymentHash": "c5be461cf5d852e51d0843a02669daa2c6bdb5936c50dd16a2eed74fb2695f2c",
-                            "htlcId": 0
-                        },
-                        "localSig": "49dcb8f0605d4dcecd56a23e6821f0cf9cddfbfbfef92d018fbe996c7fa2908909a53e3c36da331164c5a3763ac4332708768bfcc6936cf64c5746254e18d6f6",
-                        "remoteSig": "19b2c53f5ae64336a2d6aa51500944fd3e4418be72efbc0529de32e3b1bec5e1315cc9cd535a243a6426bf482dca8cb983a8ac1441d1c7ff4c03c7194fe7c878"
-                    }
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 2,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 95000000,
-                        "paymentHash": "b3c444a354a0e80f8560756fb5e02aa1e8ea09eb8fefccbc2ffc778fbe1ea0fb",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 110000000,
-                        "paymentHash": "c5be461cf5d852e51d0843a02669daa2c6bdb5936c50dd16a2eed74fb2695f2c",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 90000000,
-                "toRemote": 705000000
-            },
-            "txid": "d4756e4280b3178aa6e35eb9937681a6dded4098af1f93d055c9a693686f922c",
-            "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
-        },
-        "localChanges": {
-            "proposed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 0,
-                    "paymentPreimage": "ece8429c09332ef2f819c5886b71cc500b21956b3faa6f3ab3f9005010c9655a"
+                    "unknown": [
+                    ]
                 }
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+            },
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                    {
+                        "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "id": 0,
+                        "paymentPreimage": "ece8429c09332ef2f819c5886b71cc500b21956b3faa6f3ab3f9005010c9655a"
+                    }
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 1,
+            "remoteNextHtlcId": 1
         },
-        "localNextHtlcId": 1,
-        "remoteNextHtlcId": 1,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 110000000,
+                                "paymentHash": "c5be461cf5d852e51d0843a02669daa2c6bdb5936c50dd16a2eed74fb2695f2c",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 95000000,
+                                "paymentHash": "b3c444a354a0e80f8560756fb5e02aa1e8ea09eb8fefccbc2ffc778fbe1ea0fb",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 705000000,
+                        "toRemote": 90000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032905f010000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a79901873010000000000220020b5abcef667acd30c1793157728653afaf2ea391a4039bc875b6ad468cc2f603ab0ad010000000000220020c24f3aaf87264753868abbf958e8e7dc70352378c068e4c47b02fefc0acd114fa8a20a00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173040047304402202aad97bec2048a0ccb1d0b1d38083d49b1de4ea238f29c60e9a181fc120df0cb02205ca4257086803c52b273570ba6475ccf8b7ac02616f58531575f9215388c9f6301483045022100c35d93b87bb3187e29e181821f4f718c3b6faf853159937093a4430e8db8d20302200ce7aec5b5560eee2b27de3d43686c6b0ba3de5d98a939c0c5a2ee06ad51c17d0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "735ca47f5592a678bb13ba5ef0c27b9acf0181dbeef2073f5668022077e05d38:3",
+                                        "txOut": {
+                                            "amount": 95000,
+                                            "publicKeyScript": "0020b5abcef667acd30c1793157728653afaf2ea391a4039bc875b6ad468cc2f603a"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914f335537767c2b929f665f48046b4de72ae6e999e88ac6851b27568"
+                                    },
+                                    "tx": "0200000001385de077200268563f07f2eedb8101cf9a7bc2f05eba13bb78a692557fa45c730300000000010000000116660100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "3003b8f3d670387a33f4e443c5ad73480d15d36289a0c97a30cb188cc5c365e97d71373dd570ccad910648e1dcca5a9c814b824a4813ca1f283a9adbeef7f4b0",
+                                "remoteSig": "bbc0bb252d2e03dbfefaa3fc3d50cf7bc2fef26ad8a4f3efe2a00a1a356c74382c716ce5b8e6469bbca5cbf50e403c098ea389320ad8aed4d9bf4acce2058d4a"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "735ca47f5592a678bb13ba5ef0c27b9acf0181dbeef2073f5668022077e05d38:4",
+                                        "txOut": {
+                                            "amount": 110000,
+                                            "publicKeyScript": "0020c24f3aaf87264753868abbf958e8e7dc70352378c068e4c47b02fefc0acd114f"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a9140a2c4c072a7bbaf35ef47956a1f8e7c132af7f6f88527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "0200000001385de077200268563f07f2eedb8101cf9a7bc2f05eba13bb78a692557fa45c7304000000000100000001e69f0100000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
+                                    "paymentHash": "c5be461cf5d852e51d0843a02669daa2c6bdb5936c50dd16a2eed74fb2695f2c",
+                                    "htlcId": 0
+                                },
+                                "localSig": "49dcb8f0605d4dcecd56a23e6821f0cf9cddfbfbfef92d018fbe996c7fa2908909a53e3c36da331164c5a3763ac4332708768bfcc6936cf64c5746254e18d6f6",
+                                "remoteSig": "19b2c53f5ae64336a2d6aa51500944fd3e4418be72efbc0529de32e3b1bec5e1315cc9cd535a243a6426bf482dca8cb983a8ac1441d1c7ff4c03c7194fe7c878"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 2,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 95000000,
+                                "paymentHash": "b3c444a354a0e80f8560756fb5e02aa1e8ea09eb8fefccbc2ffc778fbe1ea0fb",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 110000000,
+                                "paymentHash": "c5be461cf5d852e51d0843a02669daa2c6bdb5936c50dd16a2eed74fb2695f2c",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 90000000,
+                        "toRemote": 705000000
+                    },
+                    "txid": "d4756e4280b3178aa6e35eb9937681a6dded4098af1f93d055c9a693686f922c",
+                    "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
             "0": "c88282fa-5e7b-43d5-b72c-883708000c69"
         },
@@ -219,24 +236,12 @@
             "left": null,
             "right": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "e9be61fb16d68c464063d2c5d88736c677c9bd37b43da36ca6d66bb79d653b7b1b8ad94e7945bb46923d3ef877cceea88ce8af842c73ee0aff520db045a8b581ab19aee9837951dece8f1d6eff19f2375855135c8a517a4d6d2e9e6bccfcb4cdc90779c577b1a75cf4d9b6ff53a7b89978f5cc239c3b11bf999549151efd5f3c1a7d751276079f3eb3741b63d263b6dea7c9bc71380e88b6650f9008633f6bfeb0055932dc97f6d1fee22f24811a44cdd249c53495c2be7dbada65f67dacf95bd4812c4cb144de96459dc52612b82c8d5d57400f02a478e7411868d2ea375f27905c7c44f99f999cd4853c5d1222b8250861cd2bf18b15508e4fed4da0c9175fc56e6a79b4d386f33dc26d793cd696295bd1b7bc42d2a3ff5cecbcd59eca1861760886f762979a987d0d3b34716bf87cc7f6f5e11e894b8a69e24fe3940cb2d63431aef3994ccce6f9ab40cd1d1ca000d3d4cd261033e94458d61811b5b1d95ab485462f2c912258f134249f60eb20c66445e7f084907f787fe62053007afcf47dd225b90a8fa419cfbf94385046d6ab6932651f3d343091e41d463fd57c98383949421ab62f0ffbbea3809ecb7807703843525c29aca6265d5d156b1594e3dd6c05443303a9529429908c1a97476ffec7c1ed84f3f1ca523526c6baf7f6be3818d3f55ead9cd20062faabc6cb5d2f7653590e617cef291f46250805f9031f79bde194af796d942b67f91cce1b198d2fc44ca284fd9c56d1de1e97f8766648e7b116a2d8c0b7fc3e8d9b700d2a7376d053299a79fd70735d41d43d92421b3579063eb5cf96804e9593c598f461035f43a56a282402f0c1f10799b3c918cb93465ee33f2d153a55fc74e35ea989f4da7b8eaa27243a4f2c6e526620180b224abbaf42bb2e8d3da5600334385a3503b318e745a2e80ded0696808634c1f3bd4c1515d07dd943a31f005790a439f4737ec85be41b635a0a88f71c3333a5ef7ce68046cdc2c320ce4d55eff0f82b863ee7ee68c1a284b6bb5337330106e0845436f26d5c33f3bb63cd962100e7761399f575f2b88ef56f3b74c1f41a68badf476a3f9097c8f96a975fc16aaec9eccc5800b280c1aa73b5a2cbc036302ee374d703b963399af99872f8b15316a19915ff877c901110b253cd7bbf7c4c1caa6f5ddfe168e930e75a6547022b4931a134055183d2758689f6d2b94548718b6c870ee4748b0654a53bd68f52cd597798513e529283ead26adf043ae816f8eefc9de704bd30d612b0f421d1d7f600eb0500d5d67120ed87244c1cd07d130461aa057e6305be01dbdbc3c3aec4a8d1b188d20e2ba3493a77622f27f54652f028fc7c23694e4c1b3cbd77d5b2c362daed5b406ba5ceb9b674ce29a8a36871eb1ccecfede3f28be0e0f3bf74aef50ac240c07209e4a19aa79279c7a6d0ee04c15191292ed407775e48acfb8b47e12eedbdb94295007ad0b916fae7d4c06fb7e0beae95fa440027d35a9bc3568f0817e29674314a1397fde8f23f569a05bc231c1ab6d81dbf585e483e5f1e3a2331fd316f5232c03286caad7b3f2d8dab725c3248a6d1e092f0b95cc321c9d420d815fa78e552d4c0359a72b43068fcc195c3df93316f0a62f1844d405e510940b03c4f376b7e88059331249f97e7aea7d39397ea0947c771b18bc065f9c1b79617a340989080e5b3548493ef73670930c06bae8654eb2673f57271add34599728cddcf4a189a5ab0a10a439694e5afba886d046301756e7a155a30550a7e8bcec333efd81dfa0fd0724aad420961c94912ba8b2466d6500ace9aab7e78a31f6b8836766f788bc1be8cd6b337f49620d09c07e9519d41fa78d0d1e397cabbab03a7356c7bb271d2aa2e7c83f48527b393bcd03c18c558fd1dacfd9d2610ac779e5dd30fdf3b363480c45dc1d41fde4e2a988322525e48a756360ce7813f118fa5ae72367494d74198ac974793a9bdb5867bf5ba9be4d6df57e2ed27c85d3973a91fec28162fb2ed4b664582857e289cdafd850d8ff9071e51ca17e4f369aa5385de5579233c3ab7a1106a623272ba76ca95b53ff56054a28309419d46af37ffd0371516da829a0c6331bf1412d2c6fe3c0b467bdd16a4b74c8d5085a3af756cc8b4a6214ad7c3f3c16ab718d6bdc04812703e87c91cd19bb046d1a4053e72d5e5db028044f900edc6c780bc1dd9ac3240195ac765fd72b078248a2efffcbb6b2570633a84a8022ec1ca908f12c3990fe1667baac6a2e92d991c5538839b3614d42c642e414f0c319f9068f526bb8f46578c8cfccabbb2120ec4c6f85e618a37fa02e342011187d2074649caa3a56945ef64a64958e794fae707a9ad1d8db01be8fce080ffb14069e90afb800599867f7ffe3f3448ee35ef58519d1f537a4343f370997e5c1d6a5c24893ec2554fed73cbc205dc6a6c73142c8ecb78638edd9f9b78c35e6464c8daa73ad43ad0df80c06c9692281a522cbe9d72820f567944cf7cd98e79acf9da6ce8d2ec079cdd5a064ec378356a27160b974eb0c93f0a1eed874c6dd9c75133428bb048ea5133c1da0c2945e1dbcd1d22858550914b30510458cc45a9c518e7ee1ffddba061dae72a2f203105a14f55d8296b7969c5af6fac7d4eff9bb0c740c3840befebcc1285bf250ca009a40cbd5a07ddeaac43ebe1b3cd6a715e3540e0c589c5b1ba40638cbfa9660bd58522268c2c480bd8aefe4de0a0e23d828d7039197b5976fedecad3b1114fb56d9222111f430bc2fda7ccf415c15296fbd0142ff6da4bcbe1b2a922bd77f78a7616431e271968692ad63ca590d2b37de714c94ac00f2d7d2d017f0746d3604c35f445d186151305862a769aa67841fecf5c0569179191d3014a1977971d6f6af3155a562a66c7b7f3b0567b8fae708a401231f7fd240a458a0df3c64c3ed3b75ac2914252d5fe2078a6f73cf358e3cc63e1b8e2295f6a5421693cce2d2b75cf96ce9047bbcb6510fc493ae3dc7b351b6ea0d48fb9fc4608c43bc37ed6a2169be3821fd5e10cba97c6052329965a149007ea9c4a2b65b269acbe72373fa092b607a17a1b39e1df438459a179011a718eb6e60c2926ace34c8c9ff70d29f389de90ae6ec95a12fbc179bd4cd010e7f5fb4048db92c7168513f2a2ddc2e6047d9bedb25bd35caac540b4e7f22fcf0c8acd0b7bc97b4d719accf3126f06473d1a892c7c60ae989332abf4ed47785b63809db98b65c94556bbda9eff2dbd21fde24b24fdd6f30a1bf0cac372fac580a0aed482fa331ba4f8cde993bb8b3c85f960e9a98f4c0ee386cc520785ace7e26671640e1a6dbfbd2aa35e0f1eccd12a041bf2bce62d114048f2dc7109ebd182debe8ada5be4025993f31f208acf6acb8bd99050441ca57047898061f3fc2d0239535f6b990ae133e9723e0b95522078765352b37c3d3f24237ab003c42c33c211a968b38ed8f01ea3f5072af95a5cac8457299734ed6bafb14f5d76df8aeaf8f134b19a4a886e5fed2b17074a43f8e9657375c4fd285c36268532e9eb6609e110107539c61a86cbc59fb4594874d9eeeaa36f4f3326afb214dc408e6adf9fa7d161fcb2112f865052263b1a46d38caa6ee5084a3ab4dd00c54336a0131c344b59028cf7dcb6f5f8bd36482301585cce7996f86d30878050b12cd8813ffd5771211185d1349caa7b2c727921158ba9f3daa870708c1b8e0cb7d63089b7aff76ef473f42c981dd2f4566031299f5445e66eca2fac24430f6ad15b039567d2078831328f89854ae898e1b3357c5f747eda1847af70bf653448c9cb7bb4df8679a8a55911b049164a6526bb8bb727d0901b19dd7460d69710e1bd507a308f114afae0bc53d342e4428387b1bf40c4964ae8fc02f91744d99ef8f11e9cbeddb48fd9e4c7ee004dfb8dd02e03c7989cc9cef5822ae2564dab46d09b123390a6783033f244510852bb3daac5e6160ce87e23247b2c8ce2ab8f80f8801f2d8767d3b13b7fc831c8ccdad6b06dd93df07495e7b3bcab93f3948cd5a25221b4138dd648e5f92ddc1f4fb82aa7eb043b610c92ca1c6727a668591a21e24c8c9624101e63d5c3721ec5b1ac2a681940ca9852dd22f274c566693d911c81035327730f547cf5ddf4167c7c1a19accf53e874fbea5c377cb512eca084499c5619110e50108fe96b4803871b70947487e7d3c2d6cf2ffc5413f50e294e65efa98a893d4730cf7ebaf8316fa21e912f3a13122dbf4672f51d0f5b7e0c2e369a6195b7c7acd78a12c31eac9cfcb4b4292f9f3b6187b8bb9c09713daa4f7fd44a8136e65314c594c0578e5397f4d7b357e8c4525e62c445bbe8787187f663b8c965ca8dc285d5cd8fcdf4c6abb6077195bfc91d0111fc230a294d299ef6e6a92be63a1391d4a3f78115fbd62e4baf7f7ec6f44043b7ccfd19b7c91f18de11c97ff4fab4b107da0ee971546ad4b506217422f97a6680f3907c7658038e4136795bd34d4679372bf14ac98d871f0c70f488d6514320dcb94723ab8c40de45431f6b1396feefc87b2f444fe6419ca4e135d9243c1879dd46f17207176afa9eed87c31bc1822455b427e6190df6f1d3d8c38ace10e93e1695b1eef13b43a17b1aff27f723d203bcaf5b60762bacb24b6369f2e724895a06c05257a5ab644180e701df34bc0a5b188f849c623533106ac6f6ccea8661b9fe18b627394acd4d6380bc125d833920083257b0849843e00b0f719740738d08d08e77975fc2f5c900cd27c1c07a301f7dd23a34de19f18a0e58f98af08c305cce74285ccc1ae97ffe557a9a7428d4991825004a4bf388a1931725905472f0ae800679a4172441377e6c0916c0459a896b496c0db738fedeb557188e83ec9f20b1d8ea8adfb24127e65a174e3ed331a5bca2a2bd3e0bf967c073437070a5e24afcebaad9cfcfd2fa1bfa03e7707da8aa815d7d3b880460199507fa489330e62a678ff976f74a822d77265ded6e8a672fe141e41a856b02183444ee5708d62b4719d257c091762d9da8f07d5c69027710e9d672393a576c766fe4808932c4349cf0d80ee6479ee3ac64da259cf23b588456e7aa6de6857801f3c4d6ef1d631367e547d837560bd69af5cda7cb3592910a279361b039abba970e5aba31d1c3ada4a67fb400a56d8d697da736a8001bf5083103682ceccd6c360058bdefb41c85d02704812a2102016649399f8dc69db1b7930049ba43dcc6cd9ba208b19f0a1efa3b5a968f2b7f"
         }
     },
-    "fundingTx": null,
     "waitingSinceBlock": 400000,
-    "alternativeCommitments": [
-    ],
     "remoteCommitPublished": {
         "commitTx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032905f010000000000220020d0b9e19e805ad1211c8395712a4225729e443223fbb3444537b6c93f5fa36839187301000000000022002018f3224d69b1cc3fbb44bd3779eb2bb07c6c5dc9722fd99f9cd6da90c4f9bd45b0ad0100000000002200206c71102142c7c3090165e8d136f64fda559496481a26e89019fc7964812fdfada8a20a0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c04004730440220784da0cd9f8ec26ce8562955e4be1585ed1e1a2d5374f45dc1ce16f7ca7a663502202f1ab8222f0500c42b0f5d18e0beb3c321cce581f3ad6acc6a6b2a0bed81b20a01473044022001ab716f317e3f7faad7f3fbe85931ae091ac4d4377dd57f9ab3997172ea87d5022003296e024cd0183d506e35b7c53afa7927aa096792f8b148b4d14442f40c70c50147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedc99dc20",
         "claimMainOutputTx": {

--- a/src/commonTest/resources/nonreg/v3/Closing_f137669f/data.json
+++ b/src/commonTest/resources/nonreg/v3/Closing_f137669f/data.json
@@ -1,164 +1,169 @@
 {
     "type": "fr.acinq.lightning.channel.Closing",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
-            "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
+                    "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
-    "fundingTx": null,
     "waitingSinceBlock": 400000,
-    "alternativeCommitments": [
-    ],
     "futureRemoteCommitPublished": {
         "commitTx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032983a00000000000022002057ccaac906d43360e6d04057204627f54da258c9e7b9420135cad270154b54bc50460000000000002200203f100862ec5d6c28c202f9329502f20a4b42de672f1449b7458e321816eb3bfee86e030000000000220020d0b9e19e805ad1211c8395712a4225729e443223fbb3444537b6c93f5fa3683930330b0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c0400473044022032a580d9dcfb7370f2f201ff42bb4610ab36990695fd23727aa4d3e8ffb8fe3b02205459c91b774edd564b1d4772ddf06e45fcf5a1d188e7e75423c6e3d914136aea014830450221009bfd4c6b20ba6b26e239ebfb1e5b858153168d4fc0ef93655f4e137a2e68e67b02202fe68350cabdb7835e682b1fe961a8df560f93a68b62ff375b01263d7db3ba840147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedc99dc20",
         "claimMainOutputTx": {

--- a/src/commonTest/resources/nonreg/v3/Negotiating_da44c6e2/data.json
+++ b/src/commonTest/resources/nonreg/v3/Negotiating_da44c6e2/data.json
@@ -1,160 +1,168 @@
 {
     "type": "fr.acinq.lightning.channel.Negotiating",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
-            "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
+                    "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "localShutdown": {
         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",

--- a/src/commonTest/resources/nonreg/v3/Negotiating_dabbed55/data.json
+++ b/src/commonTest/resources/nonreg/v3/Negotiating_dabbed55/data.json
@@ -1,160 +1,168 @@
 {
     "type": "fr.acinq.lightning.channel.Negotiating",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
-            "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
+                    "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "localShutdown": {
         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",

--- a/src/commonTest/resources/nonreg/v3/Negotiating_fadb50c1/data.json
+++ b/src/commonTest/resources/nonreg/v3/Negotiating_fadb50c1/data.json
@@ -1,162 +1,170 @@
 {
     "type": "fr.acinq.lightning.channel.Negotiating",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "option_shutdown_anysegwit": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_shutdown_anysegwit": "Optional",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "option_shutdown_anysegwit": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
-            "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_shutdown_anysegwit": "Optional",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
+                    "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "0234ea3e3929ca115acc645d07c40eada7a98d86017614c3fa466d7e19760917e4"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "localShutdown": {
         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",

--- a/src/commonTest/resources/nonreg/v3/Normal_fd10d3cc/data.json
+++ b/src/commonTest/resources/nonreg/v3/Normal_fd10d3cc/data.json
@@ -1,210 +1,227 @@
 {
     "type": "fr.acinq.lightning.channel.Normal",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 300000000,
-                        "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 200000000,
-                        "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 300000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d0300000000002200200d94818c9b1a70b689daa5af63b6c6737ea40a9de55839819bf0421217d68d80400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990a0740400000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173e093040000000000220020c9b6634f8ea3a3789e96570513e9bc701395ea27477c07e80931a2ab9bbb549c0400483045022100fd4910f0944d529ec90d2d5f2587f28d7036fccdbff3dc215f8f418dea8bb3b20220723b0c27c7e719588b7375ffd76f8246074c8d126c77c829c03f18e66a12b498014830450221009faae1d00f87d980fd620db27a06a27cca8cc0b2269611124d0dab3a5c28076e02206dce7336d5c38377f54b6b92af7db4f38b43e12afa94301fce129b19e5892e690147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "24237f2dafcc072f634bc4ffc74b34157a827567ed32e8adc85bf72b54b9a07a:2",
-                                "txOut": {
-                                    "amount": 200000,
-                                    "publicKeyScript": "00200d94818c9b1a70b689daa5af63b6c6737ea40a9de55839819bf0421217d68d80"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a9148f93e0f27c3c23aca8fb53a150df1bc2fd6a69d788ac6851b27568"
-                            },
-                            "tx": "02000000017aa0b9542bf75bc8ade832ed6775827a15344bc7ffc44b632f07ccaf2d7f2324020000000001000000013e000300000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 1
-                        },
-                        "localSig": "c880a09b595628130f63f97406bc588dc11ac2b914c28c105cb5bf3c40007a2a7473756cabb4ac0a0e5b5c8d30ea91b87b6f1e0e1ac741df10c8863bf79f568f",
-                        "remoteSig": "226e43ad5f13f16b82eb841eb528756ea8a9ab4e12659c4992eaec016e67b81d74e32adb0e4c54ad1030e82d30e75c3ae4d4abec73ec9295fc24cf6301f00c33"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "24237f2dafcc072f634bc4ffc74b34157a827567ed32e8adc85bf72b54b9a07a:5",
-                                "txOut": {
-                                    "amount": 300000,
-                                    "publicKeyScript": "0020c9b6634f8ea3a3789e96570513e9bc701395ea27477c07e80931a2ab9bbb549c"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a9145108735b412dc599563a3cda98629158bd4c649188ac6851b27568"
-                            },
-                            "tx": "02000000017aa0b9542bf75bc8ade832ed6775827a15344bc7ffc44b632f07ccaf2d7f232405000000000100000001de860400000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "ae0a956ce019ca635f347205cc792036606d626b07620e329d84835a09fe24ce3d9996c28bef74f8ceea15e088103b2c096156e43c104cb7eaa60cd237b89f3b",
-                        "remoteSig": "cb127029d3c26886560adaee978ab3f8742b995dda61b6e84f2a7d1496485a23197239a180246f0a27ba6f10abc9ed1e92119991646073194d8f5b12ff747bb7"
-                    }
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 300000000,
-                        "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 200000000,
-                        "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 300000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "86441d0d05c27ecef1fd4bd850172890c8cee07eb0aedb272034eb36f93221be",
-            "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 2,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 2,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 300000000,
+                                "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 200000000,
+                                "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 300000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d0300000000002200200d94818c9b1a70b689daa5af63b6c6737ea40a9de55839819bf0421217d68d80400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990a0740400000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173e093040000000000220020c9b6634f8ea3a3789e96570513e9bc701395ea27477c07e80931a2ab9bbb549c0400483045022100fd4910f0944d529ec90d2d5f2587f28d7036fccdbff3dc215f8f418dea8bb3b20220723b0c27c7e719588b7375ffd76f8246074c8d126c77c829c03f18e66a12b498014830450221009faae1d00f87d980fd620db27a06a27cca8cc0b2269611124d0dab3a5c28076e02206dce7336d5c38377f54b6b92af7db4f38b43e12afa94301fce129b19e5892e690147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "24237f2dafcc072f634bc4ffc74b34157a827567ed32e8adc85bf72b54b9a07a:2",
+                                        "txOut": {
+                                            "amount": 200000,
+                                            "publicKeyScript": "00200d94818c9b1a70b689daa5af63b6c6737ea40a9de55839819bf0421217d68d80"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a9148f93e0f27c3c23aca8fb53a150df1bc2fd6a69d788ac6851b27568"
+                                    },
+                                    "tx": "02000000017aa0b9542bf75bc8ade832ed6775827a15344bc7ffc44b632f07ccaf2d7f2324020000000001000000013e000300000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 1
+                                },
+                                "localSig": "c880a09b595628130f63f97406bc588dc11ac2b914c28c105cb5bf3c40007a2a7473756cabb4ac0a0e5b5c8d30ea91b87b6f1e0e1ac741df10c8863bf79f568f",
+                                "remoteSig": "226e43ad5f13f16b82eb841eb528756ea8a9ab4e12659c4992eaec016e67b81d74e32adb0e4c54ad1030e82d30e75c3ae4d4abec73ec9295fc24cf6301f00c33"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "24237f2dafcc072f634bc4ffc74b34157a827567ed32e8adc85bf72b54b9a07a:5",
+                                        "txOut": {
+                                            "amount": 300000,
+                                            "publicKeyScript": "0020c9b6634f8ea3a3789e96570513e9bc701395ea27477c07e80931a2ab9bbb549c"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a9145108735b412dc599563a3cda98629158bd4c649188ac6851b27568"
+                                    },
+                                    "tx": "02000000017aa0b9542bf75bc8ade832ed6775827a15344bc7ffc44b632f07ccaf2d7f232405000000000100000001de860400000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "ae0a956ce019ca635f347205cc792036606d626b07620e329d84835a09fe24ce3d9996c28bef74f8ceea15e088103b2c096156e43c104cb7eaa60cd237b89f3b",
+                                "remoteSig": "cb127029d3c26886560adaee978ab3f8742b995dda61b6e84f2a7d1496485a23197239a180246f0a27ba6f10abc9ed1e92119991646073194d8f5b12ff747bb7"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 300000000,
+                                "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 200000000,
+                                "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 300000000
+                    },
+                    "txid": "86441d0d05c27ecef1fd4bd850172890c8cee07eb0aedb272034eb36f93221be",
+                    "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
             "0": "28f366cb-6c14-4100-a33e-b85b809ed38a",
             "1": "c6dca627-db1e-47d7-b7a5-abe70d276099"
@@ -213,16 +230,7 @@
             "left": null,
             "right": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "c22de7c4dbb965f6418644257bcbdd7def220c33d298e1ebbcf04cd9f381521b9bee4d04e8f7a3429ed0b250b228632460c60d68d8f608968188f401215932933f8edd5f472a1129f3e9a34971ac10a13675f16d74d0dca4b5bb99a32141bbc8e1975b5d1e33bb889900dcdb07282d17ca0c0954506c1d31d724ae4e2629b99906c79de727f0b15cb89582b4ab042ea70ca81e92eb424018ead01f69e4eebb20b17920d758499809c65a188ba18c2be6738cadb8bdc00f479bd61dc4641945ce65ca3177b413098d5b17822bcf974c8b8e6d21ac7d024dc7f26eac1277963e0cff1cffe38dadbf722b5103cccafc327dee5a1e838310fa709c84411bd0fe455d16215f35773d6579fb8f3ffd7bd35e8f419fb5e00928003658a8f84c436f7d8e480c6dda05a449c4ddc5459b84e7508c9aee62412d89b9bd4eff1cd721ce19d7abc4cbc4e34528a8283b086772d4e225a64114892f7bc9f6f7462696cbf15ea90a5742aba485b6253eb1d0d80beb8730ffdf3bf490ee62385f7eae642c8ab525af6d21ee69e1f66e97f3c41c69d024676eddaed8aad8c1f6039696afe3d32b2c160f4a1438579f577055ef9989141507b07fe40144585b42ff58b2c18ee46aa2f4a782460f2ad117294d5c5ce978886a85f11b9906afbd6dce27c6567fb23ef36045c44d646e16d28c47fe637660cbc8c88524fec155b701f520a2eae4f588f0191f39efdb777af61893c8238ed85d1fe4d0ead8e24c5036a45b1d6b0cfc8529657028993e8778ca329240eb67cb5593c457c05e018f2299b374d765411c4c3216af82cef710ab882d5dff0cabb2a5b2bfd6b25caa335889d60f75d3b9e6bf2f33b2a6c6c5457ef5159ebc2c08871064c821d5450c8f31c9cda0d4b8bcadf23a305e4d77fbab2d05989ca7c5fc3d408cfd205e32f161f65e3ab7612a132c9a740632715362ee8e81d3935efefd3cde66654d4cf1fd03bd820ca7da5c91a701e5dd1743bb45a13fff950a162324d17a4bad0df6d57087b453fcc7afc9595c4ad9ffde0cd532ccc8bd49262bfe81b88b5b61576fe0fcb3d7506c08c75407d2a1215b74d61fbe36a2fa4b42f7633e6ca0fcae2aac0c6c9e3daae5a5e3ce69463cffb573abbb862c4bb4559bf72bccbef306e0cd76aada133fb961caa1935ca5a68676330caee3b6e45a1ac2545ca0cd7411b251616655d43f79d81955a8f0b6f42e043ef06622a5415ffc8782670525ac5cf8d9e27eb8b39e126144384625d3c9391620b08831ce02fa64a8289a142c78e941f6c4d0152712ddf0aab9b91219f2ff8983635f87436b194b660f12f81c0c3debabb57f925ed00a56209989bb4bda5e8293d0976abd285f9f13d309e7c2d8a3e48b65e660f8347d3d52772ec3ce533b66198c60aa107a751648b63b8c8cd604d4e7294c0b9eb8e34c1038beb29dea937b4f5c00e7dedb7752a7ecaa4eb27006b0a568f63268c6344ac068ba78d508d78c6ed0a2bf1710816ff4fbe389d11d8087a38f1c5d97b1fb19f6e77e37131847c1faa132dc579ef4fb3a6352aee4d2a6539c696ea82dde5de19ffd38f4219b5c0eb3198be205ef8f94079b56425170f16cb7b1960669dd4afdd96c8e338d4d542e311b4c1aead45a031f4180f5f4dbf5887d7f0f4b706c7c7ea87b0e91808bcba88697d1d71a726776042153b38bf23d68888b20da7300ee67814163fc437f7b66bbf13e2019b1579933fc30c99845bab8f45b9142f9cb93c449d45b0e76ffebb088b329aad6410de6b1c4a15e37c2cebe7e3b58adf3836271a470967c910025ac3dd90e73c08fb030be987b5bc40d595d1074377839f693b3613ea4cf8cc2feec7325d04aeb5be09f8c612011264745f5c847008a5d9e6694c195504b426e7a625a8bc1e1bb285e27d9da30a63e69ef8bef31d60eb4563abe38706040cb12fc30631c4fd65129c1038af870b6fc7624a7b10a549ffe298393091eeb0d40ac4140579e21b6d28ab80a9d321dd2ae7269d58e6a0a9162e3868e2373a044dea8c01b09b852df18101abf428ac5fc895a8f899cf33984ba842dec39da490570f9b6785afafc27dac4be4b19b1c825c15a1d01a51425c56e0f97ab5cafdd35b836993a055bff3e9b2ddffff32287632acc52e8a151d3f608b8346ab237c42f57c4724fc996ea637aae83a253dbafa91499c9541072a9912aca5a126d0daaa73a8994e59aa67e3fb6ed50be865f5e8de4b616f2d5d21643128c62fba6141b172723eb4775072ac814813bda5786b2647cb2d0317d43b7c2eed04b92dc0431d73b98ef3219d0e3515af91c3fbe9b1beb4d27c743d98c8e0f3ea29f241d7360a0efb44ba77508143e39f08ad2fca912195b394637ecdbd2c928a30fce1d7171bd3ca095513e734f31bac320f65ac4df8f887d67c5d77f501288a05e0291977683f0e7cbb47d712bb29edaaefae65a4979ae7ce9885b6c1d2181d7f9c458c89d403ce2b42a99235fc89afe679a6de20d5bd7a6e58274ea4d9a4f06e332b146e7ce774b4e23e93676292bd1da308bbda831e25032bcb96fc9b243a5434be8c127fbca0b11dc90cd070a546bf0538f602c76edf247e43ac29e580530a8bd01f383a00408784811f4bdf4cdeefce51f8e1f8000312570b93b15f609ac19caaaccf75ca20838a55d45eed675112d18274225bc382a73a3919c9232159e7cb2177dadd9bb538d5cee9f521c3ef2343902798afbab4f75190df6e00c0d113393f78422d0663d073d923c9a65e37b907a56b6e5d2310ea93aedfa563ead06a7e417a731e43183ff706574324043eb90946cce7964ea44c4c9746d309b29af8f93e287a2a6be8ebfbd560dcd240fd647c953dcabe53b56b122de2cdd4bd91b2265b08c4d1c83ae1494a2afe6a3c9f7cfa864b82b7075f8cccd53562472800f5b03081867f2bad11023f58c9e28aa98939c0d2eb42ff49fa543b843e5e288d961b14b58bcebb1565bd8f75f8a8a81983745e4015f6035a28faa24ac95acb919733f370943c5c7f2644320881c0bd8761da99defd8e0ce9b2712a9ba449e382f5c2f72aade7f7243dad94b4cc004abdf4cc75d10c1b95c9f84772f93736b6313ac50b7f2226fe8bddc197026ef033d423afa0b3406e57f7506f442b57a99d270437e51de96176c39f7ecca5ecdea6b4ccd7da0083311bbd89559c81b118aab92eacde00cea82b3c0636867b759da65fb9ca75c1ba0bf40054284c8743f1bb4072468b5ebf447e649f0e8eab6e4744d98fccab71f32dc5f064a2d383225123b14ee9905c0ef672ca098d3c73f303344f6cb2569afd75096acbe13ebee4b0b8e62005dbf6de7ba9e3f83e43e758cbaa58d8cb7ad4f8ff4bb9d08929c2168e90fe117803ea4195584be40947b9b8e6016d4735431251c0d2d9137dc02286eedb306ddfa1c202510c612c82cf2013b0908e62472ae53f8ee56fa545914afc19000bb9c97662cc8654698a139a3a5b5963f7929b330d106ce344b77df8a92601b9162284f4206bbfe0187e1cad7023a31abbbb2e91090a0039e5d2cf6fac5530797e0529584587953a3a1df1cf681f1f22225091e437f70d2dccd3a1045546dcb8d6b67ca4bc6b1e37ee7ac5b6ba84411f26b2db836244f3d00ebefabbe43113ca29947e7cbc9d44d3dfe948baf57a4c7e861b7405a31dae41a57c953bbf4fe056ecd565db74998d51301571d23e17d6d702852ca72665e0bfeb9312f16a5f1424d57afd3b59d4a5d2d266d048f624c729898dea0f51bc18ba19f1646d9bdf9fcfcfbacb62e017363d4f1c5c181d0594a5016ffd85dcbccf7508621bf6aae90f0a800ae63afe8076b9ede0d6a85625f58f1f54cb10f4ed4e6a0e65025f2fbac4c81fb103d7079c88686281cacb0006da43a29751ca49f9862b955cb68632bbb4898d571a37b0a67b1d0eed9895a554bf7182b747a56848db3daf2d8b568acd9f93c7bb69066b2d387bc5171b4e9c3721cedd6ea79ad0caaffc325e1cf44527160b8a32e2a0fbde430a414ee21cc9342a155b828496b1c1f6b63160c431740bbc84a2aee63d7c995c2bc31daf8a59cba61fa69fdff23bcb16ad62d9c489bcdc9dfaaf884ef531764a61a198f404d8484f3dd1875292575db94f9f534f66359d72a0d9a42c6d14422cf4be17ce84c3777e3ed2bf7d935d83429eed8af7d3e447c83ed8259dd9b0b06fbc5278f07828883a0f226d197c64a45531fc024421f1e229bd8a5eea0567627747683fdd64df8a5454c139d6d9c4a7c8b7efdca770c193f4208f79717110afb2e38f63374b17c37a2a03568c9a012fb969d4145a0918176aaf9334f0b20acfcca85ea35128067d127a71bb23cba933c2947f577802d2e342bf528e8749637dfdd6c6bc3fc339e15d91a0cc05153f11849f999b43ddf47f2a9cfa0778a0433c2ce4d08fbd96b260317e31ba993eaeba827eaa254ca601b3f8a2ed3ca8e44a0eeba0912916c8df0d1c7a7ebea8328d925075a13630cfee2cb016a8097d5056374aeba051b28b9f78c353ce458d2305ec93dd4a1712a11352d79419839a339be6a1e0e5b35eb128e52f88e8f1d2086a7cceaeee19f246a5a43b402ed03a2f795f8c9d6ce9f2d4282509d3cbce46a2d1177213199d94412425deba62bfc777f06e86189a86458595a48361587a2c2ff02f37f48273bba5520ad1f70e982e0826ebe550dbd0d682b1a24a06743473262fdb5afeff8d8e47f2240a0fea1daf660dd3cda8af269339a9d49340efdec0ec2a35eb0a7adff5a54454c6c51883c550c9c0076a9231197831174e55949c1e55311a37fbbf97e18489d698d47de825134a87c2291469a48e2df500b19734191c10a5d1bc2c1f178cc026c6afb4ea7805a3dbbe38f5d336cef8313b5987f1cd336b8cbcc7f49585c022b584697699dc98ddd45fb3cfe2214c85b5c030c1165bcde544e70089adbe074a6fee5d665b7d3d2aa87436c53e731160d7f74e27d4178ed6ba1ea2342ac9d1e2028e46a12de846c2c391ff4aac30b1e41caab901f3d57af8f25e55418ffb17d9bd75c2ffc8c1407743cdbc2e1904e3d140d1faffca8513b777331d0a698a39a1f81c62d749674e5ffe26f6868a7c702b59ae15ee7ebba76b9677500e64f7a8fb3f5cb6ef827f4e6b68342aff94b2087dc20060a45da450409987be4cff09e781c18e0ae5750386964f1664eb478fa594cd2aeac2c8a1e2c7fe3fefc3f3c6d8597970d56bfa8"
         }

--- a/src/commonTest/resources/nonreg/v3/Normal_fe897b64/data.json
+++ b/src/commonTest/resources/nonreg/v3/Normal_fe897b64/data.json
@@ -1,201 +1,210 @@
 {
     "type": "fr.acinq.lightning.channel.Normal",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
-            "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
-        },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 0,
-                    "amountMsat": 50000000,
-                    "paymentHash": "70072fca373af190b0b82e6d1741e1b793c4feba75fc95dd9e2b37b32f01fa57",
-                    "cltvExpiry": 400144,
-                    "onionRoutingPacket": "<redacted>"
+                    "unknown": [
+                    ]
                 }
-            ],
-            "acked": [
-            ]
+            },
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                    {
+                        "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "id": 0,
+                        "amountMsat": 50000000,
+                        "paymentHash": "70072fca373af190b0b82e6d1741e1b793c4feba75fc95dd9e2b37b32f01fa57",
+                        "cltvExpiry": 400144,
+                        "onionRoutingPacket": "<redacted>"
+                    }
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 1,
+            "remoteNextHtlcId": 0
         },
-        "localNextHtlcId": 1,
-        "remoteNextHtlcId": 0,
-        "payments": {
-            "0": "c10720b8-745f-4450-8f6f-1ca7472ecc76"
-        },
-        "remoteNextCommitInfo": {
-            "left": {
-                "nextRemoteCommit": {
-                    "index": 1,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
                     "spec": {
                         "htlcsIn": [
-                            {
-                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                                "id": 0,
-                                "amountMsat": 50000000,
-                                "paymentHash": "70072fca373af190b0b82e6d1741e1b793c4feba75fc95dd9e2b37b32f01fa57",
-                                "cltvExpiry": 400144,
-                                "onionRoutingPacket": "<redacted>"
-                            }
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
                         ],
                         "htlcsOut": [
                         ],
                         "feerate": 5000,
                         "toLocal": 200000000,
-                        "toRemote": 750000000
+                        "toRemote": 800000000
                     },
-                    "txid": "1a2a425ee791588293c176e4cec3d01ed0b154f99f362d9f5115d92ab947f4ef",
-                    "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
+                    "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
+                    "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
                 },
-                "sent": {
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "signature": "5a494fd49da1aa4a09b8dc38392eb8749c6d8bdf88f8800bd9c00115cb3621096727bf93a761722b8bd985de3b94a2d02a776c54ab184f64a5f68cd0aa08d11f",
-                    "htlcSignatures": [
-                        "2092dc689b4d36d11ee5ae412a00af30820afcbfdf09916b7ba31acf2a07797962c4451fca451a6d9d48e56e21d0d164d0e7f22f6400520fb01d508404e9de68"
-                    ]
-                },
+                "nextRemoteCommit": {
+                    "sig": {
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "signature": "5a494fd49da1aa4a09b8dc38392eb8749c6d8bdf88f8800bd9c00115cb3621096727bf93a761722b8bd985de3b94a2d02a776c54ab184f64a5f68cd0aa08d11f",
+                        "htlcSignatures": [
+                            "2092dc689b4d36d11ee5ae412a00af30820afcbfdf09916b7ba31acf2a07797962c4451fca451a6d9d48e56e21d0d164d0e7f22f6400520fb01d508404e9de68"
+                        ]
+                    },
+                    "commit": {
+                        "index": 1,
+                        "spec": {
+                            "htlcsIn": [
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 0,
+                                    "amountMsat": 50000000,
+                                    "paymentHash": "70072fca373af190b0b82e6d1741e1b793c4feba75fc95dd9e2b37b32f01fa57",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                }
+                            ],
+                            "htlcsOut": [
+                            ],
+                            "feerate": 5000,
+                            "toLocal": 200000000,
+                            "toRemote": 750000000
+                        },
+                        "txid": "1a2a425ee791588293c176e4cec3d01ed0b154f99f362d9f5115d92ab947f4ef",
+                        "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
+                    }
+                }
+            }
+        ],
+        "payments": {
+            "0": "c10720b8-745f-4450-8f6f-1ca7472ecc76"
+        },
+        "remoteNextCommitInfo": {
+            "left": {
                 "sentAfterLocalCommitIndex": 0
             },
             "right": null
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "cfec67f2ceaaf3222c246cfc9c550c93ea4c41e2247f68b68610f625aa4c3d812fffcc01d35842f87a8542adf7b4aab4a88bf092202548fbe0be5682118b6d0e36824929e6c5fe9b3a5bb88f3d3c28fb0f0a113ae2f7ec7fc325f5c205c3751737d1a5b28e003fac391f630bc96f470a18b341590ac2ab696aec2518384bb164a82036330200119f149c906aa8aefb0db5e7d0c3ee5f3f4b14d3c35315a3521d2d24b2c911177ad068c9ceb8a4e77daef8a68909d64bedf726c6bfdbd4e382e1de1b3f10c3a8fe2229ef50b95246bfd0fc77a8b1447752e0f2b68ab24b70d0051918ea4732eae441d8c103d60cfbb8ab0566eef2370d1ad1799d24d1b2af8289c1b72564ddea6152ffe764b97e7d59925716225f2bc1733505dbf1aeffa6725549cefa495daeb17d752c1e25ad8c4b183fe9dff452f85388ea359eb175783c985909825fd80098f0f11bc7dff45be84ea1f1bf35063673718ec0dbab04be9cdb83003c234be0932e48232fdf9a1c9ef7451b6a8ad03eb3014a2930c11f81bbc90c4b2b5be64e1d36baeceb68a6af256ec2a620dd497ea264b2f88a8cd2bf5605f2059799a2aba97af8e53a551e7f2e28ab00f62bfb53de719f640249139f45725366f9fdcc35ca516134b06f6beed60237765316b46f95995bd3bd25609520de670e90d9840575c6e6b6e86a8265e72e86aad4999159a8b23ce21eb7cefa74d177be2780de97add3dedba99ba221cf75f213e3a1492f7788ef3ba72862ba8657da0aaa077232882b82aa5831bc1308c7c590d7122d0a9b4c07aa967e4aa634a0a3cb251f51e0c880721dffc1626dcd05ecc0caa660d00d3df9e405f404cccc284cd8f37b23591b9e8b34010b02dc1e77769911d37b87455e4ff74da245a0e3c0f78775e0f8ed0448117a80e077919a2f28a934717a99158a04f139e2c3171242726319c0227781d03ff9c3f81fd1c9637e8af9b280808e4206293d5eb60ae1a5b5aae500e1b465624e1dd86d489cc394b366b626a4bdca64600936ad8fcd47155e5963811931624c8b1501b0fe8b5d4463b8f0cd7dfef119486bed5d7435cd371eaea3f0ea041311029ad2db90d914a4011805721af78295695a11d872e14dd39601a2c199325775f4cdcdf1c9711147caa57f3b1c31eb08937e02318940ef9447166623a224a1c3cf4727add4b05f199d7633ced8c5332793279bb6338b5fd4a926a14104e1cd5483e9c065f6768e8b34c1c786ffcdc817af2e860c53fd1ed5ccb99e7385429ee648dc869be252c5ac47b3d9c11dd3f0b8f07f7d44f30724b735d748e33f5c5fa0c2dede71e549bfb532f582c7f296c0e34cf8f7aed925d4eaf037ebcad9990a4a2644208473bc0c0c558312434552f8c1dcf70f8f5f315a7dfce6bff63fd42b8d2315fa116bbda2baa7b05a533115cf5c595b3b150a6ac39f7994f92044c3188ec38ba29d5692b007b82fed0d3bc50a5a72b49e3f697b7711c616dd73e3e198c7363e95b8c895a217f261c33a1a558e1dca510f408b7b018da392b0413520619dc5441367df95800cebd2b01dddb975d58813c7db8bbc92455280561456450eb3c2bc48c36474a521c6964a2f007f6d27adaeae73460730aa54fb9a6eb05a159c6d7604eae112ec2e160901fddf3e9db3bc94c3820ce268bef03f5d3b2323267bd52a9add854db7c2bd00166a929b6c321ea056241b2e852239aace0349bd83e8c425a1b42da486a5931b2dc06d7baf213e2fc2895169e31a03337eb7f63445c27df76541e5f2b9cc3d275b4985a9c5b92a3f5402feda2d81d0526bf60926bedde9a53b08bcd5887188a75230a4ff3b3d345c2b2758512b91148b8d67ffbbb6a7b3578aaa95a8aafef6b38951d83a1e7d18faee5e5a2af2ba03a7a5032ffcccdb8953271d2f303f49661a05b2da552a98d0f5fdd8306006eb53a9357e93f131d8faa6ecb95db71fe5197ec9d86d2ee1bb2594c6442dfab76522f473d9bdbfa078c5cda83e4a9bdfde8667cfea6ab57c73ff541936e39df298357ca9b8cb33203ffdaeb5592b7e704e557be3062215294eaba2988318d2577cbecb65905542e23cc0873bf5b7d4c7a9d118b4eb350690e264227dcb09f29370f6b07342b8f4f3feaffdbef012f5e35e873d597b4ad4d01bb6aee7f98d23a074128a2630591ff99b092454b41ac530618807e0ef0f2bb06553a53399218e4304c2d48355f84be060a8d01a5f25874d19c8d5f7e4c2545d4ee39fdeee7a167d6f4af5debacff2661cff8f87e67fcb79cd400a79990ed71f013aa03e4c961592c3ef37e69080229f335a927252371ac79b04555ce219c5a6c5849f4f8ccb4088b8be83c437177c99dc09a01e76f3481118a087dfa8ba5068fc409ee35f4586abdb52633736fdef2ca77cbb9be4f31862f54554f9cccf24d0430db5d824ba2828d039a0c0510052bad94ff5fbfb8a128043546edf85de81646f6b72977452b02cf1f4ae23dc234688dae98380554ae703dc047e051718dbc191dc4cc6e620cfb5332ff4e076492808843459d12f73ec3b71c505455119bcf352773404768f11715ca0c7fc0a40f1a9a5445ee85eb71083850c5a9480261dfff7a90a7aa625829dd2de337bc2b4505df81c0d58c3c0712149f20c105be675570ced31a71fb4d6e3cc2c7535323d971728b58ffca13bef38915564f9252e58af9b7043e0e073e3c6f7de80019fd614955ab6df5bbf806bcd91f311f105faef7dd0658d8d22736055414eebba35d80231c3c6d6483b29d6ca58b8ad4dd1bf45ebabef92228b024aa65b952ec3aa515eb5190b855be20b04fe0ae65532a7df504b1b311a794690c4043a080c754014e2d7eccbbcdc93b6e2aaea622672240809ec0b999d5c67836b47bdb3e58820315eb1fe2b96a5b2b50e4101e5bb92bf3cd8ecb53bb601d2a5d1919804e2b2fc826633c5dfb736875b0bd1336090d82f0fb57fe4ab24ef47ceec31f0c9f998ac4cac72567a6e1aa1794430ffcfbffc8cdf3364048f6abfa235a5254d676e31401c84099410fcca12f79d352333f96400ecbb10080e0a7b0afb31fa93826971d23d0eef56b7cd8ba871d94c2f43f8254bd4ae3cc21f0484c8984dabd8fe2b9d41b123201caebb4315bddddb837a4a6e5a00673ec5408ebeb81a98b470806105091c320a2b5bf2c4f5c0bda79aeeb36d6a42fe81d19d12b0bfdd31ba516939c4bee724f5c24160ce4a2df124b013075c6931035013daf26f421b8a387ea31d6e96e082dcf4705b84fc253fd911a2a7163faffd19c17d122bc6ac87056a20474196617ee7e182891360bb80e633c9a909aca212ca6d3496f955fa95542847819a768bdfca90af19d902e70631d55b4101e1616a51c80bb5137916ac7d7fb2ebd5505624076d048d42ae3db53380a4507c09e8c6a5d9ca8790a045a031ab07912092c6e3b2fbab226d667cf3e8696d89e658d55067d5abf63388eee9a1cc64a53a37f1d25c4a179609342427c95c1cf708279c08250c045dad82c91250045a9f5bf198ef90a76c53048c5174e9812ceed77de434d5eab4513e81e1fb91c24b1394caefb37a5af27baf6724bdc6d87315773f314b306e3e399e1b241ac0be2812398e613d19fbff0545cad10953cae7ac66fcf39163b24377ca23ce23961f2b5c63cb9415e18dc65634062710edfc676bdc292e35088d5925190bd588ece9936377b824c990019bb185d0dcb0266ff081abd01b2bda3c3e13df9323720e773e214f04ec046c7ed5888375aabdf6b5500c88d76ab7ead0c6925cc2b0863484b3ce0fd8c59dee1dc0a3d9038b35ff77990367e9703e25909b09aa7bfd79aa450b90a58b9c434c58634cc9130388405f5cdeb14bdd8234b7776d3468629aef166361e944eec93d77c6dd3683da5eafa87b58c5c5a3313753f479e9f2a242aafb8c790855e2f1d32dc6f7e9d420ffe8aa52ecd740db86b5afe5d6ac2b53b5cf959fc11daf5da83dfd44a0266aa3023e2caa0d2e1fdaeb37e1b125b3c29c42bee7c94f0949cbd08157032ba879484e02149e4171c191d67688cf6afdb9ee7f664942352905f543db1b736c19629281da3f3e048af0acbc0f517e5dc782573d932cdcb8153e252a2c6a002a2927b6231fc49f2d13a6c20ee00fe48efe88acdf0eefc737e67d2636636bf4b46d07e876932088ec39232b773dc17188309345542c1a9647b495152cacca1892f1c2c354031d9eb618e3b55fcd5be13a40ba46fd8099a1b7c6e851831f7f23816cb1e9bacb61e4f8b293c92fe2bc05dc65b29f8423a95732d398df25be6d24553992e70fe7b627bcffba620e1a16653a00dc91eb57422b5acd26ab84cec94899dbafd38cc664d14b5db08f7215415721820e5b1aef2634e5e6a310bee009f02db19d226067d2ab865d928325e61a7f5a719cb77d449e55c8a0c2f955d94e24469ffa216a5e8aee2d2178d2c746b3106e009307e2aa11642d6d6e7a93325f7a461381390096971ce87432108a6c624588bb6af29e423c8922b251f87d95845227f34523b2466ec6ea6ead6c16eb609d4e816e2568ed17bdf4106493c74a8b6e9993d1d751074265b13313d0c8310f21a96399a778ccf0cdcc5d39d50b429dc62bb39e508f5585ac1d26d8008b507566be6c0c6f2e5853a14881476b52e8658ac00387aac17480d1900ed790570ce2eca0c5cd091c2834ec53b740ce06d78043bc641f1560d883cc5917fa65d24cc4aa51fdbf19e4d8e38b2d7c60c3d4dce9b4cfa57f7226d8ebdb2e1a2866283b72ce397ed6b6a7bdba85e24445d754c43609ff829e3454212d19c6d0c36b71fe273447cf7b2696633e1556dada6d4d5081fac1fbabda277c762f5882766b9a5965e1f9782f1265865cc886e21e4fe37f4741826047ecdb850457f0233008ac0bdcdaf882c1096e8f311af9d53507ca6d5616feae10077c52311a2a0d80bbd17689cfe0cafb056cb36cd42bd104a9a42d3260f94ca8f5208334d185435f29c5675f6d0733870bc47cc242423ebee5790a6e23abdf7ea33fc96928b7145ac969a69937554f17896d4d4fef69dad517a527880838b8d3bac3ece757289ca2b1b97811cc80be42f2ac914fb206d5789163db8e96f29a4e1dcc166bc0fc5c92748b89776a4ca0cfe8f79a5e3f120d2e8304b1cd866e2d0fe07dacd4fdef94415c707155993525df50afa16ab0557e4d037ce162f78d8781103605beee3cbf824838df19"
         }

--- a/src/commonTest/resources/nonreg/v3/Normal_ff248f8d/data.json
+++ b/src/commonTest/resources/nonreg/v3/Normal_ff248f8d/data.json
@@ -1,160 +1,168 @@
 {
     "type": "fr.acinq.lightning.channel.Normal",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
-            "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
+                    "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "0234ea3e3929ca115acc645d07c40eada7a98d86017614c3fa466d7e19760917e4"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "shortChannelId": "400144x1x0",
     "buried": false,

--- a/src/commonTest/resources/nonreg/v3/Normal_ff4a71b6/data.json
+++ b/src/commonTest/resources/nonreg/v3/Normal_ff4a71b6/data.json
@@ -1,90 +1,105 @@
 {
     "type": "fr.acinq.lightning.channel.Normal",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
                 ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
                     {
+                        "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
                         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
                         "id": 0,
                         "amountMsat": 4640000,
@@ -93,6 +108,7 @@
                         "onionRoutingPacket": "<redacted>"
                     },
                     {
+                        "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
                         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
                         "id": 1,
                         "amountMsat": 4340000,
@@ -100,171 +116,133 @@
                         "cltvExpiry": 400144,
                         "onionRoutingPacket": "<redacted>"
                     }
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 4540000,
-                        "paymentHash": "954b05bac0091518574fbae7eb52457ff537cb6b88b7ee1f98147dab5a8abc63",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 4550000,
-                        "paymentHash": "7fbd08c3ac7021f5ca8295d759231b7ce2452face5f11c1d14dbbe7035e36aaa",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 790910000,
-                "toRemote": 191020000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-                    },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080074a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032bc110000000000002200208bf1a46fa0bd7ca44eda0c5df968544c280859a29a527641afac57c27bf7003fc611000000000000220020de61d4f9864b11e111190b9d11f62ebf7476d517a7bba5b0a5b0f80f4e54eb1f20120000000000002200207805c9f22468069984db4db780b44c97593e4fee2c8ee32114f1c9b4a6d70fe42cea020000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990e2ee0b00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400483045022100da0c7b59463b6a4284147a3b027c48627364bbc2640e212182fcb516124a527302202177fb27546d43967a07e90666a6433f0ceeeff9d464b8ce2ef974aea294271a014830450221008c9af1f2b41e06cb6713f33b488ee65ec8b28db0505ad6d57f25fa10ef89ceb00220688569c56bcc9027b8302cfdd2daa6b1f1a2c537ff5c7b68787ab4b0ad7ecdee0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "2ba9027cf8e58bb8298b03b361336d6453ebc9c03135afc8741c0871b167d491:2",
-                                "txOut": {
-                                    "amount": 4540,
-                                    "publicKeyScript": "00208bf1a46fa0bd7ca44eda0c5df968544c280859a29a527641afac57c27bf7003f"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914e3343ec0997580d5b583bb2025e77adaf760c37a88ac6851b27568"
-                            },
-                            "tx": "020000000191d467b171081c74c8af3531c0c9eb53646d3361b3038b29b88be5f87c02a92b02000000000100000001ba040000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "24f317d01b079986c85a1fdaaac8d7c9fc069285ef6c00afc68cbdbc39e1fa232ea6e020f29d1401374f24c1e0fda672a747774884a6bfc39a5822da0db9b0f4",
-                        "remoteSig": "d9c3afcf4a2f4f55d7250e246160809488c95964ee30daafb70d168b065cdb8a609292b9737f7e327588a5d0d6dc80fc9f14e0659853b0c0fd636979a1fdcb7d"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "2ba9027cf8e58bb8298b03b361336d6453ebc9c03135afc8741c0871b167d491:3",
-                                "txOut": {
-                                    "amount": 4550,
-                                    "publicKeyScript": "0020de61d4f9864b11e111190b9d11f62ebf7476d517a7bba5b0a5b0f80f4e54eb1f"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914bf3a02ed662f79cdd5fef9658003fec6a8d8eff288ac6851b27568"
-                            },
-                            "tx": "020000000191d467b171081c74c8af3531c0c9eb53646d3361b3038b29b88be5f87c02a92b03000000000100000001c4040000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 1
-                        },
-                        "localSig": "779952b88b9f4a4bc16fe15f68444bba160065dce2d79ba7ba42b36b7db061482cc29992803323c676d885c4622de762bf1554951bc2eb9e669208b92f7ae3da",
-                        "remoteSig": "a114cdabf6695b1f2e17d01c7c948ea83e0a3d1001ef69d83d5e41eddccf9c7e2500498ab1787039cafec7fa5815d53ffe37c4e94456d1f8b5d03aa0bf56342c"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "2ba9027cf8e58bb8298b03b361336d6453ebc9c03135afc8741c0871b167d491:4",
-                                "txOut": {
-                                    "amount": 4640,
-                                    "publicKeyScript": "00207805c9f22468069984db4db780b44c97593e4fee2c8ee32114f1c9b4a6d70fe4"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a914562c7aee508993870ab9ed39c9ea6d072b5cb78888527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "020000000191d467b171081c74c8af3531c0c9eb53646d3361b3038b29b88be5f87c02a92b0400000000010000000156040000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
-                            "paymentHash": "21cfd1bdff21a6254dd36cfd62e00733b834ec648cb36b59c10ef6172e78389e",
-                            "htlcId": 0
-                        },
-                        "localSig": "d2216ff0af9cbcccaa86e4b11b5a46d8036fcccee8956e5fc92234a9dc9f46a6642f882bb195e04bf7de06b86781c864c1ae976dda2fe13004c9b9bbbfb16fe6",
-                        "remoteSig": "9f5d72d734e17f3bb86673b895921de22d04ca5e1e16fabb5cebec97bffa22dc634f8d7170c34e389ba2da99b707ebda7509fbdacdae90edb75b67d82bd8a6c0"
-                    }
                 ]
-            }
-        },
-        "remoteCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 4540000,
-                        "paymentHash": "954b05bac0091518574fbae7eb52457ff537cb6b88b7ee1f98147dab5a8abc63",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 4550000,
-                        "paymentHash": "7fbd08c3ac7021f5ca8295d759231b7ce2452face5f11c1d14dbbe7035e36aaa",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 790910000
             },
-            "txid": "ab5641cfc9de5225bd6b32206cc83500169ac53c4d1d3d22a94e9a52a75a549e",
-            "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
+            "localNextHtlcId": 2,
+            "remoteNextHtlcId": 2
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
-        },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 0,
-                    "amountMsat": 4640000,
-                    "paymentHash": "21cfd1bdff21a6254dd36cfd62e00733b834ec648cb36b59c10ef6172e78389e",
-                    "cltvExpiry": 400144,
-                    "onionRoutingPacket": "<redacted>"
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
                 },
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 1,
-                    "amountMsat": 4340000,
-                    "paymentHash": "6da74844b47a2823a6e64f45f0963e230ca49f179d36bca71c2adca8a83b042a",
-                    "cltvExpiry": 400144,
-                    "onionRoutingPacket": "<redacted>"
-                }
-            ]
-        },
-        "localNextHtlcId": 2,
-        "remoteNextHtlcId": 2,
-        "payments": {
-            "0": "7e780474-04b9-41db-94b9-7ef99349408f",
-            "1": "683c4687-c4b7-4cb1-ac82-6808f57f4409"
-        },
-        "remoteNextCommitInfo": {
-            "left": {
-                "nextRemoteCommit": {
-                    "index": 2,
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 4640000,
+                                "paymentHash": "21cfd1bdff21a6254dd36cfd62e00733b834ec648cb36b59c10ef6172e78389e",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 4340000,
+                                "paymentHash": "6da74844b47a2823a6e64f45f0963e230ca49f179d36bca71c2adca8a83b042a",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 4540000,
+                                "paymentHash": "954b05bac0091518574fbae7eb52457ff537cb6b88b7ee1f98147dab5a8abc63",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 4550000,
+                                "paymentHash": "7fbd08c3ac7021f5ca8295d759231b7ce2452face5f11c1d14dbbe7035e36aaa",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 790910000,
+                        "toRemote": 191020000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080074a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032bc110000000000002200208bf1a46fa0bd7ca44eda0c5df968544c280859a29a527641afac57c27bf7003fc611000000000000220020de61d4f9864b11e111190b9d11f62ebf7476d517a7bba5b0a5b0f80f4e54eb1f20120000000000002200207805c9f22468069984db4db780b44c97593e4fee2c8ee32114f1c9b4a6d70fe42cea020000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990e2ee0b00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400483045022100da0c7b59463b6a4284147a3b027c48627364bbc2640e212182fcb516124a527302202177fb27546d43967a07e90666a6433f0ceeeff9d464b8ce2ef974aea294271a014830450221008c9af1f2b41e06cb6713f33b488ee65ec8b28db0505ad6d57f25fa10ef89ceb00220688569c56bcc9027b8302cfdd2daa6b1f1a2c537ff5c7b68787ab4b0ad7ecdee0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "2ba9027cf8e58bb8298b03b361336d6453ebc9c03135afc8741c0871b167d491:2",
+                                        "txOut": {
+                                            "amount": 4540,
+                                            "publicKeyScript": "00208bf1a46fa0bd7ca44eda0c5df968544c280859a29a527641afac57c27bf7003f"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914e3343ec0997580d5b583bb2025e77adaf760c37a88ac6851b27568"
+                                    },
+                                    "tx": "020000000191d467b171081c74c8af3531c0c9eb53646d3361b3038b29b88be5f87c02a92b02000000000100000001ba040000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "24f317d01b079986c85a1fdaaac8d7c9fc069285ef6c00afc68cbdbc39e1fa232ea6e020f29d1401374f24c1e0fda672a747774884a6bfc39a5822da0db9b0f4",
+                                "remoteSig": "d9c3afcf4a2f4f55d7250e246160809488c95964ee30daafb70d168b065cdb8a609292b9737f7e327588a5d0d6dc80fc9f14e0659853b0c0fd636979a1fdcb7d"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "2ba9027cf8e58bb8298b03b361336d6453ebc9c03135afc8741c0871b167d491:3",
+                                        "txOut": {
+                                            "amount": 4550,
+                                            "publicKeyScript": "0020de61d4f9864b11e111190b9d11f62ebf7476d517a7bba5b0a5b0f80f4e54eb1f"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a914bf3a02ed662f79cdd5fef9658003fec6a8d8eff288ac6851b27568"
+                                    },
+                                    "tx": "020000000191d467b171081c74c8af3531c0c9eb53646d3361b3038b29b88be5f87c02a92b03000000000100000001c4040000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 1
+                                },
+                                "localSig": "779952b88b9f4a4bc16fe15f68444bba160065dce2d79ba7ba42b36b7db061482cc29992803323c676d885c4622de762bf1554951bc2eb9e669208b92f7ae3da",
+                                "remoteSig": "a114cdabf6695b1f2e17d01c7c948ea83e0a3d1001ef69d83d5e41eddccf9c7e2500498ab1787039cafec7fa5815d53ffe37c4e94456d1f8b5d03aa0bf56342c"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "2ba9027cf8e58bb8298b03b361336d6453ebc9c03135afc8741c0871b167d491:4",
+                                        "txOut": {
+                                            "amount": 4640,
+                                            "publicKeyScript": "00207805c9f22468069984db4db780b44c97593e4fee2c8ee32114f1c9b4a6d70fe4"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c8201208763a914562c7aee508993870ab9ed39c9ea6d072b5cb78888527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "020000000191d467b171081c74c8af3531c0c9eb53646d3361b3038b29b88be5f87c02a92b0400000000010000000156040000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c17300000000",
+                                    "paymentHash": "21cfd1bdff21a6254dd36cfd62e00733b834ec648cb36b59c10ef6172e78389e",
+                                    "htlcId": 0
+                                },
+                                "localSig": "d2216ff0af9cbcccaa86e4b11b5a46d8036fcccee8956e5fc92234a9dc9f46a6642f882bb195e04bf7de06b86781c864c1ae976dda2fe13004c9b9bbbfb16fe6",
+                                "remoteSig": "9f5d72d734e17f3bb86673b895921de22d04ca5e1e16fabb5cebec97bffa22dc634f8d7170c34e389ba2da99b707ebda7509fbdacdae90edb75b67d82bd8a6c0"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 1,
                     "spec": {
                         "htlcsIn": [
                             {
@@ -285,54 +263,85 @@
                             }
                         ],
                         "htlcsOut": [
-                            {
-                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                                "id": 0,
-                                "amountMsat": 4640000,
-                                "paymentHash": "21cfd1bdff21a6254dd36cfd62e00733b834ec648cb36b59c10ef6172e78389e",
-                                "cltvExpiry": 400144,
-                                "onionRoutingPacket": "<redacted>"
-                            },
-                            {
-                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                                "id": 1,
-                                "amountMsat": 4340000,
-                                "paymentHash": "6da74844b47a2823a6e64f45f0963e230ca49f179d36bca71c2adca8a83b042a",
-                                "cltvExpiry": 400144,
-                                "onionRoutingPacket": "<redacted>"
-                            }
                         ],
                         "feerate": 5000,
-                        "toLocal": 191020000,
+                        "toLocal": 200000000,
                         "toRemote": 790910000
                     },
-                    "txid": "70a92b624690358d74df2d65c94d784f896a18648288dd1b10c54a9fc6c0401d",
-                    "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
+                    "txid": "ab5641cfc9de5225bd6b32206cc83500169ac53c4d1d3d22a94e9a52a75a549e",
+                    "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
                 },
-                "sent": {
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "signature": "d0dc87687f989fa9d9cb00875bbd7e29cc076219898281c2ad05225abec90f610fd09a46f9e3b6618c26d0159573000bb15cf9e36e99e6a42f9029f55358984b",
-                    "htlcSignatures": [
-                        "b73f21dececcaf374e766088ac1769a547b96ffa8fb7d8ec885b5c65be7ae1242beee07cbd9f7b2924b6a7ea41ca624209723f981a9624f118a51d639227feaa",
-                        "137ed5daa06fc8b58c0f5bd37dbea2e11183082dac805a75f449343f5d21cd8935e99f3f035585622d97cfceaf9e136e8e3596c8e4e7ce2a91f94893c0aa4846",
-                        "38e3c64a9188825a0814f574ea237d27373eb499dd9ca575361795e314868eab431d035f74a183d3219eae0a321affaff9ef652bf15539007a8101b8044d9822",
-                        "a547db99506cd969cd115cc455362365f784fb4b6e15b8a619ed19b45797a8a92c8e7e03f2503eab4be97c6867abff2615fc897d3f9d5d15d1d88dcd68e38ac6"
-                    ]
-                },
+                "nextRemoteCommit": {
+                    "sig": {
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "signature": "d0dc87687f989fa9d9cb00875bbd7e29cc076219898281c2ad05225abec90f610fd09a46f9e3b6618c26d0159573000bb15cf9e36e99e6a42f9029f55358984b",
+                        "htlcSignatures": [
+                            "b73f21dececcaf374e766088ac1769a547b96ffa8fb7d8ec885b5c65be7ae1242beee07cbd9f7b2924b6a7ea41ca624209723f981a9624f118a51d639227feaa",
+                            "137ed5daa06fc8b58c0f5bd37dbea2e11183082dac805a75f449343f5d21cd8935e99f3f035585622d97cfceaf9e136e8e3596c8e4e7ce2a91f94893c0aa4846",
+                            "38e3c64a9188825a0814f574ea237d27373eb499dd9ca575361795e314868eab431d035f74a183d3219eae0a321affaff9ef652bf15539007a8101b8044d9822",
+                            "a547db99506cd969cd115cc455362365f784fb4b6e15b8a619ed19b45797a8a92c8e7e03f2503eab4be97c6867abff2615fc897d3f9d5d15d1d88dcd68e38ac6"
+                        ]
+                    },
+                    "commit": {
+                        "index": 2,
+                        "spec": {
+                            "htlcsIn": [
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 0,
+                                    "amountMsat": 4540000,
+                                    "paymentHash": "954b05bac0091518574fbae7eb52457ff537cb6b88b7ee1f98147dab5a8abc63",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                },
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 1,
+                                    "amountMsat": 4550000,
+                                    "paymentHash": "7fbd08c3ac7021f5ca8295d759231b7ce2452face5f11c1d14dbbe7035e36aaa",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                }
+                            ],
+                            "htlcsOut": [
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 0,
+                                    "amountMsat": 4640000,
+                                    "paymentHash": "21cfd1bdff21a6254dd36cfd62e00733b834ec648cb36b59c10ef6172e78389e",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                },
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 1,
+                                    "amountMsat": 4340000,
+                                    "paymentHash": "6da74844b47a2823a6e64f45f0963e230ca49f179d36bca71c2adca8a83b042a",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                }
+                            ],
+                            "feerate": 5000,
+                            "toLocal": 191020000,
+                            "toRemote": 790910000
+                        },
+                        "txid": "70a92b624690358d74df2d65c94d784f896a18648288dd1b10c54a9fc6c0401d",
+                        "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
+                    }
+                }
+            }
+        ],
+        "payments": {
+            "0": "7e780474-04b9-41db-94b9-7ef99349408f",
+            "1": "683c4687-c4b7-4cb1-ac82-6808f57f4409"
+        },
+        "remoteNextCommitInfo": {
+            "left": {
                 "sentAfterLocalCommitIndex": 1
             },
             "right": null
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "0604e2cc07a6a6f4f76baeaccce8d3571d9112b8cda1132fb4ce96614c8a6f31a237323899890ed65aa1f1f2d2ee3bcda264a60e93e06cc953ed00b33827a7663ac10c9967dd1ef5f9eac23859aad530f8535ec69622a3fdf433b0d69377f8af8eb22a32948bbc5fc4bba70c6d517d75d548fda5beaccd19bf60c16a8c52893912ac862db63cc5e977f6aa2f3833765f81fbd4dba5462f74ba0b3ee2ea5582f2c503b897a8c703f03fddde1b12203bc42f8dfee976ab3471de4deeff10231ba47cd11cabdb3b7396d4b7259ee60d8bb4b0bfa017de4899aa8ad1c656acdf24a67c5a4d33e15a27953aa618d721ab518612b2a38ef287c3161e559ec3647ff979fd56e124b13a5f7330df250be2497f2a004658606018b74281b63e2c8c22215662e1d44a23cc9b62e232753a9b61f6d8c1c5af016e58708098b02746ff3aaaab58f7c5ff26044b927d206930967acdc32771e9f7a2f655f9dae0b88bf5545b427b0d9336b902fab7344fcc35df9300142889dac9084e9d3a92f1107d28dc09e20a368a367a3af68b1bac6768920aa5a1f63658a3a1caf1eb26de6bd4e1c3df88f5e48e4951fc1e0af7a9feff9c6f879ebcaf886e45130db3149d13c291731dc87a6c575efa46290a02815cbbbea2050c10438e7191d8c8ddfde36358c3f2d9b0f713c1c82992a1bbd15d592c88eb2a8a255d7ed8fc36e6e5a6233eeba6f625974f8faffa2d02c8a478cc8dd1aef5122ed7fb72354df5f62c6133fa83127da0093d26a29812514a048b65ab77a5253114cf9d2b218fa2678f18f54665f653fb35e17cdbd0e15a0a8b0e6bdc950c8f50f902c096ac74e6d02c21d0fff6fd39702802e451a854f4dce094296830de2b9570c3a9eca23dfb41640eb650c73ae9fa0d8c73a073a5fa4663f2d8329f0b46c9ea7fcc8deac9d55d49923aa48c5de0fa4f9fa2c970581ff0737f4fbba3c44da799a65611ab2af8df807654a71c6a70354fe43ce51490b8f9c240a548f819e8059a9691360fc4627c9ac17ba7707d20d01bd1f4829d499faefcbc2cfc602f8ea730c2372e5604608ac255cf261750b5a8427752f29b3a9e7d850cff8bf5171d9a3bf354c66e27203397c89cbed10746fcd4d12c7b4cd248162de87b90cbaf571b4d4f8b460b33a16fc52a1487264e5208252bdbb21b7f1645af46097e2aac9f2eee194bc72bda0124a8d92b33173e23bdbdb1495a506235953a203c0f98371b8d44067664007bdc87a7f567ac8b79f20ab398d727f5ec1dee7beadad010aca6aa9de0aaedc581e136c0cba641d0206d036603554baaf6d03f5ca647c5f019cebf49f81b380126735c76c7e519fdffb0337896f8ee46b437d8fbf29957d05514851a8fc9e15c54a3990db96dc2c55f04eb4bca0e72a17c24598bb2268a9ada03fb606fb9c1de5217df32bd729a06044417672e7547367af426eade1b00b7037bb6324f3b79a0fbd12476596bc70f79ea67de0c63e8450904482107c33d5559d1a1404370b8dc78ae9f739780f3caef407d8d59d46873897f2cedd1a6b9e8c39afd68f1cb65180b791a1a5412ada4c0434becb6089344a97fc754ab0bb675dcad2a6a3b4a405a60d152372bded8a3f1e6c26fd1eb10f4969c3d42a4d6c724711c020a3377ab749aad2163150f4954091b71e806536d9dd41298f359db8ef41f834353b9abe9d8c7456c5f1cf1fd78a0ce3134a5e8e809ba084428c384e856eaaf19cfff5f89e1da7f89cc1dfb87391beba81f99f64a8d691689971a59bddfb6362b0a71c97592f983a024987f25fe471e477ad640657b15350e042201a441fa07da7826d13798158243e9e8bd30de9e5e0e6c913277e1312f9dba0e7c3201659431bb2f894127b7e1a2d7802e8ddd449c20ac366acc91aab037e2bbf2864d6ec13226ecec4aedbf75e8c0306cf36d9652bb7177cee6542ea2e2e69fcdbf6670204e8b87859c7e34aa602dc1322997480936342eff46e820a37a07acf46b291652f17e5f06c950f37a4fbcab553e77bf20926b2af9163984f59dc424c3bb3cfcf6333ab7b362b8243ab86565b9aa2de6bdda1693b6bb139fc45fa1a7eadffad1202551afec9954174e40f1c2fc20bb3c5c9fcf19b79e4776e9c30134c1d9c935ca617101914bd5906c9af159849a69c7f623e457f2353bc6cc89ed11c047298b5d7736a8a2e3796790a4e512fe90e33628b97f4506c24bdb63f7b327abdd9cf8a3c71eb079b09ddc3d23d8977ecdb45a687fb755e6ed821a3c7f7adfa37676c66877e4c00c09e2ab8f465985fd79869d0c41a00ab493e45271998506c984eac915b07fd50324259b85de1443e186ff3635beb76be2743effffa62c4165d15d853b2667b76438ae17d8417c0c8c92e960d972ec1d60e7a922b49c659dc60443c589e20c5e94a5bfff81bb088e68b609594d7632d0656984150c34df7e02aece15b4ffcde19f788abcf795a75b0aaf565e8e9ae0efbe544f210213775586d3b4db383be0940068ae9f2a6f4f586a39132a64e53b5e344bafcdd33b6908de068f991fb8595a9606c7a34305406038f7820d91acdd209d02bfbb91f6a772112a84754541dc0c6b2d9f9e209bc6835646846ef4923173036d52352f6ebb456794c4653eea97a54a8b9f674c7083f73d622f8f76757311987bb4fd1c12942ddc019e3a2e3119093b2cc514191e5ecc18e91958fb69badba63ba3f5bd17ef10366b909aa133f578a080123aea1160ca4390e3290440b6bf6dfedcd1f849639711bf088db0a67c93ed5871343678a4bcd2cbdd6dede5943184103b21b583caa7fe0606672a4412e675b11a9f2f2c1acdbc5008d104de031c9a7169bb2b70221449b64b0ff1b1922143e3a43280011875377c8a92a24f4bd2fec3cbd0e4239e67e4cee4aac0606a90064ec7d926c69dc873f40804bff7fc1f8fff4d094b2e9450835e5ced8dff6af1e231aa49fd908bc91d09f4521c4676e73874602076e24c305ca4050db485f4207b6704e86de980dce1ca90ab42b5971667faf7519ed95631a1cb5d6a907df6d7177ccc6a55fec25591b310ace50c7146839a5dd6fd1dfbccd514a17391661d5960d8376249c4a249338bdba4028c4b0431b4814ae55c36b66eb243e21f7c0fd483a9b461fa305875997d2ce727c3f7955ce0f05ef85ee6aaca942a70b73fbd9ced11b28147005730107a4ea0152a43cb80b75da653656f680e453b6858e9fa27f64a747dbec4dfc9a90d14d178f0f6f32ba6a39deecb981c84f4994db22a8bfd925f4a92a95e6b31b161a681be21760a5f7fad811afae4da168864e8eb3ff8798b6ac3a96051abb79436b14727888cc49f8ca100064a1cc83654dd218bd58f3f777bc4b7b73bbc687bb9d8076484990a2272b54efc1a041ba57b6ed4d62a16885cd9b087dae57120e4954936a4ad0a9e5da75a21fd058c503d264f8d63e50a3c4affc90f1bbebfbbad750cbfa52ee8e89aef826af4dc0ad49b03accda524f0c4307dc545eabd1db4acba25190cf30a8b03f640f2ea89cb239ab6c250241ca31e16d17cb560508243a2116dd0c16d76784f511eb5435f0466b49d2bfa004c3651b0152bc5507e64f5a41cdd1d0da5a21b2d51cb4110c5f5de61b743c34740e620618c3bf426964250271005ed3fceab7e4e6f554d4d65588c6b39ad857e267a319c779e2f9b8ccb749597d2e8cd000f2b2266543f2755022ac5ce31011543f6e7d31ce4a3a862d4d8e55f895005a8ce766f00c40e79279d221d084584b5060e40966586d8a091d6721929ac125360c9298d9c094db3c7be23d72fd17ead90cb33f0444f1c6e2a5ab77223e446ecb5d95b238cb72594f25524c07df22a50118160a954d66c91ddef25dd7364cf7f799ac941109f84f2a53d846c25ccc46b58ea6848c1dacedbb8bb7f7a1db1194c331c2db1e7e49d23422184ac3d1803815b64158b8bbd32d92e79c5dbc49b9500d568db25fa7729a1ecb6c3a88f574aec6202098ab89e2cf685e446cf28559fa7cce28a8545f298b14e74ed7039408dff99d7366ee966b1a5f67af3841cb4e112c870e29e56cfc9cab340117602d9dd104effd72bf424fb91ea770f5b65749bb90bf6521ef365c07325cee76df867d53450549976739870572bf40b4f70008387a3376071702b984805c721b83a7b6f30249855242e289e18c302c6331fbc1664befd25fd0c4c3b1e2e5e1a9cc4c7ad693a0fec5ad98fa391a8610ffd65fceb0318225b2fc3fa990a340ba4018fedafcf9b29445a5fe12169f87bb174c9ab4a697adbfc9f890682c3da79c61c83e9bb4eb362b9b79c8f051b0a69b2057eed7d6e8809bf458701e97d052c85469113f5b156bc93a27abdc3cffae7a3bbd075f38f17d4f98afe7847d91f420b913cee1743433b5e31328a10bb95fcffb8651e3fc2246306cc575f95b3237e821cf9f2e82470d0c09809d2506fe53ec00efa984b2fb31bcc1bdaf86ccbe8f1bd5b42fd9c7e7a4b0aca3d40bbbb5911e45edf53980efb6368de25b46c88c1b168dabcb436a19ef31da31432fa5068aba62f255596bb159fc3a266be4a2a839b2e8552c7c41b357890ae4eceb84722f2f737e44171eafd88fab05bda5dc147d13cb1c6c9f4cc0377d34d1025a0c5de10f02de8c2e11066af97ae4973a1dfeccacaa13cea263ab7455b1a4e886c0f50d095095591fb4b07ce981c8fe5dd80712c42b8efde5fe42f988d3956b94e0a41a1bad7119412ebd27405c0b19fd92d0174ae74bbb204aca06b0150b5a06c9a822bdd03d11959e0f213a66b395a7d11eee53f74fbad37de86874ea0c6e372296caaec1bb50de1586192b1b469968896c4124c39837553134f66c0b8a7d2c0708861f4706801c0b41ae10bb18e2df354ffb0fcc88390155e93a4e5ad221be8751feb7136283ff55efa559bcfe6a06e69ff33b9c949e1f06d3d84eaa6b64615d75d0f36d924a65e79920e1864d2b4993df333ccc3f3e5fad84e860f9fb0e0173bc57621e4b2b7ced1488453a62e81ac8e1452b13ed69cf82e2938e10927c6981697e6dc856244ca40f00daae5a1118ee177d41fa59ef06cc465c05d1bd24695f48f8efdb59c90788cabf3522dfbd5b61b9967e1d82182ca748e2b3fe6cea05fb948ce561379b64f87e1e43050b823ca7951eec02e0325405115d52b5b8d5f4a015e3e95753ca6dd9c0258cd389f16af5e89be5f20c0bfca119b9aece1f66f2346f7e7"
         }

--- a/src/commonTest/resources/nonreg/v3/ShuttingDown_ef41a1a5/data.json
+++ b/src/commonTest/resources/nonreg/v3/ShuttingDown_ef41a1a5/data.json
@@ -1,228 +1,216 @@
 {
     "type": "fr.acinq.lightning.channel.ShuttingDown",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 300000000,
-                        "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 200000000,
-                        "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 300000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-                    },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020c69b2c7f0223bcc7777e7029c6aae25110a0eb82c3a1ccc5daf47230d08a34d0400d030000000000220020cbfc18dfba5112418175b4d4683d6fb064a77a230e2190fd50344d3290d6d4b2a074040000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40ce09304000000000022002039c8ad7d16980a6cea19c49477e44f93844c2fac06d07dcd2ad37e27d4f75071040047304402205c2b83ac40b26a2a671114830a8a6cce3c2cd9eaea2fc92004689ee58eb70ef40220082ebc49b5f6a0355fa371516f8d633da496fde6cfe4ee440aa3e41b51905ff601483045022100fa8aa60f854006c44c33fa4a4a77edf207b936704806cbd56631114cf9018040022065b9d1ae8b03f2e8a5bc552ae3ad79ce008fbc95aee2672525e45e6dfd43674f0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "86441d0d05c27ecef1fd4bd850172890c8cee07eb0aedb272034eb36f93221be:3",
-                                "txOut": {
-                                    "amount": 200000,
-                                    "publicKeyScript": "0020cbfc18dfba5112418175b4d4683d6fb064a77a230e2190fd50344d3290d6d4b2"
-                                },
-                                "redeemScript": "76a914aef8f6925558b0a595971422e2bcca65b0116cef8763ac672102f846a96b1afc033efdaf605745a9ca6824d773b8d459f0d86e9a9ee5aacdd3557c8201208763a9148f93e0f27c3c23aca8fb53a150df1bc2fd6a69d788527c21032311a586e1653dd5e9b165302c08e9e3468bfbdd676f33775b8322c16e28616652ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "0200000001be2132f936eb342027dbaeb07ee0cec890281750d84bfdf1ce7ec2050d1d44860300000000010000000176ff020000000000220020c69b2c7f0223bcc7777e7029c6aae25110a0eb82c3a1ccc5daf47230d08a34d000000000",
-                            "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
-                            "htlcId": 1
-                        },
-                        "localSig": "3a48052a0a6d3f08cd7282532ab677841d58185b4841f7cb5ce2fa7f5fa9508e0ba1c6faab996456d1b42ad928baa8dd77ba8b96ee9f77188c56d9fd0cba46ff",
-                        "remoteSig": "276855a968c96fe4ffd255fec0061e69e72d1f311b41c95616425c36da118ff27f8664a70a0379e4dbe3c47a953c9a5b1535f90c8539a205664b7d64cb2bf928"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
-                            "input": {
-                                "outPoint": "86441d0d05c27ecef1fd4bd850172890c8cee07eb0aedb272034eb36f93221be:5",
-                                "txOut": {
-                                    "amount": 300000,
-                                    "publicKeyScript": "002039c8ad7d16980a6cea19c49477e44f93844c2fac06d07dcd2ad37e27d4f75071"
-                                },
-                                "redeemScript": "76a914aef8f6925558b0a595971422e2bcca65b0116cef8763ac672102f846a96b1afc033efdaf605745a9ca6824d773b8d459f0d86e9a9ee5aacdd3557c8201208763a9145108735b412dc599563a3cda98629158bd4c649188527c21032311a586e1653dd5e9b165302c08e9e3468bfbdd676f33775b8322c16e28616652ae677503101b06b175ac6851b27568"
-                            },
-                            "tx": "0200000001be2132f936eb342027dbaeb07ee0cec890281750d84bfdf1ce7ec2050d1d4486050000000001000000011686040000000000220020c69b2c7f0223bcc7777e7029c6aae25110a0eb82c3a1ccc5daf47230d08a34d000000000",
-                            "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
-                            "htlcId": 0
-                        },
-                        "localSig": "c8e46340d683b21b765bc27db5c3fffa3742d6f131a22a9d131781e13d218d7932b4c3c79b4a30a2e5b6079e0e8ead81bb5528eb4ee2c7c502cae01f789bf552",
-                        "remoteSig": "0d0a30d748b1953bcd6c1c4a24d681089de79146cdc098578ffd4cca4ae92fd94c0c3e2c72c9619f2dec8d9a4a8fa91d7546c3095e20d9a1329e0d74bff533f4"
-                    }
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 300000000,
-                        "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 200000000,
-                        "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 300000000,
-                "toRemote": 200000000
-            },
-            "txid": "24237f2dafcc072f634bc4ffc74b34157a827567ed32e8adc85bf72b54b9a07a",
-            "remotePerCommitmentPoint": "0234ea3e3929ca115acc645d07c40eada7a98d86017614c3fa466d7e19760917e4"
-        },
-        "localChanges": {
-            "proposed": [
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
             ],
-            "signed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 0,
-                    "paymentPreimage": "2afc28d3ad7a8a83426769f6765edbcd9e320335a2e4200df95f54f22472fe3d"
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional"
+                    },
+                    "unknown": [
+                    ]
                 }
-            ],
-            "acked": [
-            ]
+            },
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                    {
+                        "type": "fr.acinq.lightning.wire.UpdateFulfillHtlc",
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "id": 0,
+                        "paymentPreimage": "2afc28d3ad7a8a83426769f6765edbcd9e320335a2e4200df95f54f22472fe3d"
+                    }
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 2
         },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 2,
-        "payments": {
-        },
-        "remoteNextCommitInfo": {
-            "left": {
-                "nextRemoteCommit": {
-                    "index": 2,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 300000000,
+                                "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 200000000,
+                                "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 300000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020c69b2c7f0223bcc7777e7029c6aae25110a0eb82c3a1ccc5daf47230d08a34d0400d030000000000220020cbfc18dfba5112418175b4d4683d6fb064a77a230e2190fd50344d3290d6d4b2a074040000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40ce09304000000000022002039c8ad7d16980a6cea19c49477e44f93844c2fac06d07dcd2ad37e27d4f75071040047304402205c2b83ac40b26a2a671114830a8a6cce3c2cd9eaea2fc92004689ee58eb70ef40220082ebc49b5f6a0355fa371516f8d633da496fde6cfe4ee440aa3e41b51905ff601483045022100fa8aa60f854006c44c33fa4a4a77edf207b936704806cbd56631114cf9018040022065b9d1ae8b03f2e8a5bc552ae3ad79ce008fbc95aee2672525e45e6dfd43674f0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "86441d0d05c27ecef1fd4bd850172890c8cee07eb0aedb272034eb36f93221be:3",
+                                        "txOut": {
+                                            "amount": 200000,
+                                            "publicKeyScript": "0020cbfc18dfba5112418175b4d4683d6fb064a77a230e2190fd50344d3290d6d4b2"
+                                        },
+                                        "redeemScript": "76a914aef8f6925558b0a595971422e2bcca65b0116cef8763ac672102f846a96b1afc033efdaf605745a9ca6824d773b8d459f0d86e9a9ee5aacdd3557c8201208763a9148f93e0f27c3c23aca8fb53a150df1bc2fd6a69d788527c21032311a586e1653dd5e9b165302c08e9e3468bfbdd676f33775b8322c16e28616652ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "0200000001be2132f936eb342027dbaeb07ee0cec890281750d84bfdf1ce7ec2050d1d44860300000000010000000176ff020000000000220020c69b2c7f0223bcc7777e7029c6aae25110a0eb82c3a1ccc5daf47230d08a34d000000000",
+                                    "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
+                                    "htlcId": 1
+                                },
+                                "localSig": "3a48052a0a6d3f08cd7282532ab677841d58185b4841f7cb5ce2fa7f5fa9508e0ba1c6faab996456d1b42ad928baa8dd77ba8b96ee9f77188c56d9fd0cba46ff",
+                                "remoteSig": "276855a968c96fe4ffd255fec0061e69e72d1f311b41c95616425c36da118ff27f8664a70a0379e4dbe3c47a953c9a5b1535f90c8539a205664b7d64cb2bf928"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx",
+                                    "input": {
+                                        "outPoint": "86441d0d05c27ecef1fd4bd850172890c8cee07eb0aedb272034eb36f93221be:5",
+                                        "txOut": {
+                                            "amount": 300000,
+                                            "publicKeyScript": "002039c8ad7d16980a6cea19c49477e44f93844c2fac06d07dcd2ad37e27d4f75071"
+                                        },
+                                        "redeemScript": "76a914aef8f6925558b0a595971422e2bcca65b0116cef8763ac672102f846a96b1afc033efdaf605745a9ca6824d773b8d459f0d86e9a9ee5aacdd3557c8201208763a9145108735b412dc599563a3cda98629158bd4c649188527c21032311a586e1653dd5e9b165302c08e9e3468bfbdd676f33775b8322c16e28616652ae677503101b06b175ac6851b27568"
+                                    },
+                                    "tx": "0200000001be2132f936eb342027dbaeb07ee0cec890281750d84bfdf1ce7ec2050d1d4486050000000001000000011686040000000000220020c69b2c7f0223bcc7777e7029c6aae25110a0eb82c3a1ccc5daf47230d08a34d000000000",
+                                    "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
+                                    "htlcId": 0
+                                },
+                                "localSig": "c8e46340d683b21b765bc27db5c3fffa3742d6f131a22a9d131781e13d218d7932b4c3c79b4a30a2e5b6079e0e8ead81bb5528eb4ee2c7c502cae01f789bf552",
+                                "remoteSig": "0d0a30d748b1953bcd6c1c4a24d681089de79146cdc098578ffd4cca4ae92fd94c0c3e2c72c9619f2dec8d9a4a8fa91d7546c3095e20d9a1329e0d74bff533f4"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 1,
                     "spec": {
                         "htlcsIn": [
                         ],
                         "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 300000000,
+                                "paymentHash": "bb9134aefd0dcfee1bb57ab492f6d794934c2823cbc99c1b975deef3b0d67d5a",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
                             {
                                 "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
                                 "id": 1,
@@ -234,32 +222,53 @@
                         ],
                         "feerate": 5000,
                         "toLocal": 300000000,
-                        "toRemote": 500000000
+                        "toRemote": 200000000
                     },
-                    "txid": "9cc11d9e60703e915ff4d2f7c4844685161e46042af4a0a42312f18abf8d0cdd",
-                    "remotePerCommitmentPoint": "03574dea18e57e2450dc92c992e7d6b8f966251f6e8d202bb737a4e28d45feb3c4"
+                    "txid": "24237f2dafcc072f634bc4ffc74b34157a827567ed32e8adc85bf72b54b9a07a",
+                    "remotePerCommitmentPoint": "0234ea3e3929ca115acc645d07c40eada7a98d86017614c3fa466d7e19760917e4"
                 },
-                "sent": {
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "signature": "76471ff891395937899d320fe60649024ff8a3fc5c849da066c246f8f5011c46775610a8b9483c8b8cc0e542326265590c56a3496245bbdc37724ba9c516f449",
-                    "htlcSignatures": [
-                        "c81afe7a07d66af6c99b38151f167f74672b15434282b46c625396f99fdde972667386e57cb1c4d1d473e098cb2fdefbab4497cf845d02c6e9da8de7f287e24b"
-                    ]
-                },
+                "nextRemoteCommit": {
+                    "sig": {
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "signature": "76471ff891395937899d320fe60649024ff8a3fc5c849da066c246f8f5011c46775610a8b9483c8b8cc0e542326265590c56a3496245bbdc37724ba9c516f449",
+                        "htlcSignatures": [
+                            "c81afe7a07d66af6c99b38151f167f74672b15434282b46c625396f99fdde972667386e57cb1c4d1d473e098cb2fdefbab4497cf845d02c6e9da8de7f287e24b"
+                        ]
+                    },
+                    "commit": {
+                        "index": 2,
+                        "spec": {
+                            "htlcsIn": [
+                            ],
+                            "htlcsOut": [
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 1,
+                                    "amountMsat": 200000000,
+                                    "paymentHash": "23d0335a29f4751d39c8e5c13d79513da2ca619cbff40fa70bc618e803e1f488",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                }
+                            ],
+                            "feerate": 5000,
+                            "toLocal": 300000000,
+                            "toRemote": 500000000
+                        },
+                        "txid": "9cc11d9e60703e915ff4d2f7c4844685161e46042af4a0a42312f18abf8d0cdd",
+                        "remotePerCommitmentPoint": "03574dea18e57e2450dc92c992e7d6b8f966251f6e8d202bb737a4e28d45feb3c4"
+                    }
+                }
+            }
+        ],
+        "payments": {
+        },
+        "remoteNextCommitInfo": {
+            "left": {
                 "sentAfterLocalCommitIndex": 1
             },
             "right": null
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "localShutdown": {
         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",

--- a/src/commonTest/resources/nonreg/v3/ShuttingDown_ef7081a1/data.json
+++ b/src/commonTest/resources/nonreg/v3/ShuttingDown_ef7081a1/data.json
@@ -1,194 +1,180 @@
 {
     "type": "fr.acinq.lightning.channel.ShuttingDown",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 25000000,
-                        "paymentHash": "af1861d86cf987de73bb7f3ef3b3fcecd5245e1e86fde5bc0f0347f97ab8b322",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 775000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080054a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032a861000000000000220020e274bcf50e49b0edcce64e854d3aa8da60dbe1e7c48f9110936dadfa5187b58f400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799074b70b00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400473044022015491e87bbf295b3de3658ce7da81f18be88c786a678a6ee9693cbccff756737022030442fc924860891f341f77543b394ccd11cda89aaafac132ee6fde8edf8c4a201473044022055e60618bc00285694c690b4faabaac6abf5fe796581b0d7e4d65794a2c4226902200bcf1f4c44817e490e25365846200c59b8e997cbe0d5ddb6ac790af715e15f550147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "05322cf6e79cbb9b6155390ecffe61d01751fe6a0d6f1be4d8f6574eebdb9e47:2",
-                                "txOut": {
-                                    "amount": 25000,
-                                    "publicKeyScript": "0020e274bcf50e49b0edcce64e854d3aa8da60dbe1e7c48f9110936dadfa5187b58f"
-                                },
-                                "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a9140aed402ced95b473dbf42ca5de5297698ad58dd788ac6851b27568"
-                            },
-                            "tx": "0200000001479edbeb4e57f6d8e41b6f0d6afe5117d061fecf0e3955619bbb9ce7f62c320502000000000100000001a6540000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "a76faf80b30c2f0f1e3eb33e3dc1787c6162fa381d24c3d737b468a2239a5513142ff3a85f3ffe6359947a64dcc8398302ec64e167927e9e352248b2902907c8",
-                        "remoteSig": "f0d23e4bae190f2899842d368f2bf4465321168ff78d0fb548ec86375f94dc944f0134171587046152c6e48634c2399de7bb7d60e6af929c9f41c8b1134537bf"
-                    }
-                ]
-            }
+                    "unknown": [
+                    ]
+                }
+            },
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "remoteCommit": {
-            "index": 1,
-            "spec": {
-                "htlcsIn": [
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
                     {
+                        "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
                         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 25000000,
-                        "paymentHash": "af1861d86cf987de73bb7f3ef3b3fcecd5245e1e86fde5bc0f0347f97ab8b322",
+                        "id": 1,
+                        "amountMsat": 35000000,
+                        "paymentHash": "db13990c9f023227b49cb9c93ffb226274e63ab23395694cab77856cb7ac14a9",
                         "cltvExpiry": 400144,
                         "onionRoutingPacket": "<redacted>"
                     }
                 ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 775000000
+                "acked": [
+                ]
             },
-            "txid": "6240a0b7460a5888a4d0c4dcd92d44710338bc3b3ac0720b5b0d9ff9cacaa377",
-            "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 2,
+            "remoteNextHtlcId": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-                {
-                    "type": "fr.acinq.lightning.wire.UpdateAddHtlc",
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "id": 1,
-                    "amountMsat": 35000000,
-                    "paymentHash": "db13990c9f023227b49cb9c93ffb226274e63ab23395694cab77856cb7ac14a9",
-                    "cltvExpiry": 400144,
-                    "onionRoutingPacket": "<redacted>"
-                }
-            ],
-            "acked": [
-            ]
-        },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 2,
-        "remoteNextHtlcId": 0,
-        "payments": {
-            "0": "87833a1a-fec1-47cd-a68b-3ebfbb2330ce",
-            "1": "7c68b0d3-68a7-425a-8601-37d35d4bd2f1"
-        },
-        "remoteNextCommitInfo": {
-            "left": {
-                "nextRemoteCommit": {
-                    "index": 2,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 1,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 25000000,
+                                "paymentHash": "af1861d86cf987de73bb7f3ef3b3fcecd5245e1e86fde5bc0f0347f97ab8b322",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 775000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080054a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032a861000000000000220020e274bcf50e49b0edcce64e854d3aa8da60dbe1e7c48f9110936dadfa5187b58f400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799074b70b00000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c1730400473044022015491e87bbf295b3de3658ce7da81f18be88c786a678a6ee9693cbccff756737022030442fc924860891f341f77543b394ccd11cda89aaafac132ee6fde8edf8c4a201473044022055e60618bc00285694c690b4faabaac6abf5fe796581b0d7e4d65794a2c4226902200bcf1f4c44817e490e25365846200c59b8e997cbe0d5ddb6ac790af715e15f550147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedf99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "05322cf6e79cbb9b6155390ecffe61d01751fe6a0d6f1be4d8f6574eebdb9e47:2",
+                                        "txOut": {
+                                            "amount": 25000,
+                                            "publicKeyScript": "0020e274bcf50e49b0edcce64e854d3aa8da60dbe1e7c48f9110936dadfa5187b58f"
+                                        },
+                                        "redeemScript": "76a9149166a758c8ce2d9f0c36df15d8624a3c2d0e01b08763ac67210212f485e05882dc6abe5ca535a3880a1c8b2fb10261ba27c56110d926775d73fc7c820120876475527c210202381f64b9573d9410b135c8f3e9ec876233af900152d2e42211a6aa73835ad952ae67a9140aed402ced95b473dbf42ca5de5297698ad58dd788ac6851b27568"
+                                    },
+                                    "tx": "0200000001479edbeb4e57f6d8e41b6f0d6afe5117d061fecf0e3955619bbb9ce7f62c320502000000000100000001a6540000000000002200206aae960776a0a9f526c5ea6841c28baa16a7ae997313ed417dbc55e38fe1c173101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "a76faf80b30c2f0f1e3eb33e3dc1787c6162fa381d24c3d737b468a2239a5513142ff3a85f3ffe6359947a64dcc8398302ec64e167927e9e352248b2902907c8",
+                                "remoteSig": "f0d23e4bae190f2899842d368f2bf4465321168ff78d0fb548ec86375f94dc944f0134171587046152c6e48634c2399de7bb7d60e6af929c9f41c8b1134537bf"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 1,
                     "spec": {
                         "htlcsIn": [
                             {
@@ -198,47 +184,70 @@
                                 "paymentHash": "af1861d86cf987de73bb7f3ef3b3fcecd5245e1e86fde5bc0f0347f97ab8b322",
                                 "cltvExpiry": 400144,
                                 "onionRoutingPacket": "<redacted>"
-                            },
-                            {
-                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                                "id": 1,
-                                "amountMsat": 35000000,
-                                "paymentHash": "db13990c9f023227b49cb9c93ffb226274e63ab23395694cab77856cb7ac14a9",
-                                "cltvExpiry": 400144,
-                                "onionRoutingPacket": "<redacted>"
                             }
                         ],
                         "htlcsOut": [
                         ],
                         "feerate": 5000,
                         "toLocal": 200000000,
-                        "toRemote": 740000000
+                        "toRemote": 775000000
                     },
-                    "txid": "9607897afde7a855d0176c4944f90fdab335dc9ebf0ca41b907c42b909c15e9a",
-                    "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
+                    "txid": "6240a0b7460a5888a4d0c4dcd92d44710338bc3b3ac0720b5b0d9ff9cacaa377",
+                    "remotePerCommitmentPoint": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
                 },
-                "sent": {
-                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                    "signature": "724dae9b1e085d1b121af3b452eaa68b7baf7408df40e751de60a4a79f639e801e5b874a29fd603b9e0bfb6be6d0b7d07bb54b58d439179fabc6a075741495aa",
-                    "htlcSignatures": [
-                        "50954c3f715a4cc76171ab634146f75c55d58c2016410e326cff2f126f949d61729559f7ac676268402c9be27a12a91c7e9aeac534175849821aecbd1c39152a",
-                        "0005041ebbefa39cbddd0a58fb05f9165b61a7962857d8e154baaa0478af48e559b226fc67a6b34fa44d589193b675110d8b89d599092156f64970c8e14a4be5"
-                    ]
-                },
+                "nextRemoteCommit": {
+                    "sig": {
+                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                        "signature": "724dae9b1e085d1b121af3b452eaa68b7baf7408df40e751de60a4a79f639e801e5b874a29fd603b9e0bfb6be6d0b7d07bb54b58d439179fabc6a075741495aa",
+                        "htlcSignatures": [
+                            "50954c3f715a4cc76171ab634146f75c55d58c2016410e326cff2f126f949d61729559f7ac676268402c9be27a12a91c7e9aeac534175849821aecbd1c39152a",
+                            "0005041ebbefa39cbddd0a58fb05f9165b61a7962857d8e154baaa0478af48e559b226fc67a6b34fa44d589193b675110d8b89d599092156f64970c8e14a4be5"
+                        ]
+                    },
+                    "commit": {
+                        "index": 2,
+                        "spec": {
+                            "htlcsIn": [
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 0,
+                                    "amountMsat": 25000000,
+                                    "paymentHash": "af1861d86cf987de73bb7f3ef3b3fcecd5245e1e86fde5bc0f0347f97ab8b322",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                },
+                                {
+                                    "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                    "id": 1,
+                                    "amountMsat": 35000000,
+                                    "paymentHash": "db13990c9f023227b49cb9c93ffb226274e63ab23395694cab77856cb7ac14a9",
+                                    "cltvExpiry": 400144,
+                                    "onionRoutingPacket": "<redacted>"
+                                }
+                            ],
+                            "htlcsOut": [
+                            ],
+                            "feerate": 5000,
+                            "toLocal": 200000000,
+                            "toRemote": 740000000
+                        },
+                        "txid": "9607897afde7a855d0176c4944f90fdab335dc9ebf0ca41b907c42b909c15e9a",
+                        "remotePerCommitmentPoint": "026c604452e1a154575f1fd5966389c2c686c0b4b72370da0b33764c66b5a8f40e"
+                    }
+                }
+            }
+        ],
+        "payments": {
+            "0": "87833a1a-fec1-47cd-a68b-3ebfbb2330ce",
+            "1": "7c68b0d3-68a7-425a-8601-37d35d4bd2f1"
+        },
+        "remoteNextCommitInfo": {
+            "left": {
                 "sentAfterLocalCommitIndex": 1
             },
             "right": null
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "8684daf9f2ccbca185ebd922cbbba98aef3f6934655497cbd9aca24f8d4e6e1cba43d85c8af61b75c248a0f9b359fa8a5456ce3b1e7042c1fbb840e4fe8c47001d372a6b96b41d96dbb2ef1f71d040be6964679e553f0895acd84cf6edb7571c0d24e16688bd8a0fcb4cd94d97b47df1048c61319112ef156107307b1b22adc91d5e5951fbe3692d1ac8947d26b0db93c016fe00e2dfa923c4e4f254cd995d3946b65c580b1914977d1088cac007aae1adc75675fe98a961b6ffc2cd7691cf9d323901ac018e5aa68161878dbb892df75d7dd80cd1bdb650b2ee734b04bd6ca89b7856bc40e458a91c48c888c001ba3c7539bd13c94022c6d25e7f9b489b7edcb500092a057567d135ffc3c6b6db4bc5ff4013e4c922ec359267bc65eb31e49e7e3801be6a9ecd56f5caa07e65532378280a5628357c6190c392141818e6a39cfc50f50d0c8a98ab54d955d01be8e5c5bd2702def14c58ab216ae0a29a9efb791eeaea060935a134ec516eea6558258f5469d55075424840a94a2ea8b4d5e49672be07d22f10ebb85db98686740e1142896eb4571a10250dd18faf0155615485e1629362211c97c912d61d40c7da6626ce6093f293d9f0d9922762fcf81eb7062b203e410c9e7834626449b39df1413bb2ba14a2345eb226f0a66c5a9016a368601b61678f6614172c8059bdb3b9aac7df859e6394e9393a88d616c31888ae2383ced54fc46c7577c66b4a24648f2f67221bf0b211e1c756aa8852c743d5a94e5b10b3ea80a6885834e8adbc1151301ced959eb0cf66e971b62b3d783b9323cbf0182e8a89e02ee7dbff88aa7c1e170b546011e161a6bd3268de96974f87f27b328dcbb06525c92f25cf525cef5905e52adcfb02fc49bfd1e3b3e6a458e4d774bf5298a595f6ba83c375d350b54638311d0483ed4c2cfea70c0cface17cb5479b3f8daa736107dea23627f9c7421dfbdd5878939d4f3e72db8cff9d946c0e8c1809fa5e6e848676f221d82589b8158e019825d0af676e793489f549e5509fc91483f6d49003bcb16089a5a0bd65c885518fba7b64e2c4c173afac0c765c3fe3b620c87d976a556cfd4d829abeec032b8b069edc22e4c05735bf8dcb41b99860d024051456261bff27dbc1dfae2f66d6258532be46b756674897ff625c7698928b6183617637aacff4f96d25f69948aadd9887e9af81cff9215dc533485d3f4cd7d63f2e81c6eecdb02ac37ec64416998d411ae3d1264502eae82b470ec39112ffdc53ce1f530642b4b1342b97abba42146e3324fe7fa6120d18ba9b70026cac8fd3c8000fb8fbcdbb82c04f2c30a0b74c9fc225c1ea80fbbd3aa4470548c601a9063eae80bd6754165c08d276f77ad21eaea63f113205fb0df292cd00f2188b4cc38eda1b4388227e92e036c2ef154104195b6cf5c48a8045171f1e2e31e64f2ce7407c6855f0eeaea131420874004624ad6dae00ffcda497711ff1d7bd508799ffbaff78213c50f67b5f68449e07858691b2a4cfc5c5bb56080dce6a6dd75a8673ea93eaa9c5aed4f3bd5c8393d8a356660f61baaf47e4b1b4eacc4421a8bdf0064cdaafd45dcf7633820f0731d9cdf6097c991318d36c33020bf13e9acaff58c5f2ee85134f3bc46fcbb4c4a9244732cfc5866fe38d29494872db6d5027ce24dbf58f30404650b63ca595f363b8abbd0a0301b220df142c9b1a423160649eae25a0431af84dd4646489d20ee961c24e6a8e382a9cb6ceeb9b3b9669f383df3f941016f81c0117db384266cf7159df3b4d23e56334003d5e6d60827e9436fd3859315225af19e2469ff1cef6cbeffee717b2043db454307669c9332d59a53eb5fdf5ebbb2c9be817fa1e09e08667ee5bf5c7caa17147d1fb14d7deaba3c9d578877b5272eb7b242c5ba454c23cb85985db02ecaf7c751532217b0636b574c6c7ea7fa06b9236b57d2f4055287fb4c8b0ff6997bdccfa6ab892342cafb0ef90acb75fd24e5597a40dafd604bb008cff0e5079c43b91b90c2e24f40a47718ca81db3e7dc5430b4a1ad5f40a7850e00477a49a3ec5cb9a07e09212e6207953f5a05c51f26052409a1867674cb144f5b024076a07459dbd4b0321109096143d9f3d4905ef8cce2d22be7ae24450cb32112f5d72b9ecc76f2d4f68e67353b4adee82dff86371578b3c69a7b01af0feec2cb0be2a3ff3b9e3b093e28da8068dba151d4da7935acdc32cfdbc6596e3e93911a3bd5da7783900465fdc629212d9c7399aa2342423fa5929683965c01e64e838b84d486bfb07ff744bbd970934493a20926d68277610025234e0dee9dac0ce51b1aa78bcaf85f4c708585080d10aa7deebbc4754449342e66aa6b3d770158efb41bbaa178412cc306f35ba7ccebe0fa2b6dc9bb966bd7e8fd55ae8c8fddda0fe95af20583a99217e267990a547cc16b07fc077cdf62c33ff5546d516eff2443c625d32c457224dff525bb74f57c4a7c7111a67e59c006f57b69229d57407f46e0d3fa477769ec8bdcd28213e212f0853fe248fc51e27a689b2b5486cfd578d80990e5f9a21f64847bbbf20f2d9b411af415ccd1d1d683a7dcd8954c8c51b3dbc0db3da6b82114e4c3f072cebd906c81d141aa78d6fac3db34aa041d9d5909be7d86cb300157946d764873d8586754001404d0de978a9039714c4f46c9721394a0e3063a7c08201240a01f8664bddf5a3220d6add43bbcc3f5ce0db8f90ad8bd3675609e4796f32bd1078ebaf00febe703fd45f9962ecc92752f1f9b64901f9445b94d91c29a08ba128730395370e465c311275ac0ea8854b174a52b99ab82a756b30be3e9cf8e56bf2c1756ea79380ca27e8337e2c8e798fa2eb7524cac45e42d577d49c9f9fa845760195494c275901999e9e5f5daa49c78980ef0d4dc306638e1d4f45ce0c532a1ea81d350b187da909a4c8db36daec5a4309005c0281718c157b54da11b693de481a1762269c1209d670972df7611659a1099cf8afa2b9fd78bca05ec8956a206ce985507bb84e49015e596e06730dc4ea3bd9c9dffbea554e60c4cab904c879be039a4c42dd5d02dc19c9bc142fc9498389b273d2a51791092531ef50ab27223a0d523fb33ab4f8869c10fa538095f2e44fec65f5055a9e6a2bc7087fded8bca334a8a9bb07fe4b4019d65827aa6a9a2a442126ea4ab2a7135eca3292292a4695cb9079ff7c1ef3879015b65a06641c674ac8cea191e1ae499841d1733b29c28a7c5367effcb3b7f2ad3fcff991e7678d5a5a528b0f4e55ba524adf73c0948d431334890d2a7259bc33bc9f3202630d2d10ccf9a041c4e3d2a6138922ed8df3647763016ff5216c9609cbc7ca8abac0505dbb4cdc66d180b7fc4fff77b09d5d06d111ea03b19b95d75b6700c787670b58b92375b85d581f3ffda871a1691da2685e761343cee7c6fae0fb95d947a453c05f2a9980e1463a8ea68c5b290a08a8e9f0c99b78595c0a56b2ddd9d5e6bce45b081dc6496f3b440ad1600747caba09705fc66966a81eba5399e35de58f60243882d7c31d6e1afe9ba4f717a33d099af3466e53d4d3048db2d9b24495b39bc6886e0ce61615643c5dcdf7208f6eeb81a1b952170478ebe172f4a228aed2380f98cb3cd7355dd95f35f3f8d04c66055f9aa0a33ee10bce81438935933c3fcbe47c574d44a41a7ef24f763ed05c7cb49dbd8c2967e93cdb8f6fc2ff3e59e73074d057d8db173d049a12b0a260aa2be9c8eecf728a8c31f1fe94b80001c12e23806f52332979ed463f61c733d273014b33ddc12e62471eb93979fe05c1f469fc44bf92e1bde7138b58b10de506059f308180c487cce856759ab610a56edfb7a69ac9a0deec944b45c8bc2aee39d57b33e704aef77a494677a7ba91a0aa31360f90756c33f0db5ab82a152eb0b5a456250c1cb6c6f8d25b55f5ccbcd4a66f869981fe7bbcb260b691d264264777e71dbeedea9121927604cc19757a1e47a364c103e05db22fc92e7862bd7edb8d1f1946cfb17096165e6c2aeea17496f3976b97c46860855d7273ec6ba28ad7d1d3b7106313ab8aa382900e914407470839e3a8c86a677a2132e72989dc996da059a2ac67e37e05ccf9f9e9fbebbd65ca4c662dab4961b0314119d789b412fd054b9b34958dda9507066e9e593c2e6d90bb1c4762c1c604e6cf22a485d5434b8b6a538596cfdd11496ceb6fa151e36bfd2633afcb499e2432621bdea4ba8e5d71c9cc6e173608c6d7bf72b57a234b586fa9d629db062dea33ff1dad7cf2a4980dd37e654cd185f51f18a90ffd327bcfddeaa50108ae0dfe0b535e7d25e346d04f8f487ce3de48722f60f35c9726b12a498bcb36b14076fe37a6e9b165b995795ee9ef12a256bbf5762daf5cfcf508c859cd5d3abc9ee6177029d4928b8332c2892421608af1685e4eee143b277b804ba9e08c46aeda2803af561d6151a30201b21730aab3c566c2ae43f3ee6f299294909623dedd92e5442b57654d7f6c8cadf1760a607f0125b48f253cb59ee1ad0e9ae651b56da97b9f3dae7eab2421b345a15b187daed8a9b785d143c2fada05df74257485abbcfcbec1c465afc14e7ef2d889bbc26b06e1c4a7a8b6f62b07c92219c02882068ad72127f2159e051cef009bcfb4436450761473cf256dd6b704172063487caf4f423677d4a01fb986a89c2be7c8cb8d995efd4a3c2f3229e904a4817f002da260162064395788f0ddf770fd9efb1ff956ada89ac6586b0f507bae54f3bfbd38e6203a610b2f70e3cbb0e1cc29c366f9b48ad2d5de8863c81c3974b0da9600bc937b138aa0d2c211e99a4348ae8214256b18923d3aa60b86b64508e3f8cc047f02c2ac0fc2272c835f49e6dba29600791ff2f94db0e57218c0b81aae6ab7092836f08a1bb7157153ab919a5b809606be1a4f6284ec8a016a7bed496473391d9f4058c02f9dbcfa959898a935bb3aaef3b747684b73771f7733c23a0d8b487e3b3d885a6d2e21b6d1ca2dfb74a0213c8d1228c07bca4b01843e06dd8458b21887b2d23d814e1ef9c0192b9f9d036867eb68a63519aca2d05b77e213e36d22eba1aea9295f6f8948ff1a42777ce1fc106a7212bbe78aeb8874b2210cf4ec4f732bae3cb0851c82a41d8f27157d4d1e22976ca15ede52f6de2f439a8623efd0cf4d12d8b548f3e7c9d2572e7b5a304db2d5066e8e7356d443067ac59c95582c8f2bf8769b1edc16de5b1f138d705a3c61e87bc74b5fe54984fa3c22b6808587435e95600e92eed5a5307c5113d67bdfb87d0d3323aad4c0d5c30f30fc37d6f3751846a73705ca88a393c35898d49d2b6a22e408d3e3382302fb6b47dee998d4f85f433e5d0105f6a605212ed1b54610cb46fce6d964a8e52a76c9fb83db8d8a6f0f7b2cb66f9f46685f34872ecd4e1c2ae55598e4b00eb1b4a06357f27bbfd46b2826b1bae551422cda7f85a5faeffc850ac3cbc79a7003249c6eded5c5e8bde382f7de2c223e5b2b11c7910d27a8d903263644e03994b9fa035928f729131341fdf4a247a56b32beedf07467802d7bfb732312ce8692538dbfac39cd7e6ca4ecad121d27c1c7eecfdfd6c9181a2415cb7913d3d5ad4a80a82d1141bb6e5a7df279e38f6cd999bcc5bb355f8b2e0e6169609a7d6a75057a3cdd65a703662df078a23b73f152d5b6f76b002398f6d0bf852f9f99194e076e42925c6b29d52954c014da1e560a46a8935054855ba45b50c3a136d5370d58e6d2c940da8307982089c5861c4a8042794812ff3e90e3125d8a257df8bb122e50d2b825e08affcd83f2d39653504bd1173b6440032635b200d620d05a585bf0a9d31c735502c673849a3dbc4dbebb13d2910df31741d8e457594ffe1021b69c92a05406d93910310c3656cfc89a077e4337a336000c975eff9944fbebc2263032785e1c4c3cbf31d4b59676f823b96bce35cb716329893c6b43b766cb085989524ca395ea58b787c1126d22420950470d2711ecac9cd1f437ce232184af58445ccb6a440f5bab7e0e87d0e9a13aa1ae645d3b14c9d7eddd2bde3517ab25f8ac7ed7171990b6066b1d1b79011bea4cbd04fb4b206aa9ab754090bd9718cff3dd9b897931c3c5509c78af70fbc57d1cf6128dbc1b7a9d0f2e9a9107a4d35d8b159be67b765a1406a327660fc2a39d2e55b56d5db412bf03f10bab6f9717a79c6d8252b4a967f2a0cda2fd828afc58fb277851ac7c205784f5129cf6c7e3d213a607622f6f9bf4f7eafe3edd7b9192194fbcf0deb609cc391c2835bdd562bc5dc03a6491067bd844b9c375ad8aee26816df7dd3415738c31331fdf2a424accba9bafe450abd0a820d127b3c2e0bba187b26fe1600bb534a878039aa8175ae219ef3fb8fce26d855a7d7e60e02e78cd46d05e86218d30ed86539f09a0fc27e683a9ad04de853adaa13c5517e9537842b1c57ddaae3250883379f1f226160c7ed4250b8b67a836e27027698869e6cd0b046f2d556214154554156f91f29eb5900165eea41c8f806324c7844b1fac10d0dce3d159bcca2089ef4ef87a326a5718591b1380789550bdb78b003acb31c577dcca2d07fa81e1d1b2ffcee024c81cca950d519a353a68fe2963a2b4fd00c4747cd86c31a632d939c9cdd13b45e4e0f748dd021d4a8a729736d83ba9081990e359e22bb853864f2cac3165b1abdfa4ef12f6e52ee2ee4050183e620fcaf128cade5e12ba30583369022f20d5e8b65d53ed52cd905143a02a1ad8a4959956699de4bd5a8091dc27fcab34dc8dc5100c96d7de2743fb4ab23b34e5da042c6dc0ad5aa38c0c8ceea5f354e31a93ccc61abec34466bd1eb8791171a9235d936f638f300d13359f8418a041b016354b5819acbcf69b451c23250530e90ca682fb312e34f2950fc8cfd2779d75be529695185d4f9da3398fd7922bee987134e95182fcbb00b9e6d0f83fa3a52479f4fb264722489df4adadeba2938d49934caa571e7e75e8fd67f5b58263e0b9050398de24f51bb946847ce2e318afcf890ff49507f7d309fc6c915b34fa005e00c59eca1267c70212883e1e9da217d48afab736decc5081abd5098bd1d199d5ed978bcaaf8c368c4c1f1fadba2b4ced8aa419b6473e6be4c7ed3fc77868227a9c939faf159a1b230d715b9a421ee21436019459fde284320123b010e220598fd876cdc23971071f724ea12c6a55b952bde0994191ab0dd5dae2e7f5c987b233a59f7d79a4a87adaf41e10f82819bae1b57ac059f8338062b80443bdb962e93a5a85cdb8328fef56b39c03fd158845b45da24cf0284a95f757a0099c82594f56a21180bf4bdfbc5adc330b8b8b0086814dd2b4c8d0b00f84bdc68fe17f912a30fa683672558e9a0e02cb503e4bd28e00f4ed3162a697ae6f97bb4ad76d40bb4ae802764fa2f493825dbfe2fa5a64c34a6a5b75d0ca2f4e3e25a50cbb306167caead9a0d1b175e1f4bc42282baee9af25b11a032e99fef177cf98cb341c84e23edb2fe28c0f7894b3b48d554ea9a1db48eb995783278d2685823530734d96b48bf8208d87bc0787c95891feae2e51129e29c5be7450012023eeacf18ba28f3772ca256e8a42e5fdb149a55bb4d7aa60256a817baea4306d0e7ae4d49edddba65f595ad8e8304f3c974fe1aa7918726dc7b49c358993e1c602829d130ad1832ce03123ad6e6cd96f1fc43ba5115907bf492904dbdf67bde28075e3e3a9605aa62c1ae911b000ea8fbb7ee931b3bbbc25a3606c0802389165f43b92efb31237874361756dae7e534cbe6e1e9f92c66c2edb870ac0474872b91d43d5a86951fa54a7ac5bd29603372cfcd54a53cf64070d681b66e55662c4e07ea678ea3ba2901aa956a591d3eea464558835a8c365cba07d0710cd0360efc5a4380b9c703b28523ddb18c894e1c20ac695be0f519a6a05aa1238295d12400a58f057760ae6dacecf6880d9192f80a0851e3cdacc64cf94cab8859ea568fe456949e51fedf06ea65e84d7fa546583d7046eb3769166e9794184e59fe31b1fb732e2bd8c5f43244c257bf4244bac23cac64d058ccdfd29a669731599e4f45bb4a50dae225f2011d08e6eff276d5cc85908152ccaebae5400e07944d3ac51d110e3473ea4f903dcbcafba59f0c36bb1d69db1f119baeb7ece09a60619dd83a7a43b608acfdf8fd9b5ffc3e6a143e4c9f8412c5deea8a44afc4a7d77403161271eaeda1da875105c7c77533745cbea9e3f2d15ffec04f9120e94684c335f47039a1a0a13072155617fb37808000af4f33789a2b694afcf0dc201584f5ce9ec0bebc887f4d3aff95c96e2e5731e467a1e10cd2ee4587db5d60f6213af69b62a3955e277711d417f2ec5f389774f71d70107348b6cc33abfe76ac09e131cfb19d57fc823b7a0efcb2405b237d67ae8463889ca0590848c1bcbffe6632c1d040a7d10ce2ca0882c40a031870f5328ef1c3ecd93c09482c5e30f56ec97e78862829eff2ce758f38e1f3fae94d25411557a353f91088a91a1be384029b11e6864e9bbcac208b266d2fd5acd82ab4e6f9a6097b0b89ab6d718111d0fccd28d2d88ccff29bcef407c6766915b3c28d09c4df0e0acb9728ffa91ff13a8b7dcb2999eba6001eb054427a80ed016493727c11caf9192dfaf24c6ed2144ca801ba73b5fe755224230cdb6bfd3e8446104c9ea4e10352d9769f6eb834cad11afedc17c560e1f4d48fae61cc13e1283505e9c327b89521a0788bc1ca66b8d1efa812d1753caa51d7cac95cd1f2296660672f693f32f17f9da2b5c9e922cab34ff401edcf47790e5d34541ac27bd59fe2fa933a9ae052f66f053c64114cbe2c45f7022ed3c593bf38dbc2a360374fb8b0b4f9d1f43f0bd7f3c27c1dfba2109a0fcd83f86e6182bde69d690e4de9bbd5eba4e4cbb057f370bec052dd5619ebead10835ba0b855296ead272304bb881af255d1e87ed1a2601d1a30e5ac393c91c651a683ac1bd30fa41505f3a3067cd9e92bc0d60c632a71e24eaa435ffaded7e0d2ac34f995b32386326b0cfe9e448a4fe19571b3528ad202a4f8a6be5dbd5b382f326e0cedacc1226c36e004968ac5da973ca13fe89522b871ad4e77d61919f9a5b6808e81e82f8f0bdf883265f0a3f3c610c46c19203a9ce9ee95caf10ea0d5c0e427101954647149f9f85c370d68c33e9680f5ade3a9d955ab51ba3b426802e7cec57c5d70d23d975de51105846c1d4c3d14228b23ab4715876b1ba43cae8501313fe30eb2af7689bd942f139b642e5d2f3b6a20b3dd2f5ad8113442e3a61bda3dd9c53b7f59965e54e66c2c1c27d7959b1aa1d09f01ca94cc6472ed0f4b3767a2d539501dbd48a94857b119605d70edd03bacfd86d0ca7b0500af931246b7f651a412ac976daee7fabcb0b28e3e712abe77db90b58363628295f3fd9479f35571b4f537490dc74e6cd0918bfe5d6bbb2463e04d8c52d7668e719f40c06247846d488121e40d681e66322523df554906a9f1f8f7b769e0d2255c71b0ca36c3a7b229785309951b34fc8de46acc8a822235b88a113b728f6e01641508e2c6886480c600da7837f011b3b53483a35156f278dff6773ea5ea8d589219b9f762851544927ebdac1e2988e668e96f3fdf56017a3f02b8c505611676f7773c87c64acf33686c3025180a7f8c4680637eec373ffdd7934f8e926409126a82d550698fd0c173c7273a6cb754202121d0bc59264cc4cbdf011701dfff2dbb7eb28b7d3e08c77003376e02c4a9baaee4575495343d639921cb99bb57ba63c49221f3898eb6c6f3f6a981f0e006c9dabc93e521d260ed5a67c5e318873f2e8b320f03df052604eb3b71c4ef39ca28e8fbf0e2cccd49ac92018cc07f05cc8bf39f36a16dbe6e1897351ab34031de65563ee616d4ee617feb1044a869a909c9ca68947fd31b7d06a7567a1bc04a4a5d64b8aa39d0789905ce1fab953be129bde54f509617795d3adce31eccfb8c4c425421976a37ee511e92dd66c8c77e3ef0f142dc2d35e33a367b00a5e4b24437c78a7222016b35bff2e7d3233086c71ccbf803a0ac4bbf673879c1c01aa5c33b96d3c405baccafdac326deedbaefa99f3e21bb175d7a8cf405fc6689248859f1bf55ddff1c50007c61eeebadbcf943adbbdbb2533e256e86557bd44c785eb3ae407a2c5f98843b201f5a7ba95e4549e365dfe302fde80546c288b45b9a1d30a93dfb3ae80fd3c2a02151665f82de17597fa67f4b6ec7bd8b1cb1ab6f64adc6443c1a17beb455694537cc6c37d30cb7034980c7ec058ff1ef743a085b95cfe981d2f6e14b06a4dacbde4088ae93b5e4adb9c20a4f75d3248a26957453f2c59dd9d4afddb6dfdbaaa2f66424114f404a7b60020536449bf97fad0b0dbb3d49e4ebd3941415d273f592ecc1a118f37794573897612a483347910c722ce90e68d405aec4e693f14fc32d0db0374c82d3a9428d7e4ac5857ffb07dcd55d8d2e60bccf299beee2949bccd75d0431e5811e56b067d574c11843e6c2a6f6a541e6bf1886e6384402d63fcbf3c3ad32f18a3f80204c8adf4defc335754c88f2fdf694d33e6bfb08e5e0772a0a10f431973f0be088a1015dc2f4df5fd322016b2559bfbf2cf059b66c83d8d378ab944de20b16d9d2955513928bbb7b99ae3711eca829f9cb0a201a70a9447aa53d64fe9c85dc83be3316e750bce4fbf9148b3b48b8eb667e2eceb0d312920915a79bd915f070e8b039e7f77c5fa5ca3f26e6f25e8fc5e903bc9957fad6967bb81d2d9d8fd407dc2bed63d3985760d21f3c1dad7dcab9bae79c9cd426d77ea29ad19375e04744a33a68424494c5e3e0c945f78deee322f415be90cd543e7fa95ed6233da33f1df64d26272fcad16b108ac65e9701c0dc1d9a69f97bda054ce2abca02eececc58a7c4643720f4a193a220929343bf7e7415e803372cea2308b4575d060afbfb8bb438210c6067a6d81f838606a31af238b58a5e3de77329efebdb31c8ce695871e3168e5ee5d3f92d8c68cb8a0f4c1e975f8655900d064bbecc1a824622eb3b58b68f0c3240c82b5856614af441539141b82c9deb925a5509c15625b42244bdccf6aacc48c148992aa2e11625adb19b5d77c4071050c3a9b4b02f3caa26b1d83373d951b0461dcffe59327a7e574332f9528a24b369a53a60c046c1af21e81933309bdb3629283534f81c36a98a10e56d1a1cf878cebca64d503a6bed081cf4706c9cf0a8c721136bab64edc7d8d68407eb01a85e29b84aa18bd8121ac50860edffb6c9d55595f11a06884b64e132a68868bbc7f5cc63681fd9ad7788a0e24e0b2597b58e4c4552226ea1ffda22041b1aff340dc3db522f6945abf500f1ac0b214542277256f4951fd400e3e190b44753ee0d406067e8cdfb223b3cefaae63c1927f1e24f58272ff905bc6604ff23393c1272356abe4c813c98f09bcc3d0e182bf9d4221b49cb27ad7b1dbba477f212b69a3d1a46f596fead4f5cb924bfde1873b68709dfa96bd09d24b41da4d6bd4813a392eaa657690279c8896519056493b38d110d370acc0d7e6811535df7f15bd01f2ffe86329d631d92265c8b357d451047ed03ca1ef78f842eaf5833c6ba680eeeabdae4bbe15faa1ce34d5057f86f81e787fbc74a9f800d09a9718235ed07fcc0656c32452d74e2147e35380a5972f516fab33cf46c12aac9553f6fa09a48a99dc3b5af63282707db710391cb3f6df90740250cce94fd72dac22e88cbabba2431a9c18df36c6a03a246b75d6b91ae1ba76becd60ef1d4f5805d884b6b3cf69ee87d44529e4df6a695ea6b7a573d29fea61a8945751082ff0c1495b736104c7e1181e12ab593c5b3904ad8a77f702cc333e3929a28137caac61ae36828dca6376a449b49c88268362d6bf71b4906df8d2ad45e9c914a9fafa583fb5df649807284cc8ab9798a7522f5f7dd58c87149c29e93d2a26b7be729cf9e4e7b6579f8093eeda577aea062709441db8bb2f3160987d7181bbb70e7f601f31a709a55b9c9021a9c56e167f8bc69c4c006e27ad986b4755e9f8a499ab7cf27c7161941dc76e99e437a5c0c2584f9be6e394b1fe996f94171bcbc7c3714182f33f403200073b19c527e997c59419a101c14da686eb2da3d2974a1f5ffe65736728f3415e617fc01412e2f9e4d8af1a237a7e2d048dc03d4e4364b7d902793b938bcaef26e39fde951b5068ecacf55a1172baa06c5a1d77786e0c17597016ee0f5ad52efe9401f070483767d6222459c9683965c956208f1501fd1ddc65b517ab1d4cc5aeac17709a8a683ed96a0c2aecb6d832928fb6c6eda823806104bc7b57e85718130e148adf6add20611af054905467bd7839e2d7e2e5ba4d725346c8cbc0b886d53ce0bb2cbb8122147a2bfe192e0516e2ee36216fa1938815ca0d6fbb6365c6322cb23e3ccc7380fc901840459f0e6ac88ed83dbd86d41240ad89f1111f00b481ca5bc1f37679bfccf18c164ac6b698f25dfa74f7cd17ad011ce76bcfda18da7f74d994280612b0efaf50309099860ab5a305fb753ac17a0f38c0e1c1f4614e812dd6516eaaa79314c761b2ab3646cc3749d391eee383b25b94940a7b513a27e943c2fa50226dd1490fb58b0613be6e49c9b171b0e612a575390aae416bb04b1cf603515b96b7dfff36ce7a9ca75cee665bf6a77ca635239863ad264c48d1a1012d5dfeae589a34f07d38e3cae5c7f1fe5f5f9bf47fd7b3914d61b95acf8e73ec18c601b845ece24be91899b42461ae1d77e22f323e5f3aa3ba765e9906652517eaa4437a2c19a2995abe3d275fe16d5e2fd699a3a17a15b552fb944c62e9440e3b27ee96f4a12013d5ed30c877bee33dcbbd8140e5588f8fd72f2135f1d5af604257a5523590bfd18f76af27502e71823a51aed2060a519d79014d97430df0fdbc61e397da2101aea80a2e0058aca882b4f0b921642617eec5e45f2d22b209b3d5d0091afe6e76e7f6e17b149d091657743950b672adc434ccf05c4ef11f0afcb9926945f5c502e312398af6bb33d24a6e1760d3750162026af022ffe0c4d2d7047e6ec170361112944c65f6e2a4614fc46cfff7fc98e6a72d53ec47f75ca623bd355936bd99ba807d1053ee1f347917e957fb0bf0790555166e953f4e5c9e8f0d3f232227b684d5c00523c7561f36054f25fcd9d87f1b46cc9feca9e88db02fe529c9598ce73243dbf53fbe06571c7c47f0277f85c922266bfc852bd41af6df595e6f008e8e9d13617ac21ba8cdf7c2a482edeb987786e63b900867022dd671e391334b2fa82960de60baa24f41d1a347e8eeea51a5637f929926e0c5092ce239369da722f7b7ef2f97fdc624c518f5cb07be19eb556bad87b3f7f488fbf9dc7f7c423a2ef4cc7b931a3655ad529d656565c304f8e1e18d864acc5ffbae00cc065ddc3dcbd8d08484e06defb7c1d1edac8163057ce415c4e2e7a5f02f8210c6735a97273cf8550e7c6dc0a749996f9b710cd68b18bfed8eb55933aae3d0b4204eb54aead7d7d72c2bfeee0c13a2b8a175c0221326fd132dec8cb0e35a848e813ca89be74f0239a210be3485fa7db4d5beda2c45706a87f1d0e59c4e5b2754bf658e6e7c77f41c0371af2cd30a3fcf8b505ee435fb1e6f0be35e2f961f492eae365299af1842b9c2ded998f91be6434038994d31ddbb2dd68813afb3810cea042099d3ef1b45de8093d2fe99ef5d64da390f14079c638835e82e699ac4ce2c6fb737776ac6e1c406084e24294de56fb2fbd8b06c58ef265d348732738aa8b00a4520e2aac39d2b8e3aa303a155e0727ac3f78a27f82e4185d44aa7f6a982b06a357968af7642b2999c75335c14893cd336bcfd8b84f7e25efe46b8b4b394ab4c7b4a783e3b93089688cc981c9274adaa1e9308514aeea7a720a75bc010eb6e1f859702f830194bbad372e47d0ec25ba2e49288016f45a748b8a3e395be84f48e8e19bbbd27cca15b69262fe7e292b763c858d1153b86910137b65db095611917812860519f1bda2579e9c05c104334f429266825e7e169a91b1f8e78a0e81f55f6884b81b66337e3ce5d066394fbaea8dbbc42b52515f9be16f0fdb94dc799d9cdeabb8a459505b00e4f283146f7dcef2eba78b66073d3f937fa0adcff2552a5732424cd9762d561fa1eb9e683b329221ae0c9e096560891ebf2242b756e51ee8fe56e2ba607316bddd4d3ad292f80140065990bed1a5fd7492b969732b19a4704910e36c1d2fd72c155fba0808788409c88435180d90b326aa71754381e2a595c07f419d72b4972f880ec7b6767d7d8dc1b89a034e68ddc35809baad167c4e81546d06f7383bc02f9d0c219c85037fa6dbf5916451c4e223cd80c542f587f66229ba86ad39313d901a2ac034fc5fe137fe5d19d806e51f2983a094b60cfca8e295a4a657a16c3378aaf5fc6a792c0347fa199db6b4e83ce0b57fbf07649a0483d57867b58fcd000b99b85b16d1719da16574a20523215e790184194071221c28f44731bfa2ad193cf540b0f153cdb82726b08c8306519f6bfcaf5de566071a7ce91f858ae200e705060fd90aac929243fa83b379cf25b2ab1974a1ab08cc1f9fd7df32d6bac337a38c706bb080a19edd53067ced39c841892266be80902c750d35baeb360edf3c910ac1b73ea050b221c2f35ded4d140e59768846737f58f16312a29e466f132e3c8c6136f4dc45e66a893fdc8fa389e9f5051e6d6e76c50a0742783ec9b5d2feffb0ba9508bda9e9729d56532f7a29b7fbb7b27f00fcea0c28ad4ac9816a66989ef07b322820e90fa84982c4163a0073bf1c7b463e47ea5eb98b10f16de27332799156f466565efe234d8626e74c310fa1038725a6b1063e6678a7de9bbafd7c58f083b8f38d05a6189bf73eea63d15b55ba1e62a941e8576aea833a077e22dfed13c5b96b3b7cbd38aba1aab43168712502655277559dfe63a875a3b1bd1732587c02caa4a3671229d79627463670caca9f85aed8acd809bae611cd036623b4bd4980d9623a3dffc220b29db91fb8c96f6778c1b7c296893b06142209c8c6d6209ebc5a2206fe025c2049a87545e5404c7b27859c164ce3e9386842c3777f7b8890b5d8dc47876afb2bf261481ac76513a17384f15f410755d622ef351d576aa342899cc1f9e4b19923a764d64c25d9c91490824527ec39afeb2be8b0f2077134bcf2c7d6886e498fe35d8f3282d608d5c5a0ffa96fff50e857ed8e1d704aaad6550b236aa6344404db4968598872ea775d02d31dce552f8270d24b9fa6f24934d1229c1a87e00f796d2d276d5a8b894726ce8a33be276a10830cd55dd805cb27e0ac96a7b3d1ae01abe4f415b7d55ebf9e5d235901b82b1e91e19a47e03e71558573187e1cfd521e8199108fedeeb74a1d424f670b4fea635fb7f1adbc988f674174855de4facb3bb1ad5bfaeac333750a87985dc0bcbc393358b149fb7db8fe2045695cbd0bb1474356021f9c1b3d24a344bbca5cf6f4919f89daf235e3414c1bdd72affd5d0c29d0ad39652e6b24fd1325d30bc53c35f3ccf9a7ae27433434dc0d216fd299e3aa08c2f5c25ee0704a4ebb7aaf359168b6d19770e589d91fca1869b42514d2df9f04ca9ee107a20cb3ad4c090dae05ca33b109fcb7e06ab3d63ed3663f72c4dc16856903b421375b28f3387550dc8205ea9ead5883e66f4849069b6aa8aa2962fce52687c94b9bba8b7a4fa3c70b588e2cf931a290bc31f1d5451aa2613fd23cd49cffe8f97512a3ac73023c6de434930976c90054112e447211d9e772356d69c268aeabc5d19b954c9b3570e60e3068c2785c31cb4928f8aa949dfaf47fc322528c9d16b68874040ac4b4aa07c982474f8c06684593b1d5453c888482bc2a8e7ed3522cb3fcd2e9f1cd1bf4a47cfe6c854ccc8faba95be2d17ee78d7609dfad30b05b1798db165456ce0c4cd9752c4fffda864e163e11726598b34dc2c0fe7a6ccfdf82ccaa"
         }

--- a/src/commonTest/resources/nonreg/v3/WaitForFundingConfirmed_fe3c5978/data.json
+++ b/src/commonTest/resources/nonreg/v3/WaitForFundingConfirmed_fe3c5978/data.json
@@ -1,163 +1,171 @@
 {
     "type": "fr.acinq.lightning.channel.LegacyWaitForFundingConfirmed",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs",
-            "zero_reserve_channels",
-            "zero_conf_channels"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "zero_conf_channels": "Mandatory"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs",
+                "zero_reserve_channels",
+                "zero_conf_channels"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "zero_conf_channels": "Mandatory"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
-            "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
+                    "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "0354950a7fbbf53329f8a3f912cbc734d94134da30555ed28470ceab5daea6fba9"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "fundingTx": null,
     "waitingSinceBlock": 0,

--- a/src/commonTest/resources/nonreg/v3/WaitForFundingConfirmed_ff74dd33/data.json
+++ b/src/commonTest/resources/nonreg/v3/WaitForFundingConfirmed_ff74dd33/data.json
@@ -1,160 +1,168 @@
 {
     "type": "fr.acinq.lightning.channel.LegacyWaitForFundingConfirmed",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
-            "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
+                    "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "03bd8a174751163f38af0abc6c513d98f05d66080e67061cadf5e2b11b665579d9"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
         "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
         "remoteChannelData": {
             "data": "2f7edc2aaf19044090c45b2fff7f644ccc3a8e46dfa833ffbbbec0053851644d3dc2178a3b9f9f1c97748d2819eabb3fc4bb1247292e313b0110f410ff68ed4ddc9a72b18eceed357436dff3a175cb7a5382fec74a47854cdde1f40413737b3bfd8a30ddf78e762b86622ee24d71e559b1db503b9c45225c787dcaebc78e0d0a203ed894c9d09211ee782603d1cb60a2b7a1d189028373676e687cf152472742defc9983ee1062d93724018d7b57ce2a0c87a8719a9c26d64d7b89255fd4e09c564b209dbf4234bd94fdee819216ce2688fb28c177b643b1ed1592a91612b03b75fc7628444f8f4b167e0621008feee70afe1424eff8f6fab0229efc4b2222b635d695d5b907ab1d775be189433dbd58a63deadb2efade687a06b6167c32aebe41b8166ec32ec8969f3d5b5bc560e5fbd9c4dac4453397373c1144dc51f8382a785bd71efe8e89fd727f7b8a0272623638c72e654e9c6a4327da3c9dfda6d54ffe3dd688efeaf49b38d0db45bb2104b27ae8fc150605856eb2fce77a17e55a302f2aca121b69380b7deef05d152fab0e846260a6c8acb7e296603b22cb912e10722b0e119802f220d900f26885f51fc244c1c2d699f18b8037c023ca95b31e12503040d15f889c0633cd501d527f28ba1c5a03738ab02e2dc25f48942e96006b8f3468225692d9726417453afee08a436de7470810a839025847a9d634d20adeeb444dbf410a451fad2fea468a585fe7c66f79da1371f1a29a0fd9da0efa2252f5e6befe9e6a9005fe04f03a05eb5fc083b213dbe249aafdd98f09b0ca71417749a373d07187a33d92530123ea05a459455873fdf0dc1179f8989cb5d85402755078705e7810a08a3c94332a9e9c0234f5a157164cf56642195c3255cf671d2ca12485b5828f4f7d31d2f23389565b40b8db54bec68c42a2d67a8d942f49ad563ec8ca6bd379920acfb21cd385f3589f8c0b2fd2b8d59d38cb026916d19a1302573abb7a1e5bb516445ebf75f5ed0a0d2d405189723d0c378082820e780929427604a1ee362e4734de3a056ee8b10a1bd2ee88b265256011f2a827b262be69396673060043d2551d8c7c4d8e4193f64373e4884c6ee221cbbca1a020d700468b579d416d931b504a6645e0368efea75a6e791f7e63ee86a69505fe829dcea4f4be3a50fb7ad812c62e0bf68e4233587a7bee34a354e9582b9b985d8dbda8eae1be3e1b2e35f31cdb8306d627e599490486f295b0e216377fd82c4500b8e2885385de2f021222a72d8481361c7fba8364d0b7bc62ea8d46748bf13ebbd91a2db97d7e17aaa621edb3b7a715c9d62c6a8a3becd1d938065883752a504da9c50b7363a415e2c0c7e925a57070113f626cac667dea80e83060cb0b9db82eaa77ef9a12759bae777dc3de68ee725719d105af1adf4f93092f96bbd12a51aa7b7ccc44209fe33e1dcc90f58e2fcd6e2ec561d03522a9e835f1780d92e7e93bc557ab138d8abe679842203e65255130ab4db1556e35ced5b2f2b99574538b54c516f0dc42a73207de9213ca99ef633d925405f883d32e05f910b972f79738c4897fd2154ce20d2d1f0fe03fbb247b30e1c3a8cb1da396fda7699cab8472e2f296cbf30a6d1e87855814fa3df7ba4dec87b8d7f5a1b24302a47c7f33460835c912379169e49353159619b5f09cbe050e08334d61bce620e83e4cf496c4953cc86ef8e84f114b62c579ec51aa6305cb056e69b6230ce109ec13b5529b72e9eac965fd7c4a4d3e4be02e21074e59b6c07b3b3c65a3e2f1e3458da0a0cbef6b69ae54464ba06e675f5718e5b28e4e1b2542f87d8d970cf04cd200a36f08cbc4b17a99d41aadd58e562d591077e603b1bc6433551bcd5b2a87e9454aa191d102412529037aceb1ab86819c4766c1b56dc6953264f2d6caa016f1a2d582363fa4c7c49e742cceb9b3a4fc38dadc2263c296c886402e05102b42cc316aff8cb73e8fd4ed72df93789730664a62ceb3ed950ae4a2a6caac8b45dbe055fc764722f80bc3bd8494cde1367b34c1aef3765a53c70cab60287fc2f2ed1253758dd5b30993ad968dd87641a269ce72a99e9d19378417cd5522e207bdde7948bfc70507d6ad14c3f25d3723ac3203e3dff6fd6e970f4e450daf267e4fa8f1e2decf36efaab9f9a6d4e0874f2400eba70d728ccda9948d8fc6f9ea09323322c3365e31f494fb8a953273acc78b5021633e913ae8a0a028e33abe87eada41847a2e4bd0b8e28e19f6cddef7adb16dd72b0f51e7a21e699d880e97c96c4a13f568d1fc4537af36a7fd04e36c084bfa7fcfcd85b1507d26315d795385cc7c9ead66349bc264c691442eab3d0dda64cec7684663a1d81fe86753fc2b40f9a17759c4992a51631e7a6e755b324d5f6b9ffd09e121e68522b782b485c85da6edb92dbb06e2ca35edd208c9245bea83b1586154a21939ab9c4f4e9a51a39ce34d1684e929467cb3461784591ed50a309dba95ac3d2d6febfb62b0ec7ed327d550f9522c2a80684b002b75d1c3e738c1f4a0e04f528f08e69336c676eec9581c8c218212bd64a6eb8c88f12bb01bf18b81066aabf6a66eb69ffe01187163ecaa1a73fe363341b977e24c4f696c7d525c1f4509655cad80a1f9edf08534e7109081eec230356023bd5b8f0576d563e49a91b63605ab84ab9e0c53232a50039b0aac128ddee708c770fe14adc52d009507f638b294d1d4564386784da0296aaf69487d34d969a4968060394be2faa0ac7e6e07183693ae3809b0822c6c6f26b5cdc3333a65cef83fba26b4cc9b44b11ed9b0b48e3b6b401c83772cb2607872584c3aa0047cd97c224a2a52b8115c6a40dd943eb4eb8407d0bb66b665c514923da85252649a075180dcad10e8dacac2710ee8760cae7185c1cebdedd278fab47a11fd32817a5e67841cd8a4761d5ff290862dafa987b7044171a53d4d881aa49717186ddd6834363d3e99df011a28af4d7513d038076c7c88ed1419eaccce33cc7ff76af9504e52553ac606e395ef337b09b37f8cab53353af8e813204adeb34f98361c579e7ddedd835be38859b4a9f128938c31365e9711f4b1bc7263692bf3b69e57668db47d8a925fb473a929c8ba3c6168944cef96bacd91ab699c85d9c09e5b9342d69d79cfe3ee91c21a07758add7e1fe26ad3a82ad2937919b5b678357208a3200ce5f76a4d2780a0c7478cb21041cf0d38db5542904a05c1b5794cec0f66a0775d9f396cd10fd362500cedaeadee2326566fc3a6525ea2edd6b4d876e206bbfa06e46ad2e648faa9dc7ae726c5d9854646ca956da0a33008dd2e5d9310a3834d42234745ecb5fec6255884cfaebb79d096a8a26fff606b2c6636b942ee45f7045738de3f3b0a5f5b509ebd40752c62c99dbeec314c7f06fc278b97245e96bb8eed207220afb4abc6e3e4c81441a14955c925d044613fab63e64d63dd0ce9864ffbf1a5529837445557b261877161b32b92e62c8692b2f666bfbb2b1b475fcc2fcf5f66e5b282023a313d6cb7ffd24639df67ba083db7508064a74970959801de5f653a447c95cd0bdafc2f8224ab4278178028c2275709939208d21170716ee5e3d42e9965fc2e584486b1cb5fbabd2cb23de0546ab8d3817b62f4f0043a7903170424cd0da5ac37dbea30e4457b66e8641b1a5297b00f2c93195219ccfa872db4aa17d628b889c15c746a4d95a8e779c504519b34ac3edc7c9b08dd140de7f818c7dc8de4963f6514fd6317f678bbe058622104fca2232ae32a9fab82106d080daa8e7c040a2d958686b34923ee05d75f684bec64b829c1072c04057bc3992b44cf631ddbd5897c8902cf54d094a8986db85ed67ac989ac0509af123c95a9200a3418ae5200643d37b74675ea17b8dd9a334450dfa4f1d50c294bc1bab463c2acaaadbebcc36ba4510788fa2c2e5b7f7b02f3b7df3126e7f8100d9a913040bcb2b738de6687d46cb4df92f4c952b78c65b23d9aaeead083654141c1bea00e9de6b4033cf33b8ea5506abef3197b2aa687b436998cd0f10509638385b204ea0b14c9d76fc4ea64e50b261b3255364ef09cfaa52698f275c248b1dd4bc38096db272b28afc8fe5dbe96f683c75d594a576341b6baf7d91fe610dff3fe1f10481fa46fe1ab60405ce8e2b3195a3f8f3584a5719e9e837289d8aad48a9486dfb23c8704a1ebba550432d0193a9eaa7e47f520a5859bd9e6c590d36147a2a96658338c96243b535bff2a61bb20a0ef932ffe12866c1d82dd37f3526622b2d908de6682aa5aa133757168a80a589e68689f7e2db0c4957064a148d87911b4fd0c7a53ee3cc85f98b09c82430108e03a984149421f281b15ccbb8b03b38fdd808e17b3d87ac04f84be7b4d349d5fef01ce3618ce60a465589349d0f3a6a65a6060a72bcf4e238d058ef66e37f007efb74114fadb75b91ab05c255e31bed4db4eca0493ac05e30ccd97fb2251bba8f75782115069f032961936de1f8b8b61784218756775e3b7a58c2c2b1d49eaf643b4b8a532dc14b7b17073ffdf8d7a68b7b52c1dd01951363a8dd25158ca49a489abc196b41323e8466c979c933478bca5e8ef0c7bbdfb00914bdfc2e508f92e0c3ad08b0d4c39b242c222a63261bf9ee07c04587eb7488e2092de8a8e400b2e5333c971f6fdc371c7984f2bd09e2d1ebf044dfbad9024f36801494d51819f79a851328f3bd8a18579dd0a1d58875716a3390fba8c0b02af6847676c5467337331365c477dde935216a8ad6cdf4bca2408035fab3a2db43ed13d3c10149369283ad1c6cf80cbb569cbe8c427ce5aaed912a6a21a0d51caf81888a063be329cb74a40ac0933530be2e048de543c8e28f5b85d98c1c803cd5ffc53a15980df9307ed250d5f6839eec69a914a557b229a3f0c5d1917c906103685fcb2de8e0782d67fbb5a9fc3a9e99495c5fa588f93e5b54e7a5ded9f55b1670031d095a0bd0fee384a7f5d539c3aeb6a3b2fcb59dff0abfc0da0afdf36345f82a7d6bd629274d9991ed0291b60ce09eae8603a72ff6204eb190ba10790b05be027417606751c57a68de165b899180dc6d1359451c2eebf9d212c706878f75dda39e6b8f96347ac5cd36b3e2fad6300d29b5b65b60e47d51b96bc2facbbac95a6bc95bff3e5747f91f8eb549de44e9db4af4ca210102fbab9fa341b2d8ad56ba1650e4d016c56767cad66718fc62cce46670d80a8c25a5d544a21a931bf136d47"
         }

--- a/src/commonTest/resources/nonreg/v3/WaitForFundingLocked_f3437082/data.json
+++ b/src/commonTest/resources/nonreg/v3/WaitForFundingLocked_f3437082/data.json
@@ -1,160 +1,168 @@
 {
     "type": "fr.acinq.lightning.channel.LegacyWaitForFundingLocked",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": false,
-            "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
-            "features": {
-                "activated": {
-                    "initial_routing_sync": "Optional",
-                    "option_data_loss_protect": "Optional",
-                    "gossip_queries": "Optional",
-                    "gossip_queries_ex": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "trampoline_payment_experimental": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "channel_backup_client": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
-            "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
-            "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
-            "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
-            "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "fundingKeyPath": "m/795924157'/565292462/1721776665'/620103361/947451165/318257970'/1822224386/616080517'/0'",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": false,
+                "defaultFinalScriptPubKey": "001434947cfb2e8f6054ddf12daed4308cbe342580d1",
+                "features": {
+                    "activated": {
+                        "initial_routing_sync": "Optional",
+                        "option_data_loss_protect": "Optional",
+                        "gossip_queries": "Optional",
+                        "gossip_queries_ex": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "trampoline_payment_experimental": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "channel_backup_client": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
-            "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+            "remoteParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "02b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c",
+                "revocationBasepoint": "037d549bc475d9b2b0098e3b2f23282671646eab09b36e2f01099f39e376552864",
+                "paymentBasepoint": "0368434fc548cb471f7ed8c94638433bfb07cceb97665c411450fdc23c60236409",
+                "delayedPaymentBasepoint": "0399d61c09ee58f1cdc497a872f6b284cbaccd54f56bcbf7acf1f5595b577506cc",
+                "htlcBasepoint": "0288fb5246c577f7ea28bc1b56f64d4c9f6c931b7075f7890bc6b4daff6253b5d6",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d03000000000022002031dbc67ef6930d0825de6c23bd311eb93d40430d543c0555aa0f15b7aaab0cbc781c0c0000000000220020958bb43c9e6d1b985001c2f4dc38d286d7fde78bb04d7ec5a5ae44d8ebf0c40c040047304402201991b61ae8ef7bf6bd03f6f965552294e7941fce3fc91a024094cbd9b3464dd202206068ef64671e59b5825408e58462613a6ad0edfc7aa23853aea36187298c493901483045022100cca233f9a14605a7adab49f959c5b42260a55156282cbc802397fc934d5e537c02203504b82653044526706d76d3ddf0f083ea77a16f6cc13c93add344069a55cb940147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "txid": "51487720c64eaa73a972e2e240f5fe4b1cc1c46d9a76854a11c62ab969222a29",
+                    "remotePerCommitmentPoint": "0332dcde49bbcc222f9e793771bca07d28b08c2d6e12992ebe5398c20194f26722"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "03bb831ea93a1d0d2540af20196552beabb0c5e385e6b358516d3c40ccde7723b1"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "shortChannelId": "400000x42x0",
     "lastSent": {

--- a/src/commonTest/resources/nonreg/v3/WaitForRemotePublishFutureCommitment_ae47fde9/data.json
+++ b/src/commonTest/resources/nonreg/v3/WaitForRemotePublishFutureCommitment_ae47fde9/data.json
@@ -1,159 +1,167 @@
 {
     "type": "fr.acinq.lightning.channel.WaitForRemotePublishFutureCommitment",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 800000000,
-                "toRemote": 200000000
-            },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
-                },
-                "htlcTxsAndSigs": [
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 0,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 800000000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
-            "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
+                    },
+                    "unknown": [
+                    ]
+                }
+            },
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 0,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 0,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 800000000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080044a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a7990781c0c00000000002200202f0860cd1fe361a1aaf5708f75b6511c92cd5a51bdaaccfbda77aead550d875104004730440220672323ca34b85c2a43e3e93ac8a642a8293b1483392f531736db975d05f3ad3c022019f7b5044cd2a230dc49484c219fd96485f98d21c6add317566f4b21816a2fb101483045022100956b481822da569bc75c1f7ab6ec34c0a1e14dd5b4701ea8473e5bfe6b6ad41702202b1a987850611c0f52cccbb6016c735a08572f61fe03616a186ca39a8b2e07970147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aede99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 0,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 800000000
+                    },
+                    "txid": "6498095b8d064f46673e7c0d919636e1dff0c0a76ed61dd96938a178253ea4cb",
+                    "remotePerCommitmentPoint": "02365f9a5e4822956750faa46230f54e47d4b6ef9d58eb8c488d80a5efed938d5b"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
         },
         "remoteNextCommitInfo": {
             "left": null,
             "right": "03c57839fd412868a398bea05d01678a752661126a2d1357a0f7cb6f0c60311125"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "remoteChannelReestablish": {
         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",

--- a/src/commonTest/resources/nonreg/v3/WaitForRemotePublishFutureCommitment_d803549f/data.json
+++ b/src/commonTest/resources/nonreg/v3/WaitForRemotePublishFutureCommitment_d803549f/data.json
@@ -1,225 +1,242 @@
 {
     "type": "fr.acinq.lightning.channel.WaitForRemotePublishFutureCommitment",
     "commitments": {
-        "channelConfig": [
-            "funding_pubkey_based_channel_keypath"
-        ],
-        "channelFeatures": [
-            "option_static_remotekey",
-            "option_support_large_channel",
-            "option_anchor_outputs"
-        ],
-        "localParams": {
-            "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
-            "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
-            "dustLimit": 1100,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 0,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "isInitiator": true,
-            "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_provider": "Optional",
-                    "pay_to_open_provider": "Optional",
-                    "trusted_swap_in_provider": "Optional",
-                    "channel_backup_provider": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "remoteParams": {
-            "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
-            "dustLimit": 1000,
-            "maxHtlcValueInFlightMsat": 1500000000,
-            "htlcMinimum": 1000,
-            "toSelfDelay": 144,
-            "maxAcceptedHtlcs": 100,
-            "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
-            "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
-            "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
-            "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
-            "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
-            "features": {
-                "activated": {
-                    "option_data_loss_protect": "Optional",
-                    "initial_routing_sync": "Optional",
-                    "gossip_queries": "Optional",
-                    "var_onion_optin": "Mandatory",
-                    "gossip_queries_ex": "Optional",
-                    "option_static_remotekey": "Mandatory",
-                    "payment_secret": "Mandatory",
-                    "basic_mpp": "Optional",
-                    "option_support_large_channel": "Optional",
-                    "option_anchor_outputs": "Mandatory",
-                    "option_channel_type": "Mandatory",
-                    "option_payment_metadata": "Optional",
-                    "wake_up_notification_client": "Optional",
-                    "pay_to_open_client": "Optional",
-                    "trusted_swap_in_client": "Optional",
-                    "trampoline_payment_experimental": "Optional"
-                },
-                "unknown": [
-                ]
-            }
-        },
-        "channelFlags": 0,
-        "localCommit": {
-            "index": 3,
-            "spec": {
-                "htlcsIn": [
-                ],
-                "htlcsOut": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 250000000,
-                        "paymentHash": "edaff8f0e5117e83b2570b5f9d7115631df9c3de0f680c041d9cdfc087b4b51e",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
+        "params": {
+            "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+            "channelConfig": [
+                "funding_pubkey_based_channel_keypath"
+            ],
+            "channelFeatures": [
+                "option_static_remotekey",
+                "option_support_large_channel",
+                "option_anchor_outputs"
+            ],
+            "localParams": {
+                "nodeId": "037108815ff0128f7ed22640485c226d9ad64a9fd6d8b41b6623565aed6b34812c",
+                "fundingKeyPath": "m/385048399/1977025879/604622566/184658546/776346346/949304342'/277944247'/2049339775'/1'",
+                "dustLimit": 1100,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 0,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "isInitiator": true,
+                "defaultFinalScriptPubKey": "001405e0104aa726e34ff5cd3a6320d05c0862b5b01c",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_provider": "Optional",
+                        "pay_to_open_provider": "Optional",
+                        "trusted_swap_in_provider": "Optional",
+                        "channel_backup_provider": "Optional",
+                        "trampoline_payment_experimental": "Optional"
                     },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 100000000,
-                        "paymentHash": "a4459f57dc69d1342cd3c880a5bdb880ccea97be95587d5c6e87234f209e1ecd",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 2,
-                        "amountMsat": 10000,
-                        "paymentHash": "90792e276988a51c9382702617df7e340cf7f0299c3eb58fda1b3a493ebcb395",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "feerate": 5000,
-                "toLocal": 449990000,
-                "toRemote": 200000000
+                    "unknown": [
+                    ]
+                }
             },
-            "publishableTxs": {
-                "commitTx": {
-                    "input": {
-                        "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-                        "txOut": {
-                            "amount": 1000000,
-                            "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-                        },
-                        "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+            "remoteParams": {
+                "nodeId": "0362b19a83930389b4468be40308efb3f352b23142ae25e6aba0465a8220f95b06",
+                "dustLimit": 1000,
+                "maxHtlcValueInFlightMsat": 1500000000,
+                "htlcMinimum": 1000,
+                "toSelfDelay": 144,
+                "maxAcceptedHtlcs": 100,
+                "fundingPubKey": "0385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa4",
+                "revocationBasepoint": "03a42aef6d1c860caffa6c71a6f8ac2b16eec25bab0c3950cdb1fad7fb38a5f2a5",
+                "paymentBasepoint": "02508e1845b8bbe0773f6bf8f3f04f59a5896426765c7b6b23e6e466c95381182b",
+                "delayedPaymentBasepoint": "02d62233b7c33f8fd0911922461a651007f1de09d8c474029caa8f2c229c10de26",
+                "htlcBasepoint": "03d05c8245bdc12efd8b070b22b276e7db4254f4693e22b3f7c978c08e67b36236",
+                "features": {
+                    "activated": {
+                        "option_data_loss_protect": "Optional",
+                        "initial_routing_sync": "Optional",
+                        "gossip_queries": "Optional",
+                        "var_onion_optin": "Mandatory",
+                        "gossip_queries_ex": "Optional",
+                        "option_static_remotekey": "Mandatory",
+                        "payment_secret": "Mandatory",
+                        "basic_mpp": "Optional",
+                        "option_support_large_channel": "Optional",
+                        "option_anchor_outputs": "Mandatory",
+                        "option_channel_type": "Mandatory",
+                        "option_payment_metadata": "Optional",
+                        "wake_up_notification_client": "Optional",
+                        "pay_to_open_client": "Optional",
+                        "trusted_swap_in_client": "Optional",
+                        "trampoline_payment_experimental": "Optional"
                     },
-                    "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032a086010000000000220020ff5d65b735c30cb217486f62f8d590e56b6c27192299584ea87dbaa4452ef679400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799090d00300000000002200204ce05fb81556eaf7911d606ec23f598ea0e05d43e722c78010e1788774bc8fa686be06000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb320400483045022100a277bf52a6558d90135e0691ac9a66a9cd8b1717367e675f7d9551b251ab37f502206bc0aa48c04c085b3bb27d2fab0a83e75eed1898d81269bea19e48bd182864f301473044022060fc42daff3f531f27399b6c8cea7753f7e327f5dca6ce3e1cf11ba7bc695da102206373ebcc82fb07f2157bdb8399abf19563f6fd202ba86ade0bceb7693093ef0b0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedd99dc20"
-                },
-                "htlcTxsAndSigs": [
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "007ffe03e47cb696972af3e747c5f0ff813953d1d127b844aa8e66d4eedd6d48:2",
-                                "txOut": {
-                                    "amount": 100000,
-                                    "publicKeyScript": "0020ff5d65b735c30cb217486f62f8d590e56b6c27192299584ea87dbaa4452ef679"
-                                },
-                                "redeemScript": "76a914c58f2d84aa3dcc020f248d3a0f0095ce66e3b7ad8763ac672102486e1f94c3b4e63555b63bea6e7ae60e550b2275dab745118ca8dfbb634604967c820120876475527c2103aef82904d176eefc9f86b138b86f4f411ed4778f341321bdfb021f5cdff7dd8752ae67a91412bb12f52c0bcac1a16e576e3e9c28d6032de7c888ac6851b27568"
-                            },
-                            "tx": "0200000001486dddeed4668eaa44b827d1d1533981fff0c547e7f32a9796b67ce403fe7f00020000000001000000019e7901000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb32101b0600",
-                            "htlcId": 1
-                        },
-                        "localSig": "5e865cf9ae0fc879ceb90e3144f2273fee1806f47b0d4949cac5e4621daaed681944f26ba277941c0619c98553dd9c7cba7be07beb9c867edf7fad1ec1602465",
-                        "remoteSig": "a392c69c1f762942710dae08a686916a493b9b1589216a57f9a4b459305cbad423289a8fa364ec92848ffa5288b8a0e3b2d56bd6fc4cb223bef73fbd90a38b29"
-                    },
-                    {
-                        "txinfo": {
-                            "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
-                            "input": {
-                                "outPoint": "007ffe03e47cb696972af3e747c5f0ff813953d1d127b844aa8e66d4eedd6d48:4",
-                                "txOut": {
-                                    "amount": 250000,
-                                    "publicKeyScript": "00204ce05fb81556eaf7911d606ec23f598ea0e05d43e722c78010e1788774bc8fa6"
-                                },
-                                "redeemScript": "76a914c58f2d84aa3dcc020f248d3a0f0095ce66e3b7ad8763ac672102486e1f94c3b4e63555b63bea6e7ae60e550b2275dab745118ca8dfbb634604967c820120876475527c2103aef82904d176eefc9f86b138b86f4f411ed4778f341321bdfb021f5cdff7dd8752ae67a914a8f988eded2363756daabbaa863a2f4c0453d67c88ac6851b27568"
-                            },
-                            "tx": "0200000001486dddeed4668eaa44b827d1d1533981fff0c547e7f32a9796b67ce403fe7f00040000000001000000018ec303000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb32101b0600",
-                            "htlcId": 0
-                        },
-                        "localSig": "db5a218afb52ce77c6484b4fcdf98a45fc8fe12476b2f34d4b776e024fe973456952aeb623f3c8b7915c2b772be6b29855edfc5f829e9f5c42aff2678d796ea0",
-                        "remoteSig": "55f5fe760f30e659a8c8b6c62b2ec9dc806a2e30e0615af16bb93e3e6c0d543b2e2103e0b1a65e12ee8c18b658d3bb0b5a3c1c7e35845a5f1976a2abe2de1a81"
-                    }
-                ]
-            }
-        },
-        "remoteCommit": {
-            "index": 3,
-            "spec": {
-                "htlcsIn": [
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 0,
-                        "amountMsat": 250000000,
-                        "paymentHash": "edaff8f0e5117e83b2570b5f9d7115631df9c3de0f680c041d9cdfc087b4b51e",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 1,
-                        "amountMsat": 100000000,
-                        "paymentHash": "a4459f57dc69d1342cd3c880a5bdb880ccea97be95587d5c6e87234f209e1ecd",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    },
-                    {
-                        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
-                        "id": 2,
-                        "amountMsat": 10000,
-                        "paymentHash": "90792e276988a51c9382702617df7e340cf7f0299c3eb58fda1b3a493ebcb395",
-                        "cltvExpiry": 400144,
-                        "onionRoutingPacket": "<redacted>"
-                    }
-                ],
-                "htlcsOut": [
-                ],
-                "feerate": 5000,
-                "toLocal": 200000000,
-                "toRemote": 449990000
+                    "unknown": [
+                    ]
+                }
             },
-            "txid": "01871396b3a2d43dd3067377ee9e84da84da3b3d1cb8b4cd140543cbbd8f6a7b",
-            "remotePerCommitmentPoint": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
+            "channelFlags": 0
         },
-        "localChanges": {
-            "proposed": [
-            ],
-            "signed": [
-            ],
-            "acked": [
-            ]
+        "changes": {
+            "localChanges": {
+                "proposed": [
+                ],
+                "signed": [
+                ],
+                "acked": [
+                ]
+            },
+            "remoteChanges": {
+                "proposed": [
+                ],
+                "acked": [
+                ],
+                "signed": [
+                ]
+            },
+            "localNextHtlcId": 3,
+            "remoteNextHtlcId": 0
         },
-        "remoteChanges": {
-            "proposed": [
-            ],
-            "acked": [
-            ],
-            "signed": [
-            ]
-        },
-        "localNextHtlcId": 3,
-        "remoteNextHtlcId": 0,
+        "active": [
+            {
+                "localFundingStatus": {
+                    "status": "unconfirmed",
+                    "txId": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f"
+                },
+                "remoteFundingStatus": {
+                    "status": "locked"
+                },
+                "localCommit": {
+                    "index": 3,
+                    "spec": {
+                        "htlcsIn": [
+                        ],
+                        "htlcsOut": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 250000000,
+                                "paymentHash": "edaff8f0e5117e83b2570b5f9d7115631df9c3de0f680c041d9cdfc087b4b51e",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 100000000,
+                                "paymentHash": "a4459f57dc69d1342cd3c880a5bdb880ccea97be95587d5c6e87234f209e1ecd",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 2,
+                                "amountMsat": 10000,
+                                "paymentHash": "90792e276988a51c9382702617df7e340cf7f0299c3eb58fda1b3a493ebcb395",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 449990000,
+                        "toRemote": 200000000
+                    },
+                    "publishableTxs": {
+                        "commitTx": {
+                            "input": {
+                                "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
+                                "txOut": {
+                                    "amount": 1000000,
+                                    "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
+                                },
+                                "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
+                            },
+                            "tx": "020000000001012f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd000000000000b77080064a0100000000000022002046672803839d10e21d43eafb532bc37cd21bd97dec7f9b50d45380cd1cce69654a01000000000000220020bbd7f17366848d8f624c28438128ce4dc8c72ea21deb0ccf25bee110920da032a086010000000000220020ff5d65b735c30cb217486f62f8d590e56b6c27192299584ea87dbaa4452ef679400d030000000000220020cb93e3adb8d213704e9a07ea2a6ce91dca51a9b76fcb6bef3cc9b5b7e10a799090d00300000000002200204ce05fb81556eaf7911d606ec23f598ea0e05d43e722c78010e1788774bc8fa686be06000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb320400483045022100a277bf52a6558d90135e0691ac9a66a9cd8b1717367e675f7d9551b251ab37f502206bc0aa48c04c085b3bb27d2fab0a83e75eed1898d81269bea19e48bd182864f301473044022060fc42daff3f531f27399b6c8cea7753f7e327f5dca6ce3e1cf11ba7bc695da102206373ebcc82fb07f2157bdb8399abf19563f6fd202ba86ade0bceb7693093ef0b0147522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452aedd99dc20"
+                        },
+                        "htlcTxsAndSigs": [
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "007ffe03e47cb696972af3e747c5f0ff813953d1d127b844aa8e66d4eedd6d48:2",
+                                        "txOut": {
+                                            "amount": 100000,
+                                            "publicKeyScript": "0020ff5d65b735c30cb217486f62f8d590e56b6c27192299584ea87dbaa4452ef679"
+                                        },
+                                        "redeemScript": "76a914c58f2d84aa3dcc020f248d3a0f0095ce66e3b7ad8763ac672102486e1f94c3b4e63555b63bea6e7ae60e550b2275dab745118ca8dfbb634604967c820120876475527c2103aef82904d176eefc9f86b138b86f4f411ed4778f341321bdfb021f5cdff7dd8752ae67a91412bb12f52c0bcac1a16e576e3e9c28d6032de7c888ac6851b27568"
+                                    },
+                                    "tx": "0200000001486dddeed4668eaa44b827d1d1533981fff0c547e7f32a9796b67ce403fe7f00020000000001000000019e7901000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb32101b0600",
+                                    "htlcId": 1
+                                },
+                                "localSig": "5e865cf9ae0fc879ceb90e3144f2273fee1806f47b0d4949cac5e4621daaed681944f26ba277941c0619c98553dd9c7cba7be07beb9c867edf7fad1ec1602465",
+                                "remoteSig": "a392c69c1f762942710dae08a686916a493b9b1589216a57f9a4b459305cbad423289a8fa364ec92848ffa5288b8a0e3b2d56bd6fc4cb223bef73fbd90a38b29"
+                            },
+                            {
+                                "txinfo": {
+                                    "type": "fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx",
+                                    "input": {
+                                        "outPoint": "007ffe03e47cb696972af3e747c5f0ff813953d1d127b844aa8e66d4eedd6d48:4",
+                                        "txOut": {
+                                            "amount": 250000,
+                                            "publicKeyScript": "00204ce05fb81556eaf7911d606ec23f598ea0e05d43e722c78010e1788774bc8fa6"
+                                        },
+                                        "redeemScript": "76a914c58f2d84aa3dcc020f248d3a0f0095ce66e3b7ad8763ac672102486e1f94c3b4e63555b63bea6e7ae60e550b2275dab745118ca8dfbb634604967c820120876475527c2103aef82904d176eefc9f86b138b86f4f411ed4778f341321bdfb021f5cdff7dd8752ae67a914a8f988eded2363756daabbaa863a2f4c0453d67c88ac6851b27568"
+                                    },
+                                    "tx": "0200000001486dddeed4668eaa44b827d1d1533981fff0c547e7f32a9796b67ce403fe7f00040000000001000000018ec303000000000022002008117266e4d6daf84ec74ea6f62ba4cc52bb32efd4acd5c6ed5569c4c396fb32101b0600",
+                                    "htlcId": 0
+                                },
+                                "localSig": "db5a218afb52ce77c6484b4fcdf98a45fc8fe12476b2f34d4b776e024fe973456952aeb623f3c8b7915c2b772be6b29855edfc5f829e9f5c42aff2678d796ea0",
+                                "remoteSig": "55f5fe760f30e659a8c8b6c62b2ec9dc806a2e30e0615af16bb93e3e6c0d543b2e2103e0b1a65e12ee8c18b658d3bb0b5a3c1c7e35845a5f1976a2abe2de1a81"
+                            }
+                        ]
+                    }
+                },
+                "remoteCommit": {
+                    "index": 3,
+                    "spec": {
+                        "htlcsIn": [
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 0,
+                                "amountMsat": 250000000,
+                                "paymentHash": "edaff8f0e5117e83b2570b5f9d7115631df9c3de0f680c041d9cdfc087b4b51e",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 1,
+                                "amountMsat": 100000000,
+                                "paymentHash": "a4459f57dc69d1342cd3c880a5bdb880ccea97be95587d5c6e87234f209e1ecd",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            },
+                            {
+                                "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",
+                                "id": 2,
+                                "amountMsat": 10000,
+                                "paymentHash": "90792e276988a51c9382702617df7e340cf7f0299c3eb58fda1b3a493ebcb395",
+                                "cltvExpiry": 400144,
+                                "onionRoutingPacket": "<redacted>"
+                            }
+                        ],
+                        "htlcsOut": [
+                        ],
+                        "feerate": 5000,
+                        "toLocal": 200000000,
+                        "toRemote": 449990000
+                    },
+                    "txid": "01871396b3a2d43dd3067377ee9e84da84da3b3d1cb8b4cd140543cbbd8f6a7b",
+                    "remotePerCommitmentPoint": "0312a332a6afe99e14c9dc4ab0512448441be3c4c369be8b7d37c5086682b33799"
+                },
+                "nextRemoteCommit": null
+            }
+        ],
         "payments": {
             "0": "d4f57ab7-0de9-4440-9aea-debd7c80496c",
             "1": "bbac2fe3-1c00-4426-804f-24fd754236ef",
@@ -229,16 +246,7 @@
             "left": null,
             "right": "036e46c0c33872871f0509fda1b455136e44b797452c86c79134b70a86a3d9abc3"
         },
-        "commitInput": {
-            "outPoint": "bdcd274e9bc89c621b30596e344389d28c3a92f820ef5a680ebfcb615b827c2f:0",
-            "txOut": {
-                "amount": 1000000,
-                "publicKeyScript": "00204ba42b50e089764e60e9e0c76c57e41d252d6beb976332f14a7b255bbb5322b8"
-            },
-            "redeemScript": "522102b6eaf304d966a6df90f3b3df7af7be6b1625854bbc096cb8b3507b2a37c2bf9c210385cfd7d8850e4cb8fcbed57310911218e5d5e1fd34f92ef5d9db14d56418caa452ae"
-        },
-        "remotePerCommitmentSecrets": "<redacted>",
-        "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd"
+        "remotePerCommitmentSecrets": "<redacted>"
     },
     "remoteChannelReestablish": {
         "channelId": "2f7c825b61cbbf0e685aef20f8923a8cd28943346e59301b629cc89b4e27cdbd",


### PR DESCRIPTION
In preparation for splices, we update the `Commitments` structure to contain a list of active commitments. The dual funding RBF attempts are included in this active commitments list.

Note that we still don't handle well cases where a commitment that isn't the `latest` is spent: this will be fixed in future PRs.