### PR TITLE
Simplify force-close and watches management

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelException.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelException.kt
@@ -80,8 +80,6 @@ data class CannotSignWithoutChanges                (override val channelId: Byte
 data class CannotSignBeforeRevocation              (override val channelId: ByteVector32) : ChannelException(channelId, "cannot sign until next revocation hash is received")
 data class UnexpectedRevocation                    (override val channelId: ByteVector32) : ChannelException(channelId, "received unexpected RevokeAndAck message")
 data class InvalidRevocation                       (override val channelId: ByteVector32) : ChannelException(channelId, "invalid revocation")
-data class InvalidRevokedCommitProof               (override val channelId: ByteVector32, val ourCommitmentNumber: Long, val theirCommitmentNumber: Long, val perCommitmentSecret: PrivateKey) : ChannelException(channelId, "counterparty claimed that we have a revoked commit but their proof doesn't check out: ourCommitmentNumber=$ourCommitmentNumber theirCommitmentNumber=$theirCommitmentNumber perCommitmentSecret=$perCommitmentSecret")
-data class CommitmentSyncError                     (override val channelId: ByteVector32) : ChannelException(channelId, "commitment sync error")
 data class RevocationSyncError                     (override val channelId: ByteVector32) : ChannelException(channelId, "revocation sync error")
 data class InvalidFailureCode                      (override val channelId: ByteVector32) : ChannelException(channelId, "UpdateFailMalformedHtlc message doesn't have BADONION bit set")
 data class PleasePublishYourCommitment             (override val channelId: ByteVector32) : ChannelException(channelId, "please publish your local commitment")

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Negotiating.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Negotiating.kt
@@ -2,10 +2,7 @@ package fr.acinq.lightning.channel
 
 import fr.acinq.bitcoin.Transaction
 import fr.acinq.bitcoin.updated
-import fr.acinq.lightning.blockchain.BITCOIN_FUNDING_SPENT
-import fr.acinq.lightning.blockchain.BITCOIN_TX_CONFIRMED
-import fr.acinq.lightning.blockchain.WatchConfirmed
-import fr.acinq.lightning.blockchain.WatchEventSpent
+import fr.acinq.lightning.blockchain.*
 import fr.acinq.lightning.channel.Channel.MAX_NEGOTIATION_ITERATIONS
 import fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.ClosingTx
 import fr.acinq.lightning.utils.Either
@@ -144,6 +141,14 @@ data class Negotiating(
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is Error -> handleRemoteError(cmd.message)
             cmd is ChannelCommand.WatchReceived -> when (val watch = cmd.watch) {
+                is WatchEventConfirmed -> when (val res = acceptFundingTxConfirmed(watch)) {
+                    is Either.Left -> Pair(this@Negotiating, listOf())
+                    is Either.Right -> {
+                        val (commitments1, _, actions) = res.value
+                        val nextState = this@Negotiating.copy(commitments = commitments1)
+                        Pair(nextState, actions + listOf(ChannelAction.Storage.StoreState(nextState)))
+                    }
+                }
                 is WatchEventSpent -> when {
                     watch.event is BITCOIN_FUNDING_SPENT && closingTxProposed.flatten().any { it.unsignedTx.tx.txid == watch.tx.txid } -> {
                         // they can publish a closing tx with any sig we sent them, even if we are not done negotiating
@@ -162,11 +167,8 @@ data class Negotiating(
                         )
                         Pair(nextState, actions)
                     }
-                    watch.tx.txid == commitments.latest.remoteCommit.txid -> handleRemoteSpentCurrent(watch.tx, commitments.latest)
-                    watch.tx.txid == commitments.latest.nextRemoteCommit?.commit?.txid -> handleRemoteSpentNext(watch.tx, commitments.latest)
-                    else -> handleRemoteSpentOther(watch.tx)
+                    else -> handlePotentialForceClose(watch)
                 }
-                else -> unhandled(cmd)
             }
             cmd is ChannelCommand.CheckHtlcTimeout -> checkHtlcTimeout()
             cmd is ChannelCommand.Disconnected -> Pair(Offline(this@Negotiating), listOf())

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Negotiating.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Negotiating.kt
@@ -141,14 +141,7 @@ data class Negotiating(
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is Error -> handleRemoteError(cmd.message)
             cmd is ChannelCommand.WatchReceived -> when (val watch = cmd.watch) {
-                is WatchEventConfirmed -> when (val res = acceptFundingTxConfirmed(watch)) {
-                    is Either.Left -> Pair(this@Negotiating, listOf())
-                    is Either.Right -> {
-                        val (commitments1, _, actions) = res.value
-                        val nextState = this@Negotiating.copy(commitments = commitments1)
-                        Pair(nextState, actions + listOf(ChannelAction.Storage.StoreState(nextState)))
-                    }
-                }
+                is WatchEventConfirmed -> updateFundingTxStatus(watch)
                 is WatchEventSpent -> when {
                     watch.event is BITCOIN_FUNDING_SPENT && closingTxProposed.flatten().any { it.unsignedTx.tx.txid == watch.tx.txid } -> {
                         // they can publish a closing tx with any sig we sent them, even if we are not done negotiating

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
@@ -3,6 +3,7 @@ package fr.acinq.lightning.channel
 import fr.acinq.lightning.Feature
 import fr.acinq.lightning.Features
 import fr.acinq.lightning.ShortChannelId
+import fr.acinq.lightning.blockchain.WatchEventConfirmed
 import fr.acinq.lightning.blockchain.WatchEventSpent
 import fr.acinq.lightning.router.Announcements
 import fr.acinq.lightning.transactions.Transactions
@@ -261,12 +262,15 @@ data class Normal(
             }
             is ChannelCommand.CheckHtlcTimeout -> checkHtlcTimeout()
             is ChannelCommand.WatchReceived -> when (val watch = cmd.watch) {
-                is WatchEventSpent -> when (watch.tx.txid) {
-                    commitments.latest.remoteCommit.txid -> handleRemoteSpentCurrent(watch.tx, commitments.latest)
-                    commitments.latest.nextRemoteCommit?.commit?.txid -> handleRemoteSpentNext(watch.tx, commitments.latest)
-                    else -> handleRemoteSpentOther(watch.tx)
+                is WatchEventConfirmed -> when (val res = acceptFundingTxConfirmed(watch)) {
+                    is Either.Left -> Pair(this@Normal, listOf())
+                    is Either.Right -> {
+                        val (commitments1, _, actions) = res.value
+                        val nextState = this@Normal.copy(commitments = commitments1)
+                        Pair(nextState, actions + listOf(ChannelAction.Storage.StoreState(nextState)))
+                    }
                 }
-                else -> unhandled(cmd)
+                is WatchEventSpent -> handlePotentialForceClose(watch)
             }
             is ChannelCommand.Disconnected -> {
                 // if we have pending unsigned outgoing htlcs, then we cancel them and advertise the fact that the channel is now disabled.

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
@@ -262,14 +262,7 @@ data class Normal(
             }
             is ChannelCommand.CheckHtlcTimeout -> checkHtlcTimeout()
             is ChannelCommand.WatchReceived -> when (val watch = cmd.watch) {
-                is WatchEventConfirmed -> when (val res = acceptFundingTxConfirmed(watch)) {
-                    is Either.Left -> Pair(this@Normal, listOf())
-                    is Either.Right -> {
-                        val (commitments1, _, actions) = res.value
-                        val nextState = this@Normal.copy(commitments = commitments1)
-                        Pair(nextState, actions + listOf(ChannelAction.Storage.StoreState(nextState)))
-                    }
-                }
+                is WatchEventConfirmed -> updateFundingTxStatus(watch)
                 is WatchEventSpent -> handlePotentialForceClose(watch)
             }
             is ChannelCommand.Disconnected -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ShuttingDown.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ShuttingDown.kt
@@ -174,14 +174,7 @@ data class ShuttingDown(
                 else -> unhandled(cmd)
             }
             is ChannelCommand.WatchReceived -> when (val watch = cmd.watch) {
-                is WatchEventConfirmed -> when (val res = acceptFundingTxConfirmed(watch)) {
-                    is Either.Left -> Pair(this@ShuttingDown, listOf())
-                    is Either.Right -> {
-                        val (commitments1, _, actions) = res.value
-                        val nextState = this@ShuttingDown.copy(commitments = commitments1)
-                        Pair(nextState, actions + listOf(ChannelAction.Storage.StoreState(nextState)))
-                    }
-                }
+                is WatchEventConfirmed -> updateFundingTxStatus(watch)
                 is WatchEventSpent -> handlePotentialForceClose(watch)
             }
             is ChannelCommand.CheckHtlcTimeout -> checkHtlcTimeout()

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForChannelReady.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForChannelReady.kt
@@ -101,14 +101,7 @@ data class WaitForChannelReady(
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is Error -> handleRemoteError(cmd.message)
             cmd is ChannelCommand.WatchReceived -> when (cmd.watch) {
-                is WatchEventConfirmed -> when (val res = acceptFundingTxConfirmed(cmd.watch)) {
-                    is Either.Left -> Pair(this@WaitForChannelReady, listOf())
-                    is Either.Right -> {
-                        val (commitments1, _, actions) = res.value
-                        val nextState = this@WaitForChannelReady.copy(commitments = commitments1)
-                        Pair(nextState, actions + listOf(ChannelAction.Storage.StoreState(nextState)))
-                    }
-                }
+                is WatchEventConfirmed -> updateFundingTxStatus(cmd.watch)
                 is WatchEventSpent -> handlePotentialForceClose(cmd.watch)
             }
             cmd is ChannelCommand.ExecuteCommand -> when (cmd.command) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -266,7 +266,7 @@ class Peer(
             val channelIds = bootChannels.map {
                 logger.info { "restoring channel ${it.channelId} from local storage" }
                 val state = WaitForInit
-                val (state1, actions) = state.process(ChannelCommand.Restore(it as ChannelState))
+                val (state1, actions) = state.process(ChannelCommand.Restore(it))
                 processActions(it.channelId, actions)
                 _channels = _channels + (it.channelId to state1)
                 it.channelId
@@ -757,7 +757,7 @@ class Peer(
                                         logger.warning { "restoring channel ${msg.channelId} from peer backup" }
                                         val backup = decrypted.result
                                         val state = WaitForInit
-                                        val event1 = ChannelCommand.Restore(backup as ChannelState)
+                                        val event1 = ChannelCommand.Restore(backup)
                                         val (state1, actions1) = state.process(event1)
                                         processActions(msg.channelId, actions1)
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
@@ -1154,6 +1154,7 @@ class ClosingTestsCommon : LightningTestSuite() {
         // alice is able to claim its main output
         val aliceTxs = aliceActions3.findTxs()
         assertEquals(listOf(futureRemoteCommitPublished.claimMainOutputTx!!.tx), aliceTxs)
+        Transaction.correctlySpends(futureRemoteCommitPublished.claimMainOutputTx!!.tx, listOf(bobCommitTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
         // simulate a wallet restart
         run {

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
@@ -59,9 +59,8 @@ class LegacyWaitForFundingConfirmedTestsCommon {
         )
         val (state3, actions3) = state2.process(ChannelCommand.MessageReceived(channelReestablish))
         assertEquals(state, state3.state)
-        assertEquals(actions3.size, 2)
+        assertEquals(actions3.size, 1)
         actions3.hasOutgoingMessage<ChannelReestablish>()
-        assertEquals(watchConfirmed, actions3.findWatch())
         // The funding tx confirms.
         val (state4, actions4) = state3.process(ChannelCommand.WatchReceived(WatchEventConfirmed(state.channelId, watchConfirmed.event, 1105, 3, fundingTx)))
         assertIs<LNChannel<LegacyWaitForFundingLocked>>(state4)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
@@ -3,9 +3,8 @@ package fr.acinq.lightning.channel.states
 import fr.acinq.bitcoin.*
 import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.blockchain.BITCOIN_FUNDING_DEEPLYBURIED
-import fr.acinq.lightning.blockchain.BITCOIN_FUNDING_SPENT
+import fr.acinq.lightning.blockchain.BITCOIN_FUNDING_DEPTHOK
 import fr.acinq.lightning.blockchain.WatchConfirmed
-import fr.acinq.lightning.blockchain.WatchSpent
 import fr.acinq.lightning.blockchain.fee.OnChainFeerates
 import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.serialization.Encryption.from
@@ -42,9 +41,9 @@ class LegacyWaitForFundingLockedTestsCommon {
         val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Restore(state))
         assertIs<LNChannel<Offline>>(state1)
         assertEquals(actions1.size, 1)
-        val watchSpent = actions1.findWatch<WatchSpent>()
-        assertEquals(watchSpent.event, BITCOIN_FUNDING_SPENT)
-        assertEquals(watchSpent.txId, fundingTx.txid)
+        val watchConfirmed = actions1.findWatch<WatchConfirmed>()
+        assertEquals(watchConfirmed.event, BITCOIN_FUNDING_DEPTHOK)
+        assertEquals(watchConfirmed.txId, fundingTx.txid)
         // Reconnect to our peer.
         val localInit = Init(state.commitments.params.localParams.features.toByteArray().byteVector())
         val remoteInit = Init(state.commitments.params.remoteParams.features.toByteArray().byteVector())
@@ -67,9 +66,9 @@ class LegacyWaitForFundingLockedTestsCommon {
         val (state4, actions4) = state3.process(ChannelCommand.MessageReceived(ChannelReady(state.channelId, randomKey().publicKey())))
         assertIs<LNChannel<Normal>>(state4)
         assertEquals(actions4.size, 3)
-        val watchConfirmed = actions4.hasWatch<WatchConfirmed>()
-        assertEquals(watchConfirmed.event, BITCOIN_FUNDING_DEEPLYBURIED)
-        assertEquals(watchConfirmed.txId, fundingTx.txid)
+        val watchDeeplyConfirmed = actions4.hasWatch<WatchConfirmed>()
+        assertEquals(watchDeeplyConfirmed.event, BITCOIN_FUNDING_DEEPLYBURIED)
+        assertEquals(watchDeeplyConfirmed.txId, fundingTx.txid)
         actions4.has<ChannelAction.Storage.StoreState>()
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
@@ -40,11 +40,11 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         val (alice, _, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputsZeroReserve, zeroConf = true)
         val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(getFundingSigs(bob)))
         val fundingTx = actionsAlice1.find<ChannelAction.Blockchain.PublishTx>().tx
-        val (alice2, actionsAlice2) = LNChannel(alice1.ctx, WaitForInit).process(ChannelCommand.Restore(alice1.state))
+        val (alice2, actionsAlice2) = LNChannel(alice1.ctx, WaitForInit).process(ChannelCommand.Restore(alice1.state as PersistedChannelState))
         assertIs<LNChannel<Offline>>(alice2)
         assertEquals(actionsAlice2.size, 2)
         assertEquals(actionsAlice2.find<ChannelAction.Blockchain.PublishTx>().tx, fundingTx)
-        assertEquals(actionsAlice2.findWatch<WatchSpent>().txId, fundingTx.txid)
+        assertEquals(actionsAlice2.findWatch<WatchConfirmed>().txId, fundingTx.txid)
     }
 
     @Test
@@ -219,11 +219,11 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
                 val (alice, commitAlice, bob, commitBob) = WaitForFundingSignedTestsCommon.init(channelType, aliceFeatures, bobFeatures, currentHeight, aliceFundingAmount, bobFundingAmount, alicePushAmount, bobPushAmount, zeroConf)
                 val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(commitBob))
                 assertIs<LNChannel<WaitForChannelReady>>(alice1)
-                assertEquals(actionsAlice1.findWatch<WatchSpent>().event, BITCOIN_FUNDING_SPENT)
+                assertEquals(actionsAlice1.findWatch<WatchConfirmed>().event, BITCOIN_FUNDING_DEPTHOK)
                 val channelReadyAlice = actionsAlice1.findOutgoingMessage<ChannelReady>()
                 val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(commitAlice))
                 assertIs<LNChannel<WaitForChannelReady>>(bob1)
-                assertEquals(actionsBob1.findWatch<WatchSpent>().event, BITCOIN_FUNDING_SPENT)
+                assertEquals(actionsBob1.findWatch<WatchConfirmed>().event, BITCOIN_FUNDING_DEPTHOK)
                 val channelReadyBob = actionsBob1.findOutgoingMessage<ChannelReady>()
                 Fixture(alice1, channelReadyAlice, bob1, channelReadyBob)
             } else {

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
@@ -164,10 +164,11 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
             assertEquals(actions1.findWatch<WatchConfirmed>().txId, fundingTx.txid)
             val (alice2, actions2) = alice1.process(ChannelCommand.WatchReceived(WatchEventConfirmed(alice.state.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)))
             assertIs<LNChannel<Offline>>(alice2)
-            assertEquals(actions2.size, 1)
+            assertEquals(actions2.size, 2)
             val watchSpent = actions2.findWatch<WatchSpent>()
             assertEquals(watchSpent.txId, fundingTx.txid)
             assertEquals(watchSpent.event, BITCOIN_FUNDING_SPENT)
+            actions2.has<ChannelAction.Storage.StoreState>()
         }
         run {
             val (bob1, actions1) = LNChannel(bob.ctx, WaitForInit).process(ChannelCommand.Restore(bob.state))
@@ -176,10 +177,11 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
             assertEquals(actions1.findWatch<WatchConfirmed>().txId, fundingTx.txid)
             val (bob2, actions2) = bob1.process(ChannelCommand.WatchReceived(WatchEventConfirmed(bob.state.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)))
             assertIs<LNChannel<Offline>>(bob2)
-            assertEquals(actions2.size, 1)
+            assertEquals(actions2.size, 2)
             val watchSpent = actions2.findWatch<WatchSpent>()
             assertEquals(watchSpent.txId, fundingTx.txid)
             assertEquals(watchSpent.event, BITCOIN_FUNDING_SPENT)
+            actions2.has<ChannelAction.Storage.StoreState>()
         }
     }
 
@@ -192,15 +194,17 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
         run {
             val (alice2, actions2) = LNChannel(alice.ctx, WaitForInit).process(ChannelCommand.Restore(alice1.state))
             assertIs<LNChannel<Offline>>(alice2)
-            assertEquals(actions2.size, 3)
+            assertEquals(actions2.size, 4)
+            actions2.hasTx(fundingTx1)
             actions2.hasTx(fundingTx2)
             assertEquals(actions2.findWatches<WatchConfirmed>().map { it.txId }.toSet(), setOf(fundingTx1.txid, fundingTx2.txid))
             val (alice3, actions3) = alice2.process(ChannelCommand.WatchReceived(WatchEventConfirmed(alice.state.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx1)))
             assertIs<LNChannel<Offline>>(alice3)
-            assertEquals(actions3.size, 1)
+            assertEquals(actions3.size, 2)
             val watchSpent = actions3.findWatch<WatchSpent>()
             assertEquals(watchSpent.txId, fundingTx1.txid)
             assertEquals(watchSpent.event, BITCOIN_FUNDING_SPENT)
+            actions3.has<ChannelAction.Storage.StoreState>()
         }
         run {
             val (bob2, actions2) = LNChannel(bob.ctx, WaitForInit).process(ChannelCommand.Restore(bob1.state))
@@ -209,10 +213,11 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
             assertEquals(actions2.findWatches<WatchConfirmed>().map { it.txId }.toSet(), setOf(fundingTx1.txid, fundingTx2.txid))
             val (bob3, actions3) = bob2.process(ChannelCommand.WatchReceived(WatchEventConfirmed(bob.state.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx1)))
             assertIs<LNChannel<Offline>>(bob3)
-            assertEquals(actions3.size, 1)
+            assertEquals(actions3.size, 2)
             val watchSpent = actions3.findWatch<WatchSpent>()
             assertEquals(watchSpent.txId, fundingTx1.txid)
             assertEquals(watchSpent.event, BITCOIN_FUNDING_SPENT)
+            actions3.has<ChannelAction.Storage.StoreState>()
         }
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
@@ -59,7 +59,7 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
             assertEquals(actionsAlice1.size, 5)
             assertTrue(actionsAlice1.hasOutgoingMessage<TxSignatures>().channelData.isEmpty())
             assertEquals(actionsAlice1.hasOutgoingMessage<ChannelReady>().alias, ShortChannelId.peerId(alice.staticParams.nodeParams.nodeId))
-            assertEquals(actionsAlice1.findWatch<WatchSpent>().txId, alice1.commitments.latest.fundingTxId)
+            assertEquals(actionsAlice1.findWatch<WatchConfirmed>().txId, alice1.commitments.latest.fundingTxId)
             actionsAlice1.has<ChannelAction.Storage.StoreState>()
             assertEquals(ChannelEvents.Created(alice1.state), actionsAlice1.find<ChannelAction.EmitEvent>().event)
         }
@@ -69,7 +69,7 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
             assertEquals(actionsBob1.size, 6)
             assertFalse(actionsBob1.hasOutgoingMessage<TxSignatures>().channelData.isEmpty())
             assertEquals(actionsBob1.hasOutgoingMessage<ChannelReady>().alias, ShortChannelId.peerId(bob.staticParams.nodeParams.nodeId))
-            assertEquals(actionsBob1.findWatch<WatchSpent>().txId, bob1.commitments.latest.fundingTxId)
+            assertEquals(actionsBob1.findWatch<WatchConfirmed>().txId, bob1.commitments.latest.fundingTxId)
             actionsBob1.has<ChannelAction.Storage.StoreState>()
             assertEquals(TestConstants.bobFundingAmount.toMilliSatoshi() + TestConstants.alicePushAmount - TestConstants.bobPushAmount, 200_000_000.msat)
             assertEquals(actionsBob1.find<ChannelAction.Storage.StoreIncomingAmount>().amount, 200_000_000.msat)


### PR DESCRIPTION
- only put WatchSpent after receiving WatchEventConfirmed
- put watches on transactions based on their funding status at restart
- handle transition confirmed->channel-ready while offline
- track funding status of zero-conf txs