### PR TITLE
(Minor) Remove unused ClaimP2WPKHOutputTx

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
@@ -142,7 +142,7 @@ object Deserialization {
 
     private fun Input.readRemoteCommitPublished(): RemoteCommitPublished = RemoteCommitPublished(
         commitTx = readTransaction(),
-        claimMainOutputTx = readNullable { readTransactionWithInputInfo() as ClaimRemoteCommitMainOutputTx },
+        claimMainOutputTx = readNullable { readTransactionWithInputInfo() as ClaimRemoteCommitMainOutputTx.ClaimRemoteDelayedOutputTx },
         claimHtlcTxs = readCollection { readOutPoint() to readNullable { readTransactionWithInputInfo() as ClaimHtlcTx } }.toMap(),
         claimAnchorTxs = readCollection { readTransactionWithInputInfo() as ClaimAnchorOutputTx }.toList(),
         irrevocablySpent = readIrrevocablySpent()
@@ -151,7 +151,7 @@ object Deserialization {
     private fun Input.readRevokedCommitPublished(): RevokedCommitPublished = RevokedCommitPublished(
         commitTx = readTransaction(),
         remotePerCommitmentSecret = PrivateKey(readByteVector32()),
-        claimMainOutputTx = readNullable { readTransactionWithInputInfo() as ClaimRemoteCommitMainOutputTx },
+        claimMainOutputTx = readNullable { readTransactionWithInputInfo() as ClaimRemoteCommitMainOutputTx.ClaimRemoteDelayedOutputTx },
         mainPenaltyTx = readNullable { readTransactionWithInputInfo() as MainPenaltyTx },
         htlcPenaltyTxs = readCollection { readTransactionWithInputInfo() as HtlcPenaltyTx }.toList(),
         claimHtlcDelayedPenaltyTxs = readCollection { readTransactionWithInputInfo() as ClaimHtlcDelayedOutputPenaltyTx }.toList(),
@@ -495,7 +495,6 @@ object Deserialization {
         0x05 -> ClaimAnchorOutputTx.ClaimLocalAnchorOutputTx(input = readInputInfo(), tx = readTransaction())
         0x06 -> ClaimAnchorOutputTx.ClaimRemoteAnchorOutputTx(input = readInputInfo(), tx = readTransaction())
         0x07 -> ClaimLocalDelayedOutputTx(input = readInputInfo(), tx = readTransaction())
-        0x08 -> ClaimRemoteCommitMainOutputTx.ClaimP2WPKHOutputTx(input = readInputInfo(), tx = readTransaction())
         0x09 -> ClaimRemoteCommitMainOutputTx.ClaimRemoteDelayedOutputTx(input = readInputInfo(), tx = readTransaction())
         0x10 -> ClaimLocalDelayedOutputTx(input = readInputInfo(), tx = readTransaction())
         0x0a -> MainPenaltyTx(input = readInputInfo(), tx = readTransaction())

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
@@ -554,9 +554,6 @@ object Serialization {
             is ClaimLocalDelayedOutputTx -> {
                 write(0x07); writeInputInfo(o.input); writeBtcObject(o.tx)
             }
-            is ClaimRemoteCommitMainOutputTx.ClaimP2WPKHOutputTx -> {
-                write(0x08); writeInputInfo(o.input); writeBtcObject(o.tx)
-            }
             is ClaimRemoteCommitMainOutputTx.ClaimRemoteDelayedOutputTx -> {
                 write(0x09); writeInputInfo(o.input); writeBtcObject(o.tx)
             }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/ChannelDataTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/ChannelDataTestsCommon.kt
@@ -12,7 +12,6 @@ import fr.acinq.lightning.channel.TestsHelper.claimHtlcTimeoutTxs
 import fr.acinq.lightning.channel.TestsHelper.crossSign
 import fr.acinq.lightning.channel.TestsHelper.htlcSuccessTxs
 import fr.acinq.lightning.channel.TestsHelper.htlcTimeoutTxs
-
 import fr.acinq.lightning.channel.TestsHelper.reachNormal
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.transactions.Transactions.InputInfo
@@ -25,7 +24,6 @@ import fr.acinq.lightning.utils.LoggingContext
 import fr.acinq.lightning.utils.MDCLogger
 import fr.acinq.lightning.utils.msat
 import fr.acinq.lightning.utils.sat
-import org.kodein.log.Logger
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 import kotlin.test.*
@@ -362,7 +360,7 @@ class ChannelDataTestsCommon : LightningTestSuite(), LoggingContext {
             }
 
             val remoteCommit = run {
-                val claimMain = ClaimRemoteCommitMainOutputTx.ClaimP2WPKHOutputTx(txInput(claimMainAlice), claimMainAlice)
+                val claimMain = ClaimRemoteCommitMainOutputTx.ClaimRemoteDelayedOutputTx(txInput(claimMainAlice), claimMainAlice)
                 val claimHtlcTxs = mapOf(
                     htlcSuccess1.txIn.first().outPoint to ClaimHtlcSuccessTx(txInput(htlcSuccess1), htlcSuccess1, 0),
                     htlcSuccess2.txIn.first().outPoint to ClaimHtlcSuccessTx(txInput(htlcSuccess2), htlcSuccess2, 1),
@@ -377,7 +375,7 @@ class ChannelDataTestsCommon : LightningTestSuite(), LoggingContext {
                     val tx = Transaction(2, listOf(TxIn(OutPoint(commitTx, 1), 0)), listOf(TxOut(39_500.sat, ByteVector.empty)), 0)
                     MainPenaltyTx(txInput(tx), tx)
                 }
-                val claimMain = ClaimRemoteCommitMainOutputTx.ClaimP2WPKHOutputTx(txInput(claimMainAlice), claimMainAlice)
+                val claimMain = ClaimRemoteCommitMainOutputTx.ClaimRemoteDelayedOutputTx(txInput(claimMainAlice), claimMainAlice)
                 val htlcPenaltyTxs = listOf(htlcSuccess1, htlcSuccess2, htlcTimeout1, htlcTimeout2).map { HtlcPenaltyTx(txInput(it), it) }
                 RevokedCommitPublished(commitTx, randomKey(), claimMain, mainPenalty, htlcPenaltyTxs)
             }


### PR DESCRIPTION
This has never been used since we've supported anchor outputs since the first version of lightning-kmp.