### PR TITLE
Exact match on minimum depth for swap-in

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -32,8 +32,8 @@ data class WalletState(val addresses: Map<String, List<UnspentItem>>, val parent
 
     fun withConfirmations(currentBlockHeight: Int, minConfirmations: Int): WalletWithConfirmations = WalletWithConfirmations(
         unconfirmed = utxos.filter { it.blockHeight == 0L },
-        weaklyConfirmed = utxos.filter { it.blockHeight > 0 && it.blockHeight + minConfirmations >= currentBlockHeight },
-        deeplyConfirmed = utxos.filter { it.blockHeight > 0 && it.blockHeight + minConfirmations < currentBlockHeight }
+        weaklyConfirmed = utxos.filter { it.blockHeight > 0 && (currentBlockHeight - it.blockHeight + 1) < minConfirmations }, // we add 1 because if a tx is confirmed at current block height, it is considered to have one confirmation
+        deeplyConfirmed = utxos.filter { it.blockHeight > 0 && (currentBlockHeight - it.blockHeight + 1) >= minConfirmations }
     )
 
     data class Utxo(val previousTx: Transaction, val outputIndex: Int, val blockHeight: Long) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
@@ -49,7 +49,7 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
         assertEquals(30_000_000.sat, walletState.totalBalance)
 
         run {
-            val withConf = walletState.withConfirmations(currentBlockHeight = 100_006, minConfirmations = 3)
+            val withConf = walletState.withConfirmations(currentBlockHeight = 100_004, minConfirmations = 3)
             assertEquals(0, withConf.unconfirmed.size)
             assertEquals(3, withConf.weaklyConfirmed.size)
             assertEquals(3, withConf.deeplyConfirmed.size)
@@ -57,7 +57,7 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
             assertEquals(15_000_000.sat, withConf.deeplyConfirmed.balance)
         }
         run {
-            val withConf = walletState.withConfirmations(currentBlockHeight = 100_007, minConfirmations = 3)
+            val withConf = walletState.withConfirmations(currentBlockHeight = 100_005, minConfirmations = 3)
             assertEquals(0, withConf.unconfirmed.size)
             assertEquals(0, withConf.weaklyConfirmed.size)
             assertEquals(6, withConf.deeplyConfirmed.size)


### PR DESCRIPTION
There is a risk that the LSP is not yet notified of the latest block and rejects the swap-in attempt, but:
- this should be handled gracefully anyway
- even when waiting for an additional block, there could be two blocks in a row