### PR TITLE
Remove unnecessary `commit_sig` retransmit

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Syncing.kt
@@ -78,13 +78,23 @@ data class Syncing(val state: PersistedChannelState, val waitForTheirReestablish
                                 val actions = listOf(ChannelAction.Message.Send(commitSig))
                                 Pair(state, actions)
                             } else if (state.latestFundingTx.txId == cmd.message.nextFundingTxId) {
-                                // We retransmit commit_sig and tx_signatures (we sent them before, but they didn't receive it).
-                                logger.info { "re-sending commit_sig and tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
-                                val commitSig = state.commitments.latest.remoteCommit.sign(keyManager, state.commitments.params, state.commitments.latest.commitInput)
-                                val actions = listOf(
-                                    ChannelAction.Message.Send(commitSig),
-                                    ChannelAction.Message.Send(state.latestFundingTx.sharedTx.localSigs)
-                                )
+                                val actions = when (state.latestFundingTx.sharedTx) {
+                                    is PartiallySignedSharedTransaction -> {
+                                        // We retransmit commit_sig and tx_signatures (we sent them before, but they didn't receive it).
+                                        logger.info { "re-sending commit_sig and tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
+                                        val commitSig = state.commitments.latest.remoteCommit.sign(keyManager, state.commitments.params, state.commitments.latest.commitInput)
+                                        listOf(
+                                            ChannelAction.Message.Send(commitSig),
+                                            ChannelAction.Message.Send(state.latestFundingTx.sharedTx.localSigs)
+                                        )
+                                    }
+                                    is FullySignedSharedTransaction -> {
+                                        // We've already received their tx_signatures, which means they've received and stored our commit_sig,
+                                        // we only need to retransmit our tx_signatures.
+                                        logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
+                                        listOf(ChannelAction.Message.Send(state.latestFundingTx.sharedTx.localSigs))
+                                    }
+                                }
                                 Pair(state, actions)
                             } else {
                                 // The fundingTxId must be for an RBF attempt that we didn't store (we got disconnected before receiving their tx_complete).


### PR DESCRIPTION
As niftynei pointed out, in the case where we've already received our peer's `tx_signatures`, we know that they must have stored our `commit_sig`, so we don't need to retransmit it again.

Note that we can merge this PR after #430, there's no direct dependency and no rush.