### PR TITLE
Do not transition `Closing` -> `Offline`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Closing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Closing.kt
@@ -314,7 +314,6 @@ data class Closing(
                 else -> unhandled(cmd)
             }
             is ChannelCommand.CheckHtlcTimeout -> checkHtlcTimeout()
-            is ChannelCommand.Disconnected -> Pair(Offline(this@Closing), listOf())
             else -> unhandled(cmd)
         }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
@@ -1655,7 +1655,7 @@ class ClosingTestsCommon : LightningTestSuite() {
     fun `recv Disconnected`() {
         val (alice0, _, _) = initMutualClose()
         val (alice1, _) = alice0.process(ChannelCommand.Disconnected)
-        assertTrue { alice1.state is Offline }
+        assertTrue { alice1.state is Closing }
     }
 
     companion object {


### PR DESCRIPTION
Once the channel is in the `Closing` state, it becomes independent from the connection status and should ignore disconnections. Otherwise, it can't properly handle the mutual close scenario while disconnected.

This is a regression caused by #123 and reported by @dpad85.