### PR TITLE
Use tlv type 0 for `next_funding_txid`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
@@ -193,6 +193,16 @@ sealed class RevokeAndAckTlv : Tlv {
 }
 
 sealed class ChannelReestablishTlv : Tlv {
+    data class NextFunding(val txHash: ByteVector32) : ChannelReestablishTlv() {
+        override val tag: Long get() = NextFunding.tag
+        override fun write(out: Output) = LightningCodecs.writeBytes(txHash, out)
+
+        companion object : TlvValueReader<NextFunding> {
+            const val tag: Long = 0
+            override fun read(input: Input): NextFunding = NextFunding(LightningCodecs.bytes(input, 32).toByteVector32())
+        }
+    }
+
     data class ChannelData(val ecb: EncryptedChannelData) : ChannelReestablishTlv() {
         override val tag: Long get() = ChannelData.tag
         override fun write(out: Output) = LightningCodecs.writeBytes(ecb.data, out)
@@ -200,16 +210,6 @@ sealed class ChannelReestablishTlv : Tlv {
         companion object : TlvValueReader<ChannelData> {
             const val tag: Long = 0x47010000
             override fun read(input: Input): ChannelData = ChannelData(EncryptedChannelData(LightningCodecs.bytes(input, input.availableBytes).toByteVector()))
-        }
-    }
-
-    data class NextFunding(val txHash: ByteVector32) : ChannelReestablishTlv() {
-        override val tag: Long get() = NextFunding.tag
-        override fun write(out: Output) = LightningCodecs.writeBytes(txHash, out)
-
-        companion object : TlvValueReader<NextFunding> {
-            const val tag: Long = 333
-            override fun read(input: Input): NextFunding = NextFunding(LightningCodecs.bytes(input, 32).toByteVector32())
         }
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -416,7 +416,7 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
         val testCases = listOf(
             // @formatter:off
             ChannelReestablish(channelId, 242842, 42, commitmentSecret, commitmentPoint) to ByteVector("0088 c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c 000000000003b49a 000000000000002a 34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55 02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867"),
-            ChannelReestablish(channelId, 242842, 42, commitmentSecret, commitmentPoint, TlvStream(ChannelReestablishTlv.NextFunding(fundingTxHash))) to ByteVector("0088 c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c 000000000003b49a 000000000000002a 34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55 02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867 fd014d 20 24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566")
+            ChannelReestablish(channelId, 242842, 42, commitmentSecret, commitmentPoint, TlvStream(ChannelReestablishTlv.NextFunding(fundingTxHash))) to ByteVector("0088 c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c 000000000003b49a 000000000000002a 34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55 02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867 00 20 24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566")
             // @formatter:on
         )
         testCases.forEach { (message, bin) ->


### PR DESCRIPTION
This is the official tlv type used in the dual funding specification, as proposed here: https://github.com/niftynei/lightning-rfc/pull/13
This seems to have broad agreement, but hasn't yet been added to the dual funding PR and it would be nice to have a cross-compatibility test before merging this change.