### PR TITLE
Fix channel reestablish in some corner cases

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -186,6 +186,13 @@ sealed class ChannelState {
             else -> Pair(Aborted, listOf())
         }
     }
+
+    val stateName: String
+        get() = when (this) {
+            is Offline -> "${this::class.simpleName}(${this.state::class.simpleName})"
+            is Syncing -> "${this::class.simpleName}(${this.state::class.simpleName})"
+            else -> "${this::class.simpleName}"
+        }
 }
 
 /** A channel state that is persisted to the DB. */

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -61,9 +61,9 @@ data class Syncing(val state: PersistedChannelState) : ChannelState() {
                                                 state.commitments.params,
                                                 fundingTxIndex = 0,
                                                 state.commitments.latest.remoteFundingPubkey,
-                                                state.commitments.latest.commitInput)
-                                            add(ChannelAction.Message.Send(commitSig)
+                                                state.commitments.latest.commitInput
                                             )
+                                            add(ChannelAction.Message.Send(commitSig))
                                         }
                                         logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
                                         add(ChannelAction.Message.Send(state.latestFundingTx.sharedTx.localSigs))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -56,9 +56,14 @@ data class Syncing(val state: PersistedChannelState) : ChannelState() {
                                         if (state.latestFundingTx.sharedTx is PartiallySignedSharedTransaction) {
                                             // We have not received their tx_signatures: we retransmit our commit_sig because we don't know if they received it.
                                             logger.info { "re-sending commit_sig for fundingTxId=${cmd.message.nextFundingTxId}" }
-                                            val commitSig =
-                                                state.commitments.latest.remoteCommit.sign(channelKeys(), state.commitments.params, fundingTxIndex = 0, state.commitments.latest.remoteFundingPubkey, state.commitments.latest.commitInput)
-                                            add(ChannelAction.Message.Send(commitSig))
+                                            val commitSig = state.commitments.latest.remoteCommit.sign(
+                                                channelKeys(),
+                                                state.commitments.params,
+                                                fundingTxIndex = 0,
+                                                state.commitments.latest.remoteFundingPubkey,
+                                                state.commitments.latest.commitInput)
+                                            add(ChannelAction.Message.Send(commitSig)
+                                            )
                                         }
                                         logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
                                         add(ChannelAction.Message.Send(state.latestFundingTx.sharedTx.localSigs))
@@ -74,10 +79,37 @@ data class Syncing(val state: PersistedChannelState) : ChannelState() {
                         }
                     }
                     state is WaitForChannelReady -> {
+                        val actions = ArrayList<ChannelAction>()
+
+                        if (state.commitments.latest.fundingTxId == cmd.message.nextFundingTxId) {
+                            if (state.commitments.latest.localFundingStatus is LocalFundingStatus.UnconfirmedFundingTx) {
+                                if (state.commitments.latest.localFundingStatus.sharedTx is PartiallySignedSharedTransaction) {
+                                    // If we have not received their tx_signatures, we can't tell whether they had received our commit_sig, so we need to retransmit it
+                                    logger.info { "re-sending commit_sig for fundingTxId=${state.commitments.latest.fundingTxId}" }
+                                    val commitSig = state.commitments.latest.remoteCommit.sign(
+                                        channelKeys(),
+                                        state.commitments.params,
+                                        fundingTxIndex = state.commitments.latest.fundingTxIndex,
+                                        state.commitments.latest.remoteFundingPubkey,
+                                        state.commitments.latest.commitInput
+                                    )
+                                    actions.add(ChannelAction.Message.Send(commitSig))
+                                }
+                                logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
+                                actions.add(ChannelAction.Message.Send(state.commitments.latest.localFundingStatus.sharedTx.localSigs))
+                            } else {
+                                // The funding tx is confirmed, and they have not received our tx_signatures, but they must have received our commit_sig, otherwise they
+                                // would not have sent their tx_signatures and we would not have been able to publish the funding tx in the first place. We could in theory
+                                // recompute our tx_signatures, but instead we do nothing: they will shortly be notified that the funding tx has confirmed.
+                                logger.warning { "cannot re-send tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}, transaction is already confirmed" }
+                            }
+                        }
+
                         logger.debug { "re-sending channel_ready" }
                         val nextPerCommitmentPoint = channelKeys().commitmentPoint(1)
                         val channelReady = ChannelReady(state.commitments.channelId, nextPerCommitmentPoint)
-                        val actions = listOf(ChannelAction.Message.Send(channelReady))
+                        actions.add(ChannelAction.Message.Send(channelReady))
+
                         Pair(state, actions)
                     }
                     state is LegacyWaitForFundingLocked -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -166,7 +166,7 @@ class Peer(
         return state.run { ctx.process(cmd) }
             .also { (state1, _) ->
                 if (state1::class != state::class) {
-                    ctx.logger.info { "${state::class.simpleName} -> ${state1::class.simpleName}" }
+                    ctx.logger.info { "${state.stateName} -> ${state1.stateName}" }
                 }
             }
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -796,9 +796,12 @@ class Peer(
 
                         msg is ChannelReestablish -> {
                             val local: ChannelState? = _channels[msg.channelId]
-                            val backup: DeserializationResult? = PersistedChannelState.from(nodeParams.nodePrivateKey, msg.channelData)
-                                .onFailure { logger.warning(it) { "unreadable backup" } }
-                                .getOrNull()
+                            val backup: DeserializationResult? = msg.channelData.takeIf { !it.isEmpty() }?.let { channelData ->
+                                PersistedChannelState
+                                    .from(nodeParams.nodePrivateKey, channelData)
+                                    .onFailure { logger.warning(it) { "unreadable backup" } }
+                                    .getOrNull()
+                            }
 
                             suspend fun recoverChannel(recovered: PersistedChannelState) {
                                 db.channels.addOrUpdateChannel(recovered)

--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/logger.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/logger.kt
@@ -72,7 +72,7 @@ fun LightningOutgoingPayment.mdc(): Map<String, Any> = mapOf(
 fun ChannelState.mdc(): Map<String, Any> {
     val state = this
     return buildMap {
-        state::class.simpleName?.let { put("state", it) }
+        put("state", state.stateName)
         when (state) {
             is WaitForOpenChannel -> put("temporaryChannelId", state.temporaryChannelId)
             is WaitForAcceptChannel -> put("temporaryChannelId", state.temporaryChannelId)


### PR DESCRIPTION
The main change is re-sending `commit_sig`/`tx_signatures` in `WaitChannelReady`, which is needed in the zero-conf case.