### PR TITLE
Factor local error handling

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelAction.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelAction.kt
@@ -14,8 +14,6 @@ import fr.acinq.lightning.wire.*
 /** Channel Actions (outputs produced by the state machine). */
 sealed class ChannelAction {
     // @formatter:off
-    data class ProcessLocalError(val error: Throwable, val trigger: ChannelCommand) : ChannelAction()
-
     sealed class Message : ChannelAction() {
         data class Send(val message: LightningMessage) : Message()
         data class SendToSelf(val command: ChannelCommand) : Message()

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -546,17 +546,6 @@ data class Commitments(
         addAll(active)
     })
 
-    /**
-     * @return true if channel was never open, or got closed immediately, had never any htlcs and local never had a positive balance
-     */
-    fun nothingAtStake(): Boolean = active.all {
-        it.localCommit.index == 0L &&
-                it.localCommit.spec.toLocal == 0.msat &&
-                it.remoteCommit.index == 0L &&
-                it.remoteCommit.spec.toRemote == 0.msat &&
-                it.nextRemoteCommit == null
-    }
-
     fun isMoreRecent(other: Commitments): Boolean {
         return this.localCommitIndex > other.localCommitIndex ||
                 this.remoteCommitIndex > other.remoteCommitIndex ||

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Aborted.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Aborted.kt
@@ -10,8 +10,4 @@ object Aborted : ChannelState() {
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return Pair(this@Aborted, listOf())
     }
-
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        return Pair(this@Aborted, listOf())
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -178,7 +178,7 @@ sealed class ChannelState {
         fun forceClose(state: ChannelStateWithCommitments): Pair<ChannelState, List<ChannelAction>> {
             val error = Error(state.channelId, t.message)
             return when {
-                state.commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
+                state.commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error), ChannelAction.Storage.RemoveChannel(state)))
                 else -> state.run { spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error)) } }
             }
         }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -165,7 +165,7 @@ sealed class ChannelState {
         logger.error(t) { "error on command ${cmd::class.simpleName}" }
         return when(val state = this@ChannelState) {
             is WaitForInit -> {
-                Pair(state, listOf(ChannelAction.ProcessLocalError(t, cmd)))
+                Pair(state, emptyList())
             }
             is WaitForOpenChannel -> {
                 val error = Error(state.temporaryChannelId, t.message)
@@ -246,10 +246,10 @@ sealed class ChannelState {
                 Pair(state, listOf())
             }
             is Offline -> {
-                Pair(state, listOf(ChannelAction.ProcessLocalError(t, cmd)))
+                Pair(state, emptyList())
             }
             is Syncing -> {
-                Pair(state, listOf(ChannelAction.ProcessLocalError(t, cmd)))
+                Pair(state, emptyList())
             }
             is WaitForRemotePublishFutureCommitment -> {
                 val error = Error(state.channelId, t.message)

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -177,10 +177,7 @@ sealed class ChannelState {
 
         fun forceClose(state: ChannelStateWithCommitments): Pair<ChannelState, List<ChannelAction>> {
             val error = Error(state.channelId, t.message)
-            return when {
-                state.commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error), ChannelAction.Storage.RemoveChannel(state)))
-                else -> state.run { spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error)) } }
-            }
+            return state.run { spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error)) } }
         }
 
         return when(val state = this@ChannelState) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -162,29 +162,24 @@ sealed class ChannelState {
     )
 
     internal fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@ChannelState::class.simpleName}" }
