### PR TITLE
Skip waiting for reestablish for unsigned channels

### DIFF
--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/RouteCalculationTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/RouteCalculationTestsCommon.kt
@@ -61,7 +61,7 @@ class RouteCalculationTestsCommon : LightningTestSuite() {
         val (channelId1, channelId2, channelId3) = listOf(randomBytes32(), randomBytes32(), randomBytes32())
         val channels = mapOf(
             channelId1 to Offline(makeChannel(channelId1, 15_000.msat, 10.msat)),
-            channelId2 to Syncing(makeChannel(channelId2, 20_000.msat, 5.msat)),
+            channelId2 to Syncing(makeChannel(channelId2, 20_000.msat, 5.msat), channelReestablishSent = true),
             channelId3 to Offline(makeChannel(channelId3, 10_000.msat, 10.msat)),
         )
         assertEquals(Either.Left(FinalFailure.NoAvailableChannels), routeCalculation.findRoutes(paymentId, 5_000.msat, channels))


### PR DESCRIPTION
When we are a backup client, we wait for our peer to send their `channel_reestablish` first to make sure we haven't lost data.

This can lead to a deadlock if we're waiting for a `channel_reestablish`, but our peer has forgotten that channel because we got disconnected before they were able to send their signatures.

To avoid this deadlock, we send our `channel_reestablish` immediately for channels where we're waiting for signatures.