### PR TITLE
Use exhaustive pattern matching

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelCommand.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelCommand.kt
@@ -15,44 +15,54 @@ import fr.acinq.lightning.crypto.KeyManager
 import fr.acinq.lightning.utils.UUID
 import fr.acinq.lightning.utils.msat
 import fr.acinq.lightning.wire.FailureMessage
-import fr.acinq.lightning.wire.Init
 import fr.acinq.lightning.wire.LightningMessage
 import fr.acinq.lightning.wire.OnionRoutingPacket
 import kotlinx.coroutines.CompletableDeferred
+import fr.acinq.lightning.wire.Init as InitMessage
 
 /** Channel Events (inputs to be fed to the state machine). */
 sealed class ChannelCommand {
     // @formatter:off
-    data class InitInitiator(
-        val fundingAmount: Satoshi,
-        val pushAmount: MilliSatoshi,
-        val walletInputs: List<WalletState.Utxo>,
-        val commitTxFeerate: FeeratePerKw,
-        val fundingTxFeerate: FeeratePerKw,
-        val localParams: LocalParams,
-        val remoteInit: Init,
-        val channelFlags: Byte,
-        val channelConfig: ChannelConfig,
-        val channelType: ChannelType.SupportedChannelType,
-        val channelOrigin: Origin? = null
-    ) : ChannelCommand() {
-        fun temporaryChannelId(keyManager: KeyManager): ByteVector32 = keyManager.channelKeys(localParams.fundingKeyPath).temporaryChannelId
+    data class Connected(val localInit: InitMessage, val remoteInit: InitMessage) : ChannelCommand()
+    object Disconnected : ChannelCommand()
+    sealed class Init : ChannelCommand() {
+        data class Initiator(
+            val fundingAmount: Satoshi,
+            val pushAmount: MilliSatoshi,
+            val walletInputs: List<WalletState.Utxo>,
+            val commitTxFeerate: FeeratePerKw,
+            val fundingTxFeerate: FeeratePerKw,
+            val localParams: LocalParams,
+            val remoteInit: InitMessage,
+            val channelFlags: Byte,
+            val channelConfig: ChannelConfig,
+            val channelType: ChannelType.SupportedChannelType,
+            val channelOrigin: Origin? = null
+        ) : Init() {
+            fun temporaryChannelId(keyManager: KeyManager): ByteVector32 = keyManager.channelKeys(localParams.fundingKeyPath).temporaryChannelId
+        }
+
+        data class NonInitiator(
+            val temporaryChannelId: ByteVector32,
+            val fundingAmount: Satoshi,
+            val pushAmount: MilliSatoshi,
+            val walletInputs: List<WalletState.Utxo>,
+            val localParams: LocalParams,
+            val channelConfig: ChannelConfig,
+            val remoteInit: InitMessage
+        ) : Init()
+
+        data class Restore(val state: PersistedChannelState) : Init()
     }
 
-    data class InitNonInitiator(
-        val temporaryChannelId: ByteVector32,
-        val fundingAmount: Satoshi,
-        val pushAmount: MilliSatoshi,
-        val walletInputs: List<WalletState.Utxo>,
-        val localParams: LocalParams,
-        val channelConfig: ChannelConfig,
-        val remoteInit: Init
-    ) : ChannelCommand()
+    sealed class Funding : ChannelCommand() {
+        // We only support a very limited fee bumping mechanism where all spendable utxos will be used (only used in tests).
+        data class BumpFundingFee(val targetFeerate: FeeratePerKw, val fundingAmount: Satoshi, val walletInputs: List<WalletState.Utxo>, val lockTime: Long) : Funding()
+    }
 
-    data class Restore(val state: PersistedChannelState) : ChannelCommand()
-    object CheckHtlcTimeout : ChannelCommand()
     data class MessageReceived(val message: LightningMessage) : ChannelCommand()
     data class WatchReceived(val watch: WatchEvent) : ChannelCommand()
+
     sealed interface ForbiddenDuringSplice
     sealed class Htlc : ChannelCommand() {
         data class Add(val amount: MilliSatoshi, val paymentHash: ByteVector32, val cltvExpiry: CltvExpiry, val onion: OnionRoutingPacket, val paymentId: UUID, val commit: Boolean = false) : Htlc(), ForbiddenDuringSplice
@@ -70,52 +80,56 @@ sealed class ChannelCommand {
             }
         }
     }
-    object Sign : ChannelCommand(), ForbiddenDuringSplice
-    data class UpdateFee(val feerate: FeeratePerKw, val commit: Boolean = false) : ChannelCommand(), ForbiddenDuringSplice
-    // We only support a very limited fee bumping mechanism where all spendable utxos will be used (only used in tests).
-    data class BumpFundingFee(val targetFeerate: FeeratePerKw, val fundingAmount: Satoshi, val walletInputs: List<WalletState.Utxo>, val lockTime: Long) : ChannelCommand()
+
+    sealed class Commitment : ChannelCommand() {
+        object Sign : Commitment(), ForbiddenDuringSplice
+        data class UpdateFee(val feerate: FeeratePerKw, val commit: Boolean = false) : Commitment(), ForbiddenDuringSplice
+        object CheckHtlcTimeout : Commitment()
+        sealed class Splice : Commitment() {
+            data class Request(val replyTo: CompletableDeferred<Response>, val spliceIn: SpliceIn?, val spliceOut: SpliceOut?, val feerate: FeeratePerKw, val origins: List<Origin.PayToOpenOrigin> = emptyList()) : Splice() {
+                val pushAmount: MilliSatoshi = spliceIn?.pushAmount ?: 0.msat
+                val spliceOutputs: List<TxOut> = spliceOut?.let { listOf(TxOut(it.amount, it.scriptPubKey)) } ?: emptyList()
+
+                data class SpliceIn(val walletInputs: List<WalletState.Utxo>, val pushAmount: MilliSatoshi = 0.msat)
+                data class SpliceOut(val amount: Satoshi, val scriptPubKey: ByteVector)
+            }
+
+            sealed class Response {
+                /**
+                 * This response doesn't fully guarantee that the splice will confirm, because our peer may potentially double-spend
+                 * the splice transaction. Callers should wait for on-chain confirmations and handle double-spend events.
+                 */
+                data class Created(
+                    val channelId: ByteVector32,
+                    val fundingTxIndex: Long,
+                    val fundingTxId: ByteVector32,
+                    val capacity: Satoshi,
+                    val balance: MilliSatoshi
+                ) : Response()
+
+                sealed class Failure : Response() {
+                    object InsufficientFunds : Failure()
+                    object InvalidSpliceOutPubKeyScript : Failure()
+                    object SpliceAlreadyInProgress : Failure()
+                    object ChannelNotIdle : Failure()
+                    data class FundingFailure(val reason: FundingContributionFailure) : Failure()
+                    object CannotStartSession : Failure()
+                    data class InteractiveTxSessionFailed(val reason: InteractiveTxSessionAction.RemoteFailure) : Failure()
+                    data class CannotCreateCommitTx(val reason: ChannelException) : Failure()
+                    data class AbortedByPeer(val reason: String) : Failure()
+                    object Disconnected : Failure()
+                }
+            }
+        }
+    }
+
     sealed class Close : ChannelCommand() {
         data class MutualClose(val scriptPubKey: ByteVector?, val feerates: ClosingFeerates?) : Close()
         object ForceClose : Close()
     }
-    sealed class Splice {
-        data class Request(val replyTo: CompletableDeferred<Response>, val spliceIn: SpliceIn?, val spliceOut: SpliceOut?, val feerate: FeeratePerKw, val origins: List<Origin.PayToOpenOrigin> = emptyList()) : ChannelCommand() {
-            val pushAmount: MilliSatoshi = spliceIn?.pushAmount ?: 0.msat
-            val spliceOutputs: List<TxOut> = spliceOut?.let { listOf(TxOut(it.amount, it.scriptPubKey)) } ?: emptyList()
 
-            data class SpliceIn(val walletInputs: List<WalletState.Utxo>, val pushAmount: MilliSatoshi = 0.msat)
-            data class SpliceOut(val amount: Satoshi, val scriptPubKey: ByteVector)
-        }
-
-        sealed class Response {
-            /**
-             * This response doesn't fully guarantee that the splice will confirm, because our peer may potentially double-spend
-             * the splice transaction. Callers should wait for on-chain confirmations and handle double-spend events.
-             */
-            data class Created(
-                val channelId: ByteVector32,
-                val fundingTxIndex: Long,
-                val fundingTxId: ByteVector32,
-                val capacity: Satoshi,
-                val balance: MilliSatoshi
-            ) : Response()
-
-            sealed class Failure : Response() {
-                object InsufficientFunds : Failure()
-                object InvalidSpliceOutPubKeyScript : Failure()
-                object SpliceAlreadyInProgress : Failure()
-                object ChannelNotIdle : Failure()
-                data class FundingFailure(val reason: FundingContributionFailure) : Failure()
-                object CannotStartSession : Failure()
-                data class InteractiveTxSessionFailed(val reason: InteractiveTxSessionAction.RemoteFailure) : Failure()
-                data class CannotCreateCommitTx(val reason: ChannelException) : Failure()
-                data class AbortedByPeer(val reason: String) : Failure()
-                object Disconnected : Failure()
-            }
-        }
+    sealed class Closing : ChannelCommand() {
+        data class GetHtlcInfosResponse(val revokedCommitTxId: ByteVector32, val htlcInfos: List<ChannelAction.Storage.HtlcInfo>) : Closing()
     }
-    data class GetHtlcInfosResponse(val revokedCommitTxId: ByteVector32, val htlcInfos: List<ChannelAction.Storage.HtlcInfo>) : ChannelCommand()
-    object Disconnected : ChannelCommand()
-    data class Connected(val localInit: Init, val remoteInit: Init) : ChannelCommand()
     // @formatter:on
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -667,7 +667,7 @@ data class Commitments(
         return Either.Right(Triple(copy(changes = changes.addRemoteProposal(fail)), paymentId, htlc))
     }
 
-    fun sendFee(cmd: ChannelCommand.UpdateFee): Either<ChannelException, Pair<Commitments, UpdateFee>> {
+    fun sendFee(cmd: ChannelCommand.Commitment.UpdateFee): Either<ChannelException, Pair<Commitments, UpdateFee>> {
         if (!params.localParams.isInitiator) return Either.Left(NonInitiatorCannotSendUpdateFee(channelId))
         // let's compute the current commitment *as seen by them* with this change taken into account
         val fee = UpdateFee(channelId, cmd.feerate)

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -102,7 +102,7 @@ object Helpers {
     }
 
     /** Called by the initiator. */
-    fun validateParamsInitiator(nodeParams: NodeParams, init: ChannelCommand.InitInitiator, open: OpenDualFundedChannel, accept: AcceptDualFundedChannel): Either<ChannelException, ChannelType> {
+    fun validateParamsInitiator(nodeParams: NodeParams, init: ChannelCommand.Init.Initiator, open: OpenDualFundedChannel, accept: AcceptDualFundedChannel): Either<ChannelException, ChannelType> {
         require(open.channelType != null) { "we should have sent a channel type in open_channel" }
         if (accept.channelType == null) {
             // We only open channels to peers who support explicit channel type negotiation.

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
@@ -853,7 +853,7 @@ data class InteractiveTxSigningSession(
 
 sealed class RbfStatus {
     object None : RbfStatus()
-    data class RbfRequested(val command: ChannelCommand.BumpFundingFee) : RbfStatus()
+    data class RbfRequested(val command: ChannelCommand.Funding.BumpFundingFee) : RbfStatus()
     data class InProgress(val rbfSession: InteractiveTxSession) : RbfStatus()
     data class WaitingForSigs(val session: InteractiveTxSigningSession) : RbfStatus()
     object RbfAborted : RbfStatus()
@@ -861,8 +861,8 @@ sealed class RbfStatus {
 
 sealed class SpliceStatus {
     object None : SpliceStatus()
-    data class Requested(val command: ChannelCommand.Splice.Request, val spliceInit: SpliceInit) : SpliceStatus()
-    data class InProgress(val replyTo: CompletableDeferred<ChannelCommand.Splice.Response>?, val spliceSession: InteractiveTxSession, val localPushAmount: MilliSatoshi, val remotePushAmount: MilliSatoshi, val origins: List<Origin.PayToOpenOrigin>) : SpliceStatus()
+    data class Requested(val command: ChannelCommand.Commitment.Splice.Request, val spliceInit: SpliceInit) : SpliceStatus()
+    data class InProgress(val replyTo: CompletableDeferred<ChannelCommand.Commitment.Splice.Response>?, val spliceSession: InteractiveTxSession, val localPushAmount: MilliSatoshi, val remotePushAmount: MilliSatoshi, val origins: List<Origin.PayToOpenOrigin>) : SpliceStatus()
     data class WaitingForSigs(val session: InteractiveTxSigningSession, val origins: List<Origin.PayToOpenOrigin>) : SpliceStatus()
     object Aborted : SpliceStatus()
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closing.kt
@@ -297,7 +297,7 @@ data class Closing(
                     else -> unhandled(cmd)
                 }
             }
-            is ChannelCommand.GetHtlcInfosResponse -> {
+            is ChannelCommand.Closing.GetHtlcInfosResponse -> {
                 val index = revokedCommitPublished.indexOfFirst { it.commitTx.txid == cmd.revokedCommitTxId }
                 if (index >= 0) {
                     val revokedCommitPublished1 = claimRevokedRemoteCommitTxHtlcOutputs(channelKeys(), commitments.params, revokedCommitPublished[index], currentOnChainFeerates, cmd.htlcInfos)
@@ -328,7 +328,7 @@ data class Closing(
                 }
                 else -> unhandled(cmd)
             }
-            is ChannelCommand.Close.MutualClose -> handleCommandError(cmd, ClosingAlreadyInProgress(channelId))
+            is ChannelCommand.Close -> handleCommandError(cmd, ClosingAlreadyInProgress(channelId))
             is ChannelCommand.Htlc.Add -> {
                 logger.info { "rejecting htlc request in state=${this::class}" }
                 // we don't provide a channel_update: this will be a permanent channel failure
@@ -368,8 +368,13 @@ data class Closing(
                 }
                 is Either.Left -> handleCommandError(cmd, result.value)
             }
-            is ChannelCommand.CheckHtlcTimeout -> checkHtlcTimeout()
-            else -> unhandled(cmd)
+            is ChannelCommand.Htlc.Settlement -> unhandled(cmd)
+            is ChannelCommand.Commitment.CheckHtlcTimeout -> checkHtlcTimeout()
+            is ChannelCommand.Commitment -> unhandled(cmd)
+            is ChannelCommand.Init -> unhandled(cmd)
+            is ChannelCommand.Funding -> unhandled(cmd)
+            is ChannelCommand.Connected -> unhandled(cmd)
+            is ChannelCommand.Disconnected -> unhandled(cmd)
         }
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmed.kt
@@ -73,9 +73,13 @@ data class LegacyWaitForFundingConfirmed(
                 }
             is ChannelCommand.Close.MutualClose -> Pair(this@LegacyWaitForFundingConfirmed, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmd, CommandUnavailableInThisState(channelId, this::class.toString()))))
             is ChannelCommand.Close.ForceClose -> handleLocalError(cmd, ForcedLocalCommit(channelId))
-            is ChannelCommand.CheckHtlcTimeout -> Pair(this@LegacyWaitForFundingConfirmed, listOf())
+            is ChannelCommand.Init -> unhandled(cmd)
+            is ChannelCommand.Funding -> unhandled(cmd)
+            is ChannelCommand.Htlc -> unhandled(cmd)
+            is ChannelCommand.Commitment -> unhandled(cmd)
+            is ChannelCommand.Closing -> unhandled(cmd)
+            is ChannelCommand.Connected -> unhandled(cmd)
             is ChannelCommand.Disconnected -> Pair(Offline(this@LegacyWaitForFundingConfirmed), listOf())
-            else -> unhandled(cmd)
         }
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLocked.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLocked.kt
@@ -67,9 +67,13 @@ data class LegacyWaitForFundingLocked(
             }
             is ChannelCommand.Close.MutualClose -> Pair(this@LegacyWaitForFundingLocked, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmd, CommandUnavailableInThisState(channelId, this::class.toString()))))
             is ChannelCommand.Close.ForceClose -> handleLocalError(cmd, ForcedLocalCommit(channelId))
-            is ChannelCommand.CheckHtlcTimeout -> Pair(this@LegacyWaitForFundingLocked, listOf())
+            is ChannelCommand.Init -> unhandled(cmd)
+            is ChannelCommand.Funding -> unhandled(cmd)
+            is ChannelCommand.Htlc -> unhandled(cmd)
+            is ChannelCommand.Commitment -> unhandled(cmd)
+            is ChannelCommand.Closing -> unhandled(cmd)
+            is ChannelCommand.Connected -> unhandled(cmd)
             is ChannelCommand.Disconnected -> Pair(Offline(this@LegacyWaitForFundingLocked), listOf())
-            else -> unhandled(cmd)
         }
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -19,315 +19,330 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
     }
 
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
-        return when {
-            cmd is ChannelCommand.MessageReceived && cmd.message is ChannelReestablish -> {
-                val (nextState, actions) = when {
-                    state is LegacyWaitForFundingConfirmed -> {
-                        Pair(state, listOf())
-                    }
-                    state is WaitForFundingSigned -> {
-                        when (cmd.message.nextFundingTxId) {
-                            // We retransmit our commit_sig, and will send our tx_signatures once we've received their commit_sig.
-                            state.signingSession.fundingTx.txId -> {
-                                val commitSig = state.signingSession.remoteCommit.sign(channelKeys(), state.channelParams, state.signingSession)
-                                Pair(state, listOf(ChannelAction.Message.Send(commitSig)))
-                            }
-                            else -> Pair(state, listOf())
+        return when (cmd) {
+            is ChannelCommand.MessageReceived -> when (cmd.message) {
+                is ChannelReestablish -> {
+                    val (nextState, actions) = when {
+                        state is LegacyWaitForFundingConfirmed -> {
+                            Pair(state, listOf())
                         }
-                    }
-                    state is WaitForFundingConfirmed -> {
-                        when (cmd.message.nextFundingTxId) {
-                            null -> Pair(state, listOf())
-                            else -> {
-                                if (state.rbfStatus is RbfStatus.WaitingForSigs && state.rbfStatus.session.fundingTx.txId == cmd.message.nextFundingTxId) {
-                                    // We retransmit our commit_sig, and will send our tx_signatures once we've received their commit_sig.
-                                    logger.info { "re-sending commit_sig for rbf attempt with fundingTxId=${cmd.message.nextFundingTxId}" }
-                                    val commitSig = state.rbfStatus.session.remoteCommit.sign(channelKeys(), state.commitments.params, state.rbfStatus.session)
-                                    val actions = listOf(ChannelAction.Message.Send(commitSig))
-                                    Pair(state, actions)
-                                } else if (state.latestFundingTx.txId == cmd.message.nextFundingTxId) {
-                                    val actions = buildList {
-                                        if (state.latestFundingTx.sharedTx is PartiallySignedSharedTransaction) {
-                                            // We have not received their tx_signatures: we retransmit our commit_sig because we don't know if they received it.
-                                            logger.info { "re-sending commit_sig for fundingTxId=${cmd.message.nextFundingTxId}" }
-                                            val commitSig = state.commitments.latest.remoteCommit.sign(
-                                                channelKeys(),
-                                                state.commitments.params,
-                                                fundingTxIndex = 0,
-                                                state.commitments.latest.remoteFundingPubkey,
-                                                state.commitments.latest.commitInput
-                                            )
-                                            add(ChannelAction.Message.Send(commitSig))
-                                        }
-                                        logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
-                                        add(ChannelAction.Message.Send(state.latestFundingTx.sharedTx.localSigs))
-                                    }
-                                    Pair(state, actions)
-                                } else {
-                                    // The fundingTxId must be for an RBF attempt that we didn't store (we got disconnected before receiving their tx_complete).
-                                    // We tell them to abort that RBF attempt.
-                                    logger.info { "aborting obsolete rbf attempt for fundingTxId=${cmd.message.nextFundingTxId}" }
-                                    Pair(state.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(state.channelId, RbfAttemptAborted(state.channelId).message))))
+                        state is WaitForFundingSigned -> {
+                            when (cmd.message.nextFundingTxId) {
+                                // We retransmit our commit_sig, and will send our tx_signatures once we've received their commit_sig.
+                                state.signingSession.fundingTx.txId -> {
+                                    val commitSig = state.signingSession.remoteCommit.sign(channelKeys(), state.channelParams, state.signingSession)
+                                    Pair(state, listOf(ChannelAction.Message.Send(commitSig)))
                                 }
+                                else -> Pair(state, listOf())
                             }
                         }
-                    }
-                    state is WaitForChannelReady -> {
-                        val actions = ArrayList<ChannelAction>()
-
-                        if (state.commitments.latest.fundingTxId == cmd.message.nextFundingTxId) {
-                            if (state.commitments.latest.localFundingStatus is LocalFundingStatus.UnconfirmedFundingTx) {
-                                if (state.commitments.latest.localFundingStatus.sharedTx is PartiallySignedSharedTransaction) {
-                                    // If we have not received their tx_signatures, we can't tell whether they had received our commit_sig, so we need to retransmit it
-                                    logger.info { "re-sending commit_sig for fundingTxId=${state.commitments.latest.fundingTxId}" }
-                                    val commitSig = state.commitments.latest.remoteCommit.sign(
-                                        channelKeys(),
-                                        state.commitments.params,
-                                        fundingTxIndex = state.commitments.latest.fundingTxIndex,
-                                        state.commitments.latest.remoteFundingPubkey,
-                                        state.commitments.latest.commitInput
-                                    )
-                                    actions.add(ChannelAction.Message.Send(commitSig))
-                                }
-                                logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
-                                actions.add(ChannelAction.Message.Send(state.commitments.latest.localFundingStatus.sharedTx.localSigs))
-                            } else {
-                                // The funding tx is confirmed, and they have not received our tx_signatures, but they must have received our commit_sig, otherwise they
-                                // would not have sent their tx_signatures and we would not have been able to publish the funding tx in the first place. We could in theory
-                                // recompute our tx_signatures, but instead we do nothing: they will shortly be notified that the funding tx has confirmed.
-                                logger.warning { "cannot re-send tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}, transaction is already confirmed" }
-                            }
-                        }
-
-                        logger.debug { "re-sending channel_ready" }
-                        val nextPerCommitmentPoint = channelKeys().commitmentPoint(1)
-                        val channelReady = ChannelReady(state.commitments.channelId, nextPerCommitmentPoint)
-                        actions.add(ChannelAction.Message.Send(channelReady))
-
-                        Pair(state, actions)
-                    }
-                    state is LegacyWaitForFundingLocked -> {
-                        logger.debug { "re-sending channel_ready" }
-                        val nextPerCommitmentPoint = channelKeys().commitmentPoint(1)
-                        val channelReady = ChannelReady(state.commitments.channelId, nextPerCommitmentPoint)
-                        val actions = listOf(ChannelAction.Message.Send(channelReady))
-                        Pair(state, actions)
-                    }
-                    state is Normal -> {
-                        when {
-                            !Helpers.checkLocalCommit(state.commitments, cmd.message.nextRemoteRevocationNumber) -> {
-                                // if next_remote_revocation_number is greater than our local commitment index, it means that either we are using an outdated commitment, or they are lying
-                                // but first we need to make sure that the last per_commitment_secret that they claim to have received from us is correct for that next_remote_revocation_number minus 1
-                                if (channelKeys().commitmentSecret(cmd.message.nextRemoteRevocationNumber - 1) == cmd.message.yourLastCommitmentSecret) {
-                                    // their data checks out, we indeed seem to be using an old revoked commitment, and must absolutely *NOT* publish it, because that would be a cheating attempt and they
-                                    // would punish us by taking all the funds in the channel
-                                    logger.warning { "counterparty proved that we have an outdated (revoked) local commitment!!! ourCommitmentNumber=${state.commitments.localCommitIndex} theirCommitmentNumber=${cmd.message.nextRemoteRevocationNumber}" }
-                                } else {
-                                    // they are deliberately trying to fool us into thinking we have a late commitment, but we cannot risk publishing it ourselves, because it may really be revoked!
-                                    logger.warning { "counterparty claims that we have an outdated commitment, but they sent an invalid proof, so our commitment may or may not be revoked: ourLocalCommitmentNumber=${state.commitments.localCommitIndex} theirRemoteCommitmentNumber=${cmd.message.nextRemoteRevocationNumber}" }
-                                }
-                                val exc = PleasePublishYourCommitment(channelId)
-                                val error = Error(channelId, exc.message.encodeToByteArray().toByteVector())
-                                val nextState = WaitForRemotePublishFutureCommitment(state.commitments, cmd.message)
-                                val actions = listOf(
-                                    ChannelAction.Storage.StoreState(nextState),
-                                    ChannelAction.Message.Send(error)
-                                )
-                                Pair(nextState, actions)
-                            }
-                            !Helpers.checkRemoteCommit(state.commitments, cmd.message.nextLocalCommitmentNumber) -> {
-                                // if next_local_commit_number is more than one more our remote commitment index, it means that either we are using an outdated commitment, or they are lying
-                                logger.warning { "counterparty says that they have a more recent commitment than the one we know of!!! ourCommitmentNumber=${state.commitments.latest.nextRemoteCommit?.commit?.index ?: state.commitments.latest.remoteCommit.index} theirCommitmentNumber=${cmd.message.nextLocalCommitmentNumber}" }
-                                // there is no way to make sure that they are saying the truth, the best thing to do is ask them to publish their commitment right now
-                                // maybe they will publish their commitment, in that case we need to remember their commitment point in order to be able to claim our outputs
-                                // not that if they don't comply, we could publish our own commitment (it is not stale, otherwise we would be in the case above)
-                                val exc = PleasePublishYourCommitment(channelId)
-                                val error = Error(channelId, exc.message.encodeToByteArray().toByteVector())
-                                val nextState = WaitForRemotePublishFutureCommitment(state.commitments, cmd.message)
-                                val actions = listOf(
-                                    ChannelAction.Storage.StoreState(nextState),
-                                    ChannelAction.Message.Send(error)
-                                )
-                                Pair(nextState, actions)
-                            }
-                            else -> {
-                                // normal case, our data is up-to-date
-                                val actions = ArrayList<ChannelAction>()
-
-                                // re-send channel_ready or splice_locked
-                                if (state.commitments.latest.fundingTxIndex == 0L && cmd.message.nextLocalCommitmentNumber == 1L && state.commitments.localCommitIndex == 0L) {
-                                    // If next_local_commitment_number is 1 in both the channel_reestablish it sent and received, then the node MUST retransmit channel_ready, otherwise it MUST NOT
-                                    logger.debug { "re-sending channel_ready" }
-                                    val nextPerCommitmentPoint = channelKeys().commitmentPoint(1)
-                                    val channelReady = ChannelReady(state.commitments.channelId, nextPerCommitmentPoint)
-                                    actions.add(ChannelAction.Message.Send(channelReady))
-                                } else {
-                                    // NB: there is a key difference between channel_ready and splice_locked:
-                                    // - channel_ready: a non-zero commitment index implies that both sides have seen the channel_ready
-                                    // - splice_locked: the commitment index can be updated as long as it is compatible with all splices, so
-                                    //   we must keep sending our most recent splice_locked at each reconnection
-                                    state.commitments.active
-                                        .filter { it.fundingTxIndex > 0L } // only consider splice txs
-                                        .firstOrNull { staticParams.useZeroConf || it.localFundingStatus is LocalFundingStatus.ConfirmedFundingTx }
-                                        ?.let {
-                                            logger.debug { "re-sending splice_locked for fundingTxId=${it.fundingTxId}" }
-                                            val spliceLocked = SpliceLocked(channelId, it.fundingTxId.reversed())
-                                            actions.add(ChannelAction.Message.Send(spliceLocked))
+                        state is WaitForFundingConfirmed -> {
+                            when (cmd.message.nextFundingTxId) {
+                                null -> Pair(state, listOf())
+                                else -> {
+                                    if (state.rbfStatus is RbfStatus.WaitingForSigs && state.rbfStatus.session.fundingTx.txId == cmd.message.nextFundingTxId) {
+                                        // We retransmit our commit_sig, and will send our tx_signatures once we've received their commit_sig.
+                                        logger.info { "re-sending commit_sig for rbf attempt with fundingTxId=${cmd.message.nextFundingTxId}" }
+                                        val commitSig = state.rbfStatus.session.remoteCommit.sign(channelKeys(), state.commitments.params, state.rbfStatus.session)
+                                        val actions = listOf(ChannelAction.Message.Send(commitSig))
+                                        Pair(state, actions)
+                                    } else if (state.latestFundingTx.txId == cmd.message.nextFundingTxId) {
+                                        val actions = buildList {
+                                            if (state.latestFundingTx.sharedTx is PartiallySignedSharedTransaction) {
+                                                // We have not received their tx_signatures: we retransmit our commit_sig because we don't know if they received it.
+                                                logger.info { "re-sending commit_sig for fundingTxId=${cmd.message.nextFundingTxId}" }
+                                                val commitSig = state.commitments.latest.remoteCommit.sign(
+                                                    channelKeys(),
+                                                    state.commitments.params,
+                                                    fundingTxIndex = 0,
+                                                    state.commitments.latest.remoteFundingPubkey,
+                                                    state.commitments.latest.commitInput
+                                                )
+                                                add(ChannelAction.Message.Send(commitSig))
+                                            }
+                                            logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
+                                            add(ChannelAction.Message.Send(state.latestFundingTx.sharedTx.localSigs))
                                         }
-                                }
-
-                                // resume splice signing session if any
-                                val spliceStatus1 = if (state.spliceStatus is SpliceStatus.WaitingForSigs && state.spliceStatus.session.fundingTx.txId == cmd.message.nextFundingTxId) {
-                                    // We retransmit our commit_sig, and will send our tx_signatures once we've received their commit_sig.
-                                    logger.info { "re-sending commit_sig for splice attempt with fundingTxIndex=${state.spliceStatus.session.fundingTxIndex} fundingTxId=${state.spliceStatus.session.fundingTx.txId}" }
-                                    val commitSig = state.spliceStatus.session.remoteCommit.sign(channelKeys(), state.commitments.params, state.spliceStatus.session)
-                                    actions.add(ChannelAction.Message.Send(commitSig))
-                                    state.spliceStatus
-                                } else if (state.commitments.latest.fundingTxId == cmd.message.nextFundingTxId) {
-                                    if (state.commitments.latest.localFundingStatus is LocalFundingStatus.UnconfirmedFundingTx) {
-                                        if (state.commitments.latest.localFundingStatus.sharedTx is PartiallySignedSharedTransaction) {
-                                            // If we have not received their tx_signatures, we can't tell whether they had received our commit_sig, so we need to retransmit it
-                                            logger.info { "re-sending commit_sig for fundingTxIndex=${state.commitments.latest.fundingTxIndex} fundingTxId=${state.commitments.latest.fundingTxId}" }
-                                            val commitSig = state.commitments.latest.remoteCommit.sign(
-                                                channelKeys(),
-                                                state.commitments.params,
-                                                fundingTxIndex = state.commitments.latest.fundingTxIndex,
-                                                state.commitments.latest.remoteFundingPubkey,
-                                                state.commitments.latest.commitInput
-                                            )
-                                            actions.add(ChannelAction.Message.Send(commitSig))
-                                        }
-                                        logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
-                                        actions.add(ChannelAction.Message.Send(state.commitments.latest.localFundingStatus.sharedTx.localSigs))
+                                        Pair(state, actions)
                                     } else {
-                                        // The funding tx is confirmed, and they have not received our tx_signatures, but they must have received our commit_sig, otherwise they
-                                        // would not have sent their tx_signatures and we would not have been able to publish the funding tx in the first place. We could in theory
-                                        // recompute our tx_signatures, but instead we do nothing: they will shortly be notified that the funding tx has confirmed.
-                                        logger.warning { "cannot re-send tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}, transaction is already confirmed" }
+                                        // The fundingTxId must be for an RBF attempt that we didn't store (we got disconnected before receiving their tx_complete).
+                                        // We tell them to abort that RBF attempt.
+                                        logger.info { "aborting obsolete rbf attempt for fundingTxId=${cmd.message.nextFundingTxId}" }
+                                        Pair(state.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(state.channelId, RbfAttemptAborted(state.channelId).message))))
                                     }
-                                    state.spliceStatus
-                                } else if (cmd.message.nextFundingTxId != null) {
-                                    // The fundingTxId must be for a splice attempt that we didn't store (we got disconnected before receiving their tx_complete)
-                                    logger.info { "aborting obsolete splice attempt for fundingTxId=${cmd.message.nextFundingTxId}" }
-                                    actions.add(ChannelAction.Message.Send(TxAbort(state.channelId, SpliceAborted(state.channelId).message)))
-                                    SpliceStatus.Aborted
-                                } else {
-                                    state.spliceStatus
                                 }
+                            }
+                        }
+                        state is WaitForChannelReady -> {
+                            val actions = ArrayList<ChannelAction>()
 
-                                try {
-                                    val (commitments1, sendQueue1) = handleSync(cmd.message, state)
-                                    actions.addAll(sendQueue1)
-                                    // BOLT 2: A node if it has sent a previous shutdown MUST retransmit shutdown.
-                                    state.localShutdown?.let {
-                                        logger.debug { "re-sending local shutdown" }
-                                        actions.add(ChannelAction.Message.Send(it))
+                            if (state.commitments.latest.fundingTxId == cmd.message.nextFundingTxId) {
+                                if (state.commitments.latest.localFundingStatus is LocalFundingStatus.UnconfirmedFundingTx) {
+                                    if (state.commitments.latest.localFundingStatus.sharedTx is PartiallySignedSharedTransaction) {
+                                        // If we have not received their tx_signatures, we can't tell whether they had received our commit_sig, so we need to retransmit it
+                                        logger.info { "re-sending commit_sig for fundingTxId=${state.commitments.latest.fundingTxId}" }
+                                        val commitSig = state.commitments.latest.remoteCommit.sign(
+                                            channelKeys(),
+                                            state.commitments.params,
+                                            fundingTxIndex = state.commitments.latest.fundingTxIndex,
+                                            state.commitments.latest.remoteFundingPubkey,
+                                            state.commitments.latest.commitInput
+                                        )
+                                        actions.add(ChannelAction.Message.Send(commitSig))
                                     }
-                                    Pair(state.copy(commitments = commitments1, spliceStatus = spliceStatus1), actions)
-                                } catch (e: RevocationSyncError) {
-                                    val error = Error(channelId, e.message)
-                                    state.run { spendLocalCurrent() }.run { copy(second = second + ChannelAction.Message.Send(error)) }
+                                    logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
+                                    actions.add(ChannelAction.Message.Send(state.commitments.latest.localFundingStatus.sharedTx.localSigs))
+                                } else {
+                                    // The funding tx is confirmed, and they have not received our tx_signatures, but they must have received our commit_sig, otherwise they
+                                    // would not have sent their tx_signatures and we would not have been able to publish the funding tx in the first place. We could in theory
+                                    // recompute our tx_signatures, but instead we do nothing: they will shortly be notified that the funding tx has confirmed.
+                                    logger.warning { "cannot re-send tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}, transaction is already confirmed" }
                                 }
                             }
+
+                            logger.debug { "re-sending channel_ready" }
+                            val nextPerCommitmentPoint = channelKeys().commitmentPoint(1)
+                            val channelReady = ChannelReady(state.commitments.channelId, nextPerCommitmentPoint)
+                            actions.add(ChannelAction.Message.Send(channelReady))
+
+                            Pair(state, actions)
                         }
-                    }
-                    // BOLT 2: A node if it has sent a previous shutdown MUST retransmit shutdown.
-                    // negotiation restarts from the beginning, and is initialized by the initiator
-                    // note: in any case we still need to keep all previously sent closing_signed, because they may publish one of them
-                    state is Negotiating && state.commitments.params.localParams.isInitiator -> {
-                        // we could use the last closing_signed we sent, but network fees may have changed while we were offline so it is better to restart from scratch
-                        val (closingTx, closingSigned) = Helpers.Closing.makeFirstClosingTx(
-                            channelKeys(),
-                            state.commitments.latest,
-                            state.localShutdown.scriptPubKey.toByteArray(),
-                            state.remoteShutdown.scriptPubKey.toByteArray(),
-                            state.closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate)
-                        )
-                        val closingTxProposed1 = state.closingTxProposed + listOf(listOf(ClosingTxProposed(closingTx, closingSigned)))
-                        val nextState = state.copy(closingTxProposed = closingTxProposed1)
-                        val actions = listOf(
-                            ChannelAction.Storage.StoreState(nextState),
-                            ChannelAction.Message.Send(state.localShutdown),
-                            ChannelAction.Message.Send(closingSigned)
-                        )
-                        return Pair(nextState, actions)
-                    }
-                    state is Negotiating -> {
-                        // we start a new round of negotiation
-                        val closingTxProposed1 = if (state.closingTxProposed.last().isEmpty()) state.closingTxProposed else state.closingTxProposed + listOf(listOf())
-                        val nextState = state.copy(closingTxProposed = closingTxProposed1)
-                        val actions = listOf(
-                            ChannelAction.Storage.StoreState(nextState),
-                            ChannelAction.Message.Send(state.localShutdown)
-                        )
-                        return Pair(nextState, actions)
-                    }
-                    else -> unhandled(cmd)
-                }
-                Pair(nextState, buildList {
-                    if (!channelReestablishSent) {
-                        val channelReestablish = state.run { createChannelReestablish() }
-                        add(ChannelAction.Message.Send(channelReestablish))
-                    }
-                    addAll(actions)
-                })
-            }
-            cmd is ChannelCommand.WatchReceived && state is ChannelStateWithCommitments -> when (val watch = cmd.watch) {
-                is WatchEventSpent -> when {
-                    state is Negotiating && state.closingTxProposed.flatten().any { it.unsignedTx.tx.txid == watch.tx.txid } -> {
-                        logger.info { "closing tx published: closingTxId=${watch.tx.txid}" }
-                        val closingTx = state.getMutualClosePublished(watch.tx)
-                        val nextState = Closing(
-                            state.commitments,
-                            waitingSinceBlock = currentBlockHeight.toLong(),
-                            mutualCloseProposed = state.closingTxProposed.flatten().map { it.unsignedTx },
-                            mutualClosePublished = listOf(closingTx)
-                        )
-                        val actions = listOf(
-                            ChannelAction.Storage.StoreState(nextState),
-                            ChannelAction.Blockchain.PublishTx(closingTx),
-                            ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.tx, staticParams.nodeParams.minDepthBlocks.toLong(), BITCOIN_TX_CONFIRMED(watch.tx)))
-                        )
-                        Pair(nextState, actions)
-                    }
-                    else -> state.run { handlePotentialForceClose(watch) }
-                }
-                is WatchEventConfirmed -> {
-                    if (watch.event is BITCOIN_FUNDING_DEPTHOK) {
-                        when (val res = state.run { acceptFundingTxConfirmed(watch) }) {
-                            is Either.Left -> Pair(this@Syncing, listOf())
-                            is Either.Right -> {
-                                val (commitments1, _, actions) = res.value
-                                val nextState = when (state) {
-                                    is WaitForFundingConfirmed -> {
-                                        logger.info { "was confirmed while syncing at blockHeight=${watch.blockHeight} txIndex=${watch.txIndex} with funding txid=${watch.tx.txid}" }
+                        state is LegacyWaitForFundingLocked -> {
+                            logger.debug { "re-sending channel_ready" }
+                            val nextPerCommitmentPoint = channelKeys().commitmentPoint(1)
+                            val channelReady = ChannelReady(state.commitments.channelId, nextPerCommitmentPoint)
+                            val actions = listOf(ChannelAction.Message.Send(channelReady))
+                            Pair(state, actions)
+                        }
+                        state is Normal -> {
+                            when {
+                                !Helpers.checkLocalCommit(state.commitments, cmd.message.nextRemoteRevocationNumber) -> {
+                                    // if next_remote_revocation_number is greater than our local commitment index, it means that either we are using an outdated commitment, or they are lying
+                                    // but first we need to make sure that the last per_commitment_secret that they claim to have received from us is correct for that next_remote_revocation_number minus 1
+                                    if (channelKeys().commitmentSecret(cmd.message.nextRemoteRevocationNumber - 1) == cmd.message.yourLastCommitmentSecret) {
+                                        // their data checks out, we indeed seem to be using an old revoked commitment, and must absolutely *NOT* publish it, because that would be a cheating attempt and they
+                                        // would punish us by taking all the funds in the channel
+                                        logger.warning { "counterparty proved that we have an outdated (revoked) local commitment!!! ourCommitmentNumber=${state.commitments.localCommitIndex} theirCommitmentNumber=${cmd.message.nextRemoteRevocationNumber}" }
+                                    } else {
+                                        // they are deliberately trying to fool us into thinking we have a late commitment, but we cannot risk publishing it ourselves, because it may really be revoked!
+                                        logger.warning { "counterparty claims that we have an outdated commitment, but they sent an invalid proof, so our commitment may or may not be revoked: ourLocalCommitmentNumber=${state.commitments.localCommitIndex} theirRemoteCommitmentNumber=${cmd.message.nextRemoteRevocationNumber}" }
+                                    }
+                                    val exc = PleasePublishYourCommitment(channelId)
+                                    val error = Error(channelId, exc.message.encodeToByteArray().toByteVector())
+                                    val nextState = WaitForRemotePublishFutureCommitment(state.commitments, cmd.message)
+                                    val actions = listOf(
+                                        ChannelAction.Storage.StoreState(nextState),
+                                        ChannelAction.Message.Send(error)
+                                    )
+                                    Pair(nextState, actions)
+                                }
+                                !Helpers.checkRemoteCommit(state.commitments, cmd.message.nextLocalCommitmentNumber) -> {
+                                    // if next_local_commit_number is more than one more our remote commitment index, it means that either we are using an outdated commitment, or they are lying
+                                    logger.warning { "counterparty says that they have a more recent commitment than the one we know of!!! ourCommitmentNumber=${state.commitments.latest.nextRemoteCommit?.commit?.index ?: state.commitments.latest.remoteCommit.index} theirCommitmentNumber=${cmd.message.nextLocalCommitmentNumber}" }
+                                    // there is no way to make sure that they are saying the truth, the best thing to do is ask them to publish their commitment right now
+                                    // maybe they will publish their commitment, in that case we need to remember their commitment point in order to be able to claim our outputs
+                                    // not that if they don't comply, we could publish our own commitment (it is not stale, otherwise we would be in the case above)
+                                    val exc = PleasePublishYourCommitment(channelId)
+                                    val error = Error(channelId, exc.message.encodeToByteArray().toByteVector())
+                                    val nextState = WaitForRemotePublishFutureCommitment(state.commitments, cmd.message)
+                                    val actions = listOf(
+                                        ChannelAction.Storage.StoreState(nextState),
+                                        ChannelAction.Message.Send(error)
+                                    )
+                                    Pair(nextState, actions)
+                                }
+                                else -> {
+                                    // normal case, our data is up-to-date
+                                    val actions = ArrayList<ChannelAction>()
+
+                                    // re-send channel_ready or splice_locked
+                                    if (state.commitments.latest.fundingTxIndex == 0L && cmd.message.nextLocalCommitmentNumber == 1L && state.commitments.localCommitIndex == 0L) {
+                                        // If next_local_commitment_number is 1 in both the channel_reestablish it sent and received, then the node MUST retransmit channel_ready, otherwise it MUST NOT
+                                        logger.debug { "re-sending channel_ready" }
                                         val nextPerCommitmentPoint = channelKeys().commitmentPoint(1)
-                                        val channelReady = ChannelReady(channelId, nextPerCommitmentPoint, TlvStream(ChannelReadyTlv.ShortChannelIdTlv(ShortChannelId.peerId(staticParams.nodeParams.nodeId))))
-                                        val shortChannelId = ShortChannelId(watch.blockHeight, watch.txIndex, commitments1.latest.commitInput.outPoint.index.toInt())
-                                        WaitForChannelReady(commitments1, shortChannelId, channelReady)
+                                        val channelReady = ChannelReady(state.commitments.channelId, nextPerCommitmentPoint)
+                                        actions.add(ChannelAction.Message.Send(channelReady))
+                                    } else {
+                                        // NB: there is a key difference between channel_ready and splice_locked:
+                                        // - channel_ready: a non-zero commitment index implies that both sides have seen the channel_ready
+                                        // - splice_locked: the commitment index can be updated as long as it is compatible with all splices, so
+                                        //   we must keep sending our most recent splice_locked at each reconnection
+                                        state.commitments.active
+                                            .filter { it.fundingTxIndex > 0L } // only consider splice txs
+                                            .firstOrNull { staticParams.useZeroConf || it.localFundingStatus is LocalFundingStatus.ConfirmedFundingTx }
+                                            ?.let {
+                                                logger.debug { "re-sending splice_locked for fundingTxId=${it.fundingTxId}" }
+                                                val spliceLocked = SpliceLocked(channelId, it.fundingTxId.reversed())
+                                                actions.add(ChannelAction.Message.Send(spliceLocked))
+                                            }
                                     }
-                                    else -> state
+
+                                    // resume splice signing session if any
+                                    val spliceStatus1 = if (state.spliceStatus is SpliceStatus.WaitingForSigs && state.spliceStatus.session.fundingTx.txId == cmd.message.nextFundingTxId) {
+                                        // We retransmit our commit_sig, and will send our tx_signatures once we've received their commit_sig.
+                                        logger.info { "re-sending commit_sig for splice attempt with fundingTxIndex=${state.spliceStatus.session.fundingTxIndex} fundingTxId=${state.spliceStatus.session.fundingTx.txId}" }
+                                        val commitSig = state.spliceStatus.session.remoteCommit.sign(channelKeys(), state.commitments.params, state.spliceStatus.session)
+                                        actions.add(ChannelAction.Message.Send(commitSig))
+                                        state.spliceStatus
+                                    } else if (state.commitments.latest.fundingTxId == cmd.message.nextFundingTxId) {
+                                        if (state.commitments.latest.localFundingStatus is LocalFundingStatus.UnconfirmedFundingTx) {
+                                            if (state.commitments.latest.localFundingStatus.sharedTx is PartiallySignedSharedTransaction) {
+                                                // If we have not received their tx_signatures, we can't tell whether they had received our commit_sig, so we need to retransmit it
+                                                logger.info { "re-sending commit_sig for fundingTxIndex=${state.commitments.latest.fundingTxIndex} fundingTxId=${state.commitments.latest.fundingTxId}" }
+                                                val commitSig = state.commitments.latest.remoteCommit.sign(
+                                                    channelKeys(),
+                                                    state.commitments.params,
+                                                    fundingTxIndex = state.commitments.latest.fundingTxIndex,
+                                                    state.commitments.latest.remoteFundingPubkey,
+                                                    state.commitments.latest.commitInput
+                                                )
+                                                actions.add(ChannelAction.Message.Send(commitSig))
+                                            }
+                                            logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
+                                            actions.add(ChannelAction.Message.Send(state.commitments.latest.localFundingStatus.sharedTx.localSigs))
+                                        } else {
+                                            // The funding tx is confirmed, and they have not received our tx_signatures, but they must have received our commit_sig, otherwise they
+                                            // would not have sent their tx_signatures and we would not have been able to publish the funding tx in the first place. We could in theory
+                                            // recompute our tx_signatures, but instead we do nothing: they will shortly be notified that the funding tx has confirmed.
+                                            logger.warning { "cannot re-send tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}, transaction is already confirmed" }
+                                        }
+                                        state.spliceStatus
+                                    } else if (cmd.message.nextFundingTxId != null) {
+                                        // The fundingTxId must be for a splice attempt that we didn't store (we got disconnected before receiving their tx_complete)
+                                        logger.info { "aborting obsolete splice attempt for fundingTxId=${cmd.message.nextFundingTxId}" }
+                                        actions.add(ChannelAction.Message.Send(TxAbort(state.channelId, SpliceAborted(state.channelId).message)))
+                                        SpliceStatus.Aborted
+                                    } else {
+                                        state.spliceStatus
+                                    }
+
+                                    try {
+                                        val (commitments1, sendQueue1) = handleSync(cmd.message, state)
+                                        actions.addAll(sendQueue1)
+                                        // BOLT 2: A node if it has sent a previous shutdown MUST retransmit shutdown.
+                                        state.localShutdown?.let {
+                                            logger.debug { "re-sending local shutdown" }
+                                            actions.add(ChannelAction.Message.Send(it))
+                                        }
+                                        Pair(state.copy(commitments = commitments1, spliceStatus = spliceStatus1), actions)
+                                    } catch (e: RevocationSyncError) {
+                                        val error = Error(channelId, e.message)
+                                        state.run { spendLocalCurrent() }.run { copy(second = second + ChannelAction.Message.Send(error)) }
+                                    }
                                 }
-                                Pair(this@Syncing.copy(state = nextState), actions + listOf(ChannelAction.Storage.StoreState(nextState)))
                             }
                         }
-                    } else {
-                        Pair(this@Syncing, listOf())
+                        // BOLT 2: A node if it has sent a previous shutdown MUST retransmit shutdown.
+                        // negotiation restarts from the beginning, and is initialized by the initiator
+                        // note: in any case we still need to keep all previously sent closing_signed, because they may publish one of them
+                        state is Negotiating && state.commitments.params.localParams.isInitiator -> {
+                            // we could use the last closing_signed we sent, but network fees may have changed while we were offline so it is better to restart from scratch
+                            val (closingTx, closingSigned) = Helpers.Closing.makeFirstClosingTx(
+                                channelKeys(),
+                                state.commitments.latest,
+                                state.localShutdown.scriptPubKey.toByteArray(),
+                                state.remoteShutdown.scriptPubKey.toByteArray(),
+                                state.closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate)
+                            )
+                            val closingTxProposed1 = state.closingTxProposed + listOf(listOf(ClosingTxProposed(closingTx, closingSigned)))
+                            val nextState = state.copy(closingTxProposed = closingTxProposed1)
+                            val actions = listOf(
+                                ChannelAction.Storage.StoreState(nextState),
+                                ChannelAction.Message.Send(state.localShutdown),
+                                ChannelAction.Message.Send(closingSigned)
+                            )
+                            return Pair(nextState, actions)
+                        }
+                        state is Negotiating -> {
+                            // we start a new round of negotiation
+                            val closingTxProposed1 = if (state.closingTxProposed.last().isEmpty()) state.closingTxProposed else state.closingTxProposed + listOf(listOf())
+                            val nextState = state.copy(closingTxProposed = closingTxProposed1)
+                            val actions = listOf(
+                                ChannelAction.Storage.StoreState(nextState),
+                                ChannelAction.Message.Send(state.localShutdown)
+                            )
+                            return Pair(nextState, actions)
+                        }
+                        else -> unhandled(cmd)
+                    }
+                    Pair(nextState, buildList {
+                        if (!channelReestablishSent) {
+                            val channelReestablish = state.run { createChannelReestablish() }
+                            add(ChannelAction.Message.Send(channelReestablish))
+                        }
+                        addAll(actions)
+                    })
+                }
+                is Error -> state.run { handleRemoteError(cmd.message) }
+                else -> unhandled(cmd)
+            }
+            is ChannelCommand.WatchReceived -> when (state) {
+                is ChannelStateWithCommitments -> when (val watch = cmd.watch) {
+                    is WatchEventSpent -> when {
+                        state is Negotiating && state.closingTxProposed.flatten().any { it.unsignedTx.tx.txid == watch.tx.txid } -> {
+                            logger.info { "closing tx published: closingTxId=${watch.tx.txid}" }
+                            val closingTx = state.getMutualClosePublished(watch.tx)
+                            val nextState = Closing(
+                                state.commitments,
+                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                mutualCloseProposed = state.closingTxProposed.flatten().map { it.unsignedTx },
+                                mutualClosePublished = listOf(closingTx)
+                            )
+                            val actions = listOf(
+                                ChannelAction.Storage.StoreState(nextState),
+                                ChannelAction.Blockchain.PublishTx(closingTx),
+                                ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.tx, staticParams.nodeParams.minDepthBlocks.toLong(), BITCOIN_TX_CONFIRMED(watch.tx)))
+                            )
+                            Pair(nextState, actions)
+                        }
+                        else -> state.run { handlePotentialForceClose(watch) }
+                    }
+                    is WatchEventConfirmed -> {
+                        if (watch.event is BITCOIN_FUNDING_DEPTHOK) {
+                            when (val res = state.run { acceptFundingTxConfirmed(watch) }) {
+                                is Either.Left -> Pair(this@Syncing, listOf())
+                                is Either.Right -> {
+                                    val (commitments1, _, actions) = res.value
+                                    val nextState = when (state) {
+                                        is WaitForFundingConfirmed -> {
+                                            logger.info { "was confirmed while syncing at blockHeight=${watch.blockHeight} txIndex=${watch.txIndex} with funding txid=${watch.tx.txid}" }
+                                            val nextPerCommitmentPoint = channelKeys().commitmentPoint(1)
+                                            val channelReady = ChannelReady(channelId, nextPerCommitmentPoint, TlvStream(ChannelReadyTlv.ShortChannelIdTlv(ShortChannelId.peerId(staticParams.nodeParams.nodeId))))
+                                            val shortChannelId = ShortChannelId(watch.blockHeight, watch.txIndex, commitments1.latest.commitInput.outPoint.index.toInt())
+                                            WaitForChannelReady(commitments1, shortChannelId, channelReady)
+                                        }
+                                        else -> state
+                                    }
+                                    Pair(this@Syncing.copy(state = nextState), actions + listOf(ChannelAction.Storage.StoreState(nextState)))
+                                }
+                            }
+                        } else {
+                            Pair(this@Syncing, listOf())
+                        }
                     }
                 }
+                is WaitForFundingSigned -> Pair(this@Syncing, listOf())
             }
-            cmd is ChannelCommand.CheckHtlcTimeout && state is ChannelStateWithCommitments -> {
-                val (newState, actions) = state.run { checkHtlcTimeout() }
-                when (newState) {
-                    is Closing -> Pair(newState, actions)
-                    is Closed -> Pair(newState, actions)
-                    else -> Pair(Syncing(newState, channelReestablishSent), actions)
+            is ChannelCommand.Commitment.CheckHtlcTimeout -> when (state) {
+                is ChannelStateWithCommitments -> {
+                    val (newState, actions) = state.run { checkHtlcTimeout() }
+                    when (newState) {
+                        is Closing -> Pair(newState, actions)
+                        is Closed -> Pair(newState, actions)
+                        else -> Pair(Syncing(newState, channelReestablishSent), actions)
+                    }
                 }
+                is WaitForFundingSigned -> Pair(this@Syncing, listOf())
             }
-            cmd is ChannelCommand.Disconnected -> Pair(Offline(state), listOf())
-            cmd is ChannelCommand.Close.ForceClose -> state.run { handleLocalError(cmd, ForcedLocalCommit(channelId)) }
-            cmd is ChannelCommand.MessageReceived && cmd.message is Error -> state.run { handleRemoteError(cmd.message) }
-            else -> unhandled(cmd)
+            is ChannelCommand.Commitment -> unhandled(cmd)
+            is ChannelCommand.Htlc -> unhandled(cmd)
+            is ChannelCommand.Connected -> unhandled(cmd)
+            is ChannelCommand.Disconnected -> Pair(Offline(state), listOf())
+            is ChannelCommand.Close.MutualClose -> Pair(this@Syncing, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmd, CommandUnavailableInThisState(channelId, stateName))))
+            is ChannelCommand.Close.ForceClose -> state.run { handleLocalError(cmd, ForcedLocalCommit(channelId)) }
+            is ChannelCommand.Init -> unhandled(cmd)
+            is ChannelCommand.Funding -> unhandled(cmd)
+            is ChannelCommand.Closing -> unhandled(cmd)
         }
     }
 
@@ -396,7 +411,7 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
             }
 
             if (commitments1.changes.localHasChanges()) {
-                sendQueue.add(ChannelAction.Message.SendToSelf(ChannelCommand.Sign))
+                sendQueue.add(ChannelAction.Message.SendToSelf(ChannelCommand.Commitment.Sign))
             }
 
             // When a channel is reestablished after a wallet restarts, we need to reprocess incoming HTLCs that may have been only partially processed

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReady.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReady.kt
@@ -19,85 +19,93 @@ data class WaitForChannelReady(
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
-        return when {
-            cmd is ChannelCommand.MessageReceived && cmd.message is TxSignatures -> when (commitments.latest.localFundingStatus) {
-                is LocalFundingStatus.UnconfirmedFundingTx -> when (commitments.latest.localFundingStatus.sharedTx) {
-                    is PartiallySignedSharedTransaction -> when (val fullySignedTx = commitments.latest.localFundingStatus.sharedTx.addRemoteSigs(channelKeys(), commitments.latest.localFundingStatus.fundingParams, cmd.message)) {
-                        null -> {
-                            logger.warning { "received invalid remote funding signatures for txId=${cmd.message.txId}" }
-                            // The funding transaction may still confirm (since our peer should be able to generate valid signatures), so we cannot close the channel yet.
-                            Pair(this@WaitForChannelReady, listOf(ChannelAction.Message.Send(Warning(channelId, InvalidFundingSignature(channelId, cmd.message.txId).message))))
-                        }
-                        else -> {
-                            when (val res = commitments.run { updateLocalFundingSigned(fullySignedTx) }) {
-                                is Either.Left -> Pair(this@WaitForChannelReady, listOf())
-                                is Either.Right -> {
-                                    logger.info { "received remote funding signatures, publishing txId=${fullySignedTx.signedTx.txid}" }
-                                    val nextState = this@WaitForChannelReady.copy(commitments = res.value.first)
-                                    val actions = buildList {
-                                        add(ChannelAction.Blockchain.PublishTx(fullySignedTx.signedTx, ChannelAction.Blockchain.PublishTx.Type.FundingTx))
-                                        add(ChannelAction.Storage.StoreState(nextState))
+        return when (cmd) {
+            is ChannelCommand.MessageReceived -> when (cmd.message) {
+                is TxSignatures -> when (commitments.latest.localFundingStatus) {
+                    is LocalFundingStatus.UnconfirmedFundingTx -> when (commitments.latest.localFundingStatus.sharedTx) {
+                        is PartiallySignedSharedTransaction -> when (val fullySignedTx = commitments.latest.localFundingStatus.sharedTx.addRemoteSigs(channelKeys(), commitments.latest.localFundingStatus.fundingParams, cmd.message)) {
+                            null -> {
+                                logger.warning { "received invalid remote funding signatures for txId=${cmd.message.txId}" }
+                                // The funding transaction may still confirm (since our peer should be able to generate valid signatures), so we cannot close the channel yet.
+                                Pair(this@WaitForChannelReady, listOf(ChannelAction.Message.Send(Warning(channelId, InvalidFundingSignature(channelId, cmd.message.txId).message))))
+                            }
+                            else -> {
+                                when (val res = commitments.run { updateLocalFundingSigned(fullySignedTx) }) {
+                                    is Either.Left -> Pair(this@WaitForChannelReady, listOf())
+                                    is Either.Right -> {
+                                        logger.info { "received remote funding signatures, publishing txId=${fullySignedTx.signedTx.txid}" }
+                                        val nextState = this@WaitForChannelReady.copy(commitments = res.value.first)
+                                        val actions = buildList {
+                                            add(ChannelAction.Blockchain.PublishTx(fullySignedTx.signedTx, ChannelAction.Blockchain.PublishTx.Type.FundingTx))
+                                            add(ChannelAction.Storage.StoreState(nextState))
+                                        }
+                                        Pair(nextState, actions)
                                     }
-                                    Pair(nextState, actions)
                                 }
                             }
                         }
+                        is FullySignedSharedTransaction -> {
+                            logger.info { "ignoring duplicate remote funding signatures" }
+                            Pair(this@WaitForChannelReady, listOf())
+                        }
                     }
-                    is FullySignedSharedTransaction -> {
-                        logger.info { "ignoring duplicate remote funding signatures" }
+                    is LocalFundingStatus.ConfirmedFundingTx -> {
+                        logger.info { "ignoring funding signatures for txId=${cmd.message.txId}, transaction is already confirmed" }
                         Pair(this@WaitForChannelReady, listOf())
                     }
                 }
-                is LocalFundingStatus.ConfirmedFundingTx -> {
-                    logger.info { "ignoring funding signatures for txId=${cmd.message.txId}, transaction is already confirmed" }
-                    Pair(this@WaitForChannelReady, listOf())
+                is TxInitRbf -> {
+                    logger.info { "rejecting tx_init_rbf, we have already accepted the channel" }
+                    Pair(this@WaitForChannelReady, listOf(ChannelAction.Message.Send(TxAbort(channelId, InvalidRbfTxConfirmed(channelId, commitments.latest.fundingTxId).message))))
                 }
+                is ChannelReady -> {
+                    // we create a channel_update early so that we can use it to send payments through this channel, but it won't be propagated to other nodes since the channel is not yet announced
+                    val initialChannelUpdate = Announcements.makeChannelUpdate(
+                        staticParams.nodeParams.chainHash,
+                        staticParams.nodeParams.nodePrivateKey,
+                        staticParams.remoteNodeId,
+                        shortChannelId,
+                        staticParams.nodeParams.expiryDeltaBlocks,
+                        commitments.params.remoteParams.htlcMinimum,
+                        staticParams.nodeParams.feeBase,
+                        staticParams.nodeParams.feeProportionalMillionth.toLong(),
+                        commitments.latest.fundingAmount.toMilliSatoshi(),
+                        enable = Helpers.aboveReserve(commitments)
+                    )
+                    val nextState = Normal(
+                        commitments,
+                        shortChannelId,
+                        initialChannelUpdate,
+                        null,
+                        null,
+                        null,
+                        null,
+                        SpliceStatus.None
+                    )
+                    val actions = listOf(
+                        ChannelAction.Storage.StoreState(nextState),
+                        ChannelAction.Storage.SetLocked(commitments.latest.fundingTxId),
+                        ChannelAction.EmitEvent(ChannelEvents.Confirmed(nextState)),
+                    )
+                    Pair(nextState, actions)
+                }
+                is Error -> handleRemoteError(cmd.message)
+                else -> unhandled(cmd)
             }
-            cmd is ChannelCommand.MessageReceived && cmd.message is TxInitRbf -> {
-                logger.info { "rejecting tx_init_rbf, we have already accepted the channel" }
-                Pair(this@WaitForChannelReady, listOf(ChannelAction.Message.Send(TxAbort(channelId, InvalidRbfTxConfirmed(channelId, commitments.latest.fundingTxId).message))))
-            }
-            cmd is ChannelCommand.MessageReceived && cmd.message is ChannelReady -> {
-                // we create a channel_update early so that we can use it to send payments through this channel, but it won't be propagated to other nodes since the channel is not yet announced
-                val initialChannelUpdate = Announcements.makeChannelUpdate(
-                    staticParams.nodeParams.chainHash,
-                    staticParams.nodeParams.nodePrivateKey,
-                    staticParams.remoteNodeId,
-                    shortChannelId,
-                    staticParams.nodeParams.expiryDeltaBlocks,
-                    commitments.params.remoteParams.htlcMinimum,
-                    staticParams.nodeParams.feeBase,
-                    staticParams.nodeParams.feeProportionalMillionth.toLong(),
-                    commitments.latest.fundingAmount.toMilliSatoshi(),
-                    enable = Helpers.aboveReserve(commitments)
-                )
-                val nextState = Normal(
-                    commitments,
-                    shortChannelId,
-                    initialChannelUpdate,
-                    null,
-                    null,
-                    null,
-                    null,
-                    SpliceStatus.None
-                )
-                val actions = listOf(
-                    ChannelAction.Storage.StoreState(nextState),
-                    ChannelAction.Storage.SetLocked(commitments.latest.fundingTxId),
-                    ChannelAction.EmitEvent(ChannelEvents.Confirmed(nextState)),
-                )
-                Pair(nextState, actions)
-            }
-            cmd is ChannelCommand.MessageReceived && cmd.message is Error -> handleRemoteError(cmd.message)
-            cmd is ChannelCommand.WatchReceived -> when (cmd.watch) {
+            is ChannelCommand.WatchReceived -> when (cmd.watch) {
                 is WatchEventConfirmed -> updateFundingTxStatus(cmd.watch)
                 is WatchEventSpent -> handlePotentialForceClose(cmd.watch)
             }
-            cmd is ChannelCommand.Close.MutualClose -> Pair(this@WaitForChannelReady, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmd, CommandUnavailableInThisState(channelId, this::class.toString()))))
-            cmd is ChannelCommand.Close.ForceClose -> handleLocalError(cmd, ForcedLocalCommit(channelId))
-            cmd is ChannelCommand.CheckHtlcTimeout -> Pair(this@WaitForChannelReady, listOf())
-            cmd is ChannelCommand.Disconnected -> Pair(Offline(this@WaitForChannelReady), listOf())
-            else -> unhandled(cmd)
+            is ChannelCommand.Close.MutualClose -> Pair(this@WaitForChannelReady, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmd, CommandUnavailableInThisState(channelId, stateName))))
+            is ChannelCommand.Close.ForceClose -> handleLocalError(cmd, ForcedLocalCommit(channelId))
+            is ChannelCommand.Commitment.CheckHtlcTimeout -> Pair(this@WaitForChannelReady, listOf())
+            is ChannelCommand.Commitment -> unhandled(cmd)
+            is ChannelCommand.Htlc -> unhandled(cmd)
+            is ChannelCommand.Init -> unhandled(cmd)
+            is ChannelCommand.Funding -> unhandled(cmd)
+            is ChannelCommand.Closing -> unhandled(cmd)
+            is ChannelCommand.Connected -> unhandled(cmd)
+            is ChannelCommand.Disconnected -> Pair(Offline(this@WaitForChannelReady), listOf())
         }
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
@@ -30,217 +30,220 @@ data class WaitForFundingConfirmed(
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
-        return when {
-            cmd is ChannelCommand.MessageReceived && cmd.message is TxSignatures -> when (latestFundingTx.sharedTx) {
-                is PartiallySignedSharedTransaction -> when (val fullySignedTx = latestFundingTx.sharedTx.addRemoteSigs(channelKeys(), latestFundingTx.fundingParams, cmd.message)) {
-                    null -> {
-                        logger.warning { "received invalid remote funding signatures for txId=${cmd.message.txId}" }
-                        // The funding transaction may still confirm (since our peer should be able to generate valid signatures), so we cannot close the channel yet.
-                        Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(Warning(channelId, InvalidFundingSignature(channelId, cmd.message.txId).message))))
-                    }
-                    else -> {
-                        when (val res = commitments.run { updateLocalFundingSigned(fullySignedTx) }) {
-                            is Either.Left -> Pair(this@WaitForFundingConfirmed, listOf())
-                            is Either.Right -> {
-                                logger.info { "received remote funding signatures, publishing txId=${fullySignedTx.signedTx.txid}" }
-                                val nextState = this@WaitForFundingConfirmed.copy(commitments = res.value.first)
-                                val actions = buildList {
-                                    add(ChannelAction.Blockchain.PublishTx(fullySignedTx.signedTx, ChannelAction.Blockchain.PublishTx.Type.FundingTx))
-                                    add(ChannelAction.Storage.StoreState(nextState))
-                                }
-                                Pair(nextState, actions)
-                            }
-                        }
-                    }
-                }
-                is FullySignedSharedTransaction -> when (rbfStatus) {
-                    is RbfStatus.WaitingForSigs -> {
-                        when (val action = rbfStatus.session.receiveTxSigs(channelKeys(), cmd.message, currentBlockHeight.toLong())) {
-                            is InteractiveTxSigningSessionAction.AbortFundingAttempt -> {
-                                logger.warning { "rbf attempt failed: ${action.reason.message}" }
-                                Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, action.reason.message))))
-                            }
-                            InteractiveTxSigningSessionAction.WaitForTxSigs -> Pair(this@WaitForFundingConfirmed, listOf())
-                            is InteractiveTxSigningSessionAction.SendTxSigs -> sendRbfTxSigs(action, cmd.message.channelData)
-                        }
-                    }
-                    else -> {
-                        logger.warning { "rejecting unexpected tx_signatures for txId=${cmd.message.txId}" }
-                        Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, UnexpectedFundingSignatures(channelId).message))))
-                    }
-                }
-            }
-            cmd is ChannelCommand.MessageReceived && cmd.message is TxInitRbf -> {
-                if (isInitiator) {
-                    logger.info { "rejecting tx_init_rbf, we're the initiator, not them!" }
-                    Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(Error(channelId, InvalidRbfNonInitiator(channelId).message))))
-                } else {
-                    val minNextFeerate = latestFundingTx.fundingParams.minNextFeerate
-                    when (rbfStatus) {
-                        RbfStatus.None -> {
-                            if (cmd.message.feerate < minNextFeerate) {
-                                logger.info { "rejecting rbf attempt: the new feerate must be at least $minNextFeerate (proposed=${cmd.message.feerate})" }
-                                Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, InvalidRbfFeerate(channelId, cmd.message.feerate, minNextFeerate).message))))
-                            } else if (cmd.message.fundingContribution.toMilliSatoshi() < remotePushAmount) {
-                                logger.info { "rejecting rbf attempt: invalid amount pushed (fundingAmount=${cmd.message.fundingContribution}, pushAmount=$remotePushAmount)" }
-                                Pair(
-                                    this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted),
-                                    listOf(ChannelAction.Message.Send(TxAbort(channelId, InvalidPushAmount(channelId, remotePushAmount, cmd.message.fundingContribution.toMilliSatoshi()).message)))
-                                )
-                            } else {
-                                logger.info { "our peer wants to raise the feerate of the funding transaction (previous=${latestFundingTx.fundingParams.targetFeerate} target=${cmd.message.feerate})" }
-                                val fundingParams = InteractiveTxParams(
-                                    channelId,
-                                    isInitiator,
-                                    latestFundingTx.fundingParams.localContribution, // we don't change our funding contribution
-                                    cmd.message.fundingContribution,
-                                    latestFundingTx.fundingParams.remoteFundingPubkey,
-                                    cmd.message.lockTime,
-                                    latestFundingTx.fundingParams.dustLimit,
-                                    cmd.message.feerate
-                                )
-                                val toSend = buildList<Either<InteractiveTxInput.Outgoing, InteractiveTxOutput.Outgoing>> {
-                                    addAll(latestFundingTx.sharedTx.tx.localInputs.map { Either.Left(it) })
-                                    addAll(latestFundingTx.sharedTx.tx.localOutputs.map { Either.Right(it) })
-                                }
-                                val session = InteractiveTxSession(channelKeys(), keyManager.swapInOnChainWallet, fundingParams, SharedFundingInputBalances(0.msat, 0.msat), toSend, previousFundingTxs.map { it.sharedTx })
-                                val nextState = this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.InProgress(session))
-                                Pair(nextState, listOf(ChannelAction.Message.Send(TxAckRbf(channelId, fundingParams.localContribution))))
-                            }
-                        }
-                        RbfStatus.RbfAborted -> {
-                            logger.info { "rejecting rbf attempt: our previous tx_abort was not acked" }
-                            Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(Warning(channelId, InvalidRbfTxAbortNotAcked(channelId).message))))
+        return when (cmd) {
+            is ChannelCommand.MessageReceived -> when (cmd.message) {
+                is TxSignatures -> when (latestFundingTx.sharedTx) {
+                    is PartiallySignedSharedTransaction -> when (val fullySignedTx = latestFundingTx.sharedTx.addRemoteSigs(channelKeys(), latestFundingTx.fundingParams, cmd.message)) {
+                        null -> {
+                            logger.warning { "received invalid remote funding signatures for txId=${cmd.message.txId}" }
+                            // The funding transaction may still confirm (since our peer should be able to generate valid signatures), so we cannot close the channel yet.
+                            Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(Warning(channelId, InvalidFundingSignature(channelId, cmd.message.txId).message))))
                         }
                         else -> {
-                            logger.info { "rejecting rbf attempt: the current rbf attempt must be completed or aborted first" }
-                            Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(Warning(channelId, InvalidRbfAlreadyInProgress(channelId).message))))
-                        }
-                    }
-                }
-            }
-            cmd is ChannelCommand.MessageReceived && cmd.message is TxAckRbf -> when (rbfStatus) {
-                is RbfStatus.RbfRequested -> {
-                    logger.info { "our peer accepted our rbf attempt and will contribute ${cmd.message.fundingContribution} to the funding transaction" }
-                    val fundingParams = InteractiveTxParams(
-                        channelId,
-                        isInitiator,
-                        rbfStatus.command.fundingAmount,
-                        cmd.message.fundingContribution,
-                        latestFundingTx.fundingParams.remoteFundingPubkey,
-                        rbfStatus.command.lockTime,
-                        latestFundingTx.fundingParams.dustLimit,
-                        rbfStatus.command.targetFeerate
-                    )
-                    when (val contributions = FundingContributions.create(channelKeys(), keyManager.swapInOnChainWallet, fundingParams, rbfStatus.command.walletInputs)) {
-                        is Either.Left -> {
-                            logger.warning { "error creating funding contributions: ${contributions.value}" }
-                            Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, ChannelFundingError(channelId).message))))
-                        }
-                        is Either.Right -> {
-                            val (session, action) = InteractiveTxSession(channelKeys(), keyManager.swapInOnChainWallet, fundingParams, 0.msat, 0.msat, contributions.value, previousFundingTxs.map { it.sharedTx }).send()
-                            when (action) {
-                                is InteractiveTxSessionAction.SendMessage -> {
-                                    val nextState = this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.InProgress(session))
-                                    Pair(nextState, listOf(ChannelAction.Message.Send(action.msg)))
-                                }
-                                else -> {
-                                    logger.warning { "could not start rbf session: $action" }
-                                    Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, ChannelFundingError(channelId).message))))
-                                }
-                            }
-                        }
-                    }
-                }
-                else -> {
-                    logger.info { "ignoring unexpected tx_ack_rbf" }
-                    Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(Warning(channelId, UnexpectedInteractiveTxMessage(channelId, cmd.message).message))))
-                }
-            }
-            cmd is ChannelCommand.MessageReceived && cmd.message is InteractiveTxConstructionMessage -> when (rbfStatus) {
-                is RbfStatus.InProgress -> {
-                    val (rbfSession1, interactiveTxAction) = rbfStatus.rbfSession.receive(cmd.message)
-                    when (interactiveTxAction) {
-                        is InteractiveTxSessionAction.SendMessage -> Pair(this@WaitForFundingConfirmed.copy(rbfStatus = rbfStatus.copy(rbfSession1)), listOf(ChannelAction.Message.Send(interactiveTxAction.msg)))
-                        is InteractiveTxSessionAction.SignSharedTx -> {
-                            val replacedCommitment = commitments.latest
-                            val signingSession = InteractiveTxSigningSession.create(
-                                keyManager,
-                                commitments.params,
-                                rbfSession1.fundingParams,
-                                fundingTxIndex = replacedCommitment.fundingTxIndex,
-                                interactiveTxAction.sharedTx,
-                                localPushAmount,
-                                remotePushAmount,
-                                commitmentIndex = replacedCommitment.localCommit.index,
-                                replacedCommitment.localCommit.spec.feerate,
-                                replacedCommitment.remoteCommit.remotePerCommitmentPoint
-                            )
-                            when (signingSession) {
-                                is Either.Left -> {
-                                    logger.error(signingSession.value) { "cannot initiate interactive-tx rbf signing session" }
-                                    Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, signingSession.value.message))))
-                                }
+                            when (val res = commitments.run { updateLocalFundingSigned(fullySignedTx) }) {
+                                is Either.Left -> Pair(this@WaitForFundingConfirmed, listOf())
                                 is Either.Right -> {
-                                    val (session, commitSig) = signingSession.value
-                                    val nextState = this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.WaitingForSigs(session))
+                                    logger.info { "received remote funding signatures, publishing txId=${fullySignedTx.signedTx.txid}" }
+                                    val nextState = this@WaitForFundingConfirmed.copy(commitments = res.value.first)
                                     val actions = buildList {
-                                        interactiveTxAction.txComplete?.let { add(ChannelAction.Message.Send(it)) }
+                                        add(ChannelAction.Blockchain.PublishTx(fullySignedTx.signedTx, ChannelAction.Blockchain.PublishTx.Type.FundingTx))
                                         add(ChannelAction.Storage.StoreState(nextState))
-                                        add(ChannelAction.Message.Send(commitSig))
                                     }
                                     Pair(nextState, actions)
                                 }
                             }
                         }
