### PR TITLE
Make liquidity policy mutable

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -12,6 +12,7 @@ import fr.acinq.lightning.utils.msat
 import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.utils.toMilliSatoshi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import org.kodein.log.LoggerFactory
@@ -96,6 +97,7 @@ data class RecipientCltvExpiryParams(val min: CltvExpiryDelta, val max: CltvExpi
  * @param paymentRecipientExpiryParams configure the expiry delta used for the final node when sending payments.
  * @param zeroConfPeers list of peers with whom we use zero-conf (note that this is a strong trust assumption).
  * @param enableTrampolinePayment enable trampoline payments.
+ * @param liquidityPolicy fee policy for liquidity events, can be modified at any time.
  */
 data class NodeParams(
     val loggerFactory: LoggerFactory,
@@ -133,7 +135,7 @@ data class NodeParams(
     val paymentRecipientExpiryParams: RecipientCltvExpiryParams,
     val zeroConfPeers: Set<PublicKey>,
     val enableTrampolinePayment: Boolean,
-    val liquidityPolicy: LiquidityPolicy
+    val liquidityPolicy: MutableStateFlow<LiquidityPolicy>
 ) {
     val nodePrivateKey get() = keyManager.nodeKeys.nodeKey.privateKey
     val nodeId get() = keyManager.nodeKeys.nodeKey.publicKey
@@ -214,7 +216,7 @@ data class NodeParams(
         enableTrampolinePayment = true,
         zeroConfPeers = emptySet(),
         paymentRecipientExpiryParams = RecipientCltvExpiryParams(CltvExpiryDelta(75), CltvExpiryDelta(200)),
-        liquidityPolicy = LiquidityPolicy.Auto(maxAbsoluteFee = 1_500.sat, maxRelativeFeeBasisPoints = 3_000 /* 3000 = 30 % */)
+        liquidityPolicy = MutableStateFlow<LiquidityPolicy>(LiquidityPolicy.Auto(maxAbsoluteFee = 1_500.sat, maxRelativeFeeBasisPoints = 3_000 /* 3000 = 30 % */))
     )
 
     sealed class Chain(val name: String, private val genesis: Block) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -750,7 +750,7 @@ class Peer(
                                 is Origin.PleaseOpenChannelOrigin -> when (val request = channelRequests[origin.requestId]) {
                                     is RequestChannelOpen -> {
                                         val totalFee = origin.serviceFee + origin.miningFee.toMilliSatoshi() - msg.pushAmount
-                                        nodeParams.liquidityPolicy.maybeReject(request.wallet.confirmedBalance.toMilliSatoshi(), totalFee, LiquidityEvents.Source.OnChainWallet, logger)?.let { rejected ->
+                                        nodeParams.liquidityPolicy.value.maybeReject(request.wallet.confirmedBalance.toMilliSatoshi(), totalFee, LiquidityEvents.Source.OnChainWallet, logger)?.let { rejected ->
                                             logger.info { "rejecting open_channel2: reason=${rejected.reason}" }
                                             nodeParams._nodeEvents.emit(rejected)
                                             sendToPeer(Error(msg.temporaryChannelId, "cancelling open due to local liquidity policy"))
@@ -931,7 +931,7 @@ class Peer(
 
                         logger.info { "requesting splice-in using confirmed balance=$balance feerate=$feerate fee=$fee" }
 
-                        nodeParams.liquidityPolicy.maybeReject(cmd.wallet.confirmedBalance.toMilliSatoshi(), fee.toMilliSatoshi(), LiquidityEvents.Source.OnChainWallet, logger)?.let { rejected ->
+                        nodeParams.liquidityPolicy.value.maybeReject(cmd.wallet.confirmedBalance.toMilliSatoshi(), fee.toMilliSatoshi(), LiquidityEvents.Source.OnChainWallet, logger)?.let { rejected ->
                             logger.info { "rejecting splice: reason=${rejected.reason}" }
                             nodeParams._nodeEvents.emit(rejected)
                             return

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -248,7 +248,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val db: IncomingPayment
                             if (payment.parts.filterIsInstance<PayToOpenPart>().isNotEmpty()) {
                                 // We consider the total amount received (not only the pay-to-open parts) to evaluate whether or not to accept the payment
                                 val payToOpenFee = payment.parts.filterIsInstance<PayToOpenPart>().map { it.payToOpenRequest.payToOpenFeeSatoshis }.sum()
-                                nodeParams.liquidityPolicy.maybeReject(payment.amountReceived, payToOpenFee.toMilliSatoshi(), LiquidityEvents.Source.OffChainPayment, logger)?.let { rejected ->
+                                nodeParams.liquidityPolicy.value.maybeReject(payment.amountReceived, payToOpenFee.toMilliSatoshi(), LiquidityEvents.Source.OffChainPayment, logger)?.let { rejected ->
                                     logger.info { "rejecting pay-to-open: reason=${rejected.reason}" }
                                     nodeParams._nodeEvents.emit(rejected)
                                     val actions = payment.parts.map { part ->

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/LiquidityPolicy.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/LiquidityPolicy.kt
@@ -17,7 +17,7 @@ sealed class LiquidityPolicy {
      * @param maxAbsoluteFee max absolute fee
      * @param maxRelativeFeeBasisPoints max relative fee (all included: service fee and mining fee) (1_000 bips = 10 %)
      */
-    data class Auto(val maxAbsoluteFee: Satoshi, val maxRelativeFeeBasisPoints: Int, ) : LiquidityPolicy() {
+    data class Auto(val maxAbsoluteFee: Satoshi, val maxRelativeFeeBasisPoints: Int) : LiquidityPolicy() {
         /** Maximum fee that we are willing to pay for a particular amount */
         fun maxFee(amount: MilliSatoshi) = maxAbsoluteFee.toMilliSatoshi().min(amount * maxRelativeFeeBasisPoints / 10_000)
     }


### PR DESCRIPTION
It is now defined as a `MutableStateFlow` and can be modified at will by the library user.

For example Phoenix users can modify their max fee setting without restarting the app and the new value will be automatically taken into account.

Note that for swap-in, we currently only do one try at startup, but that's a separate concern.