### PR TITLE
Remove `PleaseOpenChannelRejected`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -6,7 +6,6 @@ import fr.acinq.lightning.channel.ChannelStateWithCommitments
 import fr.acinq.lightning.channel.Normal
 import fr.acinq.lightning.channel.WaitForFundingCreated
 import fr.acinq.lightning.wire.PleaseOpenChannel
-import fr.acinq.lightning.wire.PleaseOpenChannelFailure
 import kotlinx.coroutines.CompletableDeferred
 
 sealed interface NodeEvents
@@ -14,7 +13,6 @@ sealed interface NodeEvents
 sealed interface SwapInEvents : NodeEvents {
     data class Requested(val req: PleaseOpenChannel) : SwapInEvents
     data class Accepted(val requestId: ByteVector32, val serviceFee: MilliSatoshi, val miningFee: Satoshi) : SwapInEvents
-    data class Rejected(val requestId: ByteVector32, val failure: PleaseOpenChannelFailure, val requiredFees: MilliSatoshi?) : SwapInEvents
 }
 
 sealed interface ChannelEvents : NodeEvents {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -737,18 +737,6 @@ class Peer(
                             logger.error { "connection error: ${msg.toAscii()}" }
                         }
 
-                        msg is PleaseOpenChannelRejected -> {
-                            when (val request = channelRequests[msg.requestId]) {
-                                is RequestChannelOpen -> {
-                                    logger.error { "peer rejected channel with failure=${msg.failure} (request=$request)" }
-                                    nodeParams._nodeEvents.emit(SwapInEvents.Rejected(msg.requestId, msg.failure, msg.expectedFees))
-                                    channelRequests = channelRequests - msg.requestId
-                                }
-
-                                else -> {}
-                            }
-                        }
-
                         msg is OpenDualFundedChannel && theirInit == null -> {
                             logger.error { "they sent open_channel before init" }
                         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -713,26 +713,6 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `encode - decode please-open-channel-rejected messages`() {
-        val testCases = listOf(
-            // @formatter:off
-            PleaseOpenChannelRejected(ByteVector32("2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25"), PleaseOpenChannelFailure.FeeInsufficient, TlvStream(PleaseOpenChannelRejectedTlv.ExpectedFees(1_578_000.msat))) to Hex.decode("8ca3 2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25 00000001 0103181410"),
-            PleaseOpenChannelRejected(ByteVector32("2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25"), PleaseOpenChannelFailure.FeeInsufficient, TlvStream(PleaseOpenChannelRejectedTlv.ExpectedFees(3_000_000.msat))) to Hex.decode("8ca3 2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25 00000001 01032dc6c0"),
-            PleaseOpenChannelRejected(ByteVector32("2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25"), PleaseOpenChannelFailure.Unknown(113)) to Hex.decode("8ca3 2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25 00000071"),
-            PleaseOpenChannelRejected(ByteVector32("2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25"), PleaseOpenChannelFailure.Unknown(113), TlvStream(setOf(), setOf(GenericTlv(57, ByteVector("deadbeef"))))) to Hex.decode("8ca3 2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25 00000071 3904deadbeef"),
-            // @formatter:on
-        )
-
-        testCases.forEach {
-            val decoded = LightningMessage.decode(it.second)
-            assertNotNull(decoded)
-            assertEquals(it.first, decoded)
-            val encoded = LightningMessage.encode(decoded)
-            assertArrayEquals(it.second, encoded)
-        }
-    }
-
-    @Test
     fun `encode - decode phoenix-android-legacy-info messages`() {
         val testCases = listOf(
             Pair(PhoenixAndroidLegacyInfo(hasChannels = true), Hex.decode("88cfff")),


### PR DESCRIPTION
The rejection is now done on lightning-kmp's side, based on the local liquidity policy.