### PR TITLE
Deduplicate `pay-to-open` success responses

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -1004,6 +1004,7 @@ class Peer(
                     processActions(key, actions)
                     _channels = _channels + (key to state1)
                 }
+                incomingPaymentHandler.purgePayToOpenRequests()
             }
         }
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -413,7 +413,8 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val db: IncomingPayment
      * will accept outdated ones.
      */
     fun purgePayToOpenRequests() {
-        pending.replaceAll { _, payment -> payment.copy(parts = payment.parts.filter { it !is PayToOpenPart }.toSet()) }
+        val valuesToReplace = pending.mapValues { entry -> entry.value.copy(parts = entry.value.parts.filter { it !is PayToOpenPart }.toSet()) }
+        pending.plusAssign(valuesToReplace)
         val keysToRemove = pending.filterValues { it.parts.isEmpty() }.keys
         pending.minusAssign(keysToRemove)
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -4,8 +4,11 @@ import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto
 import fr.acinq.bitcoin.PrivateKey
-import fr.acinq.lightning.*
+import fr.acinq.lightning.CltvExpiry
 import fr.acinq.lightning.Lightning.randomBytes32
+import fr.acinq.lightning.MilliSatoshi
+import fr.acinq.lightning.NodeParams
+import fr.acinq.lightning.PayToOpenEvents
 import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.db.IncomingPayment
 import fr.acinq.lightning.db.IncomingPaymentsDb
@@ -15,7 +18,6 @@ import fr.acinq.lightning.io.WrappedChannelCommand
 import fr.acinq.lightning.utils.*
 import fr.acinq.lightning.wire.*
 import org.kodein.log.newLogger
-import kotlin.time.Duration
 
 sealed class PaymentPart {
     abstract val amount: MilliSatoshi
@@ -274,38 +276,32 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val db: IncomingPayment
                                 null -> logger.info { "payment received (${payment.amountReceived}) without payment metadata" }
                                 else -> logger.info { "payment received (${payment.amountReceived}) with payment metadata ($paymentMetadata)" }
                             }
-                            // In the code below, we indicate the receivedWith only for htlc parts, because the pay-to-open parts
-                            // will be created later, via a new channel or a splice-in.
-                            // In the corner case where the payment is a mix of htlc and pay-to-open parts, then the payment will be considered
-                            // "received" in the db, but the sum of all parts will not reach the correct amount, until the pay-to-open parts are
-                            // added
-                            val (actions, receivedWith) = payment.parts.map { part ->
-                                when (part) {
-                                    is HtlcPart -> {
-                                        val cmd = CMD_FULFILL_HTLC(part.htlc.id, incomingPayment.preimage, true)
-                                        val channelCommand = ChannelCommand.ExecuteCommand(cmd)
-                                        WrappedChannelCommand(
-                                            channelId = part.htlc.channelId,
-                                            channelCommand = channelCommand
-                                        ) to IncomingPayment.ReceivedWith.LightningPayment(
-                                            amount = part.amount,
-                                            htlcId = part.htlc.id,
-                                            channelId = part.htlc.channelId
-                                        )
-                                    }
-                                    is PayToOpenPart -> PayToOpenResponseCommand(
-                                        PayToOpenResponse(
-                                            chainHash = part.payToOpenRequest.chainHash,
-                                            paymentHash = paymentPart.paymentHash,
-                                            result = PayToOpenResponse.Result.Success(incomingPayment.preimage)
-                                        )
-                                    ) to null
+                            val htlcParts = payment.parts.filterIsInstance<HtlcPart>()
+                            val payToOpenParts = payment.parts.filterIsInstance<PayToOpenPart>()
+                            // We only fill the DB with htlc parts, because we cannot be sure yet that our peer will honor the pay-to-open part(s).
+                            // When the payment contains pay-to-open parts, it will be considered received, but the sum of all parts will be smaller
+                            // than the expected amount. The pay-to-open part(s) will be added once we received the corresponding new channel or a splice-in.
+                            val receivedWith = htlcParts.map { part ->
+                                IncomingPayment.ReceivedWith.LightningPayment(
+                                    amount = part.amount,
+                                    htlcId = part.htlc.id,
+                                    channelId = part.htlc.channelId
+                                )
+                            }
+                            val actions = buildList {
+                                htlcParts.forEach { part ->
+                                    val cmd = CMD_FULFILL_HTLC(part.htlc.id, incomingPayment.preimage, true)
+                                    add(WrappedChannelCommand(part.htlc.channelId, ChannelCommand.ExecuteCommand(cmd)))
                                 }
-                            }.unzip()
+                                // We avoid sending duplicate pay-to-open responses, since the preimage is the same for every part.
+                                if (payToOpenParts.isNotEmpty()) {
+                                    val response = PayToOpenResponse(nodeParams.chainHash, incomingPayment.paymentHash, PayToOpenResponse.Result.Success(incomingPayment.preimage))
+                                    add(PayToOpenResponseCommand(response))
+                                }
+                            }
+
                             pending.remove(paymentPart.paymentHash)
-
-                            val received = IncomingPayment.Received(receivedWith = receivedWith.filterNotNull())
-
+                            val received = IncomingPayment.Received(receivedWith = receivedWith)
                             db.receivePayment(paymentPart.paymentHash, received.receivedWith)
 
                             return ProcessAddResult.Accepted(actions, incomingPayment.copy(received = received), received)

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -228,7 +228,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val result2 = paymentHandler.process(payToOpenRequest2, TestConstants.defaultBlockHeight)
         assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result2)
         val payToOpenResponse = PayToOpenResponseCommand(PayToOpenResponse(payToOpenRequest1.chainHash, payToOpenRequest1.paymentHash, PayToOpenResponse.Result.Success(incomingPayment.preimage)))
-        assertEquals(listOf(payToOpenResponse, payToOpenResponse), result2.actions)
+        assertEquals(listOf(payToOpenResponse), result2.actions)
 
         assertEquals(0.msat, result2.received.amount)
         assertEquals(0.msat, result2.received.fees)
@@ -473,10 +473,8 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val result = paymentHandler.process(payToOpenRequest, TestConstants.defaultBlockHeight)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
 
-            assertEquals(result.actions, listOf(
-                PayToOpenResponseCommand(PayToOpenResponse(payToOpenRequest.chainHash, payToOpenRequest.paymentHash, PayToOpenResponse.Result.Success(incomingPayment.preimage))),
-                PayToOpenResponseCommand(PayToOpenResponse(payToOpenRequest.chainHash, payToOpenRequest.paymentHash, PayToOpenResponse.Result.Success(incomingPayment.preimage))),
-            ))
+            val payToOpenResponse = PayToOpenResponse(payToOpenRequest.chainHash, payToOpenRequest.paymentHash, PayToOpenResponse.Result.Success(incomingPayment.preimage))
+            assertEquals(result.actions, listOf(PayToOpenResponseCommand(payToOpenResponse)))
 
             // pay-to-open parts are not yet provided
             assertTrue { result.received.receivedWith.isEmpty() }
@@ -1213,7 +1211,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
 
         private fun makePayToOpenRequest(incomingPayment: IncomingPayment, finalPayload: PaymentOnion.FinalPayload, payToOpenMinAmount: MilliSatoshi = 10_000.msat): PayToOpenRequest {
             return PayToOpenRequest(
-                chainHash = ByteVector32.Zeroes,
+                chainHash = Block.RegtestGenesisBlock.hash,
                 fundingSatoshis = 100_000.sat,
                 amountMsat = finalPayload.amount,
                 payToOpenMinAmountMsat = payToOpenMinAmount,


### PR DESCRIPTION
We shouldn't send duplicate pay-to-open responses, our peer will simply extract the preimage for the first one and make a channel or splice based on the total amount of all pay-to-open parts.