-                        is InteractiveTxSessionAction.RemoteFailure -> {
-                            logger.warning { "rbf attempt failed: $interactiveTxAction" }
-                            Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, ChannelFundingError(channelId).message))))
+                    }
+                    is FullySignedSharedTransaction -> when (rbfStatus) {
+                        is RbfStatus.WaitingForSigs -> {
+                            when (val action = rbfStatus.session.receiveTxSigs(channelKeys(), cmd.message, currentBlockHeight.toLong())) {
+                                is InteractiveTxSigningSessionAction.AbortFundingAttempt -> {
+                                    logger.warning { "rbf attempt failed: ${action.reason.message}" }
+                                    Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, action.reason.message))))
+                                }
+                                InteractiveTxSigningSessionAction.WaitForTxSigs -> Pair(this@WaitForFundingConfirmed, listOf())
+                                is InteractiveTxSigningSessionAction.SendTxSigs -> sendRbfTxSigs(action, cmd.message.channelData)
+                            }
+                        }
+                        else -> {
+                            logger.warning { "rejecting unexpected tx_signatures for txId=${cmd.message.txId}" }
+                            Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, UnexpectedFundingSignatures(channelId).message))))
                         }
                     }
                 }
-                else -> {
-                    logger.info { "ignoring unexpected interactive-tx message: ${cmd.message::class}" }
-                    Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(Warning(channelId, UnexpectedInteractiveTxMessage(channelId, cmd.message).message))))
-                }
-            }
-            cmd is ChannelCommand.MessageReceived && cmd.message is CommitSig -> when (rbfStatus) {
-                is RbfStatus.WaitingForSigs -> {
-                    val (signingSession1, action) = rbfStatus.session.receiveCommitSig(channelKeys(), commitments.params, cmd.message, currentBlockHeight.toLong())
-                    when (action) {
-                        is InteractiveTxSigningSessionAction.AbortFundingAttempt -> {
-                            logger.warning { "rbf attempt failed: ${action.reason.message}" }
-                            Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, action.reason.message))))
+                is TxInitRbf -> {
+                    if (isInitiator) {
+                        logger.info { "rejecting tx_init_rbf, we're the initiator, not them!" }
+                        Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(Error(channelId, InvalidRbfNonInitiator(channelId).message))))
+                    } else {
+                        val minNextFeerate = latestFundingTx.fundingParams.minNextFeerate
+                        when (rbfStatus) {
+                            RbfStatus.None -> {
+                                if (cmd.message.feerate < minNextFeerate) {
+                                    logger.info { "rejecting rbf attempt: the new feerate must be at least $minNextFeerate (proposed=${cmd.message.feerate})" }
+                                    Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, InvalidRbfFeerate(channelId, cmd.message.feerate, minNextFeerate).message))))
+                                } else if (cmd.message.fundingContribution.toMilliSatoshi() < remotePushAmount) {
+                                    logger.info { "rejecting rbf attempt: invalid amount pushed (fundingAmount=${cmd.message.fundingContribution}, pushAmount=$remotePushAmount)" }
+                                    Pair(
+                                        this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted),
+                                        listOf(ChannelAction.Message.Send(TxAbort(channelId, InvalidPushAmount(channelId, remotePushAmount, cmd.message.fundingContribution.toMilliSatoshi()).message)))
+                                    )
+                                } else {
+                                    logger.info { "our peer wants to raise the feerate of the funding transaction (previous=${latestFundingTx.fundingParams.targetFeerate} target=${cmd.message.feerate})" }
+                                    val fundingParams = InteractiveTxParams(
+                                        channelId,
+                                        isInitiator,
+                                        latestFundingTx.fundingParams.localContribution, // we don't change our funding contribution
+                                        cmd.message.fundingContribution,
+                                        latestFundingTx.fundingParams.remoteFundingPubkey,
+                                        cmd.message.lockTime,
+                                        latestFundingTx.fundingParams.dustLimit,
+                                        cmd.message.feerate
+                                    )
+                                    val toSend = buildList<Either<InteractiveTxInput.Outgoing, InteractiveTxOutput.Outgoing>> {
+                                        addAll(latestFundingTx.sharedTx.tx.localInputs.map { Either.Left(it) })
+                                        addAll(latestFundingTx.sharedTx.tx.localOutputs.map { Either.Right(it) })
+                                    }
+                                    val session = InteractiveTxSession(channelKeys(), keyManager.swapInOnChainWallet, fundingParams, SharedFundingInputBalances(0.msat, 0.msat), toSend, previousFundingTxs.map { it.sharedTx })
+                                    val nextState = this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.InProgress(session))
+                                    Pair(nextState, listOf(ChannelAction.Message.Send(TxAckRbf(channelId, fundingParams.localContribution))))
+                                }
+                            }
+                            RbfStatus.RbfAborted -> {
+                                logger.info { "rejecting rbf attempt: our previous tx_abort was not acked" }
+                                Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(Warning(channelId, InvalidRbfTxAbortNotAcked(channelId).message))))
+                            }
+                            else -> {
+                                logger.info { "rejecting rbf attempt: the current rbf attempt must be completed or aborted first" }
+                                Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(Warning(channelId, InvalidRbfAlreadyInProgress(channelId).message))))
+                            }
                         }
