### PR TITLE
Store channel state after sending `commit_sig`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
@@ -165,9 +165,9 @@ sealed class ChannelState {
                 oldState is WaitForFundingSigned && (newState is WaitForFundingConfirmed || newState is WaitForChannelReady) -> {
                     val channelCreated = ChannelAction.EmitEvent(ChannelEvents.Created(newState as ChannelStateWithCommitments))
                     when {
-                        !oldState.localParams.isInitiator -> {
-                            val amount = oldState.fundingParams.localAmount.toMilliSatoshi() + oldState.remotePushAmount - oldState.localPushAmount
-                            val localInputs = oldState.fundingTx.localInputs.map { OutPoint(it.previousTx, it.previousTxOutput) }.toSet()
+                        !oldState.channelParams.localParams.isInitiator -> {
+                            val amount = oldState.signingSession.fundingParams.localAmount.toMilliSatoshi() + oldState.remotePushAmount - oldState.localPushAmount
+                            val localInputs = oldState.signingSession.fundingTx.tx.localInputs.map { OutPoint(it.previousTx, it.previousTxOutput) }.toSet()
                             actions + ChannelAction.Storage.StoreIncomingAmount(amount, localInputs, oldState.channelOrigin) + channelCreated
                         }
                         else -> actions + channelCreated

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
@@ -282,9 +282,18 @@ sealed class ChannelState {
     }
 }
 
-sealed class ChannelStateWithCommitments : ChannelState() {
+/** A channel state that is persisted to the DB. */
+sealed class PersistedChannelState : ChannelState() {
+    abstract val channelId: ByteVector32
+
+    companion object {
+        // this companion object is used by static extended function `fun PersistedChannelState.Companion.from` in Encryption.kt
+    }
+}
+
+sealed class ChannelStateWithCommitments : PersistedChannelState() {
     abstract val commitments: Commitments
-    val channelId: ByteVector32 get() = commitments.channelId
+    override val channelId: ByteVector32 get() = commitments.channelId
     val isInitiator: Boolean get() = commitments.params.localParams.isInitiator
     val remoteNodeId: PublicKey get() = commitments.remoteNodeId
 
@@ -526,12 +535,6 @@ sealed class ChannelStateWithCommitments : ChannelState() {
                 }
             }
         }
-    }
-}
-
-sealed class PersistedChannelState : ChannelStateWithCommitments() {
-    companion object {
-        // this companion object is used by static extended function `fun PersistedChannelState.Companion.from` in Encryption.kt
     }
 }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Channel.kt
@@ -320,7 +320,7 @@ sealed class ChannelStateWithCommitments : PersistedChannelState() {
             is Either.Right -> {
                 val (commitments1, _, actions) = res.value
                 val nextState = this@ChannelStateWithCommitments.updateCommitments(commitments1)
-                Pair(nextState, actions + listOf(ChannelAction.Storage.StoreState(nextState as PersistedChannelState)))
+                Pair(nextState, actions + listOf(ChannelAction.Storage.StoreState(nextState)))
             }
         }
     }
