### PR TITLE
Publish `NodeEvent` when a pay-to-open is rejected

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -24,8 +24,12 @@ sealed interface ChannelEvents : NodeEvents {
 }
 
 sealed interface PayToOpenEvents : NodeEvents {
-    abstract val request: PayToOpenRequest
+    val paymentHash: ByteVector32
+    /** Total incoming amount, incoming htlcs parts. */
+    val totalAmount: MilliSatoshi
+    /** Total amount for pay-to-open parts. */
+    val payToOpenAmount: MilliSatoshi
     sealed class Rejected: PayToOpenEvents {
-        data class BelowMin(override val request: PayToOpenRequest): Rejected()
+        data class BelowMin(override val paymentHash: ByteVector32, override val totalAmount: MilliSatoshi, override val payToOpenAmount: MilliSatoshi, val payToOpenMinAmount: MilliSatoshi): Rejected()
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -5,6 +5,7 @@ import fr.acinq.bitcoin.Satoshi
 import fr.acinq.lightning.channel.ChannelStateWithCommitments
 import fr.acinq.lightning.channel.Normal
 import fr.acinq.lightning.channel.WaitForFundingCreated
+import fr.acinq.lightning.wire.PayToOpenRequest
 import fr.acinq.lightning.wire.PleaseOpenChannel
 import fr.acinq.lightning.wire.PleaseOpenChannelFailure
 
@@ -20,4 +21,11 @@ sealed interface ChannelEvents : NodeEvents {
     data class Creating(val state: WaitForFundingCreated) : ChannelEvents
     data class Created(val state: ChannelStateWithCommitments) : ChannelEvents
     data class Confirmed(val state: Normal) : ChannelEvents
+}
+
+sealed interface PayToOpenEvents : NodeEvents {
+    abstract val request: PayToOpenRequest
+    sealed class Rejected: PayToOpenEvents {
+        data class BelowMin(override val request: PayToOpenRequest): Rejected()
+    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -99,7 +99,6 @@ data class PurgeExpiredPayments(val fromCreatedAt: Long, val toCreatedAt: Long) 
 
 sealed class PeerEvent
 data class PaymentRequestGenerated(val receivePayment: ReceivePayment, val request: String) : PeerEvent()
-data class PaymentNotReceived(val actions: List<PeerCommand>, val incomingPayment: IncomingPayment?) : PeerEvent()
 data class PaymentReceived(val incomingPayment: IncomingPayment, val received: IncomingPayment.Received) : PeerEvent()
 data class PaymentProgress(val request: SendPayment, val fees: MilliSatoshi) : PeerEvent()
 data class PaymentNotSent(val request: SendPayment, val reason: OutgoingPaymentFailure) : PeerEvent()
@@ -560,7 +559,6 @@ class Peer(
             is Either.Left -> incomingPaymentHandler.process(item.value, currentBlockHeight)
         }
         when (result) {
-            is IncomingPaymentHandler.ProcessAddResult.Rejected -> _eventsFlow.emit(PaymentNotReceived(result.actions, result.incomingPayment))
             is IncomingPaymentHandler.ProcessAddResult.Accepted -> _eventsFlow.emit(PaymentReceived(result.incomingPayment, result.received))
             else -> Unit
         }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -99,6 +99,7 @@ data class PurgeExpiredPayments(val fromCreatedAt: Long, val toCreatedAt: Long) 
 
 sealed class PeerEvent
 data class PaymentRequestGenerated(val receivePayment: ReceivePayment, val request: String) : PeerEvent()
+data class PaymentNotReceived(val actions: List<PeerCommand>, val incomingPayment: IncomingPayment?) : PeerEvent()
 data class PaymentReceived(val incomingPayment: IncomingPayment, val received: IncomingPayment.Received) : PeerEvent()
 data class PaymentProgress(val request: SendPayment, val fees: MilliSatoshi) : PeerEvent()
 data class PaymentNotSent(val request: SendPayment, val reason: OutgoingPaymentFailure) : PeerEvent()
@@ -559,6 +560,7 @@ class Peer(
             is Either.Left -> incomingPaymentHandler.process(item.value, currentBlockHeight)
         }
         when (result) {
+            is IncomingPaymentHandler.ProcessAddResult.Rejected -> _eventsFlow.emit(PaymentNotReceived(result.actions, result.incomingPayment))
             is IncomingPaymentHandler.ProcessAddResult.Accepted -> _eventsFlow.emit(PaymentReceived(result.incomingPayment, result.received))
             else -> Unit
         }

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -259,7 +259,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
                                 }
                             }
                             payment.parts.filterIsInstance<PayToOpenPart>().firstOrNull()?.let {
-                                nodeParams._nodeEvents.emit(PayToOpenEvents.Rejected.BelowMin(it.payToOpenRequest))
+                                nodeParams._nodeEvents.emit(PayToOpenEvents.Rejected.BelowMin(it.paymentHash, it.totalAmount, payToOpenAmount, payToOpenMinAmount))
                             }
                             pending.remove(paymentPart.paymentHash)
                             return ProcessAddResult.Rejected(actions, incomingPayment)


### PR DESCRIPTION
We publish new pay-to-open events in `NodeParams.nodeEvents`. Those events can be used by a front app like Phoenix to know when a pay-to-open succeeds or is rejected.

For now, only the rejection scenario implemented, and only when it's because the amount is below minimum. This event is emitted by the incoming payment handler.

```kotlin
sealed interface PayToOpenEvents : NodeEvents {
    sealed class Rejected: PayToOpenEvents {
        data class BelowMin(val request: PayToOpenRequest): Rejected()
    }
}
```

The event contains the `PayToOpenRequest` so that the front can display a nice message like so:

<img width="455" alt="image" src="https://user-images.githubusercontent.com/5765435/223516265-a1b105f7-454a-4b16-849a-d61e983e4e2a.png">

Note: this PR has been significantly reworked, hence the revert commits that can be dismissed.