-                        // No need to store their commit_sig, they will re-send it if we disconnect.
-                        InteractiveTxSigningSessionAction.WaitForTxSigs -> Pair(this@WaitForFundingConfirmed.copy(rbfStatus = rbfStatus.copy(session = signingSession1)), listOf())
-                        is InteractiveTxSigningSessionAction.SendTxSigs -> sendRbfTxSigs(action, cmd.message.channelData)
                     }
                 }
-                else -> {
-                    logger.info { "ignoring redundant commit_sig" }
-                    Pair(this@WaitForFundingConfirmed, listOf())
+                is TxAckRbf -> when (rbfStatus) {
+                    is RbfStatus.RbfRequested -> {
+                        logger.info { "our peer accepted our rbf attempt and will contribute ${cmd.message.fundingContribution} to the funding transaction" }
+                        val fundingParams = InteractiveTxParams(
+                            channelId,
+                            isInitiator,
+                            rbfStatus.command.fundingAmount,
+                            cmd.message.fundingContribution,
+                            latestFundingTx.fundingParams.remoteFundingPubkey,
+                            rbfStatus.command.lockTime,
+                            latestFundingTx.fundingParams.dustLimit,
+                            rbfStatus.command.targetFeerate
+                        )
+                        when (val contributions = FundingContributions.create(channelKeys(), keyManager.swapInOnChainWallet, fundingParams, rbfStatus.command.walletInputs)) {
+                            is Either.Left -> {
+                                logger.warning { "error creating funding contributions: ${contributions.value}" }
+                                Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, ChannelFundingError(channelId).message))))
+                            }
+                            is Either.Right -> {
+                                val (session, action) = InteractiveTxSession(channelKeys(), keyManager.swapInOnChainWallet, fundingParams, 0.msat, 0.msat, contributions.value, previousFundingTxs.map { it.sharedTx }).send()
+                                when (action) {
+                                    is InteractiveTxSessionAction.SendMessage -> {
+                                        val nextState = this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.InProgress(session))
+                                        Pair(nextState, listOf(ChannelAction.Message.Send(action.msg)))
+                                    }
+                                    else -> {
+                                        logger.warning { "could not start rbf session: $action" }
+                                        Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, ChannelFundingError(channelId).message))))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else -> {
+                        logger.info { "ignoring unexpected tx_ack_rbf" }
+                        Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(Warning(channelId, UnexpectedInteractiveTxMessage(channelId, cmd.message).message))))
+                    }
                 }
