### PR TITLE
Forget unsigned channels on errors

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelAction.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelAction.kt
@@ -71,6 +71,7 @@ sealed class ChannelAction {
 
     sealed class Storage : ChannelAction() {
         data class StoreState(val data: PersistedChannelState) : Storage()
+        data class RemoveChannel(val data: PersistedChannelState) : Storage()
         data class HtlcInfo(val channelId: ByteVector32, val commitmentNumber: Long, val paymentHash: ByteVector32, val cltvExpiry: CltvExpiry)
         data class StoreHtlcInfos(val htlcs: List<HtlcInfo>) : Storage()
         data class GetHtlcInfos(val revokedCommitTxId: ByteVector32, val commitmentNumber: Long) : Storage()

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
@@ -158,6 +158,10 @@ data class WaitForFundingSigned(
     override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
         logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForFundingSigned::class.simpleName}" }
         val error = Error(channelId, t.message)
-        return Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
+        val actions = listOf(
+            ChannelAction.Message.Send(error),
+            ChannelAction.Storage.RemoveChannel(this@WaitForFundingSigned),
+        )
+        return Pair(Aborted, actions)
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -558,6 +558,11 @@ class Peer(
                         db.channels.addOrUpdateChannel(action.data)
                     }
 
+                    is ChannelAction.Storage.RemoveChannel -> {
+                        logger.info { "removing channelId=${action.data.channelId} state=${action.data::class.simpleName}" }
+                        db.channels.removeChannel(action.data.channelId)
+                    }
+
                     is ChannelAction.Storage.StoreHtlcInfos -> {
                         action.htlcs.forEach { db.channels.addHtlcInfo(actualChannelId, it.commitmentNumber, it.paymentHash, it.cltvExpiry) }
                     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/OfflineTestsCommon.kt
@@ -703,7 +703,8 @@ class OfflineTestsCommon : LightningTestSuite() {
         // When receiving Bob's error, Alice forgets the channel.
         val (alice4, actions4) = alice3.process(ChannelCommand.MessageReceived(Error(alice.channelId, "unknown channel")))
         assertIs<Aborted>(alice4.state)
-        assertTrue(actions4.isEmpty())
+        assertEquals(1, actions4.size)
+        actions4.find<ChannelAction.Storage.RemoveChannel>().also { assertEquals(alice.channelId, it.data.channelId) }
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SyncingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SyncingTestsCommon.kt
@@ -83,7 +83,8 @@ class SyncingTestsCommon : LightningTestSuite() {
         // Alice acts as if they were disconnected before she sent commit_sig: she has forgotten that channel.
         val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(Error(channelReestablishBob.channelId, "sorry bro no channel here")))
         assertIs<Aborted>(bob2.state)
-        assertTrue(actionsBob2.isEmpty())
+        assertEquals(1, actionsBob2.size)
+        actionsBob2.find<ChannelAction.Storage.RemoveChannel>().also { assertEquals(bob.channelId, it.data.channelId) }
     }
 
     @Test


### PR DESCRIPTION
We were previously updating the state to `Aborted`, but we weren't updating the DB, which means that a restart of the app would show the channel again.