### PR TITLE
Add `LiquidityEvents.Accepted`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -27,6 +27,8 @@ sealed interface LiquidityEvents : NodeEvents {
     val source: Source
 
     enum class Source { OnChainWallet, OffChainPayment }
+
+    data class Accepted(override val amount: MilliSatoshi, override val fee: MilliSatoshi, override val source: Source) : LiquidityEvents
     data class Rejected(override val amount: MilliSatoshi, override val fee: MilliSatoshi, override val source: Source, val reason: Reason) : LiquidityEvents {
         sealed class Reason {
             object PolicySetToDisabled : Reason()


### PR DESCRIPTION
For an incoming lightning payment, the existing `LiquidityEvents.Rejected` seems sufficient for the UI. But for managing the user's swap-in wallet, it's a different story. The goal is to distinguish when there is and is NOT a problem:

<br/>
<img src="https://github.com/ACINQ/lightning-kmp/assets/304604/daad3c5a-57dd-4303-ac2e-47e1e914d678"/>
<br/>&nbsp;<br/>
<img src="https://github.com/ACINQ/lightning-kmp/assets/304604/f8f989b2-9677-449e-a5db-e48571a3cac9"/>
<br/>&nbsp;<br/>

For example, if a swap-in is rejected due to the user's liquidity policy, the UI should:

* change the swap-in balance to red (maybe with a different icon)
* tapping on the red balance displays a screen with information ("The fee was Y, but your max fee was set to X. To resolve this issue you can either ...")


To accomplish this, the ideal solution is to have something like:
`var swapInRejected: StateFlow<LiquidityEvents.Rejected?>`.

* This would only include events where `rejected.source == onchain`.
* This would be implemented outside of lightning-kmp (e.g. within Phoenix layer) 

The problem I'm having is that I don't see a clean way to unset the `swapInRejected` value. For example:

1. User sends 4,500 sat to their swap-in wallet
2. After confirmation, the splice-in is rejected due to the user's liquidity policy setting. The `LiquidityEvents.Rejected` is emitted, and we catch it to set `swapInRejected`
3. The user sees our helpful message, and sends another 15,000 sat
4. After confirmation, the splice-in is initiated
5. How do we unset the `swapInRejected` variable ???

I thought that a simple & clean solution would be to add a `LiquidityEvents.Accepted` event.

However, maybe I'm missing something. Perhaps there's a better solution ?

