### PR TITLE
Persist channel state on `tx_abort` in status `WaitForTxSigned`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
@@ -184,6 +184,7 @@ data class Normal(
                             when (action) {
                                 is InteractiveTxSigningSessionAction.AbortFundingAttempt -> {
                                     logger.warning { "splice attempt failed: ${action.reason.message}" }
+                                    logger.warning { "funding tx was txId=${spliceStatus.session.fundingTx.txId} tx=${spliceStatus.session.fundingTx.tx.buildUnsignedTx()}" }
                                     Pair(this@Normal.copy(spliceStatus = SpliceStatus.Aborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, action.reason.message))))
                                 }
                                 // No need to store their commit_sig, they will re-send it if we disconnect.

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Normal.kt
@@ -579,10 +579,12 @@ data class Normal(
                         }
                         is SpliceStatus.WaitingForSigs -> {
                             logger.info { "our peer aborted the splice attempt: ascii='${cmd.message.toAscii()}' bin=${cmd.message.data}" }
-                            Pair(
-                                this@Normal.copy(spliceStatus = SpliceStatus.None),
-                                listOf(ChannelAction.Message.Send(TxAbort(channelId, SpliceAborted(channelId).message)))
+                            val nextState = this@Normal.copy(spliceStatus = SpliceStatus.None)
+                            val actions = listOf(
+                                ChannelAction.Storage.StoreState(nextState),
+                                ChannelAction.Message.Send(TxAbort(channelId, SpliceAborted(channelId).message))
                             )
+                            Pair(nextState, actions)
                         }
                         is SpliceStatus.Aborted -> {
                             logger.info { "our peer acked our previous tx_abort" }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SpliceTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SpliceTestsCommon.kt
@@ -115,15 +115,17 @@ class SpliceTestsCommon : LightningTestSuite() {
             val (alice6, actionsAlice6) = alice5.process(ChannelCommand.MessageReceived(TxAbort(alice.channelId, "internal error")))
             assertIs<Normal>(alice6.state)
             assertEquals(alice6.state.spliceStatus, SpliceStatus.None)
-            assertEquals(actionsAlice6.size, 1)
+            assertEquals(actionsAlice6.size, 2)
             actionsAlice6.hasOutgoingMessage<TxAbort>()
+            actionsAlice6.has<ChannelAction.Storage.StoreState>()
         }
         run {
             val (bob6, actionsBob6) = bob5.process(ChannelCommand.MessageReceived(TxAbort(alice.channelId, "internal error")))
             assertIs<Normal>(bob6.state)
             assertEquals(bob6.state.spliceStatus, SpliceStatus.None)
-            assertEquals(actionsBob6.size, 1)
+            assertEquals(actionsBob6.size, 2)
             actionsBob6.hasOutgoingMessage<TxAbort>()
+            actionsBob6.has<ChannelAction.Storage.StoreState>()
         }
     }
 


### PR DESCRIPTION
We must persist the channel state if a splice is aborted in status `WaitForTxSigned`.