+                is InteractiveTxConstructionMessage -> when (rbfStatus) {
+                    is RbfStatus.InProgress -> {
+                        val (rbfSession1, interactiveTxAction) = rbfStatus.rbfSession.receive(cmd.message)
+                        when (interactiveTxAction) {
+                            is InteractiveTxSessionAction.SendMessage -> Pair(this@WaitForFundingConfirmed.copy(rbfStatus = rbfStatus.copy(rbfSession1)), listOf(ChannelAction.Message.Send(interactiveTxAction.msg)))
+                            is InteractiveTxSessionAction.SignSharedTx -> {
+                                val replacedCommitment = commitments.latest
+                                val signingSession = InteractiveTxSigningSession.create(
+                                    keyManager,
+                                    commitments.params,
+                                    rbfSession1.fundingParams,
+                                    fundingTxIndex = replacedCommitment.fundingTxIndex,
+                                    interactiveTxAction.sharedTx,
+                                    localPushAmount,
+                                    remotePushAmount,
+                                    commitmentIndex = replacedCommitment.localCommit.index,
+                                    replacedCommitment.localCommit.spec.feerate,
+                                    replacedCommitment.remoteCommit.remotePerCommitmentPoint
+                                )
+                                when (signingSession) {
+                                    is Either.Left -> {
+                                        logger.error(signingSession.value) { "cannot initiate interactive-tx rbf signing session" }
+                                        Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, signingSession.value.message))))
+                                    }
+                                    is Either.Right -> {
+                                        val (session, commitSig) = signingSession.value
+                                        val nextState = this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.WaitingForSigs(session))
+                                        val actions = buildList {
+                                            interactiveTxAction.txComplete?.let { add(ChannelAction.Message.Send(it)) }
+                                            add(ChannelAction.Storage.StoreState(nextState))
+                                            add(ChannelAction.Message.Send(commitSig))
+                                        }
+                                        Pair(nextState, actions)
+                                    }
+                                }
+                            }
+                            is InteractiveTxSessionAction.RemoteFailure -> {
+                                logger.warning { "rbf attempt failed: $interactiveTxAction" }
+                                Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, ChannelFundingError(channelId).message))))
+                            }
+                        }
+                    }
+                    else -> {
+                        logger.info { "ignoring unexpected interactive-tx message: ${cmd.message::class}" }
+                        Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(Warning(channelId, UnexpectedInteractiveTxMessage(channelId, cmd.message).message))))
+                    }
+                }
+                is CommitSig -> when (rbfStatus) {
+                    is RbfStatus.WaitingForSigs -> {
+                        val (signingSession1, action) = rbfStatus.session.receiveCommitSig(channelKeys(), commitments.params, cmd.message, currentBlockHeight.toLong())
+                        when (action) {
+                            is InteractiveTxSigningSessionAction.AbortFundingAttempt -> {
+                                logger.warning { "rbf attempt failed: ${action.reason.message}" }
+                                Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfAborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, action.reason.message))))
+                            }
+                            // No need to store their commit_sig, they will re-send it if we disconnect.
+                            InteractiveTxSigningSessionAction.WaitForTxSigs -> Pair(this@WaitForFundingConfirmed.copy(rbfStatus = rbfStatus.copy(session = signingSession1)), listOf())
+                            is InteractiveTxSigningSessionAction.SendTxSigs -> sendRbfTxSigs(action, cmd.message.channelData)
+                        }
+                    }
+                    else -> {
+                        logger.info { "ignoring redundant commit_sig" }
+                        Pair(this@WaitForFundingConfirmed, listOf())
+                    }
+                }
+                is TxAbort -> when (rbfStatus) {
+                    RbfStatus.None -> {
+                        logger.info { "our peer wants to abort the funding attempt, but we've already negotiated a funding transaction: ascii='${cmd.message.toAscii()}' bin=${cmd.message.data.toHex()}" }
+                        // We ack their tx_abort but we keep monitoring the funding transaction until it's confirmed or double-spent.
+                        Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(TxAbort(channelId, DualFundingAborted(channelId, "requested by remote").message))))
+                    }
+                    RbfStatus.RbfAborted -> {
+                        logger.info { "our peer acked our previous tx_abort" }
+                        Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.None), listOf())
+                    }
+                    else -> {
+                        logger.info { "our peer aborted the rbf attempt: ascii='${cmd.message.toAscii()}' bin=${cmd.message.data.toHex()}" }
+                        Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.None), listOf(ChannelAction.Message.Send(TxAbort(channelId, RbfAttemptAborted(channelId).message))))
+                    }
+                }
+                is ChannelReady -> Pair(this@WaitForFundingConfirmed.copy(deferred = cmd.message), listOf())
+                is Error -> handleRemoteError(cmd.message)
+                else -> unhandled(cmd)
             }