+        logger.error(t) { "error on command ${cmd::class.simpleName}" }
         return when(val state = this@ChannelState) {
             is WaitForInit -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 Pair(state, listOf(ChannelAction.ProcessLocalError(t, cmd)))
             }
             is WaitForOpenChannel -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 val error = Error(state.temporaryChannelId, t.message)
                 Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
             }
             is WaitForAcceptChannel -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 val error = Error(state.temporaryChannelId, t.message)
                 Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
             }
             is WaitForFundingCreated -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 val error = Error(state.channelId, t.message)
                 Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
             }
             is WaitForFundingSigned -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 val error = Error(state.channelId, t.message)
                 Pair(Aborted, listOf(
                     ChannelAction.Message.Send(error),
@@ -192,7 +187,6 @@ sealed class ChannelState {
                 ))
             }
             is WaitForFundingConfirmed -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 val error = Error(state.channelId, t.message)
                 when {
                     state.commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
@@ -200,7 +194,6 @@ sealed class ChannelState {
                 }
             }
             is WaitForChannelReady -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 val error = Error(state.channelId, t.message)
                 when {
                     state.commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
@@ -208,7 +201,6 @@ sealed class ChannelState {
                 }
             }
             is Normal -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 val error = Error(state.channelId, t.message)
                 when {
                     state.commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
@@ -216,12 +208,10 @@ sealed class ChannelState {
                 }
             }
             is ShuttingDown -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 val error = Error(state.channelId, t.message)
                 state.run { spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error)) } }
             }
             is Negotiating -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 val error = Error(state.channelId, t.message)
                 when {
                     state.commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
@@ -244,34 +234,28 @@ sealed class ChannelState {
                 }
             }
             is Closing -> {
-                logger.error(t) { "error processing ${cmd::class} in state ${this::class}" }
                 state.localCommitPublished?.let {
                     // we're already trying to claim our commitment, there's nothing more we can do
                     Pair(state, listOf())
                 } ?: state.run { spendLocalCurrent() }
             }
             is Closed -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 Pair(state, listOf())
             }
             is Aborted -> {
                 Pair(state, listOf())
             }
             is Offline -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 Pair(state, listOf(ChannelAction.ProcessLocalError(t, cmd)))
             }
             is Syncing -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 Pair(state, listOf(ChannelAction.ProcessLocalError(t, cmd)))
             }
             is WaitForRemotePublishFutureCommitment -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class}" }
                 val error = Error(state.channelId, t.message)
                 Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
             }
             is LegacyWaitForFundingConfirmed -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 val error = Error(state.channelId, t.message)
                 when {
                     state.commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
@@ -279,7 +263,6 @@ sealed class ChannelState {
                 }
             }
             is LegacyWaitForFundingLocked -> {
-                logger.error(t) { "error on command ${cmd::class.simpleName} in state ${state::class.simpleName}" }
                 val error = Error(state.channelId, t.message)
                 when {
                     state.commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closed.kt
@@ -17,9 +17,4 @@ data class Closed(val state: Closing) : ChannelStateWithCommitments() {
     override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return Pair(this@Closed, listOf())
     }
-
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@Closed::class.simpleName}" }
-        return Pair(this@Closed, listOf())
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closing.kt
@@ -373,14 +373,6 @@ data class Closing(
         }
     }
 
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error processing ${cmd::class} in state ${this::class}" }
-        return localCommitPublished?.let {
-            // we're already trying to claim our commitment, there's nothing more we can do
-            Pair(this@Closing, listOf())
-        } ?: spendLocalCurrent()
-    }
-
     /**
      * Checks if a channel is closed (i.e. its closing tx has been confirmed)
      *

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmed.kt
@@ -78,13 +78,4 @@ data class LegacyWaitForFundingConfirmed(
             else -> unhandled(cmd)
         }
     }
-
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@LegacyWaitForFundingConfirmed::class.simpleName}" }
-        val error = Error(channelId, t.message)
-        return when {
-            commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
-            else -> spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error)) }
-        }
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLocked.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLocked.kt
@@ -72,13 +72,4 @@ data class LegacyWaitForFundingLocked(
             else -> unhandled(cmd)
         }
     }
-
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@LegacyWaitForFundingLocked::class.simpleName}" }
-        val error = Error(channelId, t.message)
-        return when {
-            commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
-            else -> spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error)) }
-        }
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -733,15 +733,6 @@ data class Normal(
         else -> null
     }
 
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@Normal::class.simpleName}" }
-        val error = Error(channelId, t.message)
-        return when {
-            commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
-            else -> spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error)) }
-        }
-    }
-
     private fun ChannelContext.handleCommandResult(command: ChannelCommand, result: Either<ChannelException, Pair<Commitments, LightningMessage>>, commit: Boolean): Pair<ChannelState, List<ChannelAction>> {
         return when (result) {
             is Either.Left -> handleCommandError(command, result.value, channelUpdate)

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
@@ -111,9 +111,4 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
             else -> unhandled(cmd)
         }
     }
-
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@Offline::class.simpleName}" }
-        return Pair(this@Offline, listOf(ChannelAction.ProcessLocalError(t, cmd)))
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/ShuttingDown.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/ShuttingDown.kt
@@ -190,12 +190,6 @@ data class ShuttingDown(
         }
     }
 
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@ShuttingDown::class.simpleName}" }
-        val error = Error(channelId, t.message)
-        return spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error)) }
-    }
-
     private fun ChannelContext.handleCommandResult(command: ChannelCommand, result: Either<ChannelException, Pair<Commitments, LightningMessage>>, commit: Boolean): Pair<ChannelState, List<ChannelAction>> {
         return when (result) {
             is Either.Left -> handleCommandError(command, result.value)

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -331,11 +331,6 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
         }
     }
 
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@Syncing::class.simpleName}" }
-        return Pair(this@Syncing, listOf(ChannelAction.ProcessLocalError(t, cmd)))
-    }
-
     companion object {
         private fun ChannelContext.handleSync(channelReestablish: ChannelReestablish, d: ChannelStateWithCommitments): Pair<Commitments, List<ChannelAction>> {
             val sendQueue = ArrayList<ChannelAction>()

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannel.kt
@@ -104,10 +104,4 @@ data class WaitForAcceptChannel(
             else -> unhandled(cmd)
         }
     }
-
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForAcceptChannel::class.simpleName}" }
-        val error = Error(temporaryChannelId, t.message)
-        return Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReady.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReady.kt
@@ -100,13 +100,4 @@ data class WaitForChannelReady(
             else -> unhandled(cmd)
         }
     }
-
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForChannelReady::class.simpleName}" }
-        val error = Error(channelId, t.message)
-        return when {
-            commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
-            else -> spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error)) }
-        }
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
@@ -331,13 +331,4 @@ data class WaitForFundingConfirmed(
             }
         }
     }
-
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForFundingConfirmed::class.simpleName}" }
-        val error = Error(channelId, t.message)
-        return when {
-            commitments.nothingAtStake() -> Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
-            else -> spendLocalCurrent().run { copy(second = second + ChannelAction.Message.Send(error)) }
-        }
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreated.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreated.kt
@@ -125,10 +125,4 @@ data class WaitForFundingCreated(
             else -> unhandled(cmd)
         }
     }
-
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForFundingCreated::class.simpleName}" }
-        val error = Error(channelId, t.message)
-        return Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
@@ -154,14 +154,4 @@ data class WaitForFundingSigned(
             Pair(nextState, actions)
         }
     }
-
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForFundingSigned::class.simpleName}" }
-        val error = Error(channelId, t.message)
-        val actions = listOf(
-            ChannelAction.Message.Send(error),
-            ChannelAction.Storage.RemoveChannel(this@WaitForFundingSigned),
-        )
-        return Pair(Aborted, actions)
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
@@ -58,10 +58,6 @@ object WaitForInit : ChannelState() {
                 val nextState = WaitForAcceptChannel(cmd, open)
                 Pair(nextState, listOf(ChannelAction.Message.Send(open)))
             }
-            cmd is ChannelCommand.Restore && cmd.state is Closing && cmd.state.commitments.nothingAtStake() -> {
-                logger.info { "we have nothing at stake, going straight to CLOSED" }
-                Pair(Closed(cmd.state), listOf())
-            }
             cmd is ChannelCommand.Restore -> {
                 logger.info { "restoring channel ${cmd.state.channelId} to state ${cmd.state::class.simpleName}" }
                 // We republish unconfirmed transactions.

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
@@ -147,9 +147,4 @@ object WaitForInit : ChannelState() {
             else -> unhandled(cmd)
         }
     }
-
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForInit::class.simpleName}" }
-        return Pair(this@WaitForInit, listOf(ChannelAction.ProcessLocalError(t, cmd)))
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannel.kt
@@ -129,10 +129,4 @@ data class WaitForOpenChannel(
             else -> unhandled(cmd)
         }
     }
-
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForOpenChannel::class.simpleName}" }
-        val error = Error(temporaryChannelId, t.message)
-        return Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForRemotePublishFutureCommitment.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForRemotePublishFutureCommitment.kt
@@ -21,10 +21,4 @@ data class WaitForRemotePublishFutureCommitment(
             else -> unhandled(cmd)
         }
     }
-
-    override fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
-        logger.error(t) { "error on command ${cmd::class.simpleName} in state ${this@WaitForRemotePublishFutureCommitment::class}" }
-        val error = Error(channelId, t.message)
-        return Pair(Aborted, listOf(ChannelAction.Message.Send(error)))
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -632,8 +632,6 @@ class Peer(
                         _channels[action.temporaryChannelId]?.let { _channels = _channels + (action.channelId to it) - action.temporaryChannelId }
                     }
 
-                    is ChannelAction.ProcessLocalError -> logger.error(action.error) { "error in channel $actualChannelId" }
-
                     is ChannelAction.EmitEvent -> nodeParams._nodeEvents.emit(action.event)
                 }
             }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -47,11 +47,6 @@ internal fun List<ChannelAction>.findPublishTxs(): List<Transaction> = filterIsI
 internal fun List<ChannelAction>.hasPublishTx(tx: Transaction) = assertContains(findPublishTxs(), tx)
 internal fun List<ChannelAction>.hasPublishTx(txType: ChannelAction.Blockchain.PublishTx.Type): Transaction = assertNotNull(filterIsInstance<ChannelAction.Blockchain.PublishTx>().firstOrNull { it.txType == txType }).tx
 
-// Errors
-internal inline fun <reified T : Throwable> List<ChannelAction>.findErrorOpt(): T? = filterIsInstance<ChannelAction.ProcessLocalError>().map { it.error }.filterIsInstance<T>().firstOrNull()
-internal inline fun <reified T : Throwable> List<ChannelAction>.findError(): T = findErrorOpt<T>() ?: fail("cannot find error ${T::class}")
-internal inline fun <reified T : Throwable> List<ChannelAction>.hasError() = assertNotNull(findErrorOpt<T>(), "cannot find error ${T::class}")
-
 internal inline fun <reified T : ChannelException> List<ChannelAction>.findCommandErrorOpt(): T? {
     val cmdAddError = filterIsInstance<ChannelAction.ProcessCmdRes.AddFailed>().map { it.error }.filterIsInstance<T>().firstOrNull()
     val otherCmdError = filterIsInstance<ChannelAction.ProcessCmdRes.NotExecuted>().map { it.t }.filterIsInstance<T>().firstOrNull()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
@@ -2214,7 +2214,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val (bob1, actions) = bob0.process(ChannelCommand.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
         val txs = actions.filterIsInstance<ChannelAction.Blockchain.PublishTx>().map { it.tx }
         assertEquals(txs, listOf(bobCommitTx))
-        assertIs<LNChannel<Closing>>(bob1)
+        assertIs<Closing>(bob1.state)
         assertEquals(bob1.state.localCommitPublished!!.commitTx, bobCommitTx)
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
@@ -190,9 +190,9 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         val (_, _, bob, _) = init(bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
         val (bob1, actions1) = bob.process(ChannelCommand.Close.ForceClose)
         assertIs<Aborted>(bob1.state)
-        assertEquals(1, actions1.size)
-        val error = actions1.hasOutgoingMessage<Error>()
-        assertEquals(ForcedLocalCommit(bob.channelId).message, error.toAscii())
+        assertEquals(2, actions1.size)
+        assertEquals(ForcedLocalCommit(bob.channelId).message, actions1.hasOutgoingMessage<Error>().toAscii())
+        actions1.has<ChannelAction.Storage.RemoveChannel>()
     }
 
     private fun getFundingSigs(channel: LNChannel<WaitForChannelReady>): TxSignatures {

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
@@ -185,16 +185,6 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         }
     }
 
-    @Test
-    fun `recv ChannelCommand_Close_ForceClose -- nothing at stake`() {
-        val (_, _, bob, _) = init(bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
-        val (bob1, actions1) = bob.process(ChannelCommand.Close.ForceClose)
-        assertIs<Aborted>(bob1.state)
-        assertEquals(2, actions1.size)
-        assertEquals(ForcedLocalCommit(bob.channelId).message, actions1.hasOutgoingMessage<Error>().toAscii())
-        actions1.has<ChannelAction.Storage.RemoveChannel>()
-    }
-
     private fun getFundingSigs(channel: LNChannel<WaitForChannelReady>): TxSignatures {
         assertIs<LocalFundingStatus.UnconfirmedFundingTx>(channel.commitments.latest.localFundingStatus)
         return (channel.commitments.latest.localFundingStatus as LocalFundingStatus.UnconfirmedFundingTx).sharedTx.localSigs

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
@@ -365,12 +365,12 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
 
     @Test
     fun `recv ChannelCommand_Close_ForceClose -- nothing at stake`() {
-        val (alice, bob) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
+        val (_, bob) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
         val (bob1, actions1) = bob.process(ChannelCommand.Close.ForceClose)
         assertIs<Aborted>(bob1.state)
-        assertEquals(1, actions1.size)
-        val error = actions1.hasOutgoingMessage<Error>()
-        assertEquals(ForcedLocalCommit(alice.state.channelId).message, error.toAscii())
+        assertEquals(2, actions1.size)
+        assertEquals(ForcedLocalCommit(bob.channelId).message, actions1.hasOutgoingMessage<Error>().toAscii())
+        actions1.has<ChannelAction.Storage.RemoveChannel>()
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
@@ -364,16 +364,6 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv ChannelCommand_Close_ForceClose -- nothing at stake`() {
-        val (_, bob) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
-        val (bob1, actions1) = bob.process(ChannelCommand.Close.ForceClose)
-        assertIs<Aborted>(bob1.state)
-        assertEquals(2, actions1.size)
-        assertEquals(ForcedLocalCommit(bob.channelId).message, actions1.hasOutgoingMessage<Error>().toAscii())
-        actions1.has<ChannelAction.Storage.RemoveChannel>()
-    }
-
-    @Test
     fun `recv CheckHtlcTimeout`() {
         val (alice, bob) = init(ChannelType.SupportedChannelType.AnchorOutputs)
         listOf(alice, bob).forEach { state ->


### PR DESCRIPTION
Replace the `abstract` function with an exhaustive `when`, which makes it easy to see at a glance how we handle errors in the various states.

Changes in behavior:
- removed useless `ProcessLocalError`
- do not force close in Closing if a mutual close has been published (consistent with the Negotiating case)
- do not go to Aborted in WaitForRemotePublishFutureCommitment