### PR TITLE
startTLS negotiation with expectedHostName

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
@@ -30,7 +30,13 @@ interface TcpSocket {
         object DISABLED : TLS()
 
         /** Used for Electrum servers when expecting a valid certificate */
-        object TRUSTED_CERTIFICATES : TLS()
+        data class TRUSTED_CERTIFICATES(
+            /**
+             * Specify an expectedHostName when it's different than the `host` value you used
+             * within TcpSocket.Builder.connect(). This may be the case when using Tor.
+             */
+            val expectedHostName: String? = null
+        ) : TLS()
 
         /** Only used in unit tests */
         object UNSAFE_CERTIFICATES : TLS()

--- a/src/iosMain/kotlin/fr/acinq/lightning/io/IosTcpSocket.kt
+++ b/src/iosMain/kotlin/fr/acinq/lightning/io/IosTcpSocket.kt
@@ -160,8 +160,8 @@ fun TcpSocket.TLS.toNativeSocketTLS(): NativeSocketTLS {
     return when (this) {
         TcpSocket.TLS.DISABLED ->
             NativeSocketTLS.disabled()
-        TcpSocket.TLS.TRUSTED_CERTIFICATES ->
-            NativeSocketTLS.trustedCertificates()
+        is TcpSocket.TLS.TRUSTED_CERTIFICATES ->
+            NativeSocketTLS.trustedCertificates(this.expectedHostName)
         TcpSocket.TLS.UNSAFE_CERTIFICATES ->
             NativeSocketTLS.allowUnsafeCertificates()
         is TcpSocket.TLS.PINNED_PUBLIC_KEY ->

--- a/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
+++ b/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
@@ -67,7 +67,7 @@ class JvmTcpSocket(val socket: Socket, val loggerFactory: LoggerFactory) : TcpSo
 
     override suspend fun startTls(tls: TcpSocket.TLS): TcpSocket = try {
         when (tls) {
-            TcpSocket.TLS.TRUSTED_CERTIFICATES -> JvmTcpSocket(connection.tls(Dispatchers.IO), loggerFactory)
+            is TcpSocket.TLS.TRUSTED_CERTIFICATES -> JvmTcpSocket(connection.tls(Dispatchers.IO), loggerFactory)
             TcpSocket.TLS.UNSAFE_CERTIFICATES -> JvmTcpSocket(connection.tls(Dispatchers.IO) {
                 logger.warning { "using unsafe TLS!" }
                 trustManager = unsafeX509TrustManager()
@@ -161,7 +161,7 @@ internal actual object PlatformSocketBuilder : TcpSocket.Builder {
             try {
                 val socket = aSocket(selectorManager).tcp().connect(host, port).let { socket ->
                     when (tls) {
-                        TcpSocket.TLS.TRUSTED_CERTIFICATES -> socket.tls(Dispatchers.IO)
+                        is TcpSocket.TLS.TRUSTED_CERTIFICATES -> socket.tls(Dispatchers.IO)
                         TcpSocket.TLS.UNSAFE_CERTIFICATES -> socket.tls(Dispatchers.IO) {
                             logger.warning { "using unsafe TLS!" }
                             trustManager = JvmTcpSocket.unsafeX509TrustManager()


### PR DESCRIPTION
This PR adds an option to TcpSocket.TLS.TRUSTED_CERTIFICATES:

```kotlin
/** Used for Electrum servers when expecting a valid certificate */
data class TRUSTED_CERTIFICATES(
  /**
   * Specify an expectedHostName when it's different than the `host` value you used
   * within TcpSocket.Builder.connect(). This may be the case when using Tor.
   */
  val expectedHostName: String? = null // <- NEW
) : TLS()
```

This is needed by iOS to properly perform the TLS handshake when Tor is being used. Because the `socket.connect` method is passed the parameters for the proxy (e.g. host="127.0.0.1"). And the TLS validation subsequently fails, unless we can override the expected host name (e.g. expectedHostName="electrum.acinq.co").