-            cmd is ChannelCommand.MessageReceived && cmd.message is TxAbort -> when (rbfStatus) {
-                RbfStatus.None -> {
-                    logger.info { "our peer wants to abort the funding attempt, but we've already negotiated a funding transaction: ascii='${cmd.message.toAscii()}' bin=${cmd.message.data.toHex()}" }
-                    // We ack their tx_abort but we keep monitoring the funding transaction until it's confirmed or double-spent.
-                    Pair(this@WaitForFundingConfirmed, listOf(ChannelAction.Message.Send(TxAbort(channelId, DualFundingAborted(channelId, "requested by remote").message))))
-                }
-                RbfStatus.RbfAborted -> {
-                    logger.info { "our peer acked our previous tx_abort" }
-                    Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.None), listOf())
-                }
-                else -> {
-                    logger.info { "our peer aborted the rbf attempt: ascii='${cmd.message.toAscii()}' bin=${cmd.message.data.toHex()}" }
-                    Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.None), listOf(ChannelAction.Message.Send(TxAbort(channelId, RbfAttemptAborted(channelId).message))))
-                }
-            }
-            cmd is ChannelCommand.MessageReceived && cmd.message is ChannelReady -> Pair(this@WaitForFundingConfirmed.copy(deferred = cmd.message), listOf())
-            cmd is ChannelCommand.MessageReceived && cmd.message is Error -> handleRemoteError(cmd.message)
-            cmd is ChannelCommand.WatchReceived && cmd.watch is WatchEventConfirmed -> {
-                when (val res = acceptFundingTxConfirmed(cmd.watch)) {
+            is ChannelCommand.WatchReceived -> when (cmd.watch) {
+                is WatchEventConfirmed -> when (val res = acceptFundingTxConfirmed(cmd.watch)) {
                     is Either.Left -> Pair(this@WaitForFundingConfirmed, listOf())
                     is Either.Right -> {
                         val (commitments1, commitment, actions) = res.value
@@ -265,8 +268,9 @@ data class WaitForFundingConfirmed(
                         }
                     }
                 }
+                else -> unhandled(cmd)
             }
-            cmd is ChannelCommand.BumpFundingFee -> when {
+            is ChannelCommand.Funding.BumpFundingFee -> when {
                 !latestFundingTx.fundingParams.isInitiator -> {
                     logger.warning { "cannot initiate rbf, we're not the initiator" }
                     Pair(this@WaitForFundingConfirmed, listOf())
@@ -281,13 +285,18 @@ data class WaitForFundingConfirmed(
                     Pair(this@WaitForFundingConfirmed.copy(rbfStatus = RbfStatus.RbfRequested(cmd)), listOf(ChannelAction.Message.Send(txInitRbf)))
                 }
             }
-            cmd is ChannelCommand.Close.MutualClose -> Pair(
+            is ChannelCommand.Close.MutualClose -> Pair(
                 this@WaitForFundingConfirmed,
-                listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmd, CommandUnavailableInThisState(channelId, this::class.toString())))
+                listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmd, CommandUnavailableInThisState(channelId, stateName)))
             )
-            cmd is ChannelCommand.Close.ForceClose -> handleLocalError(cmd, ForcedLocalCommit(channelId))
-            cmd is ChannelCommand.CheckHtlcTimeout -> Pair(this@WaitForFundingConfirmed, listOf())
-            cmd is ChannelCommand.Disconnected -> {
+            is ChannelCommand.Close.ForceClose -> handleLocalError(cmd, ForcedLocalCommit(channelId))
+            is ChannelCommand.Commitment.CheckHtlcTimeout -> Pair(this@WaitForFundingConfirmed, listOf())
+            is ChannelCommand.Commitment -> unhandled(cmd)
+            is ChannelCommand.Htlc -> unhandled(cmd)
+            is ChannelCommand.Init -> unhandled(cmd)
+            is ChannelCommand.Closing -> unhandled(cmd)
+            is ChannelCommand.Connected -> unhandled(cmd)
+            is ChannelCommand.Disconnected -> {
                 val rbfStatus1 = when (rbfStatus) {
                     // We keep track of the RBF status: we should be able to complete the signature steps on reconnection.
                     is RbfStatus.WaitingForSigs -> rbfStatus
@@ -295,7 +304,6 @@ data class WaitForFundingConfirmed(
                 }
                 Pair(Offline(this@WaitForFundingConfirmed.copy(rbfStatus = rbfStatus1)), listOf())
             }
-            else -> unhandled(cmd)
         }
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannel.kt
@@ -30,103 +30,108 @@ data class WaitForOpenChannel(
     val remoteInit: Init
 ) : ChannelState() {
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
-        return when {
-            cmd is ChannelCommand.MessageReceived ->
-                when (cmd.message) {
-                    is OpenDualFundedChannel -> {
-                        val open = cmd.message
-                        when (val res = Helpers.validateParamsNonInitiator(staticParams.nodeParams, open)) {
-                            is Either.Right -> {
-                                val channelType = res.value
-                                val channelFeatures = ChannelFeatures(channelType, localFeatures = localParams.features, remoteFeatures = remoteInit.features)
-                                val minimumDepth = if (staticParams.useZeroConf) 0 else Helpers.minDepthForFunding(staticParams.nodeParams, open.fundingAmount)
-                                val channelKeys = keyManager.channelKeys(localParams.fundingKeyPath)
-                                val accept = AcceptDualFundedChannel(
-                                    temporaryChannelId = open.temporaryChannelId,
-                                    fundingAmount = fundingAmount,
-                                    dustLimit = localParams.dustLimit,
-                                    maxHtlcValueInFlightMsat = localParams.maxHtlcValueInFlightMsat,
-                                    htlcMinimum = localParams.htlcMinimum,
-                                    minimumDepth = minimumDepth.toLong(),
-                                    toSelfDelay = localParams.toSelfDelay,
-                                    maxAcceptedHtlcs = localParams.maxAcceptedHtlcs,
-                                    fundingPubkey = channelKeys.fundingPubKey(0),
-                                    revocationBasepoint = channelKeys.revocationBasepoint,
-                                    paymentBasepoint = channelKeys.paymentBasepoint,
-                                    delayedPaymentBasepoint = channelKeys.delayedPaymentBasepoint,
-                                    htlcBasepoint = channelKeys.htlcBasepoint,
-                                    firstPerCommitmentPoint = channelKeys.commitmentPoint(0),
-                                    secondPerCommitmentPoint = channelKeys.commitmentPoint(1),
-                                    tlvStream = TlvStream(
-                                        buildSet {
-                                            add(ChannelTlv.ChannelTypeTlv(channelType))
-                                            if (pushAmount > 0.msat) add(ChannelTlv.PushAmountTlv(pushAmount))
-                                        }
-                                    ),
-                                )
-                                val remoteParams = RemoteParams(
-                                    nodeId = staticParams.remoteNodeId,
-                                    dustLimit = open.dustLimit,
-                                    maxHtlcValueInFlightMsat = open.maxHtlcValueInFlightMsat,
-                                    htlcMinimum = open.htlcMinimum,
-                                    toSelfDelay = open.toSelfDelay,
-                                    maxAcceptedHtlcs = open.maxAcceptedHtlcs,
-                                    revocationBasepoint = open.revocationBasepoint,
-                                    paymentBasepoint = open.paymentBasepoint,
-                                    delayedPaymentBasepoint = open.delayedPaymentBasepoint,
-                                    htlcBasepoint = open.htlcBasepoint,
-                                    features = remoteInit.features
-                                )
-                                val channelId = computeChannelId(open, accept)
-                                val remoteFundingPubkey = open.fundingPubkey
-                                val dustLimit = open.dustLimit.max(localParams.dustLimit)
-                                val fundingParams = InteractiveTxParams(channelId, false, fundingAmount, open.fundingAmount, remoteFundingPubkey, open.lockTime, dustLimit, open.fundingFeerate)
-                                when (val fundingContributions = FundingContributions.create(channelKeys, keyManager.swapInOnChainWallet, fundingParams, walletInputs)) {
-                                    is Either.Left -> {
-                                        logger.error { "could not fund channel: ${fundingContributions.value}" }
-                                        Pair(Aborted, listOf(ChannelAction.Message.Send(Error(temporaryChannelId, ChannelFundingError(temporaryChannelId).message))))
+        return when (cmd) {
+            is ChannelCommand.MessageReceived -> when (cmd.message) {
+                is OpenDualFundedChannel -> {
+                    val open = cmd.message
+                    when (val res = Helpers.validateParamsNonInitiator(staticParams.nodeParams, open)) {
+                        is Either.Right -> {
+                            val channelType = res.value
+                            val channelFeatures = ChannelFeatures(channelType, localFeatures = localParams.features, remoteFeatures = remoteInit.features)
+                            val minimumDepth = if (staticParams.useZeroConf) 0 else Helpers.minDepthForFunding(staticParams.nodeParams, open.fundingAmount)
+                            val channelKeys = keyManager.channelKeys(localParams.fundingKeyPath)
+                            val accept = AcceptDualFundedChannel(
+                                temporaryChannelId = open.temporaryChannelId,
+                                fundingAmount = fundingAmount,
+                                dustLimit = localParams.dustLimit,
+                                maxHtlcValueInFlightMsat = localParams.maxHtlcValueInFlightMsat,
+                                htlcMinimum = localParams.htlcMinimum,
+                                minimumDepth = minimumDepth.toLong(),
+                                toSelfDelay = localParams.toSelfDelay,
+                                maxAcceptedHtlcs = localParams.maxAcceptedHtlcs,
+                                fundingPubkey = channelKeys.fundingPubKey(0),
+                                revocationBasepoint = channelKeys.revocationBasepoint,
+                                paymentBasepoint = channelKeys.paymentBasepoint,
+                                delayedPaymentBasepoint = channelKeys.delayedPaymentBasepoint,
+                                htlcBasepoint = channelKeys.htlcBasepoint,
+                                firstPerCommitmentPoint = channelKeys.commitmentPoint(0),
+                                secondPerCommitmentPoint = channelKeys.commitmentPoint(1),
+                                tlvStream = TlvStream(
+                                    buildSet {
+                                        add(ChannelTlv.ChannelTypeTlv(channelType))
+                                        if (pushAmount > 0.msat) add(ChannelTlv.PushAmountTlv(pushAmount))
                                     }
-                                    is Either.Right -> {
-                                        val interactiveTxSession = InteractiveTxSession(channelKeys, keyManager.swapInOnChainWallet, fundingParams, 0.msat, 0.msat, fundingContributions.value)
-                                        val nextState = WaitForFundingCreated(
-                                            localParams,
-                                            remoteParams,
-                                            interactiveTxSession,
-                                            pushAmount,
-                                            open.pushAmount,
-                                            open.commitmentFeerate,
-                                            open.firstPerCommitmentPoint,
-                                            open.secondPerCommitmentPoint,
-                                            open.channelFlags,
-                                            channelConfig,
-                                            channelFeatures,
-                                            open.origin
-                                        )
-                                        val actions = listOf(
-                                            ChannelAction.ChannelId.IdAssigned(staticParams.remoteNodeId, temporaryChannelId, channelId),
-                                            ChannelAction.Message.Send(accept),
-                                            ChannelAction.EmitEvent(ChannelEvents.Creating(nextState))
-                                        )
-                                        Pair(nextState, actions)
-                                    }
+                                ),
+                            )
+                            val remoteParams = RemoteParams(
+                                nodeId = staticParams.remoteNodeId,
+                                dustLimit = open.dustLimit,
+                                maxHtlcValueInFlightMsat = open.maxHtlcValueInFlightMsat,
+                                htlcMinimum = open.htlcMinimum,
+                                toSelfDelay = open.toSelfDelay,
+                                maxAcceptedHtlcs = open.maxAcceptedHtlcs,
+                                revocationBasepoint = open.revocationBasepoint,
+                                paymentBasepoint = open.paymentBasepoint,
+                                delayedPaymentBasepoint = open.delayedPaymentBasepoint,
+                                htlcBasepoint = open.htlcBasepoint,
+                                features = remoteInit.features
+                            )
+                            val channelId = computeChannelId(open, accept)
+                            val remoteFundingPubkey = open.fundingPubkey
+                            val dustLimit = open.dustLimit.max(localParams.dustLimit)
+                            val fundingParams = InteractiveTxParams(channelId, false, fundingAmount, open.fundingAmount, remoteFundingPubkey, open.lockTime, dustLimit, open.fundingFeerate)
+                            when (val fundingContributions = FundingContributions.create(channelKeys, keyManager.swapInOnChainWallet, fundingParams, walletInputs)) {
+                                is Either.Left -> {
+                                    logger.error { "could not fund channel: ${fundingContributions.value}" }
+                                    Pair(Aborted, listOf(ChannelAction.Message.Send(Error(temporaryChannelId, ChannelFundingError(temporaryChannelId).message))))
+                                }
+                                is Either.Right -> {
+                                    val interactiveTxSession = InteractiveTxSession(channelKeys, keyManager.swapInOnChainWallet, fundingParams, 0.msat, 0.msat, fundingContributions.value)
+                                    val nextState = WaitForFundingCreated(
+                                        localParams,
+                                        remoteParams,
+                                        interactiveTxSession,
+                                        pushAmount,
+                                        open.pushAmount,
+                                        open.commitmentFeerate,
+                                        open.firstPerCommitmentPoint,
+                                        open.secondPerCommitmentPoint,
+                                        open.channelFlags,
+                                        channelConfig,
+                                        channelFeatures,
+                                        open.origin
+                                    )
+                                    val actions = listOf(
+                                        ChannelAction.ChannelId.IdAssigned(staticParams.remoteNodeId, temporaryChannelId, channelId),
+                                        ChannelAction.Message.Send(accept),
+                                        ChannelAction.EmitEvent(ChannelEvents.Creating(nextState))
+                                    )
+                                    Pair(nextState, actions)
                                 }
                             }
-                            is Either.Left -> {
-                                logger.error(res.value) { "invalid ${cmd.message::class} in state ${this::class}" }
-                                Pair(Aborted, listOf(ChannelAction.Message.Send(Error(temporaryChannelId, res.value.message))))
-                            }
+                        }
+                        is Either.Left -> {
+                            logger.error(res.value) { "invalid ${cmd.message::class} in state ${this::class}" }
+                            Pair(Aborted, listOf(ChannelAction.Message.Send(Error(temporaryChannelId, res.value.message))))
                         }
                     }
-                    is Error -> {
-                        logger.error { "peer sent error: ascii=${cmd.message.toAscii()} bin=${cmd.message.data.toHex()}" }
-                        return Pair(Aborted, listOf())
-                    }
-                    else -> unhandled(cmd)
                 }
-
-            cmd is ChannelCommand.Close -> Pair(Aborted, listOf())
-            cmd is ChannelCommand.CheckHtlcTimeout -> Pair(this@WaitForOpenChannel, listOf())
-            else -> unhandled(cmd)
+                is Error -> {
+                    logger.error { "peer sent error: ascii=${cmd.message.toAscii()} bin=${cmd.message.data.toHex()}" }
+                    return Pair(Aborted, listOf())
+                }
+                else -> unhandled(cmd)
+            }
+            is ChannelCommand.Close.MutualClose -> Pair(this@WaitForOpenChannel, listOf(ChannelAction.ProcessCmdRes.NotExecuted(cmd, CommandUnavailableInThisState(temporaryChannelId, stateName))))
+            is ChannelCommand.Close.ForceClose -> handleLocalError(cmd, ForcedLocalCommit(temporaryChannelId))
+            is ChannelCommand.Connected -> unhandled(cmd)
+            is ChannelCommand.Disconnected -> Pair(Aborted, listOf())
+            is ChannelCommand.Init -> unhandled(cmd)
+            is ChannelCommand.Commitment -> unhandled(cmd)
+            is ChannelCommand.Htlc -> unhandled(cmd)
+            is ChannelCommand.WatchReceived -> unhandled(cmd)
+            is ChannelCommand.Funding -> unhandled(cmd)
+            is ChannelCommand.Closing -> unhandled(cmd)
         }
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
@@ -381,7 +381,7 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
         assertEquals(c1.availableBalanceForSend(), 0.msat)
 
         // We should be able to handle a fee increase.
-        val (c2, _) = c1.sendFee(ChannelCommand.UpdateFee(FeeratePerKw(3000.sat))).right!!
+        val (c2, _) = c1.sendFee(ChannelCommand.Commitment.UpdateFee(FeeratePerKw(3000.sat))).right!!
 
         // Now we shouldn't be able to send until we receive enough to handle the updated commit tx fee (even trimmed HTLCs shouldn't be sent).
         val (_, cmdAdd1) = TestsHelper.makeCmdAdd(100.msat, randomKey().publicKey(), currentBlockHeight)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
@@ -320,7 +320,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             val (nodes1, _, add) = addHtlc(50_000_000.msat, alice0, bob0)
             val alice1 = nodes1.first
             // alice signs it, but bob doesn't receive the signature
-            val (alice2, actions2) = alice1.process(ChannelCommand.Sign)
+            val (alice2, actions2) = alice1.process(ChannelCommand.Commitment.Sign)
             actions2.hasOutgoingMessage<CommitSig>()
             val (aliceClosing, localCommitPublished) = localClose(alice2)
             Triple(aliceClosing, localCommitPublished, add)
@@ -393,12 +393,12 @@ class ClosingTestsCommon : LightningTestSuite() {
             val (alice1, bob1) = nodes1
             val (alice2, bob2) = crossSign(alice1, bob1)
             val (alice3, bob3) = failHtlc(htlc.id, alice2, bob2)
-            val (bob4, bobActions4) = bob3.process(ChannelCommand.Sign)
+            val (bob4, bobActions4) = bob3.process(ChannelCommand.Commitment.Sign)
             val sigBob = bobActions4.hasOutgoingMessage<CommitSig>()
             val (alice4, aliceActions4) = alice3.process(ChannelCommand.MessageReceived(sigBob))
             val revAlice = aliceActions4.hasOutgoingMessage<RevokeAndAck>()
-            aliceActions4.hasCommand<ChannelCommand.Sign>()
-            val (alice5, aliceActions5) = alice4.process(ChannelCommand.Sign)
+            aliceActions4.hasCommand<ChannelCommand.Commitment.Sign>()
+            val (alice5, aliceActions5) = alice4.process(ChannelCommand.Commitment.Sign)
             val sigAlice = aliceActions5.hasOutgoingMessage<CommitSig>()
             val (bob5, _) = bob4.process(ChannelCommand.MessageReceived(revAlice))
             val (_, bobActions6) = bob5.process(ChannelCommand.MessageReceived(sigAlice))
@@ -511,7 +511,7 @@ class ClosingTestsCommon : LightningTestSuite() {
 
         // Simulate a wallet restart
         val initState = LNChannel(aliceClosing.ctx, WaitForInit)
-        val (alice1, actions1) = initState.process(ChannelCommand.Restore(aliceClosing.state))
+        val (alice1, actions1) = initState.process(ChannelCommand.Init.Restore(aliceClosing.state))
         assertIs<Closing>(alice1.state)
         assertEquals(aliceClosing, alice1)
         actions1.doesNotHave<ChannelAction.Storage.StoreOutgoingPayment.ViaClose>()
@@ -647,7 +647,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             val (nodes1, _, add) = addHtlc(50_000_000.msat, alice0, bob0)
             val alice1 = nodes1.first
             // alice signs it, but bob doesn't receive the signature
-            val (alice2, actions2) = alice1.process(ChannelCommand.Sign)
+            val (alice2, actions2) = alice1.process(ChannelCommand.Commitment.Sign)
             actions2.hasOutgoingMessage<CommitSig>()
             val (aliceClosing, remoteCommitPublished) = remoteClose(bobCommitTx, alice2)
             Triple(aliceClosing, remoteCommitPublished, add)
@@ -807,7 +807,7 @@ class ClosingTestsCommon : LightningTestSuite() {
 
         // Simulate a wallet restart
         val initState = LNChannel(aliceClosing.ctx, WaitForInit)
-        val (alice1, actions1) = initState.process(ChannelCommand.Restore(aliceClosing.state))
+        val (alice1, actions1) = initState.process(ChannelCommand.Init.Restore(aliceClosing.state))
         assertIs<Closing>(alice1.state)
         assertEquals(aliceClosing, alice1)
         actions1.doesNotHave<ChannelAction.Storage.StoreOutgoingPayment.ViaClose>()
@@ -838,7 +838,7 @@ class ClosingTestsCommon : LightningTestSuite() {
         val (alice1, bob1) = nodes1
         val bobCommitTx1 = bob1.state.commitments.latest.localCommit.publishableTxs.commitTx.tx
         // alice signs it, but bob doesn't revoke
-        val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Sign)
+        val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Commitment.Sign)
         val commitSig = actionsAlice2.hasOutgoingMessage<CommitSig>()
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(commitSig))
         actionsBob2.hasOutgoingMessage<RevokeAndAck>() // not forwarded to Alice (malicious Bob)
@@ -871,7 +871,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             // add more htlcs that bob doesn't revoke
             val (_, cmd3) = makeCmdAdd(20_000_000.msat, bob0.staticParams.nodeParams.nodeId, alice3.currentBlockHeight.toLong(), preimage)
             val (alice4, bob4, _) = addHtlc(cmd3, alice3, bob3)
-            val (alice5, actionsAlice5) = alice4.process(ChannelCommand.Sign)
+            val (alice5, actionsAlice5) = alice4.process(ChannelCommand.Commitment.Sign)
             val commitSig = actionsAlice5.hasOutgoingMessage<CommitSig>()
             val (bob5, actionsBob5) = bob4.process(ChannelCommand.MessageReceived(commitSig))
             actionsBob5.hasOutgoingMessage<RevokeAndAck>() // not forwarded to Alice (malicious Bob)
@@ -911,7 +911,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             // add another htlc that bob doesn't revoke
             val (nodes4, _, _) = addHtlc(20_000_000.msat, alice3, bob3)
             val (alice4, bob4) = nodes4
-            val (alice5, actionsAlice5) = alice4.process(ChannelCommand.Sign)
+            val (alice5, actionsAlice5) = alice4.process(ChannelCommand.Commitment.Sign)
             val commitSig = actionsAlice5.hasOutgoingMessage<CommitSig>()
             val (bob5, actionsBob5) = bob4.process(ChannelCommand.MessageReceived(commitSig))
             actionsBob5.hasOutgoingMessage<RevokeAndAck>() // not forwarded to Alice (malicious Bob)
@@ -965,7 +965,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             // add another htlc that bob doesn't revoke
             val (nodes6, _, _) = addHtlc(20_000_000.msat, alice5, bob5)
             val (alice6, bob6) = nodes6
-            val (alice7, actionsAlice7) = alice6.process(ChannelCommand.Sign)
+            val (alice7, actionsAlice7) = alice6.process(ChannelCommand.Commitment.Sign)
             val commitSig = actionsAlice7.hasOutgoingMessage<CommitSig>()
             val (bob7, actionsBob7) = bob6.process(ChannelCommand.MessageReceived(commitSig))
             actionsBob7.hasOutgoingMessage<RevokeAndAck>() // not forwarded to Alice (malicious Bob)
@@ -1044,7 +1044,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             // add more htlcs that bob doesn't revoke
             val (_, cmd1) = makeCmdAdd(20_000_000.msat, bob0.staticParams.nodeParams.nodeId, alice1.currentBlockHeight.toLong(), preimage)
             val (alice2, bob2, _) = addHtlc(cmd1, alice1, bob1)
-            val (alice3, actionsAlice3) = alice2.process(ChannelCommand.Sign)
+            val (alice3, actionsAlice3) = alice2.process(ChannelCommand.Commitment.Sign)
             val commitSig = actionsAlice3.hasOutgoingMessage<CommitSig>()
             val (bob3, actionsBob3) = bob2.process(ChannelCommand.MessageReceived(commitSig))
             assertIs<Normal>(bob3.state)
@@ -1061,7 +1061,7 @@ class ClosingTestsCommon : LightningTestSuite() {
 
         // Simulate a wallet restart
         val initState = LNChannel(aliceClosing.ctx, WaitForInit)
-        val (alice1, actions1) = initState.process(ChannelCommand.Restore(aliceClosing.state))
+        val (alice1, actions1) = initState.process(ChannelCommand.Init.Restore(aliceClosing.state))
         assertTrue(alice1.state is Closing)
         assertEquals(aliceClosing, alice1)
         actions1.doesNotHave<ChannelAction.Storage.StoreOutgoingPayment.ViaClose>()
@@ -1160,7 +1160,7 @@ class ClosingTestsCommon : LightningTestSuite() {
         // simulate a wallet restart
         run {
             val initState = LNChannel(alice3.ctx, WaitForInit)
-            val (alice4, actions4) = initState.process(ChannelCommand.Restore(alice3.state))
+            val (alice4, actions4) = initState.process(ChannelCommand.Init.Restore(alice3.state))
             assertIs<Closing>(alice4.state)
             assertEquals(alice3, alice4)
             assertEquals(actions4.findPublishTxs(), listOf(futureRemoteCommitPublished.claimMainOutputTx!!.tx))
@@ -1224,7 +1224,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             ChannelAction.Storage.HtlcInfo(alice0.channelId, 2, htlcsAlice[0].paymentHash, htlcsAlice[0].cltvExpiry),
             ChannelAction.Storage.HtlcInfo(alice0.channelId, 2, htlcsBob[0].paymentHash, htlcsBob[0].cltvExpiry),
         )
-        val (alice2, aliceActions2) = alice1.process(ChannelCommand.GetHtlcInfosResponse(bobRevokedTx.txid, htlcInfos))
+        val (alice2, aliceActions2) = alice1.process(ChannelCommand.Closing.GetHtlcInfosResponse(bobRevokedTx.txid, htlcInfos))
         assertIs<LNChannel<Closing>>(alice2)
         assertIs<Closing>(alice2.state)
         assertNull(aliceActions2.findOutgoingMessageOpt<Error>())
@@ -1256,7 +1256,7 @@ class ClosingTestsCommon : LightningTestSuite() {
         // simulate a wallet restart
         run {
             val initState = LNChannel(alice2.ctx, WaitForInit)
-            val (alice3, actions3) = initState.process(ChannelCommand.Restore(alice2.state))
+            val (alice3, actions3) = initState.process(ChannelCommand.Init.Restore(alice2.state))
             assertIs<Closing>(alice3.state)
             assertEquals(alice2, alice3)
             actions3.doesNotHave<ChannelAction.Storage.StoreOutgoingPayment>()
@@ -1327,7 +1327,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             assertEquals(ChannelAction.Storage.GetHtlcInfos(bobCommitTxs[1].commitTx.tx.txid, 2), aliceActions2.find())
         }
 
-        val (alice3, aliceActions3) = alice2.process(ChannelCommand.GetHtlcInfosResponse(bobCommitTxs[0].commitTx.tx.txid, listOf()))
+        val (alice3, aliceActions3) = alice2.process(ChannelCommand.Closing.GetHtlcInfosResponse(bobCommitTxs[0].commitTx.tx.txid, listOf()))
         assertIs<Closing>(alice3.state)
         assertNull(aliceActions3.findOutgoingMessageOpt<Error>())
         aliceActions3.has<ChannelAction.Storage.StoreState>()
@@ -1353,7 +1353,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             ChannelAction.Storage.HtlcInfo(alice0.channelId, 2, htlcsAlice[0].paymentHash, htlcsAlice[0].cltvExpiry),
             ChannelAction.Storage.HtlcInfo(alice0.channelId, 2, htlcsBob[0].paymentHash, htlcsBob[0].cltvExpiry),
         )
-        val (alice4, aliceActions4) = alice3.process(ChannelCommand.GetHtlcInfosResponse(bobCommitTxs[1].commitTx.tx.txid, htlcInfos))
+        val (alice4, aliceActions4) = alice3.process(ChannelCommand.Closing.GetHtlcInfosResponse(bobCommitTxs[1].commitTx.tx.txid, htlcInfos))
         assertIs<LNChannel<Closing>>(alice4)
         assertIs<Closing>(alice4.state)
         assertNull(aliceActions4.findOutgoingMessageOpt<Error>())
@@ -1436,7 +1436,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             ChannelAction.Storage.HtlcInfo(alice0.channelId, 1, htlcs1[0].paymentHash, htlcs1[0].cltvExpiry),
             ChannelAction.Storage.HtlcInfo(alice0.channelId, 1, htlcs1[1].paymentHash, htlcs1[1].cltvExpiry)
         )
-        val (alice4, actions4) = alice3.process(ChannelCommand.GetHtlcInfosResponse(bobRevokedTx.txid, htlcInfos))
+        val (alice4, actions4) = alice3.process(ChannelCommand.Closing.GetHtlcInfosResponse(bobRevokedTx.txid, htlcInfos))
         assertIs<Closing>(alice4.state)
         actions4.doesNotHave<ChannelAction.Storage.StoreOutgoingPayment>()
 
@@ -1488,7 +1488,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             ChannelAction.Storage.HtlcInfo(alice0.channelId, 4, htlcsBob[0].paymentHash, htlcsBob[0].cltvExpiry),
             ChannelAction.Storage.HtlcInfo(alice0.channelId, 4, htlcsBob[1].paymentHash, htlcsBob[1].cltvExpiry),
         )
-        val (alice2, aliceActions2) = alice1.process(ChannelCommand.GetHtlcInfosResponse(bobRevokedTx.commitTx.tx.txid, htlcInfos))
+        val (alice2, aliceActions2) = alice1.process(ChannelCommand.Closing.GetHtlcInfosResponse(bobRevokedTx.commitTx.tx.txid, htlcInfos))
         assertIs<Closing>(alice2.state)
         assertNull(aliceActions2.findOutgoingMessageOpt<Error>())
         aliceActions2.has<ChannelAction.Storage.StoreState>()
@@ -1576,7 +1576,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             ChannelAction.Storage.HtlcInfo(alice0.channelId, 4, htlcsBob[0].paymentHash, htlcsBob[0].cltvExpiry),
             ChannelAction.Storage.HtlcInfo(alice0.channelId, 4, htlcsBob[1].paymentHash, htlcsBob[1].cltvExpiry),
         )
-        val (alice2, _) = alice1.process(ChannelCommand.GetHtlcInfosResponse(bobRevokedTx.commitTx.tx.txid, htlcInfos))
+        val (alice2, _) = alice1.process(ChannelCommand.Closing.GetHtlcInfosResponse(bobRevokedTx.commitTx.tx.txid, htlcInfos))
         assertIs<Closing>(alice2.state)
 
         // bob claims multiple htlc outputs in a single transaction (this is possible with anchor outputs because signatures
@@ -1661,7 +1661,7 @@ class ClosingTestsCommon : LightningTestSuite() {
 
         run {
             val alice1 = aliceClosing.copy(ctx = alice.ctx.copy(currentBlockHeight = htlc.cltvExpiry.toLong().toInt()))
-            val (alice2, actions) = alice1.process(ChannelCommand.CheckHtlcTimeout)
+            val (alice2, actions) = alice1.process(ChannelCommand.Commitment.CheckHtlcTimeout)
             assertEquals(alice1.state, alice2.state)
             assertTrue(actions.isEmpty())
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
@@ -39,7 +39,7 @@ class LegacyWaitForFundingConfirmedTestsCommon {
             OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
             MDCLogger(LoggerFactory.default.newLogger(ChannelState::class))
         )
-        val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Restore(state))
+        val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Init.Restore(state))
         assertIs<LNChannel<Offline>>(state1)
         assertEquals(actions1.size, 1)
         val watchConfirmed = actions1.findWatch<WatchConfirmed>()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
@@ -38,7 +38,7 @@ class LegacyWaitForFundingLockedTestsCommon {
             OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
             MDCLogger(LoggerFactory.default.newLogger(ChannelState::class))
         )
-        val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Restore(state))
+        val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Init.Restore(state))
         assertIs<LNChannel<Offline>>(state1)
         assertEquals(actions1.size, 1)
         val watchConfirmed = actions1.findWatch<WatchConfirmed>()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannelTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannelTestsCommon.kt
@@ -143,14 +143,6 @@ class WaitForAcceptChannelTestsCommon : LightningTestSuite() {
         assertTrue(actions1.isEmpty())
     }
 
-    @Test
-    fun `recv ChannelCommand_Close_MutualClose`() {
-        val (alice, _, _) = init()
-        val (alice1, actions1) = alice.process(ChannelCommand.Close.MutualClose(null, null))
-        assertIs<LNChannel<Aborted>>(alice1)
-        assertTrue(actions1.isEmpty())
-    }
-
     companion object {
         fun init(
             channelType: ChannelType.SupportedChannelType = ChannelType.SupportedChannelType.AnchorOutputs,

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
@@ -34,7 +34,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         val txSigsAlice = getFundingSigs(alice)
         val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(txSigsAlice))
         val fundingTx = actionsBob1.find<ChannelAction.Blockchain.PublishTx>().tx
-        val (bob2, actionsBob2) = LNChannel(bob1.ctx, WaitForInit).process(ChannelCommand.Restore(bob1.state as PersistedChannelState))
+        val (bob2, actionsBob2) = LNChannel(bob1.ctx, WaitForInit).process(ChannelCommand.Init.Restore(bob1.state as PersistedChannelState))
         assertIs<Offline>(bob2.state)
         assertEquals(actionsBob2.size, 2)
         assertEquals(actionsBob2.find<ChannelAction.Blockchain.PublishTx>().tx, fundingTx)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
@@ -106,7 +106,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
     fun `recv BITCOIN_FUNDING_DEPTHOK -- after restart`() {
         val (alice, bob, fundingTx) = init(ChannelType.SupportedChannelType.AnchorOutputs)
         run {
-            val (alice1, _) = LNChannel(alice.ctx, WaitForInit).process(ChannelCommand.Restore(alice.state))
+            val (alice1, _) = LNChannel(alice.ctx, WaitForInit).process(ChannelCommand.Init.Restore(alice.state))
                 .also { (state, actions) ->
                     assertIs<Offline>(state.state)
                     assertEquals(actions.size, 2)
@@ -122,7 +122,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
                 }
         }
         run {
-            val (bob1, _) = LNChannel(bob.ctx, WaitForInit).process(ChannelCommand.Restore(bob.state))
+            val (bob1, _) = LNChannel(bob.ctx, WaitForInit).process(ChannelCommand.Init.Restore(bob.state))
                 .also { (state, actions) ->
                     assertIs<Offline>(state.state)
                     assertEquals(actions.size, 2)
@@ -144,7 +144,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
         val (alice, bob, fundingTx1, walletAlice) = init(ChannelType.SupportedChannelType.AnchorOutputs)
         val (alice1, bob1, fundingTx2) = rbf(alice, bob, walletAlice)
         run {
-            val (alice2, _) = LNChannel(alice.ctx, WaitForInit).process(ChannelCommand.Restore(alice1.state))
+            val (alice2, _) = LNChannel(alice.ctx, WaitForInit).process(ChannelCommand.Init.Restore(alice1.state))
                 .also { (state, actions) ->
                     assertIs<Offline>(state.state)
                     assertEquals(actions.size, 4)
@@ -164,7 +164,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
                 }
         }
         run {
-            val (bob2, _) = LNChannel(bob.ctx, WaitForInit).process(ChannelCommand.Restore(bob1.state))
+            val (bob2, _) = LNChannel(bob.ctx, WaitForInit).process(ChannelCommand.Init.Restore(bob1.state))
                 .also { (state, actions) ->
                     assertIs<Offline>(state.state)
                     assertEquals(actions.size, 4)
@@ -368,7 +368,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
         val (alice, bob) = init(ChannelType.SupportedChannelType.AnchorOutputs)
         listOf(alice, bob).forEach { state ->
             run {
-                val (state1, actions1) = state.process(ChannelCommand.CheckHtlcTimeout)
+                val (state1, actions1) = state.process(ChannelCommand.Commitment.CheckHtlcTimeout)
                 assertEquals(state, state1)
                 assertTrue(actions1.isEmpty())
             }
@@ -438,7 +438,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
             return Fixture(alice2, bob2, fundingTxAlice, walletAlice)
         }
 
-        fun createRbfCommand(alice: LNChannel<WaitForFundingConfirmed>, wallet: List<WalletState.Utxo>): ChannelCommand.BumpFundingFee {
+        fun createRbfCommand(alice: LNChannel<WaitForFundingConfirmed>, wallet: List<WalletState.Utxo>): ChannelCommand.Funding.BumpFundingFee {
             val previousFundingParams = alice.state.latestFundingTx.fundingParams
             val previousFundingTx = alice.state.latestFundingTx.sharedTx
             assertIs<FullySignedSharedTransaction>(previousFundingTx)
@@ -446,7 +446,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
             val script = alice.staticParams.nodeParams.keyManager.swapInOnChainWallet.pubkeyScript
             val parentTx = Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 1), 0)), listOf(TxOut(30_000.sat, script)), 0)
             val wallet1 = wallet + listOf(WalletState.Utxo(parentTx, 0, 42))
-            return ChannelCommand.BumpFundingFee(previousFundingTx.feerate * 1.1, previousFundingParams.localContribution + 20_000.sat, wallet1, previousFundingTx.tx.lockTime + 1)
+            return ChannelCommand.Funding.BumpFundingFee(previousFundingTx.feerate * 1.1, previousFundingParams.localContribution + 20_000.sat, wallet1, previousFundingTx.tx.lockTime + 1)
         }
 
         fun rbf(alice: LNChannel<WaitForFundingConfirmed>, bob: LNChannel<WaitForFundingConfirmed>, walletAlice: List<WalletState.Utxo>): Triple<LNChannel<WaitForFundingConfirmed>, LNChannel<WaitForFundingConfirmed>, Transaction> {

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreatedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreatedTestsCommon.kt
@@ -276,18 +276,10 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv ChannelCommand_Close_MutualClose`() {
-        val (_, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat)
-        val (bob1, actions1) = bob.process(ChannelCommand.Close.MutualClose(null, null))
-        assertEquals(actions1.findOutgoingMessage<Error>().toAscii(), ChannelFundingError(bob.channelId).message)
-        assertIs<Aborted>(bob1.state)
-    }
-
-    @Test
     fun `recv ChannelCommand_Close_ForceClose`() {
         val (_, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat)
         val (bob1, actions1) = bob.process(ChannelCommand.Close.ForceClose)
-        assertEquals(actions1.findOutgoingMessage<Error>().toAscii(), ChannelFundingError(bob.channelId).message)
+        assertEquals(actions1.findOutgoingMessage<Error>().toAscii(), ForcedLocalCommit(bob.channelId).message)
         assertIs<Aborted>(bob1.state)
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
@@ -259,14 +259,6 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv ChannelCommand_Close_MutualClose`() {
-        val (alice, _, _, _) = init()
-        val (alice1, actions1) = alice.process(ChannelCommand.Close.MutualClose(null, null))
-        assertEquals(actions1.findOutgoingMessage<Error>().toAscii(), ChannelFundingError(alice.channelId).message)
-        assertIs<Aborted>(alice1.state)
-    }
-
-    @Test
     fun `recv ChannelCommand_Close_ForceClose`() {
         val (alice, _, _, _) = init()
         val (alice1, actions1) = alice.process(ChannelCommand.Close.ForceClose)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannelTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannelTestsCommon.kt
@@ -147,14 +147,6 @@ class WaitForOpenChannelTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv ChannelCommand_Close_MutualClose`() {
-        val (_, bob, _) = TestsHelper.init()
-        val (bob1, actions) = bob.process(ChannelCommand.Close.MutualClose(null, null))
-        assertIs<LNChannel<Aborted>>(bob1)
-        assertTrue(actions.isEmpty())
-    }
-
-    @Test
     fun `recv Disconnected`() {
         val (_, bob, _) = TestsHelper.init()
         val (bob1, actions) = bob.process(ChannelCommand.Disconnected)

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -43,7 +43,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         var actions = processResult.second
         assertEquals(2, actions.size)
         val add = actions.findOutgoingMessage<UpdateAddHtlc>()
-        val aliceCmdSign = actions.findCommand<ChannelCommand.Sign>()
+        val aliceCmdSign = actions.findCommand<ChannelCommand.Commitment.Sign>()
 
         processResult = bob.processSameState(ChannelCommand.MessageReceived(add))
         bob = processResult.first
@@ -69,7 +69,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         bob = processResult.first
         actions = processResult.second
         val bobRev = actions.findOutgoingMessage<RevokeAndAck>()
-        val bobCmdSign = actions.findCommand<ChannelCommand.Sign>()
+        val bobCmdSign = actions.findCommand<ChannelCommand.Commitment.Sign>()
 
         assertTrue { alice.commitments.changes.localChanges.proposed.isEmpty() }
         assertTrue { alice.commitments.changes.localChanges.signed.size == 1 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/serialization/StateSerializationTestsCommon.kt
@@ -80,11 +80,11 @@ class StateSerializationTestsCommon : LightningTestSuite() {
         fun commitSigSize(maxIncoming: Int, maxOutgoing: Int): Int {
             val (alice1, bob1) = addHtlcs(alice, bob, MilliSatoshi(6000_000), maxOutgoing)
             val (bob2, alice2) = addHtlcs(bob1, alice1, MilliSatoshi(6000_000), maxIncoming)
-            val (_, actions) = alice2.process(ChannelCommand.Sign)
+            val (_, actions) = alice2.process(ChannelCommand.Commitment.Sign)
             val commitSig0 = actions.findOutgoingMessage<CommitSig>()
 
             val (bob3, actions1) = bob2.process(ChannelCommand.MessageReceived(commitSig0))
-            val commandSign0 = actions1.findCommand<ChannelCommand.Sign>()
+            val commandSign0 = actions1.findCommand<ChannelCommand.Commitment.Sign>()
 
             val (_, actions2) = bob3.process(commandSign0)
             val commitSig1 = actions2.findOutgoingMessage<CommitSig>()


### PR DESCRIPTION
When using `when` without a clause and with a `Unit` return type, the compiler does not check for exhaustiveness, which could lead to issues.

:warning: this PR should be reviewed using the `Hide whitespace` github option, otherwise it will be hard to review the diff (which is actually not that big)