@@ -328,7 +328,7 @@ sealed class ChannelStateWithCommitments : PersistedChannelState() {
     /**
      * Analyze and react to a potential force-close transaction spending one of our funding transactions.
      */
-    internal fun ChannelContext.handlePotentialForceClose(w: WatchEventSpent): Pair<ChannelState, List<ChannelAction>> = when {
+    internal fun ChannelContext.handlePotentialForceClose(w: WatchEventSpent): Pair<ChannelStateWithCommitments, List<ChannelAction>> = when {
         w.event != BITCOIN_FUNDING_SPENT -> Pair(this@ChannelStateWithCommitments, listOf())
         commitments.active.any { it.fundingTxId == w.tx.txid } -> Pair(this@ChannelStateWithCommitments, listOf())
         w.tx.txid == commitments.latest.localCommit.publishableTxs.commitTx.tx.txid -> spendLocalCurrent()
@@ -369,7 +369,7 @@ sealed class ChannelStateWithCommitments : PersistedChannelState() {
         })
     }
 
-    internal fun ChannelContext.handleRemoteSpentNext(commitTx: Transaction, commitment: FullCommitment): Pair<ChannelState, List<ChannelAction>> {
+    internal fun ChannelContext.handleRemoteSpentNext(commitTx: Transaction, commitment: FullCommitment): Pair<ChannelStateWithCommitments, List<ChannelAction>> {
         logger.warning { "they published their next commit in txid=${commitTx.txid}" }
         require(commitment.nextRemoteCommit != null) { "next remote commit must be defined" }
         val remoteCommit = commitment.nextRemoteCommit.commit
@@ -398,7 +398,7 @@ sealed class ChannelStateWithCommitments : PersistedChannelState() {
         })
     }
 
-    internal fun ChannelContext.handleRemoteSpentOther(tx: Transaction): Pair<ChannelState, List<ChannelAction>> {
+    internal fun ChannelContext.handleRemoteSpentOther(tx: Transaction): Pair<ChannelStateWithCommitments, List<ChannelAction>> {
         logger.warning { "funding tx spent in txid=${tx.txid}" }
         return getRemotePerCommitmentSecret(keyManager, commitments.params, commitments.remotePerCommitmentSecrets, tx)?.let { (remotePerCommitmentSecret, commitmentNumber) ->
             logger.warning { "txid=${tx.txid} was a revoked commitment, publishing the penalty tx" }
@@ -453,7 +453,7 @@ sealed class ChannelStateWithCommitments : PersistedChannelState() {
         }
     }
 
-    internal fun ChannelContext.spendLocalCurrent(): Pair<ChannelState, List<ChannelAction>> {
+    internal fun ChannelContext.spendLocalCurrent(): Pair<ChannelStateWithCommitments, List<ChannelAction>> {
         val outdatedCommitment = when (this@ChannelStateWithCommitments) {
             is WaitForRemotePublishFutureCommitment -> true
             is Closing -> this@ChannelStateWithCommitments.futureRemoteCommitPublished != null
@@ -462,7 +462,7 @@ sealed class ChannelStateWithCommitments : PersistedChannelState() {
 
         return if (outdatedCommitment) {
             logger.warning { "we have an outdated commitment: will not publish our local tx" }
-            Pair(this@ChannelStateWithCommitments as ChannelState, listOf())
+            Pair(this@ChannelStateWithCommitments, listOf())
         } else {
             val commitTx = commitments.latest.localCommit.publishableTxs.commitTx.tx
             val localCommitPublished = claimCurrentLocalCommitTxOutputs(
@@ -497,7 +497,7 @@ sealed class ChannelStateWithCommitments : PersistedChannelState() {
      * Check HTLC timeout in our commitment and our remote's.
      * If HTLCs are at risk, we will publish our local commitment and close the channel.
      */
-    internal fun ChannelContext.checkHtlcTimeout(): Pair<ChannelState, List<ChannelAction>> {
+    internal fun ChannelContext.checkHtlcTimeout(): Pair<ChannelStateWithCommitments, List<ChannelAction>> {
         logger.info { "checking htlcs timeout at blockHeight=${currentBlockHeight}" }
         val timedOutOutgoing = commitments.timedOutOutgoingHtlcs(currentBlockHeight.toLong())
         val almostTimedOutIncoming = commitments.almostTimedOutIncomingHtlcs(currentBlockHeight.toLong(), staticParams.nodeParams.fulfillSafetyBeforeTimeoutBlocks)

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Closed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Closed.kt
@@ -3,7 +3,7 @@ package fr.acinq.lightning.channel
 /**
  * Channel is closed i.t its funding tx has been spent and the spending transactions have been confirmed, it can be forgotten
  */
-data class Closed(val state: Closing) : PersistedChannelState() {
+data class Closed(val state: Closing) : ChannelStateWithCommitments() {
     override val commitments: Commitments get() = state.commitments
 
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Closing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Closing.kt
@@ -44,7 +44,7 @@ data class Closing(
     val nextRemoteCommitPublished: RemoteCommitPublished? = null,
     val futureRemoteCommitPublished: RemoteCommitPublished? = null,
     val revokedCommitPublished: List<RevokedCommitPublished> = emptyList()
-) : PersistedChannelState() {
+) : ChannelStateWithCommitments() {
 
     private val spendingTxs: List<Transaction> by lazy {
         mutualClosePublished.map { it.tx } + revokedCommitPublished.map { it.commitTx } + listOfNotNull(

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -101,7 +101,7 @@ sealed class LocalFundingStatus {
     abstract val signedTx: Transaction?
     abstract val txId: ByteVector32
 
-    data class UnconfirmedFundingTx(val sharedTx: SignedSharedTransaction, val fundingParams: InteractiveTxParams, val localCommitSig: CommitSig, val createdAt: Long) : LocalFundingStatus() {
+    data class UnconfirmedFundingTx(val sharedTx: SignedSharedTransaction, val fundingParams: InteractiveTxParams, val createdAt: Long) : LocalFundingStatus() {
         override val signedTx: Transaction? = sharedTx.signedTx
         override val txId: ByteVector32 = sharedTx.localSigs.txId
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -90,6 +90,8 @@ data class HtlcTxAndSigs(val txinfo: HtlcTx, val localSig: ByteVector64, val rem
 data class PublishableTxs(val commitTx: CommitTx, val htlcTxsAndSigs: List<HtlcTxAndSigs>)
 /** The local commitment maps to a commitment transaction that we can sign and broadcast if necessary. */
 data class LocalCommit(val index: Long, val spec: CommitmentSpec, val publishableTxs: PublishableTxs)
+/** A local commitment for which we haven't received our peer's signatures. */
+data class UnsignedLocalCommit(val index: Long, val spec: CommitmentSpec, val commitTx: CommitTx, val htlcTxs: List<HtlcTx>)
 /** The remote commitment maps to a commitment transaction that only our peer can sign and broadcast. */
 data class RemoteCommit(val index: Long, val spec: CommitmentSpec, val txid: ByteVector32, val remotePerCommitmentPoint: PublicKey)
 /** We have the next remote commit when we've sent our commit_sig but haven't yet received their revoke_and_ack. */

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -90,8 +90,6 @@ data class HtlcTxAndSigs(val txinfo: HtlcTx, val localSig: ByteVector64, val rem
 data class PublishableTxs(val commitTx: CommitTx, val htlcTxsAndSigs: List<HtlcTxAndSigs>)
 /** The local commitment maps to a commitment transaction that we can sign and broadcast if necessary. */
 data class LocalCommit(val index: Long, val spec: CommitmentSpec, val publishableTxs: PublishableTxs)
-/** A local commitment for which we haven't received our peer's signatures. */
-data class UnsignedLocalCommit(val index: Long, val spec: CommitmentSpec, val commitTx: CommitTx, val htlcTxs: List<HtlcTx>)
 /** The remote commitment maps to a commitment transaction that only our peer can sign and broadcast. */
 data class RemoteCommit(val index: Long, val spec: CommitmentSpec, val txid: ByteVector32, val remotePerCommitmentPoint: PublicKey)
 /** We have the next remote commit when we've sent our commit_sig but haven't yet received their revoke_and_ack. */

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -101,7 +101,7 @@ sealed class LocalFundingStatus {
     abstract val signedTx: Transaction?
     abstract val txId: ByteVector32
 
-    data class UnconfirmedFundingTx(val sharedTx: SignedSharedTransaction, val fundingParams: InteractiveTxParams, val createdAt: Long) : LocalFundingStatus() {
+    data class UnconfirmedFundingTx(val sharedTx: SignedSharedTransaction, val fundingParams: InteractiveTxParams, val localCommitSig: CommitSig, val createdAt: Long) : LocalFundingStatus() {
         override val signedTx: Transaction? = sharedTx.signedTx
         override val txId: ByteVector32 = sharedTx.localSigs.txId
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -329,45 +329,6 @@ object Helpers {
 
             return Either.Right(FirstCommitTx(localSpec, localCommitTx, remoteSpec, remoteCommitTx))
         }
-
-        sealed class ReceiveFirstCommitResult
-        data class FirstCommitment(val fundingTx: PartiallySignedSharedTransaction, val commitment: Commitment) : ReceiveFirstCommitResult()
-        object InvalidRemoteCommitSig : ReceiveFirstCommitResult()
-        object FundingSigFailure : ReceiveFirstCommitResult()
-
-        fun receiveFirstCommit(
-            keyManager: KeyManager,
-            fundingParams: InteractiveTxParams,
-            localParams: LocalParams,
-            remoteParams: RemoteParams,
-            fundingTx: SharedTransaction,
-            firstCommitTx: FirstCommitTx,
-            remoteCommit: CommitSig,
-            remoteFirstPerCommitmentPoint: PublicKey,
-            currentBlockHeight: Long,
-        ): ReceiveFirstCommitResult {
-            val fundingPubKey = localParams.channelKeys(keyManager).fundingPubKey
-            val localSigOfLocalTx = keyManager.sign(firstCommitTx.localCommitTx, localParams.channelKeys(keyManager).fundingPrivateKey)
-            val signedLocalCommitTx = Transactions.addSigs(firstCommitTx.localCommitTx, fundingPubKey, remoteParams.fundingPubKey, localSigOfLocalTx, remoteCommit.signature)
-            return when (Transactions.checkSpendable(signedLocalCommitTx)) {
-                is Try.Failure -> InvalidRemoteCommitSig
-                is Try.Success -> {
-                    when (val signedFundingTx = fundingTx.sign(keyManager, fundingParams, localParams)) {
-                        null -> FundingSigFailure
-                        else -> {
-                            val commitment = Commitment(
-                                LocalFundingStatus.UnconfirmedFundingTx(signedFundingTx, fundingParams, currentBlockHeight),
-                                RemoteFundingStatus.NotLocked,
-                                LocalCommit(0, firstCommitTx.localSpec, PublishableTxs(signedLocalCommitTx, listOf())),
-                                RemoteCommit(0, firstCommitTx.remoteSpec, firstCommitTx.remoteCommitTx.tx.txid, remoteFirstPerCommitmentPoint),
-                                nextRemoteCommit = null
-                            )
-                            FirstCommitment(signedFundingTx, commitment)
-                        }
-                    }
-                }
-            }
-        }
     }
 
     object Closing {
@@ -727,7 +688,7 @@ object Helpers {
          *
          * This function returns the per-commitment secret in the first case, and null in the other cases.
          */
-        fun LoggingContext.getRemotePerCommitmentSecret(keyManager: KeyManager, params: ChannelParams, remotePerCommitmentSecrets: ShaChain, tx: Transaction): Pair<PrivateKey, Long>? {
+        fun getRemotePerCommitmentSecret(keyManager: KeyManager, params: ChannelParams, remotePerCommitmentSecrets: ShaChain, tx: Transaction): Pair<PrivateKey, Long>? {
             // a valid tx will always have at least one input, but this ensures we don't throw in tests
             val sequence = tx.txIn.first().sequence
             val channelKeyPath = keyManager.channelKeyPath(params.localParams, params.channelConfig)

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -330,16 +330,6 @@ object Helpers {
             return Either.Right(FirstCommitTx(localSpec, localCommitTx, remoteSpec, remoteCommitTx))
         }
 
-        /** Sign the current remote commit, for example when retransmitting our commit_sig after a disconnection. */
-        fun signRemoteCommit(keyManager: KeyManager, params: ChannelParams, commitInput: Transactions.InputInfo, remoteCommit: RemoteCommit): CommitSig {
-            val (remoteCommitTx, htlcTxs) = Commitments.makeRemoteTxs(keyManager, remoteCommit.index, params.localParams, params.remoteParams, commitInput, remoteCommit.remotePerCommitmentPoint, remoteCommit.spec)
-            val channelKeys = params.localParams.channelKeys(keyManager)
-            val sig = keyManager.sign(remoteCommitTx, channelKeys.fundingPrivateKey)
-            // we sign our peer's HTLC txs with SIGHASH_SINGLE || SIGHASH_ANYONECANPAY
-            val sortedHtlcsTxs = htlcTxs.sortedBy { it.input.outPoint.index }
-            val htlcSigs = sortedHtlcsTxs.map { keyManager.sign(it, channelKeys.htlcKey, remoteCommit.remotePerCommitmentPoint, SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
-            return CommitSig(params.channelId, sig, htlcSigs.toList())
-        }
     }
 
     object Closing {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
@@ -6,6 +6,7 @@ import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.blockchain.electrum.WalletState
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.crypto.KeyManager
+import fr.acinq.lightning.transactions.CommitmentSpec
 import fr.acinq.lightning.transactions.Scripts
 import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.*
@@ -685,6 +686,9 @@ data class InteractiveTxSigningSession(
     }
 
     companion object {
+        /** A local commitment for which we haven't received our peer's signatures. */
+        data class UnsignedLocalCommit(val index: Long, val spec: CommitmentSpec, val commitTx: Transactions.TransactionWithInputInfo.CommitTx, val htlcTxs: List<Transactions.TransactionWithInputInfo.HtlcTx>)
+
         fun create(
             keyManager: KeyManager,
             channelParams: ChannelParams,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingConfirmed.kt
@@ -21,7 +21,7 @@ data class LegacyWaitForFundingConfirmed(
     val waitingSinceBlock: Long, // how many blocks have we been waiting for the funding tx to confirm
     val deferred: ChannelReady?,
     val lastSent: Either<FundingCreated, FundingSigned>
-) : PersistedChannelState() {
+) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingLocked.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/LegacyWaitForFundingLocked.kt
@@ -21,7 +21,7 @@ data class LegacyWaitForFundingLocked(
     override val commitments: Commitments,
     val shortChannelId: ShortChannelId,
     val lastSent: ChannelReady
-) : PersistedChannelState() {
+) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Negotiating.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Negotiating.kt
@@ -19,7 +19,7 @@ data class Negotiating(
     val closingTxProposed: List<List<ClosingTxProposed>>, // one list for every negotiation (there can be several in case of disconnection)
     val bestUnpublishedClosingTx: ClosingTx?,
     val closingFeerates: ClosingFeerates?
-) : PersistedChannelState() {
+) : ChannelStateWithCommitments() {
     init {
         require(closingTxProposed.isNotEmpty()) { "there must always be a list for the current negotiation" }
         require(!commitments.params.localParams.isInitiator || !closingTxProposed.any { it.isEmpty() }) { "initiator must have at least one closing signature for every negotiation attempt because it initiates the closing" }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
@@ -20,7 +20,7 @@ data class Normal(
     val localShutdown: Shutdown?,
     val remoteShutdown: Shutdown?,
     val closingFeerates: ClosingFeerates?
-) : PersistedChannelState() {
+) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Offline.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Offline.kt
@@ -43,7 +43,7 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
                                 nextRemoteRevocationNumber = 0,
                                 yourLastCommitmentSecret = PrivateKey(ByteVector32.Zeroes),
                                 myCurrentPerCommitmentPoint = myFirstPerCommitmentPoint,
-                                TlvStream(listOf(ChannelReestablishTlv.NextFunding(state.signingSession.fundingTx.txId)))
+                                TlvStream(listOf(ChannelReestablishTlv.NextFunding(state.signingSession.fundingTx.txId.reversed())))
                             ).withChannelData(state.remoteChannelData, logger)
                             logger.info { "syncing ${state::class}" }
                             val nextState = state.copy(channelParams = state.channelParams.updateFeatures(cmd.localInit, cmd.remoteInit))
@@ -53,7 +53,7 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
                             val yourLastPerCommitmentSecret = state.commitments.remotePerCommitmentSecrets.lastIndex?.let { state.commitments.remotePerCommitmentSecrets.getHash(it) } ?: ByteVector32.Zeroes
                             val myCurrentPerCommitmentPoint = keyManager.commitmentPoint(state.commitments.params.localParams.channelKeys(keyManager).shaSeed, state.commitments.localCommitIndex)
                             val tlvs: TlvStream<ChannelReestablishTlv> = when (state) {
-                                is WaitForFundingConfirmed -> state.getUnsignedFundingTxId()?.let { TlvStream(listOf(ChannelReestablishTlv.NextFunding(it))) } ?: TlvStream.empty()
+                                is WaitForFundingConfirmed -> state.getUnsignedFundingTxId()?.let { TlvStream(listOf(ChannelReestablishTlv.NextFunding(it.reversed()))) } ?: TlvStream.empty()
                                 else -> TlvStream.empty()
                             }
                             val channelReestablish = ChannelReestablish(

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Offline.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Offline.kt
@@ -88,7 +88,7 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
                                     }
                                     else -> state
                                 }
-                                Pair(this@Offline.copy(state = nextState), actions + listOf(ChannelAction.Storage.StoreState(nextState as PersistedChannelState)))
+                                Pair(this@Offline.copy(state = nextState), actions + listOf(ChannelAction.Storage.StoreState(nextState)))
                             }
                         }
                     } else {
@@ -120,7 +120,7 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
                 when (newState) {
                     is Closing -> Pair(newState, actions)
                     is Closed -> Pair(newState, actions)
-                    else -> Pair(Offline(newState as PersistedChannelState), actions)
+                    else -> Pair(Offline(newState), actions)
                 }
             }
             cmd is ChannelCommand.ExecuteCommand && cmd.command is CMD_FORCECLOSE -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Offline.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Offline.kt
@@ -30,7 +30,7 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
                         logger.info { "syncing ${state::class}, waiting fo their channelReestablish message" }
                         val nextState = when (state) {
                             is ChannelStateWithCommitments -> state.updateCommitments(state.commitments.copy(params = state.commitments.params.updateFeatures(cmd.localInit, cmd.remoteInit)))
-                            else -> state
+                            is WaitForFundingSigned -> state.copy(channelParams = state.channelParams.updateFeatures(cmd.localInit, cmd.remoteInit))
                         }
                         Pair(Syncing(nextState, true), listOf())
                     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ShuttingDown.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ShuttingDown.kt
@@ -11,7 +11,7 @@ data class ShuttingDown(
     val localShutdown: Shutdown,
     val remoteShutdown: Shutdown,
     val closingFeerates: ClosingFeerates?
-) : PersistedChannelState() {
+) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
@@ -288,7 +288,7 @@ data class Syncing(val state: PersistedChannelState, val waitForTheirReestablish
                                     }
                                     else -> state
                                 }
-                                Pair(this@Syncing.copy(state = nextState), actions + listOf(ChannelAction.Storage.StoreState(nextState as PersistedChannelState)))
+                                Pair(this@Syncing.copy(state = nextState), actions + listOf(ChannelAction.Storage.StoreState(nextState)))
                             }
                         }
                     } else {
@@ -301,7 +301,7 @@ data class Syncing(val state: PersistedChannelState, val waitForTheirReestablish
                 when (newState) {
                     is Closing -> Pair(newState, actions)
                     is Closed -> Pair(newState, actions)
-                    else -> Pair(Syncing(newState as PersistedChannelState, waitForTheirReestablishMessage), actions)
+                    else -> Pair(Syncing(newState, waitForTheirReestablishMessage), actions)
                 }
             }
             cmd is ChannelCommand.Disconnected -> Pair(Offline(state), listOf())

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
@@ -31,7 +31,7 @@ data class Syncing(val state: PersistedChannelState, val waitForTheirReestablish
                         logger.info { "channel_reestablish includes a peer backup" }
                         when (val decrypted = runTrying { PersistedChannelState.from(staticParams.nodeParams.nodePrivateKey, cmd.message.channelData) }) {
                             is Try.Success -> {
-                                val decryptedState = decrypted.get()
+                                val decryptedState = decrypted.result
                                 when {
                                     decryptedState is ChannelStateWithCommitments && state is ChannelStateWithCommitments && decryptedState.commitments.isMoreRecent(state.commitments) -> {
                                         logger.warning { "they have a more recent commitment, using it instead" }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
@@ -59,14 +59,14 @@ data class Syncing(val state: PersistedChannelState, val waitForTheirReestablish
                                 nextRemoteRevocationNumber = 0,
                                 yourLastCommitmentSecret = PrivateKey(ByteVector32.Zeroes),
                                 myCurrentPerCommitmentPoint = myFirstPerCommitmentPoint,
-                                TlvStream(listOf(ChannelReestablishTlv.NextFunding(nextState.signingSession.fundingTx.txId)))
+                                TlvStream(listOf(ChannelReestablishTlv.NextFunding(nextState.signingSession.fundingTx.txId.reversed())))
                             ).withChannelData(nextState.remoteChannelData, logger)
                         }
                         is ChannelStateWithCommitments -> {
                             val yourLastPerCommitmentSecret = nextState.commitments.remotePerCommitmentSecrets.lastIndex?.let { nextState.commitments.remotePerCommitmentSecrets.getHash(it) } ?: ByteVector32.Zeroes
                             val myCurrentPerCommitmentPoint = keyManager.commitmentPoint(nextState.commitments.params.localParams.channelKeys(keyManager).shaSeed, nextState.commitments.localCommitIndex)
                             val tlvs: TlvStream<ChannelReestablishTlv> = when (nextState) {
-                                is WaitForFundingConfirmed -> nextState.getUnsignedFundingTxId()?.let { TlvStream(listOf(ChannelReestablishTlv.NextFunding(it))) } ?: TlvStream.empty()
+                                is WaitForFundingConfirmed -> nextState.getUnsignedFundingTxId()?.let { TlvStream(listOf(ChannelReestablishTlv.NextFunding(it.reversed()))) } ?: TlvStream.empty()
                                 else -> TlvStream.empty()
                             }
                             ChannelReestablish(

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForAcceptChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForAcceptChannel.kt
@@ -67,7 +67,6 @@ data class WaitForAcceptChannel(
                                         val nextState = WaitForFundingCreated(
                                             init.localParams,
                                             remoteParams,
-                                            init.wallet,
                                             interactiveTxSession,
                                             lastSent.pushAmount,
                                             accept.pushAmount,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForChannelReady.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForChannelReady.kt
@@ -17,7 +17,7 @@ data class WaitForChannelReady(
     override val commitments: Commitments,
     val shortChannelId: ShortChannelId,
     val lastSent: ChannelReady
-) : PersistedChannelState() {
+) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingConfirmed.kt
@@ -19,7 +19,7 @@ data class WaitForFundingConfirmed(
     val deferred: ChannelReady?,
     // We can have at most one ongoing RBF attempt.
     val rbfStatus: RbfStatus
-) : PersistedChannelState() {
+) : ChannelStateWithCommitments() {
 
     val latestFundingTx = commitments.latest.localFundingStatus as LocalFundingStatus.UnconfirmedFundingTx
     private val allFundingTxs = commitments.active.map { it.localFundingStatus }.filterIsInstance<LocalFundingStatus.UnconfirmedFundingTx>()

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingConfirmed.kt
@@ -178,11 +178,12 @@ data class WaitForFundingConfirmed(
                                     Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, signingSession.value.message))))
                                 }
                                 is Either.Right -> {
-                                    val nextState = this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.WaitingForSigs(signingSession.value))
+                                    val (session, commitSig) = signingSession.value
+                                    val nextState = this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.WaitingForSigs(session))
                                     val actions = buildList {
                                         interactiveTxAction.txComplete?.let { add(ChannelAction.Message.Send(it)) }
                                         add(ChannelAction.Storage.StoreState(nextState))
-                                        add(ChannelAction.Message.Send(signingSession.value.localCommitSig))
+                                        add(ChannelAction.Message.Send(commitSig))
                                     }
                                     Pair(nextState, actions)
                                 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingCreated.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingCreated.kt
@@ -68,9 +68,10 @@ data class WaitForFundingCreated(
                                 handleLocalError(cmd, signingSession.value)
                             }
                             is Either.Right -> {
+                                val (session, commitSig) = signingSession.value
                                 val nextState = WaitForFundingSigned(
                                     channelParams,
-                                    signingSession.value,
+                                    session,
                                     localPushAmount,
                                     remotePushAmount,
                                     remoteSecondPerCommitmentPoint,
@@ -79,7 +80,7 @@ data class WaitForFundingCreated(
                                 val actions = buildList {
                                     interactiveTxAction.txComplete?.let { add(ChannelAction.Message.Send(it)) }
                                     add(ChannelAction.Storage.StoreState(nextState))
-                                    add(ChannelAction.Message.Send(signingSession.value.localCommitSig))
+                                    add(ChannelAction.Message.Send(commitSig))
                                 }
                                 Pair(nextState, actions)
                             }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingCreated.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingCreated.kt
@@ -3,7 +3,6 @@ package fr.acinq.lightning.channel
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.PublicKey
 import fr.acinq.lightning.MilliSatoshi
-import fr.acinq.lightning.blockchain.electrum.WalletState
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.utils.Either
 import fr.acinq.lightning.wire.*
@@ -32,7 +31,6 @@ import fr.acinq.lightning.wire.*
 data class WaitForFundingCreated(
     val localParams: LocalParams,
     val remoteParams: RemoteParams,
-    val wallet: WalletState,
     val interactiveTxSession: InteractiveTxSession,
     val localPushAmount: MilliSatoshi,
     val remotePushAmount: MilliSatoshi,
@@ -53,48 +51,34 @@ data class WaitForFundingCreated(
                 when (interactiveTxAction) {
                     is InteractiveTxSessionAction.SendMessage -> Pair(this@WaitForFundingCreated.copy(interactiveTxSession = interactiveTxSession1), listOf(ChannelAction.Message.Send(interactiveTxAction.msg)))
                     is InteractiveTxSessionAction.SignSharedTx -> {
-                        val firstCommitTxRes = Helpers.Funding.makeFirstCommitTxs(
+                        val channelParams = ChannelParams(channelId, channelConfig, channelFeatures, localParams, remoteParams, channelFlags)
+                        val signingSession = InteractiveTxSigningSession.create(
                             keyManager,
-                            channelId,
-                            localParams,
-                            remoteParams,
-                            interactiveTxSession.fundingParams.localAmount,
-                            interactiveTxSession.fundingParams.remoteAmount,
+                            channelParams,
+                            interactiveTxSession.fundingParams,
+                            interactiveTxAction.sharedTx,
                             localPushAmount,
                             remotePushAmount,
                             commitTxFeerate,
-                            interactiveTxAction.sharedTx.buildUnsignedTx().hash,
-                            interactiveTxAction.sharedOutputIndex,
                             remoteFirstPerCommitmentPoint
                         )
-                        when (firstCommitTxRes) {
+                        when (signingSession) {
                             is Either.Left -> {
-                                logger.error(firstCommitTxRes.value) { "cannot create first commit tx" }
-                                handleLocalError(cmd, firstCommitTxRes.value)
+                                logger.error(signingSession.value) { "cannot initiate interactive-tx signing session" }
+                                handleLocalError(cmd, signingSession.value)
                             }
                             is Either.Right -> {
-                                val firstCommitTx = firstCommitTxRes.value
-                                val localSigOfRemoteTx = keyManager.sign(firstCommitTx.remoteCommitTx, localParams.channelKeys(keyManager).fundingPrivateKey)
-                                val commitSig = CommitSig(channelId, localSigOfRemoteTx, listOf())
                                 val nextState = WaitForFundingSigned(
-                                    localParams,
-                                    remoteParams,
-                                    wallet,
-                                    interactiveTxSession1.fundingParams,
+                                    channelParams,
+                                    signingSession.value,
                                     localPushAmount,
                                     remotePushAmount,
-                                    interactiveTxAction.sharedTx,
-                                    firstCommitTx,
-                                    remoteFirstPerCommitmentPoint,
                                     remoteSecondPerCommitmentPoint,
-                                    channelFlags,
-                                    channelConfig,
-                                    channelFeatures,
                                     channelOrigin
                                 )
                                 val actions = buildList {
                                     interactiveTxAction.txComplete?.let { add(ChannelAction.Message.Send(it)) }
-                                    add(ChannelAction.Message.Send(commitSig))
+                                    add(ChannelAction.Message.Send(signingSession.value.localCommitSig))
                                 }
                                 Pair(nextState, actions)
                             }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingCreated.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingCreated.kt
@@ -78,6 +78,7 @@ data class WaitForFundingCreated(
                                 )
                                 val actions = buildList {
                                     interactiveTxAction.txComplete?.let { add(ChannelAction.Message.Send(it)) }
+                                    add(ChannelAction.Storage.StoreState(nextState))
                                     add(ChannelAction.Message.Send(signingSession.value.localCommitSig))
                                 }
                                 Pair(nextState, actions)

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingSigned.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingSigned.kt
@@ -14,6 +14,7 @@ import kotlin.math.absoluteValue
 
 /*
  * We exchange signatures for a new channel.
+ * We have already sent our commit_sig.
  * If we send our tx_signatures first, the protocol flow is:
  *
  *       Local                        Remote

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingSigned.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForFundingSigned.kt
@@ -7,7 +7,6 @@ import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.ShortChannelId
 import fr.acinq.lightning.blockchain.BITCOIN_FUNDING_DEPTHOK
 import fr.acinq.lightning.blockchain.WatchConfirmed
-import fr.acinq.lightning.blockchain.electrum.WalletState
 import fr.acinq.lightning.crypto.ShaChain
 import fr.acinq.lightning.utils.Either
 import fr.acinq.lightning.wire.*
@@ -15,101 +14,51 @@ import kotlin.math.absoluteValue
 
 /*
  * We exchange signatures for a new channel.
+ * If we send our tx_signatures first, the protocol flow is:
  *
  *       Local                        Remote
  *         |         commit_sig         |
  *         |<---------------------------|
  *         |        tx_signatures       |
  *         |--------------------------->|
+ *
+ * Otherwise, it is:
+ *
+ *       Local                        Remote
+ *         |         commit_sig         |
+ *         |<---------------------------|
+ *         |        tx_signatures       |
+ *         |<---------------------------|
+ *         |        tx_signatures       |
+ *         |--------------------------->|
  */
 data class WaitForFundingSigned(
-    val localParams: LocalParams,
-    val remoteParams: RemoteParams,
-    val wallet: WalletState,
-    val fundingParams: InteractiveTxParams,
+    val channelParams: ChannelParams,
+    val signingSession: InteractiveTxSigningSession,
     val localPushAmount: MilliSatoshi,
     val remotePushAmount: MilliSatoshi,
-    val fundingTx: SharedTransaction,
-    val firstCommitTx: Helpers.Funding.FirstCommitTx,
-    val remoteFirstPerCommitmentPoint: PublicKey,
     val remoteSecondPerCommitmentPoint: PublicKey,
-    val channelFlags: Byte,
-    val channelConfig: ChannelConfig,
-    val channelFeatures: ChannelFeatures,
     val channelOrigin: ChannelOrigin?
 ) : ChannelState() {
-    val channelId: ByteVector32 = fundingParams.channelId
+    val channelId: ByteVector32 = channelParams.channelId
 
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when {
             cmd is ChannelCommand.MessageReceived && cmd.message is CommitSig -> {
-                val firstCommitmentRes = Helpers.Funding.receiveFirstCommit(
-                    keyManager, fundingParams, localParams, remoteParams,
-                    fundingTx, firstCommitTx, cmd.message,
-                    remoteFirstPerCommitmentPoint,
-                    currentBlockHeight.toLong()
-                )
-                when (firstCommitmentRes) {
-                    Helpers.Funding.InvalidRemoteCommitSig -> handleLocalError(cmd, InvalidCommitmentSignature(channelId, firstCommitTx.localCommitTx.tx.txid))
-                    Helpers.Funding.FundingSigFailure -> {
-                        logger.warning { "could not sign funding tx" }
-                        Pair(Aborted, listOf(ChannelAction.Message.Send(Error(channelId, ChannelFundingError(channelId).message))))
-                    }
-                    is Helpers.Funding.FirstCommitment -> {
-                        val (signedFundingTx, commitment) = firstCommitmentRes
-                        val commitments = Commitments(
-                            ChannelParams(channelId, channelConfig, channelFeatures, localParams, remoteParams, channelFlags),
-                            CommitmentChanges.init(),
-                            listOf(commitment),
-                            payments = mapOf(),
-                            remoteNextCommitInfo = Either.Right(remoteSecondPerCommitmentPoint),
-                            remotePerCommitmentSecrets = ShaChain.init,
-                            remoteChannelData = cmd.message.channelData
-                        )
-                        logger.info { "funding tx created with txId=${commitment.fundingTxId}. ${fundingTx.localInputs.size} local inputs, ${fundingTx.remoteInputs.size} remote inputs, ${fundingTx.localOutputs.size} local outputs and ${fundingTx.remoteOutputs.size} remote outputs" }
-                        // We watch for confirmation in all cases, to allow pruning outdated commitments when transactions confirm.
-                        val fundingMinDepth = Helpers.minDepthForFunding(staticParams.nodeParams, fundingParams.fundingAmount)
-                        val watchConfirmed = WatchConfirmed(channelId, commitment.fundingTxId, commitment.commitInput.txOut.publicKeyScript, fundingMinDepth.toLong(), BITCOIN_FUNDING_DEPTHOK)
-                        if (staticParams.useZeroConf) {
-                            logger.info { "channel is using 0-conf, we won't wait for the funding tx to confirm" }
-                            val nextPerCommitmentPoint = keyManager.commitmentPoint(localParams.channelKeys(keyManager).shaSeed, 1)
-                            val channelReady = ChannelReady(channelId, nextPerCommitmentPoint, TlvStream(listOf(ChannelReadyTlv.ShortChannelIdTlv(ShortChannelId.peerId(staticParams.nodeParams.nodeId)))))
-                            // We use part of the funding txid to create a dummy short channel id.
-                            // This gives us a probability of collisions of 0.1% for 5 0-conf channels and 1% for 20
-                            // Collisions mean that users may temporarily see incorrect numbers for their 0-conf channels (until they've been confirmed).
-                            val shortChannelId = ShortChannelId(0, Pack.int32BE(commitment.fundingTxId.slice(0, 16).toByteArray()).absoluteValue, commitment.commitInput.outPoint.index.toInt())
-                            val nextState = WaitForChannelReady(commitments, shortChannelId, channelReady)
-                            val actions = buildList {
-                                add(ChannelAction.Blockchain.SendWatch(watchConfirmed))
-                                // We're not a liquidity provider, so we don't mind sending our signatures immediately.
-                                add(ChannelAction.Message.Send(signedFundingTx.localSigs))
-                                add(ChannelAction.Message.Send(channelReady))
-                                add(ChannelAction.Storage.StoreState(nextState))
-                            }
-                            Pair(nextState, actions)
-                        } else {
-                            logger.info { "will wait for $fundingMinDepth confirmations" }
-                            val nextState = WaitForFundingConfirmed(
-                                commitments,
-                                localPushAmount,
-                                remotePushAmount,
-                                currentBlockHeight.toLong(),
-                                null
-                            )
-                            val actions = buildList {
-                                add(ChannelAction.Blockchain.SendWatch(watchConfirmed))
-                                add(ChannelAction.Storage.StoreState(nextState))
-                                // We're not a liquidity provider, so we don't mind sending our signatures immediately.
-                                add(ChannelAction.Message.Send(signedFundingTx.localSigs))
-                            }
-                            Pair(nextState, actions)
-                        }
-                    }
+                val (signingSession1, action) = signingSession.receiveCommitSig(keyManager, channelParams, cmd.message, currentBlockHeight.toLong())
+                when (action) {
+                    is InteractiveTxSigningSessionAction.AbortFundingAttempt -> handleLocalError(cmd, action.reason)
+                    // No need to store their commit_sig, they will re-send it if we disconnect.
+                    InteractiveTxSigningSessionAction.WaitForTxSigs -> Pair(this@WaitForFundingSigned.copy(signingSession = signingSession1, remoteChannelData = cmd.message.channelData), listOf())
+                    is InteractiveTxSigningSessionAction.SendTxSigs -> sendTxSigs(action, cmd.message.channelData)
                 }
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is TxSignatures -> {
-                logger.warning { "received tx_signatures before commit_sig, aborting" }
-                handleLocalError(cmd, UnexpectedFundingSignatures(channelId))
+                when (val action = signingSession.receiveTxSigs(cmd.message, currentBlockHeight.toLong())) {
+                    is InteractiveTxSigningSessionAction.AbortFundingAttempt -> handleLocalError(cmd, action.reason)
+                    InteractiveTxSigningSessionAction.WaitForTxSigs -> Pair(this@WaitForFundingSigned, listOf())
+                    is InteractiveTxSigningSessionAction.SendTxSigs -> sendTxSigs(action, cmd.message.channelData)
+                }
             }
             cmd is ChannelCommand.MessageReceived && cmd.message is TxInitRbf -> {
                 logger.info { "ignoring unexpected tx_init_rbf message" }
@@ -131,6 +80,57 @@ data class WaitForFundingSigned(
             cmd is ChannelCommand.CheckHtlcTimeout -> Pair(this@WaitForFundingSigned, listOf())
             cmd is ChannelCommand.Disconnected -> Pair(Aborted, listOf())
             else -> unhandled(cmd)
+        }
+    }
+
+    private fun ChannelContext.sendTxSigs(action: InteractiveTxSigningSessionAction.SendTxSigs, remoteChannelData: EncryptedChannelData): Pair<ChannelState, List<ChannelAction>> {
+        logger.info { "funding tx created with txId=${action.fundingTx.txId}, ${action.fundingTx.sharedTx.tx.localInputs.size} local inputs, ${action.fundingTx.sharedTx.tx.remoteInputs.size} remote inputs, ${action.fundingTx.sharedTx.tx.localOutputs.size} local outputs and ${action.fundingTx.sharedTx.tx.remoteOutputs.size} remote outputs" }
+        // We watch for confirmation in all cases, to allow pruning outdated commitments when transactions confirm.
+        val fundingMinDepth = Helpers.minDepthForFunding(staticParams.nodeParams, action.fundingTx.fundingParams.fundingAmount)
+        val watchConfirmed = WatchConfirmed(channelId, action.commitment.fundingTxId, action.commitment.commitInput.txOut.publicKeyScript, fundingMinDepth.toLong(), BITCOIN_FUNDING_DEPTHOK)
+        val commitments = Commitments(
+            channelParams,
+            CommitmentChanges.init(),
+            listOf(action.commitment),
+            payments = mapOf(),
+            remoteNextCommitInfo = Either.Right(remoteSecondPerCommitmentPoint),
+            remotePerCommitmentSecrets = ShaChain.init,
+            remoteChannelData = remoteChannelData
+        )
+        return if (staticParams.useZeroConf) {
+            logger.info { "channel is using 0-conf, we won't wait for the funding tx to confirm" }
+            val nextPerCommitmentPoint = keyManager.commitmentPoint(channelParams.localParams.channelKeys(keyManager).shaSeed, 1)
+            val channelReady = ChannelReady(channelId, nextPerCommitmentPoint, TlvStream(listOf(ChannelReadyTlv.ShortChannelIdTlv(ShortChannelId.peerId(staticParams.nodeParams.nodeId)))))
+            // We use part of the funding txid to create a dummy short channel id.
+            // This gives us a probability of collisions of 0.1% for 5 0-conf channels and 1% for 20
+            // Collisions mean that users may temporarily see incorrect numbers for their 0-conf channels (until they've been confirmed).
+            val shortChannelId = ShortChannelId(0, Pack.int32BE(action.commitment.fundingTxId.slice(0, 16).toByteArray()).absoluteValue, action.commitment.commitInput.outPoint.index.toInt())
+            val nextState = WaitForChannelReady(commitments, shortChannelId, channelReady)
+            val actions = buildList {
+                add(ChannelAction.Storage.StoreState(nextState))
+                action.fundingTx.signedTx?.let { add(ChannelAction.Blockchain.PublishTx(it)) }
+                add(ChannelAction.Blockchain.SendWatch(watchConfirmed))
+                add(ChannelAction.Message.Send(action.localSigs))
+                add(ChannelAction.Message.Send(channelReady))
+            }
+            Pair(nextState, actions)
+        } else {
+            logger.info { "will wait for $fundingMinDepth confirmations" }
+            val nextState = WaitForFundingConfirmed(
+                commitments,
+                localPushAmount,
+                remotePushAmount,
+                currentBlockHeight.toLong(),
+                null,
+                RbfStatus.None
+            )
+            val actions = buildList {
+                add(ChannelAction.Storage.StoreState(nextState))
+                action.fundingTx.signedTx?.let { add(ChannelAction.Blockchain.PublishTx(it)) }
+                add(ChannelAction.Blockchain.SendWatch(watchConfirmed))
+                add(ChannelAction.Message.Send(action.localSigs))
+            }
+            Pair(nextState, actions)
         }
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForOpenChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForOpenChannel.kt
@@ -95,7 +95,6 @@ data class WaitForOpenChannel(
                                         val nextState = WaitForFundingCreated(
                                             localParams,
                                             remoteParams,
-                                            wallet,
                                             interactiveTxSession,
                                             pushAmount,
                                             open.pushAmount,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForRemotePublishFutureCommitment.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/WaitForRemotePublishFutureCommitment.kt
@@ -8,7 +8,7 @@ import fr.acinq.lightning.wire.Error
 data class WaitForRemotePublishFutureCommitment(
     override val commitments: Commitments,
     val remoteChannelReestablish: ChannelReestablish
-) : PersistedChannelState() {
+) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
@@ -270,7 +270,7 @@ object JsonSerializers {
         delegateSerializer = InteractiveTxSigningSessionSurrogate.serializer()
     )
 
-    @Serializer(forClass = WaitForFundingConfirmed.Companion.RbfStatus::class)
+    @Serializer(forClass = RbfStatus::class)
     object RbfStatusSerializer
 
     @Serializer(forClass = ChannelParams::class)

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/Encryption.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/Encryption.kt
@@ -27,8 +27,7 @@ object Encryption {
         val ciphertext = data.dropLast(12 + 16)
         val nonce = data.takeLast(12 + 16).take(12)
         val tag = data.takeLast(16)
-        val plaintext = ChaCha20Poly1305.decrypt(key.toByteArray(), nonce.toByteArray(), ciphertext.toByteArray(), ByteArray(0), tag.toByteArray())
-        return plaintext
+        return ChaCha20Poly1305.decrypt(key.toByteArray(), nonce.toByteArray(), ciphertext.toByteArray(), ByteArray(0), tag.toByteArray())
     }
 
     /**
@@ -50,8 +49,7 @@ object Encryption {
         val decrypted = runTrying { decrypt(key.value, encryptedChannelData.data.drop(2).toByteArray()) }
             .recoverWith { runTrying { decrypt(key.value, encryptedChannelData.data.toByteArray()) } }
             .get()
-        val state = Serialization.deserialize(decrypted)
-        return state
+        return Serialization.deserialize(decrypted)
     }
 
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
@@ -399,7 +399,6 @@ internal data class Commitments(
                         TxSignatures(channelId, commitInput.outPoint.hash, listOf()),
                     ),
                     fr.acinq.lightning.channel.InteractiveTxParams(channelId, localParams.isFunder, commitInput.txOut.amount, commitInput.txOut.amount, commitInput.txOut.publicKeyScript, 0, localParams.dustLimit, localCommit.spec.feerate),
-                    CommitSig(channelId, ByteVector64.Zeroes, listOf()),
                     0
                 ),
                 fr.acinq.lightning.channel.RemoteFundingStatus.Locked,

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
@@ -399,6 +399,7 @@ internal data class Commitments(
                         TxSignatures(channelId, commitInput.outPoint.hash, listOf()),
                     ),
                     fr.acinq.lightning.channel.InteractiveTxParams(channelId, localParams.isFunder, commitInput.txOut.amount, commitInput.txOut.amount, commitInput.txOut.publicKeyScript, 0, localParams.dustLimit, localCommit.spec.feerate),
+                    CommitSig(channelId, ByteVector64.Zeroes, listOf()),
                     0
                 ),
                 fr.acinq.lightning.channel.RemoteFundingStatus.Locked,

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/Serialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/Serialization.kt
@@ -87,7 +87,7 @@ object Serialization {
         }
     }
 
-    fun decrypt(key: ByteVector32, data: ByteArray): fr.acinq.lightning.channel.ChannelStateWithCommitments {
+    fun decrypt(key: ByteVector32, data: ByteArray): fr.acinq.lightning.channel.PersistedChannelState {
         // nonce is 12B, tag is 16B
         val ciphertext = data.dropLast(12 + 16)
         val nonce = data.takeLast(12 + 16).take(12)
@@ -96,8 +96,8 @@ object Serialization {
         return deserialize(plaintext)
     }
 
-    fun decrypt(key: PrivateKey, data: ByteArray): fr.acinq.lightning.channel.ChannelStateWithCommitments = decrypt(key.value, data)
-    fun decrypt(key: PrivateKey, backup: EncryptedChannelData): fr.acinq.lightning.channel.ChannelStateWithCommitments = decrypt(key, backup.data.toByteArray())
+    fun decrypt(key: PrivateKey, data: ByteArray): fr.acinq.lightning.channel.PersistedChannelState = decrypt(key.value, data)
+    fun decrypt(key: PrivateKey, backup: EncryptedChannelData): fr.acinq.lightning.channel.PersistedChannelState = decrypt(key, backup.data.toByteArray())
 
     @OptIn(ExperimentalSerializationApi::class)
     @ExperimentalSerializationApi

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
@@ -392,6 +392,7 @@ internal data class Commitments(
                         TxSignatures(channelId, commitInput.outPoint.hash, listOf()),
                     ),
                     fr.acinq.lightning.channel.InteractiveTxParams(channelId, localParams.isFunder, commitInput.txOut.amount, commitInput.txOut.amount, commitInput.txOut.publicKeyScript, 0, localParams.dustLimit, localCommit.spec.feerate),
+                    CommitSig(channelId, ByteVector64.Zeroes, listOf()),
                     0
                 ),
                 fr.acinq.lightning.channel.RemoteFundingStatus.Locked,

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
@@ -392,7 +392,6 @@ internal data class Commitments(
                         TxSignatures(channelId, commitInput.outPoint.hash, listOf()),
                     ),
                     fr.acinq.lightning.channel.InteractiveTxParams(channelId, localParams.isFunder, commitInput.txOut.amount, commitInput.txOut.amount, commitInput.txOut.publicKeyScript, 0, localParams.dustLimit, localCommit.spec.feerate),
-                    CommitSig(channelId, ByteVector64.Zeroes, listOf()),
                     0
                 ),
                 fr.acinq.lightning.channel.RemoteFundingStatus.Locked,

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
@@ -59,7 +59,8 @@ object Deserialization {
         localPushAmount = readNumber().msat,
         remotePushAmount = readNumber().msat,
         waitingSinceBlock = readNumber(),
-        deferred = readNullable { readLightningMessage() as ChannelReady }
+        deferred = readNullable { readLightningMessage() as ChannelReady },
+        rbfStatus = WaitForFundingConfirmed.Companion.RbfStatus.None
     )
 
     private fun Input.readWaitForChannelReady() = WaitForChannelReady(

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
@@ -72,9 +72,9 @@ object Deserialization {
         waitingSinceBlock = readNumber(),
         deferred = readNullable { readLightningMessage() as ChannelReady },
         rbfStatus = when (val discriminator = read()) {
-            0x00 -> WaitForFundingConfirmed.Companion.RbfStatus.None
-            0x01 -> WaitForFundingConfirmed.Companion.RbfStatus.WaitingForSigs(readInteractiveTxSigningSession())
-            else -> error("unknown discriminator $discriminator for class ${WaitForFundingConfirmed.Companion.RbfStatus::class}")
+            0x00 -> RbfStatus.None
+            0x01 -> RbfStatus.WaitingForSigs(readInteractiveTxSigningSession())
+            else -> error("unknown discriminator $discriminator for class ${RbfStatus::class}")
         }
     )
 
@@ -376,6 +376,7 @@ object Deserialization {
             0x00 -> LocalFundingStatus.UnconfirmedFundingTx(
                 sharedTx = readSignedSharedTransaction(),
                 fundingParams = readInteractiveTxParams(),
+                localCommitSig = readLightningMessage() as CommitSig,
                 createdAt = readNumber()
             )
             0x01 -> LocalFundingStatus.ConfirmedFundingTx(

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
@@ -275,7 +275,6 @@ object Deserialization {
     private fun Input.readInteractiveTxSigningSession(): InteractiveTxSigningSession = InteractiveTxSigningSession(
         fundingParams = readInteractiveTxParams(),
         fundingTx = readSignedSharedTransaction() as PartiallySignedSharedTransaction,
-        localCommitSig = readLightningMessage() as CommitSig,
         localCommit = readEither(
             readLeft = {
                 UnsignedLocalCommit(
@@ -376,7 +375,6 @@ object Deserialization {
             0x00 -> LocalFundingStatus.UnconfirmedFundingTx(
                 sharedTx = readSignedSharedTransaction(),
                 fundingParams = readInteractiveTxParams(),
-                localCommitSig = readLightningMessage() as CommitSig,
                 createdAt = readNumber()
             )
             0x01 -> LocalFundingStatus.ConfirmedFundingTx(

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
@@ -277,7 +277,7 @@ object Deserialization {
         fundingTx = readSignedSharedTransaction() as PartiallySignedSharedTransaction,
         localCommit = readEither(
             readLeft = {
-                UnsignedLocalCommit(
+                InteractiveTxSigningSession.Companion.UnsignedLocalCommit(
                     index = readNumber(),
                     spec = readCommitmentSpecWithHtlcs(),
                     commitTx = readTransactionWithInputInfo() as CommitTx,

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
@@ -34,6 +34,8 @@ object Deserialization {
         0x05 -> readClosing()
         0x06 -> readWaitForRemotePublishFutureCommitment()
         0x07 -> readClosed()
+        0x0a -> readWaitForFundingSigned()
+        0x0b -> readErrorInformationLeak()
         else -> error("unknown discriminator $discriminator for class ${PersistedChannelState::class}")
     }
 
@@ -54,13 +56,26 @@ object Deserialization {
         lastSent = readLightningMessage() as ChannelReady
     )
 
+    private fun Input.readWaitForFundingSigned() = WaitForFundingSigned(
+        channelParams = readChannelParams(),
+        signingSession = readInteractiveTxSigningSession(),
+        localPushAmount = readNumber().msat,
+        remotePushAmount = readNumber().msat,
+        remoteSecondPerCommitmentPoint = readPublicKey(),
+        channelOrigin = readNullable { readChannelOrigin() }
+    )
+
     private fun Input.readWaitForFundingConfirmed() = WaitForFundingConfirmed(
         commitments = readCommitments(),
         localPushAmount = readNumber().msat,
         remotePushAmount = readNumber().msat,
         waitingSinceBlock = readNumber(),
         deferred = readNullable { readLightningMessage() as ChannelReady },
-        rbfStatus = WaitForFundingConfirmed.Companion.RbfStatus.None
+        rbfStatus = when (val discriminator = read()) {
+            0x00 -> WaitForFundingConfirmed.Companion.RbfStatus.None
+            0x01 -> WaitForFundingConfirmed.Companion.RbfStatus.WaitingForSigs(readInteractiveTxSigningSession())
+            else -> error("unknown discriminator $discriminator for class ${WaitForFundingConfirmed.Companion.RbfStatus::class}")
+        }
     )
 
     private fun Input.readWaitForChannelReady() = WaitForChannelReady(
@@ -150,6 +165,10 @@ object Deserialization {
     private fun Input.readWaitForRemotePublishFutureCommitment(): WaitForRemotePublishFutureCommitment = WaitForRemotePublishFutureCommitment(
         commitments = readCommitments(),
         remoteChannelReestablish = readLightningMessage() as ChannelReestablish
+    )
+
+    private fun Input.readErrorInformationLeak(): ErrorInformationLeak = ErrorInformationLeak(
+        commitments = readCommitments()
     )
 
     private fun Input.readClosed(): Closed = Closed(
@@ -253,6 +272,57 @@ object Deserialization {
         else -> error("unknown discriminator $discriminator for class ${SignedSharedTransaction::class}")
     }
 
+    private fun Input.readInteractiveTxSigningSession(): InteractiveTxSigningSession = InteractiveTxSigningSession(
+        fundingParams = readInteractiveTxParams(),
+        fundingTx = readSignedSharedTransaction() as PartiallySignedSharedTransaction,
+        localCommitSig = readLightningMessage() as CommitSig,
+        localCommit = readEither(
+            readLeft = {
+                UnsignedLocalCommit(
+                    index = readNumber(),
+                    spec = readCommitmentSpecWithHtlcs(),
+                    commitTx = readTransactionWithInputInfo() as CommitTx,
+                    htlcTxs = readCollection { readTransactionWithInputInfo() as HtlcTx }.toList(),
+                )
+            },
+            readRight = {
+                LocalCommit(
+                    index = readNumber(),
+                    spec = readCommitmentSpecWithHtlcs(),
+                    publishableTxs = PublishableTxs(
+                        commitTx = readTransactionWithInputInfo() as CommitTx,
+                        htlcTxsAndSigs = readCollection {
+                            HtlcTxAndSigs(
+                                txinfo = readTransactionWithInputInfo() as HtlcTx,
+                                localSig = readByteVector64(),
+                                remoteSig = readByteVector64()
+                            )
+                        }.toList()
+                    )
+                )
+            },
+        ),
+        remoteCommit = RemoteCommit(
+            index = readNumber(),
+            spec = readCommitmentSpecWithHtlcs(),
+            txid = readByteVector32(),
+            remotePerCommitmentPoint = readPublicKey()
+        )
+    )
+
+    private fun Input.readChannelOrigin(): ChannelOrigin = when (val discriminator = read()) {
+        0x01 -> ChannelOrigin.PayToOpenOrigin(
+            paymentHash = readByteVector32(),
+            fee = readNumber().sat,
+        )
+        0x02 -> ChannelOrigin.PleaseOpenChannelOrigin(
+            requestId = readByteVector32(),
+            serviceFee = readNumber().msat,
+            fundingFee = readNumber().sat,
+        )
+        else -> error("unknown discriminator $discriminator for class ${ChannelOrigin::class}")
+    }
+
     private fun Input.readChannelParams(): ChannelParams = ChannelParams(
         channelId = readByteVector32(),
         channelConfig = ChannelConfig(readDelimitedByteArray()),
@@ -320,7 +390,7 @@ object Deserialization {
         },
         localCommit = LocalCommit(
             index = readNumber(),
-            spec = readCommitmentSpec(htlcs),
+            spec = readCommitmentSpecWithoutHtlcs(htlcs),
             publishableTxs = PublishableTxs(
                 commitTx = readTransactionWithInputInfo() as CommitTx,
                 htlcTxsAndSigs = readCollection {
@@ -334,7 +404,7 @@ object Deserialization {
         ),
         remoteCommit = RemoteCommit(
             index = readNumber(),
-            spec = readCommitmentSpec(htlcs.map { it.opposite() }.toSet()),
+            spec = readCommitmentSpecWithoutHtlcs(htlcs.map { it.opposite() }.toSet()),
             txid = readByteVector32(),
             remotePerCommitmentPoint = readPublicKey()
         ),
@@ -343,7 +413,7 @@ object Deserialization {
                 sig = readLightningMessage() as CommitSig,
                 commit = RemoteCommit(
                     index = readNumber(),
-                    spec = readCommitmentSpec(htlcs.map { it.opposite() }.toSet()),
+                    spec = readCommitmentSpecWithoutHtlcs(htlcs.map { it.opposite() }.toSet()),
                     txid = readByteVector32(),
                     remotePerCommitmentPoint = readPublicKey()
                 )
@@ -381,7 +451,14 @@ object Deserialization {
         else -> error("invalid discriminator $discriminator for class ${DirectedHtlc::class}")
     }
 
-    private fun Input.readCommitmentSpec(htlcs: Set<DirectedHtlc>): CommitmentSpec = CommitmentSpec(
+    private fun Input.readCommitmentSpecWithHtlcs(): CommitmentSpec = CommitmentSpec(
+        htlcs = readCollection { readDirectedHtlc() }.toSet(),
+        feerate = FeeratePerKw(readNumber().sat),
+        toLocal = readNumber().msat,
+        toRemote = readNumber().msat
+    )
+
+    private fun Input.readCommitmentSpecWithoutHtlcs(htlcs: Set<DirectedHtlc>): CommitmentSpec = CommitmentSpec(
         htlcs = readCollection {
             when (val discriminator = read()) {
                 0 -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
@@ -328,7 +328,6 @@ object Serialization {
     private fun Output.writeInteractiveTxSigningSession(s: InteractiveTxSigningSession) = s.run {
         writeInteractiveTxParams(fundingParams)
         writeSignedSharedTransaction(fundingTx)
-        writeLightningMessage(localCommitSig)
         // We don't bother removing the duplication across HTLCs: this is a short-lived state during which the channel cannot be used for payments.
         writeEither(localCommit,
             writeLeft = { localCommit ->
@@ -426,7 +425,6 @@ object Serialization {
                 write(0x00)
                 writeSignedSharedTransaction(localFundingStatus.sharedTx)
                 writeInteractiveTxParams(localFundingStatus.fundingParams)
-                writeLightningMessage(localFundingStatus.localCommitSig)
                 writeNumber(localFundingStatus.createdAt)
             }
             is LocalFundingStatus.ConfirmedFundingTx -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
@@ -112,7 +112,7 @@ object Serialization {
         writeNumber(waitingSinceBlock)
         writeNullable(deferred) { writeLightningMessage(it) }
         when (rbfStatus) {
-            is WaitForFundingConfirmed.Companion.RbfStatus.WaitingForSigs -> {
+            is RbfStatus.WaitingForSigs -> {
                 write(0x01)
                 writeInteractiveTxSigningSession(rbfStatus.session)
             }
@@ -426,6 +426,7 @@ object Serialization {
                 write(0x00)
                 writeSignedSharedTransaction(localFundingStatus.sharedTx)
                 writeInteractiveTxParams(localFundingStatus.fundingParams)
+                writeLightningMessage(localFundingStatus.localCommitSig)
                 writeNumber(localFundingStatus.createdAt)
             }
             is LocalFundingStatus.ConfirmedFundingTx -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
@@ -1,9 +1,6 @@
 package fr.acinq.lightning.wire
 
-import fr.acinq.bitcoin.ByteVector
-import fr.acinq.bitcoin.OutPoint
-import fr.acinq.bitcoin.Satoshi
-import fr.acinq.bitcoin.byteVector32
+import fr.acinq.bitcoin.*
 import fr.acinq.bitcoin.io.Input
 import fr.acinq.bitcoin.io.Output
 import fr.acinq.lightning.Features
@@ -169,6 +166,16 @@ sealed class ChannelReestablishTlv : Tlv {
         companion object : TlvValueReader<ChannelData> {
             const val tag: Long = 0x47010000
             override fun read(input: Input): ChannelData = ChannelData(EncryptedChannelData(LightningCodecs.bytes(input, input.availableBytes).toByteVector()))
+        }
+    }
+
+    data class NextFunding(val txId: ByteVector32) : ChannelReestablishTlv() {
+        override val tag: Long get() = NextFunding.tag
+        override fun write(out: Output) = LightningCodecs.writeBytes(txId, out)
+
+        companion object : TlvValueReader<NextFunding> {
+            const val tag: Long = 333
+            override fun read(input: Input): NextFunding = NextFunding(LightningCodecs.bytes(input, 32).toByteVector32())
         }
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
@@ -169,9 +169,9 @@ sealed class ChannelReestablishTlv : Tlv {
         }
     }
 
-    data class NextFunding(val txId: ByteVector32) : ChannelReestablishTlv() {
+    data class NextFunding(val txHash: ByteVector32) : ChannelReestablishTlv() {
         override val tag: Long get() = NextFunding.tag
-        override fun write(out: Output) = LightningCodecs.writeBytes(txId, out)
+        override fun write(out: Output) = LightningCodecs.writeBytes(txHash, out)
 
         companion object : TlvValueReader<NextFunding> {
             const val tag: Long = 333

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -1063,6 +1063,7 @@ data class ChannelReestablish(
 ) : HasChannelId, HasEncryptedChannelData {
     override val type: Long get() = ChannelReestablish.type
 
+    val nextFundingTxId: ByteVector32? = tlvStream.get<ChannelReestablishTlv.NextFunding>()?.txId
     override val channelData: EncryptedChannelData get() = tlvStream.get<ChannelReestablishTlv.ChannelData>()?.ecb ?: EncryptedChannelData.empty
     override fun withNonEmptyChannelData(ecd: EncryptedChannelData): ChannelReestablish = copy(tlvStream = tlvStream.addOrUpdate(ChannelReestablishTlv.ChannelData(ecd)))
 
@@ -1079,7 +1080,10 @@ data class ChannelReestablish(
         const val type: Long = 136
 
         @Suppress("UNCHECKED_CAST")
-        val readers = mapOf(ChannelReestablishTlv.ChannelData.tag to ChannelReestablishTlv.ChannelData.Companion as TlvValueReader<ChannelReestablishTlv>)
+        val readers = mapOf(
+            ChannelReestablishTlv.ChannelData.tag to ChannelReestablishTlv.ChannelData.Companion as TlvValueReader<ChannelReestablishTlv>,
+            ChannelReestablishTlv.NextFunding.tag to ChannelReestablishTlv.NextFunding.Companion as TlvValueReader<ChannelReestablishTlv>,
+        )
 
         override fun read(input: Input): ChannelReestablish {
             return ChannelReestablish(

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -1063,7 +1063,7 @@ data class ChannelReestablish(
 ) : HasChannelId, HasEncryptedChannelData {
     override val type: Long get() = ChannelReestablish.type
 
-    val nextFundingTxId: ByteVector32? = tlvStream.get<ChannelReestablishTlv.NextFunding>()?.txId
+    val nextFundingTxId: ByteVector32? = tlvStream.get<ChannelReestablishTlv.NextFunding>()?.txHash?.reversed()
     override val channelData: EncryptedChannelData get() = tlvStream.get<ChannelReestablishTlv.ChannelData>()?.ecb ?: EncryptedChannelData.empty
     override fun withNonEmptyChannelData(ecd: EncryptedChannelData): ChannelReestablish = copy(tlvStream = tlvStream.addOrUpdate(ChannelReestablishTlv.ChannelData(ecd)))
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
@@ -66,7 +66,6 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertNotEquals(outputA1.pubkeyScript, outputA2.pubkeyScript)
         assertEquals(listOf(outputA1, outputA2).count { it.pubkeyScript == f.fundingParamsA.fundingPubkeyScript && it.amount == f.fundingParamsA.fundingAmount }, 1)
 
-        assertEquals(sharedTxA.sharedOutputIndex, sharedTxB.sharedOutputIndex)
         assertEquals(sharedTxA.sharedTx.localAmountIn, 145_000.sat)
         assertEquals(sharedTxA.sharedTx.remoteAmountIn, 100_000.sat)
         assertEquals(sharedTxA.sharedTx.totalAmountIn, 245_000.sat)
@@ -138,7 +137,6 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertNotEquals(outputA1.pubkeyScript, outputA2.pubkeyScript)
         assertEquals(listOf(outputA1, outputA2).count { it.pubkeyScript == f.fundingParamsA.fundingPubkeyScript && it.amount == f.fundingParamsA.fundingAmount }, 1)
 
-        assertEquals(sharedTxA.sharedOutputIndex, sharedTxB.sharedOutputIndex)
         assertEquals(sharedTxA.sharedTx.totalAmountIn, 130_000.sat)
         assertEquals(sharedTxA.sharedTx.fees, 3024.sat)
         assertTrue(sharedTxB.sharedTx.localFees < sharedTxA.sharedTx.localFees)
@@ -197,7 +195,6 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertNotEquals(outputA1.pubkeyScript, outputA2.pubkeyScript)
         assertEquals(listOf(outputA1, outputA2).count { it.pubkeyScript == f.fundingParamsA.fundingPubkeyScript && it.amount == f.fundingParamsA.fundingAmount }, 1)
 
-        assertEquals(sharedTxA.sharedOutputIndex, sharedTxB.sharedOutputIndex)
         assertEquals(sharedTxA.sharedTx.totalAmountIn, 350_000.sat)
         assertEquals(sharedTxA.sharedTx.fees, 5040.sat)
         assertTrue(sharedTxA.sharedTx.remoteFees < sharedTxA.sharedTx.localFees)
@@ -251,7 +248,6 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertNotEquals(outputA1.pubkeyScript, outputA2.pubkeyScript)
         assertEquals(listOf(outputA1, outputA2).count { it.pubkeyScript == f.fundingParamsA.fundingPubkeyScript && it.amount == f.fundingParamsA.fundingAmount }, 1)
 
-        assertEquals(sharedTxA.sharedOutputIndex, sharedTxB.sharedOutputIndex)
         assertEquals(sharedTxA.sharedTx.totalAmountIn, 200_000.sat)
         assertEquals(sharedTxA.sharedTx.fees, 2205.sat)
         assertEquals(sharedTxA.sharedTx.localFees, 2205.sat)
@@ -322,7 +318,6 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertNotEquals(outputA1.pubkeyScript, outputA2.pubkeyScript)
         assertEquals(listOf(outputA1, outputA2).count { it.pubkeyScript == f.fundingParamsA.fundingPubkeyScript && it.amount == f.fundingParamsA.fundingAmount }, 1)
 
-        assertEquals(sharedTxA.sharedOutputIndex, sharedTxB.sharedOutputIndex)
         assertEquals(sharedTxA.sharedTx.totalAmountIn, 315_000.sat)
         assertNotNull(sharedTxA.sharedTx.sharedInput)
         assertEquals(sharedTxA.sharedTx.localFees, 998.sat)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
@@ -156,14 +156,12 @@ class ClosingTestsCommon : LightningTestSuite() {
 
     @Test
     fun `recv BITCOIN_FUNDING_DEPTHOK -- previous funding tx`() {
-        val (alice, bob, txSigsBob, walletAlice) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs, alicePushAmount = 0.msat)
-        val (alice1, bob1) = WaitForFundingConfirmedTestsCommon.rbf(alice, bob, txSigsBob, walletAlice)
-        val fundingTxId = alice1.commitments.latest.fundingTxId
-        val previousFundingTx = alice1.state.previousFundingTxs.first().signedTx!!
-        assertNotEquals(previousFundingTx.txid, fundingTxId)
+        val (alice, bob, previousFundingTx, walletAlice) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs, alicePushAmount = 0.msat)
+        val (alice1, bob1, fundingTx) = WaitForFundingConfirmedTestsCommon.rbf(alice, bob, walletAlice)
+        assertNotEquals(previousFundingTx.txid, fundingTx.txid)
         run {
             val (aliceClosing, localCommitPublished) = localClose(alice1)
-            assertEquals(aliceClosing.commitments.latest.fundingTxId, fundingTxId)
+            assertEquals(aliceClosing.commitments.latest.fundingTxId, fundingTx.txid)
             assertEquals(aliceClosing.commitments.active.size, 2)
             val (alice2, actions2) = aliceClosing.process(ChannelCommand.WatchReceived(WatchEventConfirmed(alice.state.channelId, BITCOIN_FUNDING_DEPTHOK, 561, 3, previousFundingTx)))
             assertIs<LNChannel<Closing>>(alice2)
@@ -178,7 +176,7 @@ class ClosingTestsCommon : LightningTestSuite() {
         }
         run {
             val (bobClosing, localCommitPublished) = localClose(bob1)
-            assertEquals(bobClosing.commitments.latest.fundingTxId, fundingTxId)
+            assertEquals(bobClosing.commitments.latest.fundingTxId, fundingTx.txid)
             assertEquals(bobClosing.commitments.active.size, 2)
             val (bob2, actions2) = bobClosing.process(ChannelCommand.WatchReceived(WatchEventConfirmed(bob.state.channelId, BITCOIN_FUNDING_DEPTHOK, 561, 3, previousFundingTx)))
             assertIs<LNChannel<Closing>>(bob2)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
@@ -8,7 +8,6 @@ import fr.acinq.lightning.blockchain.*
 import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.channel.TestsHelper.htlcSuccessTxs
 import fr.acinq.lightning.channel.TestsHelper.htlcTimeoutTxs
-
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.utils.UUID
@@ -27,10 +26,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val remoteInit = Init(ByteVector(bob.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actions) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         val channelReestablishA = actions.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actions1) = bob1.process(ChannelCommand.Connected(remoteInit, localInit))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         val channelReestablishB = actions1.findOutgoingMessage<ChannelReestablish>()
 
         val bobCommitments = bob.commitments
@@ -88,10 +87,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val remoteInit = Init(ByteVector(bob0.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         val channelReestablishA = actionsAlice2.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.Connected(remoteInit, localInit))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>()
 
         val bobCommitments = bob0.commitments
@@ -131,11 +130,11 @@ class OfflineTestsCommon : LightningTestSuite() {
 
         val (alice4, _) = alice3.process(ChannelCommand.MessageReceived(revB))
         val (alice5, actionsAlice5) = alice4.process(ChannelCommand.MessageReceived(sigB))
-        assertIs<LNChannel<Normal>>(alice5)
+        assertIs<Normal>(alice5.state)
         val revA = actionsAlice5.hasOutgoingMessage<RevokeAndAck>()
 
         val (bob7, _) = bob6.process(ChannelCommand.MessageReceived(revA))
-        assertIs<LNChannel<Normal>>(bob7)
+        assertIs<Normal>(bob7.state)
 
         assertEquals(1, alice5.commitments.changes.localNextHtlcId)
         assertEquals(1, bob7.commitments.changes.remoteNextHtlcId)
@@ -167,10 +166,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val remoteInit = Init(ByteVector(bob0.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         val channelReestablishA = actionsAlice2.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.Connected(remoteInit, localInit))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>()
 
         val bobCommitments = bob0.commitments
@@ -201,11 +200,11 @@ class OfflineTestsCommon : LightningTestSuite() {
 
         val (alice4, _) = alice3.process(ChannelCommand.MessageReceived(revB))
         val (alice5, actionsAlice5) = alice4.process(ChannelCommand.MessageReceived(sigB))
-        assertIs<LNChannel<Normal>>(alice5)
+        assertIs<Normal>(alice5.state)
         val revA = actionsAlice5.hasOutgoingMessage<RevokeAndAck>()
 
         val (bob4, _) = bob3.process(ChannelCommand.MessageReceived(revA))
-        assertIs<LNChannel<Normal>>(bob4)
+        assertIs<Normal>(bob4.state)
 
         assertEquals(1, alice5.commitments.changes.localNextHtlcId)
         assertEquals(1, bob4.commitments.changes.remoteNextHtlcId)
@@ -235,10 +234,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val initA = Init(ByteVector(alice0.commitments.params.localParams.features.toByteArray()))
         val initB = Init(ByteVector(bob0.commitments.params.localParams.features.toByteArray()))
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(initA, initB))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         val channelReestablishA = actionsAlice2.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.Connected(initB, initA))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>()
         assertEquals(channelReestablishA.nextLocalCommitmentNumber, 4)
         assertEquals(channelReestablishA.nextRemoteRevocationNumber, 3)
@@ -264,8 +263,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (bob5, actionsBob5) = bob4.process(ChannelCommand.MessageReceived(revA))
         assertTrue(actionsBob5.filterIsInstance<ChannelAction.Message.Send>().isEmpty())
 
-        assertIs<LNChannel<Normal>>(alice5)
-        assertIs<LNChannel<Normal>>(bob5)
+        assertIs<Normal>(alice5.state)
+        assertIs<Normal>(bob5.state)
         assertEquals(4, alice5.commitments.localCommitIndex)
         assertEquals(4, bob5.commitments.localCommitIndex)
     }
@@ -301,10 +300,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val remoteInit = Init(ByteVector(bob.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         val channelReestablishA = actionsAlice2.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.Connected(remoteInit, localInit))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         val channelReestablishB = actionsBob2.findOutgoingMessage<ChannelReestablish>()
 
         // alice realizes she has an old state...
@@ -312,18 +311,18 @@ class OfflineTestsCommon : LightningTestSuite() {
         // ...and asks bob to publish its current commitment
         val error = actionsAlice3.findOutgoingMessage<Error>()
         assertEquals(error.toAscii(), PleasePublishYourCommitment(aliceOld.channelId).message)
-        assertIs<LNChannel<WaitForRemotePublishFutureCommitment>>(alice3)
+        assertIs<WaitForRemotePublishFutureCommitment>(alice3.state)
 
         // bob is nice and publishes its commitment as soon as it detects that alice has an outdated commitment
         val (bob3, actionsBob3) = bob2.process(ChannelCommand.MessageReceived(channelReestablishA))
-        assertIs<LNChannel<Closing>>(bob3)
+        assertIs<Closing>(bob3.state)
         assertNotNull(bob3.state.localCommitPublished)
         val bobCommitTx = bob3.state.localCommitPublished!!.commitTx
         actionsBob3.hasTx(bobCommitTx)
 
         // alice is able to claim her main output
         val (alice4, actionsAlice4) = alice3.process(ChannelCommand.WatchReceived(WatchEventSpent(aliceOld.channelId, BITCOIN_FUNDING_SPENT, bobCommitTx)))
-        assertIs<LNChannel<Closing>>(alice4)
+        assertIs<Closing>(alice4.state)
         assertNotNull(alice4.state.futureRemoteCommitPublished)
         assertEquals(bobCommitTx, alice4.state.futureRemoteCommitPublished!!.commitTx)
         assertNotNull(alice4.state.futureRemoteCommitPublished!!.claimMainOutputTx)
@@ -341,15 +340,15 @@ class OfflineTestsCommon : LightningTestSuite() {
         val localInit = Init(ByteVector(alice0.commitments.params.localParams.features.toByteArray()))
         val remoteInit = Init(ByteVector(bob0.commitments.params.localParams.features.toByteArray()))
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         actionsAlice2.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.Connected(remoteInit, localInit))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         val invalidReestablish = actionsBob2.findOutgoingMessage<ChannelReestablish>().copy(nextRemoteRevocationNumber = 42)
 
         // Alice then asks Bob to publish his commitment to find out if Bob is lying.
         val (alice3, actionsAlice3) = alice2.process(ChannelCommand.MessageReceived(invalidReestablish))
-        assertIs<LNChannel<WaitForRemotePublishFutureCommitment>>(alice3)
+        assertIs<WaitForRemotePublishFutureCommitment>(alice3.state)
         assertEquals(alice3.state.remoteChannelReestablish, invalidReestablish)
         assertEquals(actionsAlice3.size, 2)
         val error = actionsAlice3.hasOutgoingMessage<Error>()
@@ -381,20 +380,20 @@ class OfflineTestsCommon : LightningTestSuite() {
 
         // Bob's wallet disconnects, but doesn't restart.
         val (bob1, _) = bob.process(ChannelCommand.Disconnected)
-        assertIs<LNChannel<Offline>>(bob1)
+        assertIs<Offline>(bob1.state)
 
         // Alice's wallet restarts.
         val initState = LNChannel(alice.ctx, WaitForInit)
         val (alice1, actions1) = initState.process(ChannelCommand.Restore(alice.state))
         assertEquals(1, actions1.size)
         actions1.hasWatch<WatchSpent>()
-        assertIs<LNChannel<Offline>>(alice1)
+        assertIs<Offline>(alice1.state)
 
         val localInit = Init(ByteVector(alice.commitments.params.localParams.features.toByteArray()))
         val remoteInit = Init(ByteVector(bob.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         assertTrue(actionsAlice2.filterIsInstance<ChannelAction.ProcessIncomingHtlc>().isEmpty())
         val channelReestablishAlice = actionsAlice2.hasOutgoingMessage<ChannelReestablish>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.Connected(localInit, remoteInit))
@@ -447,8 +446,8 @@ class OfflineTestsCommon : LightningTestSuite() {
 
         val (alice2, actionsAlice) = alice1.process(ChannelCommand.Connected(aliceInit, bobInit))
         val (bob2, _) = bob1.process(ChannelCommand.Connected(bobInit, aliceInit))
-        assertIs<LNChannel<Syncing>>(alice2)
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(alice2.state)
+        assertIs<Syncing>(bob2.state)
         val channelReestablishAlice = actionsAlice.hasOutgoingMessage<ChannelReestablish>()
 
         // Bob resends htlc settlement messages to Alice and reprocesses unsettled htlcs.
@@ -472,59 +471,51 @@ class OfflineTestsCommon : LightningTestSuite() {
         val remoteInit = Init(ByteVector(bob.commitments.params.localParams.features.toByteArray()))
 
         val (alice2, actions) = alice1.process(ChannelCommand.Connected(localInit, remoteInit))
-        assertIs<LNChannel<Syncing>>(alice2)
+        assertIs<Syncing>(alice2.state)
         actions.findOutgoingMessage<ChannelReestablish>()
         val (bob2, actions1) = bob1.process(ChannelCommand.Connected(remoteInit, localInit))
-        assertIs<LNChannel<Syncing>>(bob2)
+        assertIs<Syncing>(bob2.state)
         // Bob waits to receive Alice's channel reestablish before sending his own.
         assertTrue(actions1.isEmpty())
     }
 
     @Test
     fun `republish unconfirmed funding tx after restart`() {
-        val (alice, bob, txSigsBob) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs, alicePushAmount = 0.msat)
-        val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(txSigsBob))
-        assertIs<LNChannel<WaitForFundingConfirmed>>(alice1)
-        val fundingTx = actionsAlice1.find<ChannelAction.Blockchain.PublishTx>().tx
-        assertEquals(fundingTx.hash, alice1.state.latestFundingTx.sharedTx.localSigs.txHash)
-        val (bob1, _) = bob.process(ChannelCommand.MessageReceived(alice1.state.latestFundingTx.sharedTx.localSigs))
-        assertIs<LNChannel<WaitForFundingConfirmed>>(bob1)
+        val (alice, bob, fundingTx) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs, alicePushAmount = 0.msat)
         // Alice restarts:
-        val (alice2, actionsAlice2) = LNChannel(alice1.ctx, WaitForInit).process(ChannelCommand.Restore(alice1.state))
-        assertEquals(alice2.state, Offline(alice1.state))
-        assertEquals(actionsAlice2.size, 2)
-        actionsAlice2.hasTx(fundingTx)
-        assertEquals(actionsAlice2.findWatch<WatchConfirmed>().txId, fundingTx.txid)
+        val (alice1, actionsAlice1) = LNChannel(alice.ctx, WaitForInit).process(ChannelCommand.Restore(alice.state))
+        assertEquals(alice1.state, Offline(alice.state))
+        assertEquals(actionsAlice1.size, 2)
+        actionsAlice1.hasTx(fundingTx)
+        assertEquals(actionsAlice1.findWatch<WatchConfirmed>().txId, fundingTx.txid)
         // Bob restarts:
-        val (bob2, actionsBob2) = LNChannel(bob1.ctx, WaitForInit).process(ChannelCommand.Restore(bob1.state))
-        assertEquals(bob2.state, Offline(bob1.state))
-        assertEquals(actionsBob2.size, 2)
-        actionsBob2.hasTx(fundingTx)
-        assertEquals(actionsBob2.findWatch<WatchConfirmed>().txId, fundingTx.txid)
+        val (bob1, actionsBob1) = LNChannel(bob.ctx, WaitForInit).process(ChannelCommand.Restore(bob.state))
+        assertEquals(bob1.state, Offline(bob.state))
+        assertEquals(actionsBob1.size, 2)
+        actionsBob1.hasTx(fundingTx)
+        assertEquals(actionsBob1.findWatch<WatchConfirmed>().txId, fundingTx.txid)
     }
 
     @Test
     fun `republish unconfirmed funding tx with previous funding txs after restart`() {
-        val (alice, bob, txSigs, walletAlice) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs)
-        val (alice1, bob1) = WaitForFundingConfirmedTestsCommon.rbf(alice, bob, txSigs, walletAlice)
+        val (alice, bob, previousFundingTx, walletAlice) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs)
+        val (alice1, bob1, fundingTx) = WaitForFundingConfirmedTestsCommon.rbf(alice, bob, walletAlice)
         assertEquals(alice1.commitments.active.size, 2)
-        val fundingTx1 = alice1.commitments.active.last().localFundingStatus.signedTx!!
-        val fundingTx2 = alice1.commitments.active.first().localFundingStatus.signedTx!!
-        assertNotEquals(fundingTx1.txid, fundingTx2.txid)
+        assertNotEquals(previousFundingTx.txid, fundingTx.txid)
         // Alice restarts:
         val (alice2, actionsAlice2) = LNChannel(alice1.ctx, WaitForInit).process(ChannelCommand.Restore(alice1.state))
         assertEquals(alice2.state, Offline(alice1.state))
         assertEquals(actionsAlice2.size, 4)
-        actionsAlice2.hasTx(fundingTx1)
-        actionsAlice2.hasTx(fundingTx2)
-        assertEquals(actionsAlice2.findWatches<WatchConfirmed>().map { it.txId }.toSet(), setOf(fundingTx1.txid, fundingTx2.txid))
+        actionsAlice2.hasTx(previousFundingTx)
+        actionsAlice2.hasTx(fundingTx)
+        assertEquals(actionsAlice2.findWatches<WatchConfirmed>().map { it.txId }.toSet(), setOf(previousFundingTx.txid, fundingTx.txid))
         // Bob restarts:
         val (bob2, actionsBob2) = LNChannel(bob1.ctx, WaitForInit).process(ChannelCommand.Restore(bob1.state))
         assertEquals(bob2.state, Offline(bob1.state))
-        assertEquals(actionsBob2.size, 2)
-        // Bob doesn't have Alice's signatures, so he cannot publish the funding transactions.
-        bob1.commitments.active.forEach { assertNull(it.localFundingStatus.signedTx) }
-        assertEquals(actionsBob2.findWatches<WatchConfirmed>().map { it.txId }.toSet(), setOf(fundingTx1.txid, fundingTx2.txid))
+        assertEquals(actionsBob2.size, 4)
+        actionsBob2.hasTx(previousFundingTx)
+        actionsBob2.hasTx(fundingTx)
+        assertEquals(actionsBob2.findWatches<WatchConfirmed>().map { it.txId }.toSet(), setOf(previousFundingTx.txid, fundingTx.txid))
     }
 
     @Test
@@ -535,13 +526,13 @@ class OfflineTestsCommon : LightningTestSuite() {
         assertIs<WaitForFundingConfirmed>(alice1.state.state)
         assertIs<WaitForFundingConfirmed>(bob1.state.state)
         val (alice2, actionsAlice2) = alice1.process(ChannelCommand.WatchReceived(WatchEventConfirmed(alice.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)))
-        assertIs<LNChannel<Offline>>(alice2)
+        assertIs<Offline>(alice2.state)
         assertIs<WaitForChannelReady>(alice2.state.state)
         assertEquals(actionsAlice2.size, 2)
         assertEquals(actionsAlice2.hasWatch<WatchSpent>().txId, fundingTx.txid)
         actionsAlice2.has<ChannelAction.Storage.StoreState>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.WatchReceived(WatchEventConfirmed(bob.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, fundingTx)))
-        assertIs<LNChannel<Offline>>(bob2)
+        assertIs<Offline>(bob2.state)
         assertIs<WaitForChannelReady>(bob2.state.state)
         assertEquals(actionsBob2.size, 2)
         assertEquals(actionsBob2.hasWatch<WatchSpent>().txId, fundingTx.txid)
@@ -550,14 +541,13 @@ class OfflineTestsCommon : LightningTestSuite() {
 
     @Test
     fun `recv BITCOIN_FUNDING_DEPTHOK -- previous funding tx`() {
-        val (alice, bob, txSigsBob, walletAlice) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs, alicePushAmount = 0.msat)
-        val (alice1, bob1) = WaitForFundingConfirmedTestsCommon.rbf(alice, bob, txSigsBob, walletAlice)
-        val previousFundingTx = alice1.state.previousFundingTxs.first().signedTx!!
+        val (alice, bob, previousFundingTx, walletAlice) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs, alicePushAmount = 0.msat)
+        val (alice1, bob1) = WaitForFundingConfirmedTestsCommon.rbf(alice, bob, walletAlice)
         val (alice2, bob2) = disconnect(alice1, bob1)
         assertIs<WaitForFundingConfirmed>(alice2.state.state)
         assertIs<WaitForFundingConfirmed>(bob2.state.state)
         val (alice3, actionsAlice3) = alice2.process(ChannelCommand.WatchReceived(WatchEventConfirmed(alice.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, previousFundingTx)))
-        assertIs<LNChannel<Offline>>(alice3)
+        assertIs<Offline>(alice3.state)
         val aliceState3 = alice3.state.state
         assertIs<WaitForChannelReady>(aliceState3)
         assertEquals(aliceState3.commitments.active.size, 1)
@@ -566,7 +556,7 @@ class OfflineTestsCommon : LightningTestSuite() {
         assertEquals(actionsAlice3.hasWatch<WatchSpent>().txId, previousFundingTx.txid)
         actionsAlice3.has<ChannelAction.Storage.StoreState>()
         val (bob3, actionsBob3) = bob2.process(ChannelCommand.WatchReceived(WatchEventConfirmed(bob.channelId, BITCOIN_FUNDING_DEPTHOK, 42, 0, previousFundingTx)))
-        assertIs<LNChannel<Offline>>(bob3)
+        assertIs<Offline>(bob3.state)
         val bobState3 = bob3.state.state
         assertIs<WaitForChannelReady>(bobState3)
         assertEquals(bobState3.commitments.active.size, 1)
@@ -582,10 +572,10 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (nodes, _, _) = TestsHelper.addHtlc(50_000_000.msat, alice0, bob0)
         val (alice1, _) = TestsHelper.crossSign(nodes.first, nodes.second)
         val (alice2, _) = alice1.process(ChannelCommand.Disconnected)
-        assertIs<LNChannel<Offline>>(alice2)
+        assertIs<Offline>(alice2.state)
 
         val (alice3, actions3) = alice2.process(ChannelCommand.CheckHtlcTimeout)
-        assertIs<LNChannel<Offline>>(alice3)
+        assertIs<Offline>(alice3.state)
         assertEquals(alice2.state.state, alice3.state.state)
         assertTrue(actions3.isEmpty())
     }
@@ -596,7 +586,7 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (nodes, _, htlc) = TestsHelper.addHtlc(50_000_000.msat, alice0, bob0)
         val (alice1, _) = TestsHelper.crossSign(nodes.first, nodes.second)
         val (alice2, _) = alice1.process(ChannelCommand.Disconnected)
-        assertIs<LNChannel<Offline>>(alice2)
+        assertIs<Offline>(alice2.state)
 
         // alice restarted after the htlc timed out
         val alice3 = alice2.copy(
@@ -604,7 +594,7 @@ class OfflineTestsCommon : LightningTestSuite() {
             state = alice2.state.state
         )
         val (alice4, actions) = alice3.process(ChannelCommand.CheckHtlcTimeout)
-        assertIs<LNChannel<Closing>>(alice4)
+        assertIs<Closing>(alice4.state)
         assertNotNull(alice4.state.localCommitPublished)
         actions.hasOutgoingMessage<Error>()
         actions.has<ChannelAction.Storage.StoreState>()
@@ -625,14 +615,14 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (bob2, actions2) = bob1.process(ChannelCommand.ExecuteCommand(CMD_FULFILL_HTLC(htlc.id, preimage)))
         actions2.hasOutgoingMessage<UpdateFulfillHtlc>()
         val (bob3, _) = bob2.process(ChannelCommand.Disconnected)
-        assertIs<LNChannel<Offline>>(bob3)
+        assertIs<Offline>(bob3.state)
 
         // bob restarts when the fulfilled htlc is close to timing out: alice hasn't signed, so bob closes the channel
         val (bob4, actions4) = run {
             val tmp = bob3.copy(ctx = bob3.ctx.copy(currentBlockHeight = htlc.cltvExpiry.toLong().toInt()))
             tmp.process(ChannelCommand.CheckHtlcTimeout)
         }
-        assertIs<LNChannel<Closing>>(bob4)
+        assertIs<Closing>(bob4.state)
         assertNotNull(bob4.state.localCommitPublished)
         actions4.has<ChannelAction.Storage.StoreState>()
 
@@ -655,12 +645,115 @@ class OfflineTestsCommon : LightningTestSuite() {
     fun `recv CMD_FORCECLOSE`() {
         val (alice, _) = TestsHelper.reachNormal()
         val (alice1, _) = alice.process(ChannelCommand.Disconnected)
-        assertIs<LNChannel<Offline>>(alice1)
-        val commitTx = alice1.state.state.commitments.latest.localCommit.publishableTxs.commitTx.tx
+        assertIs<Offline>(alice1.state)
+        val commitTx = alice1.commitments.latest.localCommit.publishableTxs.commitTx.tx
         val (alice2, actions2) = alice1.process(ChannelCommand.ExecuteCommand(CMD_FORCECLOSE))
-        assertIs<LNChannel<Closing>>(alice2)
+        assertIs<Closing>(alice2.state)
         actions2.hasTx(commitTx)
         assertNull(actions2.findOutgoingMessageOpt<Error>()) // we're offline so we shouldn't try to send messages
+    }
+
+    @Test
+    fun `forget unsigned channel`() {
+        val (alice, bob, fundingTxId) = run {
+            val (alice, bob, inputAlice) = WaitForFundingCreatedTestsCommon.init()
+            val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(inputAlice))
+            val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(actionsBob1.findOutgoingMessage<TxAddInput>()))
+            val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(actionsAlice1.findOutgoingMessage<TxAddOutput>()))
+            val (alice2, actionsAlice2) = alice1.process(ChannelCommand.MessageReceived(actionsBob2.findOutgoingMessage<TxComplete>()))
+            actionsAlice2.hasOutgoingMessage<TxComplete>()
+            actionsAlice2.hasOutgoingMessage<CommitSig>()
+            assertIs<WaitForFundingCreated>(bob2.state)
+            assertIs<WaitForFundingSigned>(alice2.state)
+            Triple(alice2, bob2, alice2.state.signingSession.fundingTx.txId)
+        }
+
+        // Bob has not received Alice's tx_complete, so he's not storing the channel.
+        val (bob1, _) = bob.process(ChannelCommand.Disconnected)
+        assertIs<Aborted>(bob1.state)
+
+        // On reconnection, Alice tries to resume the signing session.
+        val (alice1, _) = alice.process(ChannelCommand.Disconnected)
+        assertIs<Offline>(alice1.state)
+        val (alice2, _) = LNChannel(alice1.ctx, WaitForInit).process(ChannelCommand.Restore(alice1.state.state))
+        assertIs<Offline>(alice2.state)
+        val aliceInit = Init(ByteVector((alice.state as WaitForFundingSigned).channelParams.localParams.features.toByteArray()))
+        val bobInit = Init(ByteVector((bob.state as WaitForFundingCreated).localParams.features.toByteArray()))
+        val (alice3, actions3) = alice2.process(ChannelCommand.Connected(aliceInit, bobInit))
+        assertIs<Syncing>(alice3.state)
+        assertEquals(alice.state, alice3.state.state)
+        assertEquals(actions3.size, 1)
+        assertEquals(actions3.hasOutgoingMessage<ChannelReestablish>().nextFundingTxId, fundingTxId)
+        // When receiving Bob's error, Alice forgets the channel.
+        val (alice4, actions4) = alice3.process(ChannelCommand.MessageReceived(Error(alice.channelId, "unknown channel")))
+        assertIs<Aborted>(alice4.state)
+        assertTrue(actions4.isEmpty())
+    }
+
+    @Test
+    fun `forget unsigned rbf attempt`() {
+        val (alice, bob, rbfFundingTxId) = run {
+            val (alice, bob, _, wallet) = WaitForFundingConfirmedTestsCommon.init()
+            val command = WaitForFundingConfirmedTestsCommon.createRbfCommand(alice, wallet)
+            val (alice1, actionsAlice1) = alice.process(ChannelCommand.ExecuteCommand(command))
+            val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(actionsAlice1.findOutgoingMessage<TxInitRbf>()))
+            val (alice2, actionsAlice2) = alice1.process(ChannelCommand.MessageReceived(actionsBob1.findOutgoingMessage<TxAckRbf>()))
+            val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(actionsAlice2.findOutgoingMessage<TxAddInput>()))
+            val (alice3, actionsAlice3) = alice2.process(ChannelCommand.MessageReceived(actionsBob2.findOutgoingMessage<TxAddInput>()))
+            val (bob3, actionsBob3) = bob2.process(ChannelCommand.MessageReceived(actionsAlice3.findOutgoingMessage<TxAddInput>()))
+            val (alice4, actionsAlice4) = alice3.process(ChannelCommand.MessageReceived(actionsBob3.findOutgoingMessage<TxComplete>()))
+            val (bob4, actionsBob4) = bob3.process(ChannelCommand.MessageReceived(actionsAlice4.findOutgoingMessage<TxAddOutput>()))
+            val (alice5, actionsAlice5) = alice4.process(ChannelCommand.MessageReceived(actionsBob4.findOutgoingMessage<TxComplete>()))
+            actionsAlice5.hasOutgoingMessage<TxComplete>()
+            actionsAlice5.hasOutgoingMessage<CommitSig>()
+            actionsAlice5.has<ChannelAction.Storage.StoreState>()
+            assertIs<WaitForFundingConfirmed>(bob4.state)
+            assertIs<RbfStatus.InProgress>(bob4.state.rbfStatus)
+            assertIs<WaitForFundingConfirmed>(alice5.state)
+            assertIs<RbfStatus.WaitingForSigs>(alice5.state.rbfStatus)
+            Triple(alice5, bob4, (alice5.state.rbfStatus as RbfStatus.WaitingForSigs).session.fundingTx.txId)
+        }
+
+        val aliceInit = Init(ByteVector(alice.commitments.params.localParams.features.toByteArray()))
+        val bobInit = Init(ByteVector(bob.commitments.params.localParams.features.toByteArray()))
+
+        // Bob has not received Alice's tx_complete, so he's not storing the RBF attempt.
+        val (bob1, _) = bob.process(ChannelCommand.Disconnected)
+        assertIs<Offline>(bob1.state)
+        assertIs<WaitForFundingConfirmed>(bob1.state.state)
+        assertEquals((bob1.state.state as WaitForFundingConfirmed).rbfStatus, RbfStatus.None)
+
+        // Alice has sent commit_sig, so she's storing the RBF attempt.
+        val (alice1, _) = alice.process(ChannelCommand.Disconnected)
+        assertIs<Offline>(alice1.state)
+        assertIs<WaitForFundingConfirmed>(alice1.state.state)
+        assertIs<RbfStatus.WaitingForSigs>((alice1.state.state as WaitForFundingConfirmed).rbfStatus)
+
+        // On reconnection, Alice tries to resume the RBF signing session: Bob reacts by aborting it.
+        val (alice2, _) = LNChannel(alice1.ctx, WaitForInit).process(ChannelCommand.Restore(alice1.state.state))
+        val (bob2, _) = LNChannel(bob1.ctx, WaitForInit).process(ChannelCommand.Restore(bob1.state.state))
+        val (alice3, actionsAlice3) = alice2.process(ChannelCommand.Connected(aliceInit, bobInit))
+        assertIs<Syncing>(alice3.state)
+        val channelReestablishAlice = actionsAlice3.hasOutgoingMessage<ChannelReestablish>()
+        assertEquals(channelReestablishAlice.nextFundingTxId, rbfFundingTxId)
+        val (bob3, actionsBob3) = bob2.process(ChannelCommand.Connected(bobInit, aliceInit))
+        assertIs<Syncing>(bob3.state)
+        assertTrue(actionsBob3.isEmpty())
+        val (bob4, actionsBob4) = bob3.process(ChannelCommand.MessageReceived(channelReestablishAlice))
+        assertIs<WaitForFundingConfirmed>(bob4.state)
+        val channelReestablishBob = actionsBob4.hasOutgoingMessage<ChannelReestablish>()
+        assertNull(channelReestablishBob.nextFundingTxId)
+        val txAbortBob = actionsBob4.hasOutgoingMessage<TxAbort>()
+        assertEquals(bob4.state.rbfStatus, RbfStatus.RbfAborted)
+        val (alice4, actionsAlice4) = alice3.process(ChannelCommand.MessageReceived(channelReestablishBob))
+        assertIs<WaitForFundingConfirmed>(alice4.state)
+        assertIs<RbfStatus.WaitingForSigs>(alice4.state.rbfStatus)
+        assertTrue(actionsAlice4.isEmpty())
+        val (alice5, actionsAlice5) = alice4.process(ChannelCommand.MessageReceived(txAbortBob))
+        assertIs<WaitForFundingConfirmed>(alice5.state)
+        assertEquals(alice5.state.rbfStatus, RbfStatus.None)
+        assertEquals(alice5.state.commitments.active.size, 1)
+        actionsAlice5.hasOutgoingMessage<TxAbort>()
     }
 
     @Test
@@ -676,7 +769,7 @@ class OfflineTestsCommon : LightningTestSuite() {
 
         val state = LNChannel(bob.ctx, WaitForInit)
         val (state1, actions) = state.process(ChannelCommand.Restore(bob.state))
-        assertIs<LNChannel<Closing>>(state1)
+        assertIs<Closing>(state1.state)
         assertEquals(4, actions.size)
         val watchSpent = actions.hasWatch<WatchSpent>()
         assertEquals(bob.commitments.latest.commitInput.outPoint.txid, watchSpent.txId)

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/RouteCalculationTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/RouteCalculationTestsCommon.kt
@@ -46,7 +46,7 @@ class RouteCalculationTestsCommon : LightningTestSuite() {
             channelId2 to Offline(makeChannel(channelId2, 20_000.msat, 5.msat)),
             channelId3 to Offline(makeChannel(channelId3, 10_000.msat, 10.msat)),
         )
-        assertEquals(setOf(10_000.msat, 15_000.msat, 20_000.msat), offlineChannels.map { it.value.state.commitments.availableBalanceForSend() }.toSet())
+        assertEquals(setOf(10_000.msat, 15_000.msat, 20_000.msat), offlineChannels.map { (it.value.state as Normal).commitments.availableBalanceForSend() }.toSet())
 
         val normalChannels = mapOf(
             channelId1 to makeChannel(channelId1, 15_000.msat, 10.msat),

--- a/src/commonTest/kotlin/fr/acinq/lightning/serialization/CompatibilityTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/serialization/CompatibilityTestsCommon.kt
@@ -22,13 +22,7 @@ class CompatibilityTestsCommon {
     @Test
     fun `generate data`() {
         // generate test data
-        val (alice, bob, fundingTx) = run {
-            val (alice0, bob0, txSigsBob) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs)
-            val (alice1, actions1) = alice0.process(ChannelCommand.MessageReceived(txSigsBob))
-            assertIs<LNChannel<WaitForFundingConfirmed>>(alice1)
-            val fundingTx = actions1.find<ChannelAction.Blockchain.PublishTx>().tx
-            Triple(alice1, bob0, fundingTx)
-        }
+        val (alice, bob, fundingTx) = WaitForFundingConfirmedTestsCommon.init(ChannelType.SupportedChannelType.AnchorOutputs)
         println("funding_tx: ${Transaction.write(fundingTx).byteVector().toHex()}")
         val bin = EncryptedChannelData.from(TestConstants.Bob.nodeParams.nodePrivateKey, bob.state)
         println("wait_for_funding_confirmed: ${bin.data}")

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -383,11 +383,11 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
         val channelId = ByteVector32("c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c")
         val commitmentSecret = PrivateKey.fromHex("34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55")
         val commitmentPoint = PublicKey.fromHex("02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867")
-        val fundingTxId = ByteVector32("24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566")
+        val fundingTxHash = ByteVector32("24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566")
         val testCases = listOf(
             // @formatter:off
             ChannelReestablish(channelId, 242842, 42, commitmentSecret, commitmentPoint) to ByteVector("0088 c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c 000000000003b49a 000000000000002a 34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55 02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867"),
-            ChannelReestablish(channelId, 242842, 42, commitmentSecret, commitmentPoint, TlvStream(listOf(ChannelReestablishTlv.NextFunding(fundingTxId)))) to ByteVector("0088 c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c 000000000003b49a 000000000000002a 34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55 02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867 fd014d 20 24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566")
+            ChannelReestablish(channelId, 242842, 42, commitmentSecret, commitmentPoint, TlvStream(listOf(ChannelReestablishTlv.NextFunding(fundingTxHash)))) to ByteVector("0088 c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c 000000000003b49a 000000000000002a 34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55 02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867 fd014d 20 24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566")
             // @formatter:on
         )
         testCases.forEach { (message, bin) ->

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -380,17 +380,23 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
 
     @Test
     fun `encode - decode channel_reestablish`() {
-        val channelReestablish = ChannelReestablish(
-            ByteVector32("c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c"),
-            242842,
-            42,
-            PrivateKey.fromHex("34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55"),
-            PublicKey.fromHex("02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867")
+        val channelId = ByteVector32("c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c")
+        val commitmentSecret = PrivateKey.fromHex("34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55")
+        val commitmentPoint = PublicKey.fromHex("02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867")
+        val fundingTxId = ByteVector32("24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566")
+        val testCases = listOf(
+            // @formatter:off
+            ChannelReestablish(channelId, 242842, 42, commitmentSecret, commitmentPoint) to ByteVector("0088 c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c 000000000003b49a 000000000000002a 34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55 02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867"),
+            ChannelReestablish(channelId, 242842, 42, commitmentSecret, commitmentPoint, TlvStream(listOf(ChannelReestablishTlv.NextFunding(fundingTxId)))) to ByteVector("0088 c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c 000000000003b49a 000000000000002a 34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55 02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867 fd014d 20 24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566")
+            // @formatter:on
         )
-        val encoded = LightningMessage.encode(channelReestablish)
-        val expected =
-            "0088c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c000000000003b49a000000000000002a34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b5502bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867"
-        assertEquals(expected, Hex.encode(encoded))
+        testCases.forEach { (message, bin) ->
+            val decoded = LightningMessage.decode(bin.toByteArray())
+            assertNotNull(decoded)
+            assertEquals(decoded, message)
+            val encoded = LightningMessage.encode(message)
+            assertEquals(encoded.byteVector(), bin)
+        }
     }
 
     @Test


### PR DESCRIPTION
We must store the channel state after sending our `tx_signatures`, because our peer may broadcast the transaction at that point. But it's useful to store it earlier than that, to allow resuming the signatures exchange if we get disconnected, otherwise we could end up in a state where one peer has forgotten the channel while the other has sent `tx_signatures` and must thus wait for the channel to be spent or double-spent.

With that change, we can cleanly handle any disconnection:

- if we get disconnected before any peer sent `commitment_signed`, the channel is forgotten by both peers
- if we get disconnected after one peer send `commitment_signed` but the other peer didn't, the channel will be forgotten when reconnecting (this is safe because the peer that sent `commitment_signed` did *not* send `tx_signatures` since the other peer didn't send `commitment_signed`)
- if we get disconnected after both peers sent `commitment_signed`, we simply resume the signatures exchange on reconnection

We introduce a new TLV field to `channel_reestablish` that contains the `txid` of the funding transaction that is partially signed: this lets peers figure out which messages to send back on reconnection.

See https://github.com/lightning/bolts/pull/851#discussion_r1135205227 for more details.