### PR TITLE
Do not recursively call `ChannelState.process`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -513,11 +513,7 @@ sealed class ChannelStateWithCommitments : PersistedChannelState() {
                     }
                     else -> {
                         val error = Error(channelId, channelEx.message)
-                        val (nextState, actions) = spendLocalCurrent()
-                        Pair(nextState, buildList {
-                            addAll(actions)
-                            add(ChannelAction.Message.Send(error))
-                        })
+                        spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error))}
                     }
                 }
             }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
@@ -5,6 +5,7 @@ import fr.acinq.lightning.ShortChannelId
 import fr.acinq.lightning.blockchain.*
 import fr.acinq.lightning.channel.ChannelAction
 import fr.acinq.lightning.channel.ChannelCommand
+import fr.acinq.lightning.channel.ForcedLocalCommit
 import fr.acinq.lightning.channel.PleasePublishYourCommitment
 import fr.acinq.lightning.utils.Either
 import fr.acinq.lightning.wire.ChannelReady
@@ -107,7 +108,7 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
                 }
             }
             cmd is ChannelCommand.Close.ForceClose -> {
-                val (newState, actions) = state.run { process(cmd) }
+                val (newState, actions) = state.run { handleLocalError(cmd, ForcedLocalCommit(channelId)) }
                 when (newState) {
                     // NB: it doesn't make sense to try to send outgoing messages if we're offline.
                     is Closing -> Pair(newState, actions.filterNot { it is ChannelAction.Message.Send })

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
@@ -107,15 +107,7 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
                     else -> Pair(Offline(newState), actions)
                 }
             }
-            cmd is ChannelCommand.Close.ForceClose -> {
-                val (newState, actions) = state.run { handleLocalError(cmd, ForcedLocalCommit(channelId)) }
-                when (newState) {
-                    // NB: it doesn't make sense to try to send outgoing messages if we're offline.
-                    is Closing -> Pair(newState, actions.filterNot { it is ChannelAction.Message.Send })
-                    is Closed -> Pair(newState, actions.filterNot { it is ChannelAction.Message.Send })
-                    else -> Pair(Offline(newState as PersistedChannelState), actions)
-                }
-            }
+            cmd is ChannelCommand.Close.ForceClose -> state.run { handleLocalError(cmd, ForcedLocalCommit(channelId)) }
             else -> unhandled(cmd)
         }
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -326,7 +326,7 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
             }
             cmd is ChannelCommand.Disconnected -> Pair(Offline(state), listOf())
             cmd is ChannelCommand.Close.ForceClose -> {
-                val (newState, actions) = state.run { process(cmd) }
+                val (newState, actions) = state.run { handleLocalError(cmd, ForcedLocalCommit(channelId)) }
                 when (newState) {
                     is Closing -> Pair(newState, actions)
                     is Closed -> Pair(newState, actions)

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -325,14 +325,7 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
                 }
             }
             cmd is ChannelCommand.Disconnected -> Pair(Offline(state), listOf())
-            cmd is ChannelCommand.Close.ForceClose -> {
-                val (newState, actions) = state.run { handleLocalError(cmd, ForcedLocalCommit(channelId)) }
-                when (newState) {
-                    is Closing -> Pair(newState, actions)
-                    is Closed -> Pair(newState, actions)
-                    else -> Pair(Syncing(newState as PersistedChannelState, channelReestablishSent), actions)
-                }
-            }
+            cmd is ChannelCommand.Close.ForceClose -> state.run { handleLocalError(cmd, ForcedLocalCommit(channelId)) }
             cmd is ChannelCommand.MessageReceived && cmd.message is Error -> state.run { handleRemoteError(cmd.message) }
             else -> unhandled(cmd)
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
@@ -663,7 +663,7 @@ class OfflineTestsCommon : LightningTestSuite() {
         val (alice2, actions2) = alice1.process(ChannelCommand.Close.ForceClose)
         assertIs<Closing>(alice2.state)
         assertTrue(actions2.contains(ChannelAction.Storage.StoreState(alice2.state)))
-        assertEquals(commitTx, actions2.hasPublishTx(ChannelAction.Blockchain.PublishTx.Type.CommitTx))
+        actions2.hasPublishTx(commitTx)
         actions2.hasWatchConfirmed(commitTx.txid)
         actions2.hasOutgoingMessage<Error>()
         assertEquals(1, actions2.filterIsInstance<ChannelAction.Storage.StoreOutgoingPayment.ViaClose>().size)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
@@ -664,9 +664,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         assertIs<Closing>(alice2.state)
         assertTrue(actions2.contains(ChannelAction.Storage.StoreState(alice2.state)))
         assertEquals(commitTx, actions2.hasPublishTx(ChannelAction.Blockchain.PublishTx.Type.CommitTx))
-        assertTrue(actions2.findWatches<WatchConfirmed>().isNotEmpty())
-        assertTrue(actions2.filterIsInstance<ChannelAction.Blockchain.SendWatch>().all { it.watch is WatchConfirmed })
-        assertNull(actions2.findOutgoingMessageOpt<Error>()) // we're offline so we shouldn't try to send messages
+        actions2.hasWatchConfirmed(commitTx.txid)
+        actions2.hasOutgoingMessage<Error>()
         assertEquals(1, actions2.filterIsInstance<ChannelAction.Storage.StoreOutgoingPayment.ViaClose>().size)
     }
 


### PR DESCRIPTION
Otherwise reasoning about transitions becomes very difficult and error-prone.

In this instance, we were emitting a duplicate `StoreOutgoingPayment.ViaClose` when force-closing in offline `Offline` (reported by @dpad85). It is safer to directly call the `handleLocalError()` function, and also more consistent with e.g. `checkHtlcTimeout()`.