### PR TITLE
Derive per-user swap-in server keys

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
@@ -117,7 +117,6 @@ interface KeyManager {
         val userPublicKey: PublicKey = userPrivateKey.publicKey()
 
         private val localServerExtendedPrivateKey: DeterministicWallet.ExtendedPrivateKey = DeterministicWallet.derivePrivateKey(master, swapInKeyBasePath(chain) / hardened(1))
-        val localServerExtendedPublicKey: DeterministicWallet.ExtendedPublicKey = DeterministicWallet.publicKey(localServerExtendedPrivateKey)
         fun localServerPrivateKey(remoteNodeId: PublicKey): PrivateKey = DeterministicWallet.derivePrivateKey(localServerExtendedPrivateKey, perUserPath(remoteNodeId)).privateKey
 
         val redeemScript: List<ScriptElt> = Scripts.swapIn2of2(userPublicKey, remoteServerPublicKey, refundDelay)

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
@@ -2,9 +2,11 @@ package fr.acinq.lightning.crypto
 
 import fr.acinq.bitcoin.*
 import fr.acinq.bitcoin.DeterministicWallet.hardened
+import fr.acinq.bitcoin.io.ByteArrayInput
 import fr.acinq.lightning.NodeParams
 import fr.acinq.lightning.transactions.Scripts
 import fr.acinq.lightning.utils.toByteVector
+import fr.acinq.lightning.wire.LightningCodecs
 
 interface KeyManager {
 
@@ -114,8 +116,9 @@ interface KeyManager {
         val userPrivateKey: PrivateKey = DeterministicWallet.derivePrivateKey(master, swapInKeyBasePath(chain) / hardened(0)).privateKey
         val userPublicKey: PublicKey = userPrivateKey.publicKey()
 
-        val localServerPrivateKey: PrivateKey = DeterministicWallet.derivePrivateKey(master, swapInKeyBasePath(chain) / hardened(1)).privateKey
-        val localServerPublicKey: PublicKey = localServerPrivateKey.publicKey()
+        private val localServerExtendedPrivateKey: DeterministicWallet.ExtendedPrivateKey = DeterministicWallet.derivePrivateKey(master, swapInKeyBasePath(chain) / hardened(1))
+        val localServerExtendedPublicKey: DeterministicWallet.ExtendedPublicKey = DeterministicWallet.publicKey(localServerExtendedPrivateKey)
+        fun localServerPrivateKey(remoteNodeId: PublicKey): PrivateKey = DeterministicWallet.derivePrivateKey(localServerExtendedPrivateKey, perUserPath(remoteNodeId)).privateKey
 
         val redeemScript: List<ScriptElt> = Scripts.swapIn2of2(userPublicKey, remoteServerPublicKey, refundDelay)
         val pubkeyScript: List<ScriptElt> = Script.pay2wsh(redeemScript)
@@ -128,6 +131,13 @@ interface KeyManager {
             fun swapInKeyBasePath(chain: NodeParams.Chain) = when (chain) {
                 NodeParams.Chain.Regtest, NodeParams.Chain.Testnet -> KeyPath.empty / hardened(51) / hardened(0)
                 NodeParams.Chain.Mainnet -> KeyPath.empty / hardened(52) / hardened(0)
+            }
+
+            /** Swap-in servers use a different swap-in key for different users. */
+            fun perUserPath(remoteNodeId: PublicKey): KeyPath {
+                // We hash the remote node_id and break it into 2-byte values to get non-hardened path indices.
+                val h = ByteArrayInput(Crypto.sha256(remoteNodeId.value))
+                return KeyPath((0 until 16).map { _ -> LightningCodecs.u16(h).toLong() })
             }
         }
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
@@ -45,7 +45,12 @@ data class LocalKeyManager(val seed: ByteVector, val chain: Chain, val remoteSwa
 
     override val finalOnChainWallet: KeyManager.Bip84OnChainKeys = KeyManager.Bip84OnChainKeys(chain, master, account = 0)
     override val swapInOnChainWallet: KeyManager.SwapInOnChainKeys = run {
-        val xpub = DeterministicWallet.ExtendedPublicKey.decode(remoteSwapInExtendedPublicKey).second
+        val (prefix, xpub) = DeterministicWallet.ExtendedPublicKey.decode(remoteSwapInExtendedPublicKey)
+        val expectedPrefix = when (chain) {
+            Chain.Mainnet -> DeterministicWallet.xpub
+            else -> DeterministicWallet.tpub
+        }
+        require(prefix == expectedPrefix) { "unexpected swap-in xpub prefix $prefix (expected $expectedPrefix)" }
         val remoteSwapInPublicKey = DeterministicWallet.derivePublicKey(xpub, KeyManager.SwapInOnChainKeys.perUserPath(nodeKeys.nodeKey.publicKey)).publicKey
         KeyManager.SwapInOnChainKeys(chain, master, remoteSwapInPublicKey)
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
@@ -32,9 +32,9 @@ import fr.acinq.lightning.crypto.LocalKeyManager.Companion.channelKeyPath
  * ```
  *
  * @param seed seed from which the channel keys will be derived
- * @param remoteSwapInServerKey public key belonging to our swap-in server, that must be used in our swap address
+ * @param remoteSwapInExtendedPublicKey xpub belonging to our swap-in server, that must be used in our swap address
  */
-data class LocalKeyManager(val seed: ByteVector, val chain: Chain, val remoteSwapInServerKey: PublicKey) : KeyManager {
+data class LocalKeyManager(val seed: ByteVector, val chain: Chain, val remoteSwapInExtendedPublicKey: String) : KeyManager {
 
     private val master = DeterministicWallet.generate(seed)
 
@@ -44,7 +44,11 @@ data class LocalKeyManager(val seed: ByteVector, val chain: Chain, val remoteSwa
     )
 
     override val finalOnChainWallet: KeyManager.Bip84OnChainKeys = KeyManager.Bip84OnChainKeys(chain, master, account = 0)
-    override val swapInOnChainWallet: KeyManager.SwapInOnChainKeys = KeyManager.SwapInOnChainKeys(chain, master, remoteSwapInServerKey)
+    override val swapInOnChainWallet: KeyManager.SwapInOnChainKeys = run {
+        val xpub = DeterministicWallet.ExtendedPublicKey.decode(remoteSwapInExtendedPublicKey).second
+        val remoteSwapInPublicKey = DeterministicWallet.derivePublicKey(xpub, KeyManager.SwapInOnChainKeys.perUserPath(nodeKeys.nodeKey.publicKey)).publicKey
+        KeyManager.SwapInOnChainKeys(chain, master, remoteSwapInPublicKey)
+    }
 
     private val channelKeyBasePath: KeyPath = channelKeyBasePath(chain)
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
@@ -74,24 +74,24 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertTrue(sharedTxB.sharedTx.localFees < sharedTxA.sharedTx.localFees)
 
         // Bob sends signatures first as he contributed less than Alice.
-        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB)
+        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB, f.localParamsA.nodeId)
         assertEquals(signedTxB.localSigs.swapInUserSigs.size, 1)
         assertEquals(signedTxB.localSigs.swapInServerSigs.size, 3)
 
         // Alice detects invalid signatures from Bob.
         val sigsInvalidTxId = signedTxB.localSigs.copy(txHash = randomBytes32())
-        assertNull(sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA).addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidTxId))
+        assertNull(sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId).addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidTxId))
         val sigsMissingUserSigs = signedTxB.localSigs.copy(tlvs = TlvStream(TxSignaturesTlv.SwapInUserSigs(listOf()), TxSignaturesTlv.SwapInServerSigs(signedTxB.localSigs.swapInServerSigs)))
-        assertNull(sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA).addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingUserSigs))
+        assertNull(sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId).addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingUserSigs))
         val sigsMissingServerSigs = signedTxB.localSigs.copy(tlvs = TlvStream(TxSignaturesTlv.SwapInUserSigs(signedTxB.localSigs.swapInUserSigs), TxSignaturesTlv.SwapInServerSigs(listOf())))
-        assertNull(sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA).addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingServerSigs))
+        assertNull(sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId).addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingServerSigs))
         val sigsInvalidUserSig = signedTxB.localSigs.copy(tlvs = TlvStream(TxSignaturesTlv.SwapInUserSigs(listOf(randomBytes64())), TxSignaturesTlv.SwapInServerSigs(signedTxB.localSigs.swapInServerSigs)))
-        assertNull(sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA).addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidUserSig))
+        assertNull(sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId).addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidUserSig))
         val sigsInvalidServerSig = signedTxB.localSigs.copy(tlvs = TlvStream(TxSignaturesTlv.SwapInUserSigs(signedTxB.localSigs.swapInUserSigs), TxSignaturesTlv.SwapInServerSigs(signedTxB.localSigs.swapInServerSigs.reversed())))
-        assertNull(sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA).addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidServerSig))
+        assertNull(sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId).addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidServerSig))
 
         // The resulting transaction is valid and has the right feerate.
-        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
+        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
         assertNotNull(signedTxA)
         assertEquals(signedTxA.localSigs.swapInUserSigs.size, 3)
         assertEquals(signedTxA.localSigs.swapInServerSigs.size, 1)
@@ -146,13 +146,13 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertTrue(sharedTxB.sharedTx.localFees < sharedTxA.sharedTx.localFees)
 
         // Alice sends signatures first as she contributed less than Bob.
-        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA)
+        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId)
         assertNotNull(signedTxA)
         assertEquals(signedTxA.localSigs.swapInUserSigs.size, 1)
         assertEquals(signedTxA.localSigs.swapInServerSigs.size, 1)
 
         // The resulting transaction is valid and has the right feerate.
-        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB).addRemoteSigs(f.channelKeysB, f.fundingParamsB, signedTxA.localSigs)
+        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB, f.localParamsA.nodeId).addRemoteSigs(f.channelKeysB, f.fundingParamsB, signedTxA.localSigs)
         assertNotNull(signedTxB)
         assertEquals(signedTxB.localSigs.swapInUserSigs.size, 1)
         assertEquals(signedTxB.localSigs.swapInServerSigs.size, 1)
@@ -206,13 +206,13 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertTrue(sharedTxA.sharedTx.remoteFees < sharedTxA.sharedTx.localFees)
 
         // Alice contributes more than Bob to the funding output, but Bob's inputs are bigger than Alice's, so Alice must sign first.
-        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA)
+        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId)
         assertNotNull(signedTxA)
         assertEquals(signedTxA.localSigs.swapInUserSigs.size, 1)
         assertEquals(signedTxA.localSigs.swapInServerSigs.size, 1)
 
         // The resulting transaction is valid and has the right feerate.
-        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB).addRemoteSigs(f.channelKeysB, f.fundingParamsB, signedTxA.localSigs)
+        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB, f.localParamsA.nodeId).addRemoteSigs(f.channelKeysB, f.fundingParamsB, signedTxA.localSigs)
         assertNotNull(signedTxB)
         Transaction.correctlySpends(signedTxB.signedTx, (sharedTxA.sharedTx.localInputs + sharedTxB.sharedTx.localInputs).map { it.previousTx }, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
         val feerate = Transactions.fee2rate(signedTxB.tx.fees, signedTxB.signedTx.weight())
@@ -263,13 +263,13 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertEquals(sharedTxB.sharedTx.remoteFees, 2_800_000.msat)
 
         // Bob sends signatures first as he did not contribute at all.
-        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB)
+        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB, f.localParamsA.nodeId)
         assertNotNull(signedTxB)
         assertEquals(signedTxB.localSigs.swapInUserSigs.size, 0)
         assertEquals(signedTxB.localSigs.swapInServerSigs.size, 2)
 
         // The resulting transaction is valid and has the right feerate.
-        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
+        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
         assertNotNull(signedTxA)
         assertEquals(signedTxA.localSigs.swapInUserSigs.size, 2)
         assertEquals(signedTxA.localSigs.swapInServerSigs.size, 0)
@@ -338,14 +338,14 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertEquals(sharedTxB.sharedTx.remoteFees, 1_116_000.msat)
 
         // Bob sends signatures first as he contributed less than Alice.
-        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB)
+        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB, f.localParamsA.nodeId)
         assertNotNull(signedTxB)
         assertEquals(signedTxB.localSigs.swapInUserSigs.size, 1)
         assertEquals(signedTxB.localSigs.swapInServerSigs.size, 1)
         assertNotNull(signedTxB.localSigs.previousFundingTxSig)
 
         // The resulting transaction is valid and has the right feerate.
-        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
+        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
         assertNotNull(signedTxA)
         assertEquals(signedTxA.localSigs.swapInUserSigs.size, 1)
         assertEquals(signedTxA.localSigs.swapInServerSigs.size, 1)
@@ -412,7 +412,7 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertEquals(sharedTxB.sharedTx.remoteFees, 1_000_000.msat)
 
         // Bob sends signatures first as he did not contribute.
-        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB)
+        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB, f.localParamsA.nodeId)
         assertNotNull(signedTxB)
         assertTrue(signedTxB.localSigs.witnesses.isEmpty())
         assertTrue(signedTxB.localSigs.swapInUserSigs.isEmpty())
@@ -420,7 +420,7 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertNotNull(signedTxB.localSigs.previousFundingTxSig)
 
         // The resulting transaction is valid.
-        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
+        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
         assertNotNull(signedTxA)
         assertTrue(signedTxA.localSigs.witnesses.isEmpty())
         assertTrue(signedTxA.localSigs.swapInUserSigs.isEmpty())
@@ -492,13 +492,13 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertEquals(sharedTxB.sharedTx.remoteFees, 1_000_000.msat)
 
         // Bob sends signatures first as he did not contribute.
-        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB)
+        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB, f.localParamsA.nodeId)
         assertNotNull(signedTxB)
         assertTrue(signedTxB.localSigs.swapInUserSigs.isEmpty())
         assertNotNull(signedTxB.localSigs.previousFundingTxSig)
 
         // The resulting transaction is valid.
-        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
+        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
         assertNotNull(signedTxA)
         assertTrue(signedTxA.localSigs.swapInUserSigs.isEmpty())
         assertNotNull(signedTxA.localSigs.previousFundingTxSig)
@@ -569,14 +569,14 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertEquals(sharedTxB.sharedTx.remoteFees, 1_240_000.msat)
 
         // Bob sends signatures first as he did not contribute.
-        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB)
+        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB, f.localParamsA.nodeId)
         assertNotNull(signedTxB)
         assertEquals(signedTxB.localSigs.swapInUserSigs.size, 1)
         assertEquals(signedTxB.localSigs.swapInServerSigs.size, 1)
         assertNotNull(signedTxB.localSigs.previousFundingTxSig)
 
         // The resulting transaction is valid.
-        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
+        val signedTxA = sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
         assertNotNull(signedTxA)
         assertEquals(signedTxA.localSigs.swapInUserSigs.size, 1)
         assertEquals(signedTxA.localSigs.swapInServerSigs.size, 1)
@@ -869,10 +869,10 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertNull(sharedTxB.txComplete)
 
         // Alice didn't send her user key, so Bob thinks there aren't any swap inputs
-        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB)
+        val signedTxB = sharedTxB.sharedTx.sign(f.keyManagerB, f.fundingParamsB, f.localParamsB, f.localParamsA.nodeId)
         assertTrue(signedTxB.localSigs.swapInServerSigs.isEmpty())
         // Alice is unable to sign her input since Bob didn't provide his signature.
-        assertNull(sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs))
+        assertNull(sharedTxA.sharedTx.sign(f.keyManagerA, f.fundingParamsA, f.localParamsA, f.localParamsB.nodeId).addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs))
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/RecoveryTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/RecoveryTestsCommon.kt
@@ -1,11 +1,9 @@
 package fr.acinq.lightning.channel
 
 import fr.acinq.bitcoin.*
-import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.NodeParams
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
-
 import fr.acinq.lightning.crypto.LocalKeyManager
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.transactions.Scripts
@@ -39,7 +37,7 @@ class RecoveryTestsCommon {
 
         // use Bob's mnemonic words to initialise his key manager
         val seed = MnemonicCode.toSeed(TestConstants.Bob.mnemonics, "").toByteVector32()
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, randomKey().publicKey())
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
 
         // recompute our channel keys from the extracted funding pubkey and see if we can find and spend our output
         fun findAndSpend(fundingKey: PublicKey): Transaction? {

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/RecoveryTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/RecoveryTestsCommon.kt
@@ -37,7 +37,7 @@ class RecoveryTestsCommon {
 
         // use Bob's mnemonic words to initialise his key manager
         val seed = MnemonicCode.toSeed(TestConstants.Bob.mnemonics, "").toByteVector32()
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.aliceSwapInServerXpub)
 
         // recompute our channel keys from the extracted funding pubkey and see if we can find and spend our output
         fun findAndSpend(fundingKey: PublicKey): Transaction? {

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
@@ -2,7 +2,6 @@ package fr.acinq.lightning.crypto
 
 import fr.acinq.bitcoin.*
 import fr.acinq.bitcoin.crypto.Pack
-import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.NodeParams
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
@@ -19,7 +18,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         // if this test breaks it means that we will generate a different node id from
         // the same seed, which could be a problem during an upgrade
         val seed = ByteVector("17b086b228025fa8f4416324b6ba2ec36e68570ae2fc3d392520969f2a9d0c1501")
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, randomKey().publicKey())
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
         assertEquals(keyManager.nodeKeys.nodeKey.publicKey, PublicKey.fromHex("0392ea6e914abcee840dc8a763b02ba5ac47e0ac3fadcd5294f9516fe353882522"))
     }
 
@@ -28,14 +27,14 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         // if this test breaks it means that we will generate a different legacy node id from
         // the same seed, which could be a problem during migration from legacy to kmp
         val seed = MnemonicCode.toSeed("sock able evoke work output half bamboo energy simple fiber unhappy afford", passphrase = "").byteVector()
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, randomKey().publicKey())
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
         assertEquals(keyManager.nodeKeys.legacyNodeKey.publicKey, PublicKey.fromHex("0388a99397c5a599c4c56ea2b9f938bd2893744a590af7c1f05c9c3ee822c13fdc"))
     }
 
     @Test
     fun `generate channel keys`() {
         val seed = ByteVector("aeb3e9b5642cd4523e9e09164047f60adb413633549c3c6189192921311894d501")
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, randomKey().publicKey())
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
         val fundingKeyPath = makeFundingKeyPath(ByteVector("06535806c1aa73971ec4877a5e2e684fa636136c073810f190b63eefc58ca488"), isInitiator = false)
         val channelKeys = keyManager.channelKeys(fundingKeyPath)
 
@@ -55,8 +54,8 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     @Test
     fun `generate different node ids from the same seed on different chains`() {
         val seed = ByteVector("17b086b228025fa8f4416324b6ba2ec36e68570ae2fc3d392520969f2a9d0c1501")
-        val keyManager1 = LocalKeyManager(seed, NodeParams.Chain.Regtest, randomKey().publicKey())
-        val keyManager2 = LocalKeyManager(seed, NodeParams.Chain.Mainnet, randomKey().publicKey())
+        val keyManager1 = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
+        val keyManager2 = LocalKeyManager(seed, NodeParams.Chain.Mainnet, TestConstants.Alice.swapInServerXpub)
         assertTrue { keyManager1.nodeKeys.nodeKey.publicKey != keyManager2.nodeKeys.nodeKey.publicKey }
         val fundingKeyPath = KeyPath("1")
         val channelKeys1 = keyManager1.channelKeys(fundingKeyPath)
@@ -74,7 +73,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         assertEquals(keyPath.toString(), "m/1909530642'/1080788911/847211985'/1791010671/1303008749'/34154019'/723973395/767609665")
     }
 
-    fun makeFundingKeyPath(entropy: ByteVector, isInitiator: Boolean): KeyPath {
+    private fun makeFundingKeyPath(entropy: ByteVector, isInitiator: Boolean): KeyPath {
         val items = (0..7).toList().map { Pack.int32BE(entropy.toByteArray(), it * 4).toLong() and 0xFFFFFFFFL }
         val last = DeterministicWallet.hardened(if (isInitiator) 1L else 0L)
         return KeyPath(items + last)
@@ -83,7 +82,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     @Test
     fun `test vectors -- testnet + initiator`() {
         val seed = ByteVector("17b086b228025fa8f4416324b6ba2ec36e68570ae2fc3d392520969f2a9d0c1501")
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, randomKey().publicKey())
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
         val fundingKeyPath = makeFundingKeyPath(ByteVector("be4fa97c62b9f88437a3be577b31eb48f2165c7bc252194a15ff92d995778cfb"), isInitiator = true)
 
         val localParams = TestConstants.Alice.channelParams().copy(fundingKeyPath = fundingKeyPath)
@@ -100,7 +99,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     @Test
     fun `test vectors -- testnet + non-initiator`() {
         val seed = ByteVector("aeb3e9b5642cd4523e9e09164047f60adb413633549c3c6189192921311894d501")
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, randomKey().publicKey())
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
         val fundingKeyPath = makeFundingKeyPath(ByteVector("06535806c1aa73971ec4877a5e2e684fa636136c073810f190b63eefc58ca488"), isInitiator = false)
 
         val localParams = TestConstants.Alice.channelParams().copy(fundingKeyPath = fundingKeyPath)
@@ -117,7 +116,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     @Test
     fun `test vectors -- mainnet + initiator`() {
         val seed = ByteVector("d8d5431487c2b19ee6486aad6c3bdfb99d10b727bade7fa848e2ab7901c15bff01")
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Mainnet, randomKey().publicKey())
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Mainnet, TestConstants.Alice.swapInServerXpub)
         val fundingKeyPath = makeFundingKeyPath(ByteVector("ec1c41cd6be2b6e4ef46c1107f6c51fbb2066d7e1f7720bde4715af233ae1322"), isInitiator = true)
 
         val localParams = TestConstants.Alice.channelParams().copy(fundingKeyPath = fundingKeyPath)
@@ -134,7 +133,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     @Test
     fun `test vectors -- mainnet + non-initiator`() {
         val seed = ByteVector("4b809dd593b36131c454d60c2f7bdfd49d12ec455e5b657c47a9ca0f5dfc5eef01")
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Mainnet, randomKey().publicKey())
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Mainnet, TestConstants.Alice.swapInServerXpub)
         val fundingKeyPath = makeFundingKeyPath(ByteVector("2b4f045be5303d53f9d3a84a1e70c12251168dc29f300cf9cece0ec85cd8182b"), isInitiator = false)
 
         val localParams = TestConstants.Alice.channelParams().copy(fundingKeyPath = fundingKeyPath)
@@ -153,7 +152,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         // basic test taken from https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
         val mnemonics = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" ")
         val seed = MnemonicCode.toSeed(mnemonics, "").toByteVector()
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Mainnet, randomKey().publicKey())
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Mainnet, TestConstants.Alice.swapInServerXpub)
         assertEquals(keyManager.finalOnChainWallet.address(addressIndex = 0L), "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu")
         assertEquals(keyManager.finalOnChainWallet.address(addressIndex = 1L), "bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g")
         assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 1L).toBase58(Base58.Prefix.SecretKey), "Kxpf5b8p3qX56DKEe5NqWbNUP9MnqoRFzZwHRtsFqhzuvUJsYZCy")
@@ -166,7 +165,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         // reference data was generated from electrum 4.1.5
         val mnemonics = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" ")
         val seed = MnemonicCode.toSeed(mnemonics, "").toByteVector()
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Testnet, randomKey().publicKey())
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Testnet, TestConstants.Alice.swapInServerXpub)
         assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 0L).toBase58(Base58.Prefix.SecretKeyTestnet), "cTGhosGriPpuGA586jemcuH9pE9spwUmneMBmYYzrQEbY92DJrbo")
         assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 1L).toBase58(Base58.Prefix.SecretKeyTestnet), "cQFUndrpAyMaE3HAsjMCXiT94MzfsABCREat1x7Qe3Mtq9KihD4V")
         assertEquals(keyManager.finalOnChainWallet.xpub, "vpub5Y6cjg78GGuNLsaPhmYsiw4gYX3HoQiRBiSwDaBXKUafCt9bNwWQiitDk5VZ5BVxYnQdwoTyXSs2JHRPAgjAvtbBrf8ZhDYe2jWAqvZVnsc")
@@ -174,11 +173,9 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
 
     @Test
     fun `swap-in addresses regtest`() {
-        assertEquals(PublicKey.fromHex("0359f13771c78a0fd9fb45fc2bf666008c591a35877684be46247dfe02c9af2b58"), TestConstants.Alice.keyManager.swapInOnChainWallet.localServerPublicKey)
         assertEquals(PublicKey.fromHex("03d598883dc23081c5926dab28dbd075d542c4fba544471921dbb96a31d7bc4919"), TestConstants.Alice.keyManager.swapInOnChainWallet.userPublicKey)
-        assertEquals(PublicKey.fromHex("02cd0e2ed9c42af42e0b30e2a0b339c8335bbdc1f895fe552d8e224aedc82d6c88"), TestConstants.Bob.keyManager.swapInOnChainWallet.localServerPublicKey)
         assertEquals(PublicKey.fromHex("020bc21d9cb5ecc60fc2002195429d55ff4dfd0888e377a1b3226b4dc1ee7cedf3"), TestConstants.Bob.keyManager.swapInOnChainWallet.userPublicKey)
-        assertEquals(TestConstants.Alice.keyManager.remoteSwapInServerKey, TestConstants.Bob.keyManager.swapInOnChainWallet.localServerPublicKey)
-        assertEquals(TestConstants.Bob.keyManager.remoteSwapInServerKey, TestConstants.Alice.keyManager.swapInOnChainWallet.localServerPublicKey)
+        assertEquals(TestConstants.Alice.keyManager.swapInOnChainWallet.remoteServerPublicKey, TestConstants.Bob.keyManager.swapInOnChainWallet.localServerPrivateKey(TestConstants.Alice.nodeParams.nodeId).publicKey())
+        assertEquals(TestConstants.Bob.keyManager.swapInOnChainWallet.remoteServerPublicKey, TestConstants.Alice.keyManager.swapInOnChainWallet.localServerPrivateKey(TestConstants.Bob.nodeParams.nodeId).publicKey())
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
@@ -9,7 +9,6 @@ import fr.acinq.lightning.utils.toByteVector
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 class LocalKeyManagerTestsCommon : LightningTestSuite() {
 
@@ -18,7 +17,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         // if this test breaks it means that we will generate a different node id from
         // the same seed, which could be a problem during an upgrade
         val seed = ByteVector("17b086b228025fa8f4416324b6ba2ec36e68570ae2fc3d392520969f2a9d0c1501")
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.aliceSwapInServerXpub)
         assertEquals(keyManager.nodeKeys.nodeKey.publicKey, PublicKey.fromHex("0392ea6e914abcee840dc8a763b02ba5ac47e0ac3fadcd5294f9516fe353882522"))
     }
 
@@ -27,14 +26,14 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         // if this test breaks it means that we will generate a different legacy node id from
         // the same seed, which could be a problem during migration from legacy to kmp
         val seed = MnemonicCode.toSeed("sock able evoke work output half bamboo energy simple fiber unhappy afford", passphrase = "").byteVector()
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.aliceSwapInServerXpub)
         assertEquals(keyManager.nodeKeys.legacyNodeKey.publicKey, PublicKey.fromHex("0388a99397c5a599c4c56ea2b9f938bd2893744a590af7c1f05c9c3ee822c13fdc"))
     }
 
     @Test
     fun `generate channel keys`() {
         val seed = ByteVector("aeb3e9b5642cd4523e9e09164047f60adb413633549c3c6189192921311894d501")
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.aliceSwapInServerXpub)
         val fundingKeyPath = makeFundingKeyPath(ByteVector("06535806c1aa73971ec4877a5e2e684fa636136c073810f190b63eefc58ca488"), isInitiator = false)
         val channelKeys = keyManager.channelKeys(fundingKeyPath)
 
@@ -54,9 +53,9 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     @Test
     fun `generate different node ids from the same seed on different chains`() {
         val seed = ByteVector("17b086b228025fa8f4416324b6ba2ec36e68570ae2fc3d392520969f2a9d0c1501")
-        val keyManager1 = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
-        val keyManager2 = LocalKeyManager(seed, NodeParams.Chain.Mainnet, TestConstants.Alice.swapInServerXpub)
-        assertTrue { keyManager1.nodeKeys.nodeKey.publicKey != keyManager2.nodeKeys.nodeKey.publicKey }
+        val keyManager1 = LocalKeyManager(seed, NodeParams.Chain.Regtest, DeterministicWallet.encode(dummyExtendedPubkey, testnet = true))
+        val keyManager2 = LocalKeyManager(seed, NodeParams.Chain.Mainnet, DeterministicWallet.encode(dummyExtendedPubkey, testnet = false))
+        assertNotEquals(keyManager1.nodeKeys.nodeKey.publicKey, keyManager2.nodeKeys.nodeKey.publicKey)
         val fundingKeyPath = KeyPath("1")
         val channelKeys1 = keyManager1.channelKeys(fundingKeyPath)
         val channelKeys2 = keyManager2.channelKeys(fundingKeyPath)
@@ -82,7 +81,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     @Test
     fun `test vectors -- testnet + initiator`() {
         val seed = ByteVector("17b086b228025fa8f4416324b6ba2ec36e68570ae2fc3d392520969f2a9d0c1501")
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.aliceSwapInServerXpub)
         val fundingKeyPath = makeFundingKeyPath(ByteVector("be4fa97c62b9f88437a3be577b31eb48f2165c7bc252194a15ff92d995778cfb"), isInitiator = true)
 
         val localParams = TestConstants.Alice.channelParams().copy(fundingKeyPath = fundingKeyPath)
@@ -99,7 +98,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     @Test
     fun `test vectors -- testnet + non-initiator`() {
         val seed = ByteVector("aeb3e9b5642cd4523e9e09164047f60adb413633549c3c6189192921311894d501")
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.Alice.swapInServerXpub)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, TestConstants.aliceSwapInServerXpub)
         val fundingKeyPath = makeFundingKeyPath(ByteVector("06535806c1aa73971ec4877a5e2e684fa636136c073810f190b63eefc58ca488"), isInitiator = false)
 
         val localParams = TestConstants.Alice.channelParams().copy(fundingKeyPath = fundingKeyPath)
@@ -116,7 +115,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     @Test
     fun `test vectors -- mainnet + initiator`() {
         val seed = ByteVector("d8d5431487c2b19ee6486aad6c3bdfb99d10b727bade7fa848e2ab7901c15bff01")
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Mainnet, TestConstants.Alice.swapInServerXpub)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Mainnet, DeterministicWallet.encode(dummyExtendedPubkey, testnet = false))
         val fundingKeyPath = makeFundingKeyPath(ByteVector("ec1c41cd6be2b6e4ef46c1107f6c51fbb2066d7e1f7720bde4715af233ae1322"), isInitiator = true)
 
         val localParams = TestConstants.Alice.channelParams().copy(fundingKeyPath = fundingKeyPath)
@@ -133,7 +132,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
     @Test
     fun `test vectors -- mainnet + non-initiator`() {
         val seed = ByteVector("4b809dd593b36131c454d60c2f7bdfd49d12ec455e5b657c47a9ca0f5dfc5eef01")
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Mainnet, TestConstants.Alice.swapInServerXpub)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Mainnet, DeterministicWallet.encode(dummyExtendedPubkey, testnet = false))
         val fundingKeyPath = makeFundingKeyPath(ByteVector("2b4f045be5303d53f9d3a84a1e70c12251168dc29f300cf9cece0ec85cd8182b"), isInitiator = false)
 
         val localParams = TestConstants.Alice.channelParams().copy(fundingKeyPath = fundingKeyPath)
@@ -152,7 +151,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         // basic test taken from https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
         val mnemonics = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" ")
         val seed = MnemonicCode.toSeed(mnemonics, "").toByteVector()
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Mainnet, TestConstants.Alice.swapInServerXpub)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Mainnet, DeterministicWallet.encode(dummyExtendedPubkey, testnet = false))
         assertEquals(keyManager.finalOnChainWallet.address(addressIndex = 0L), "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu")
         assertEquals(keyManager.finalOnChainWallet.address(addressIndex = 1L), "bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g")
         assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 1L).toBase58(Base58.Prefix.SecretKey), "Kxpf5b8p3qX56DKEe5NqWbNUP9MnqoRFzZwHRtsFqhzuvUJsYZCy")
@@ -165,7 +164,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         // reference data was generated from electrum 4.1.5
         val mnemonics = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" ")
         val seed = MnemonicCode.toSeed(mnemonics, "").toByteVector()
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Testnet, TestConstants.Alice.swapInServerXpub)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Testnet, TestConstants.aliceSwapInServerXpub)
         assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 0L).toBase58(Base58.Prefix.SecretKeyTestnet), "cTGhosGriPpuGA586jemcuH9pE9spwUmneMBmYYzrQEbY92DJrbo")
         assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 1L).toBase58(Base58.Prefix.SecretKeyTestnet), "cQFUndrpAyMaE3HAsjMCXiT94MzfsABCREat1x7Qe3Mtq9KihD4V")
         assertEquals(keyManager.finalOnChainWallet.xpub, "vpub5Y6cjg78GGuNLsaPhmYsiw4gYX3HoQiRBiSwDaBXKUafCt9bNwWQiitDk5VZ5BVxYnQdwoTyXSs2JHRPAgjAvtbBrf8ZhDYe2jWAqvZVnsc")
@@ -177,5 +176,9 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         assertEquals(PublicKey.fromHex("020bc21d9cb5ecc60fc2002195429d55ff4dfd0888e377a1b3226b4dc1ee7cedf3"), TestConstants.Bob.keyManager.swapInOnChainWallet.userPublicKey)
         assertEquals(TestConstants.Alice.keyManager.swapInOnChainWallet.remoteServerPublicKey, TestConstants.Bob.keyManager.swapInOnChainWallet.localServerPrivateKey(TestConstants.Alice.nodeParams.nodeId).publicKey())
         assertEquals(TestConstants.Bob.keyManager.swapInOnChainWallet.remoteServerPublicKey, TestConstants.Alice.keyManager.swapInOnChainWallet.localServerPrivateKey(TestConstants.Bob.nodeParams.nodeId).publicKey())
+    }
+
+    companion object {
+        val dummyExtendedPubkey = DeterministicWallet.publicKey(DeterministicWallet.generate(ByteVector("deadbeef")))
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
@@ -35,13 +35,15 @@ object TestConstants {
         TrampolineFees(5.sat, 1200, CltvExpiryDelta(576))
     )
 
+    const val aliceSwapInServerXpub = "tpubDCvYeHUZisCMVTSfWDa1yevTf89NeF6TWxXUQwqkcmFrNvNdNvZQh1j4m4uTA4QcmPEwcrKVF8bJih1v16zDZacRr4j9MCAFQoSydKKy66q"
+    const val bobSwapInServerXpub = "tpubDDt5vQap1awkyDXx1z1cP7QFKSZHDCCpbU8nSq9jy7X2grTjUVZDePexf6gc6AHtRRzkgfPW87K6EKUVV6t3Hu2hg7YkHkmMeLSfrP85x41"
+
     object Alice {
         private val entropy = Hex.decode("0101010101010101010101010101010101010101010101010101010101010101")
         private val mnemonics = MnemonicCode.toMnemonics(entropy)
         private val seed = MnemonicCode.toSeed(mnemonics, "").toByteVector32()
-        const val swapInServerXpub = "tpubDCvYeHUZisCMVTSfWDa1yevTf89NeF6TWxXUQwqkcmFrNvNdNvZQh1j4m4uTA4QcmPEwcrKVF8bJih1v16zDZacRr4j9MCAFQoSydKKy66q"
 
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, Bob.swapInServerXpub)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, bobSwapInServerXpub)
         val walletParams = WalletParams(NodeUri(Bob.keyManager.nodeKeys.nodeKey.publicKey, "bob.com", 9735), trampolineFees, InvoiceDefaultRoutingFees(1_000.msat, 100, CltvExpiryDelta(144)), swapInConfirmations)
         val nodeParams = NodeParams(
             chain = NodeParams.Chain.Regtest,
@@ -89,9 +91,8 @@ object TestConstants {
         private val entropy = Hex.decode("0202020202020202020202020202020202020202020202020202020202020202")
         val mnemonics = MnemonicCode.toMnemonics(entropy)
         private val seed = MnemonicCode.toSeed(mnemonics, "").toByteVector32()
-        const val swapInServerXpub = "tpubDDt5vQap1awkyDXx1z1cP7QFKSZHDCCpbU8nSq9jy7X2grTjUVZDePexf6gc6AHtRRzkgfPW87K6EKUVV6t3Hu2hg7YkHkmMeLSfrP85x41"
 
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, Alice.swapInServerXpub)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, aliceSwapInServerXpub)
         val walletParams = WalletParams(NodeUri(Alice.keyManager.nodeKeys.nodeKey.publicKey, "alice.com", 9735), trampolineFees, InvoiceDefaultRoutingFees(1_000.msat, 100, CltvExpiryDelta(144)), swapInConfirmations)
         val nodeParams = NodeParams(
             chain = NodeParams.Chain.Regtest,

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
@@ -3,7 +3,6 @@ package fr.acinq.lightning.tests
 import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.MnemonicCode
-import fr.acinq.bitcoin.PublicKey
 import fr.acinq.lightning.*
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.blockchain.fee.FeerateTolerance
@@ -40,9 +39,9 @@ object TestConstants {
         private val entropy = Hex.decode("0101010101010101010101010101010101010101010101010101010101010101")
         private val mnemonics = MnemonicCode.toMnemonics(entropy)
         private val seed = MnemonicCode.toSeed(mnemonics, "").toByteVector32()
-        private val bobServerSwapInKey = PublicKey.fromHex("02cd0e2ed9c42af42e0b30e2a0b339c8335bbdc1f895fe552d8e224aedc82d6c88")
+        const val swapInServerXpub = "tpubDCvYeHUZisCMVTSfWDa1yevTf89NeF6TWxXUQwqkcmFrNvNdNvZQh1j4m4uTA4QcmPEwcrKVF8bJih1v16zDZacRr4j9MCAFQoSydKKy66q"
 
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, bobServerSwapInKey)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, Bob.swapInServerXpub)
         val walletParams = WalletParams(NodeUri(Bob.keyManager.nodeKeys.nodeKey.publicKey, "bob.com", 9735), trampolineFees, InvoiceDefaultRoutingFees(1_000.msat, 100, CltvExpiryDelta(144)), swapInConfirmations)
         val nodeParams = NodeParams(
             chain = NodeParams.Chain.Regtest,
@@ -90,9 +89,9 @@ object TestConstants {
         private val entropy = Hex.decode("0202020202020202020202020202020202020202020202020202020202020202")
         val mnemonics = MnemonicCode.toMnemonics(entropy)
         private val seed = MnemonicCode.toSeed(mnemonics, "").toByteVector32()
-        private val aliceServerSwapInKey = PublicKey.fromHex("0359f13771c78a0fd9fb45fc2bf666008c591a35877684be46247dfe02c9af2b58")
+        const val swapInServerXpub = "tpubDDt5vQap1awkyDXx1z1cP7QFKSZHDCCpbU8nSq9jy7X2grTjUVZDePexf6gc6AHtRRzkgfPW87K6EKUVV6t3Hu2hg7YkHkmMeLSfrP85x41"
 
-        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, aliceServerSwapInKey)
+        val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, Alice.swapInServerXpub)
         val walletParams = WalletParams(NodeUri(Alice.keyManager.nodeKeys.nodeKey.publicKey, "alice.com", 9735), trampolineFees, InvoiceDefaultRoutingFees(1_000.msat, 100, CltvExpiryDelta(144)), swapInConfirmations)
         val nodeParams = NodeParams(
             chain = NodeParams.Chain.Regtest,

--- a/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
@@ -460,7 +460,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             )
             val userSig = Transactions.signSwapInputUser(fundingTx, 0, swapInTx.txOut.first(), userWallet.userPrivateKey, userWallet.remoteServerPublicKey, userWallet.refundDelay)
             val serverWallet = TestConstants.Bob.keyManager.swapInOnChainWallet
-            val serverSig = Transactions.signSwapInputServer(fundingTx, 0, swapInTx.txOut.first(), userWallet.userPublicKey, serverWallet.localServerPrivateKey, serverWallet.refundDelay)
+            val serverSig = Transactions.signSwapInputServer(fundingTx, 0, swapInTx.txOut.first(), userWallet.userPublicKey, serverWallet.localServerPrivateKey(TestConstants.Alice.nodeParams.nodeId), serverWallet.refundDelay)
             val witness = Scripts.witnessSwapIn2of2(userSig, userWallet.userPublicKey, serverSig, userWallet.remoteServerPublicKey, userWallet.refundDelay)
             val signedTx = fundingTx.updateWitness(0, witness)
             Transaction.correctlySpends(signedTx, listOf(swapInTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/InitTlvTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/InitTlvTestsCommon.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
 class InitTlvTestsCommon : LightningTestSuite() {
     @Test
     fun `legacy phoenix TLV`() {
-        val keyManager = LocalKeyManager(MnemonicCode.toSeed("sock able evoke work output half bamboo energy simple fiber unhappy afford", passphrase = "").byteVector(), NodeParams.Chain.Testnet, TestConstants.Alice.swapInServerXpub)
+        val keyManager = LocalKeyManager(MnemonicCode.toSeed("sock able evoke work output half bamboo energy simple fiber unhappy afford", passphrase = "").byteVector(), NodeParams.Chain.Testnet, TestConstants.aliceSwapInServerXpub)
         val testCases = listOf(
             Pair(
                 first = keyManager.nodeKeys.legacyNodeKey.publicKey,

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/InitTlvTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/InitTlvTestsCommon.kt
@@ -3,9 +3,9 @@ package fr.acinq.lightning.wire
 import fr.acinq.bitcoin.Crypto
 import fr.acinq.bitcoin.MnemonicCode
 import fr.acinq.bitcoin.byteVector
-import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.NodeParams
 import fr.acinq.lightning.crypto.LocalKeyManager
+import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.secp256k1.Hex
 import kotlin.test.Test
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
 class InitTlvTestsCommon : LightningTestSuite() {
     @Test
     fun `legacy phoenix TLV`() {
-        val keyManager = LocalKeyManager(MnemonicCode.toSeed("sock able evoke work output half bamboo energy simple fiber unhappy afford", passphrase = "").byteVector(), NodeParams.Chain.Testnet, randomKey().publicKey())
+        val keyManager = LocalKeyManager(MnemonicCode.toSeed("sock able evoke work output half bamboo energy simple fiber unhappy afford", passphrase = "").byteVector(), NodeParams.Chain.Testnet, TestConstants.Alice.swapInServerXpub)
         val testCases = listOf(
             Pair(
                 first = keyManager.nodeKeys.legacyNodeKey.publicKey,


### PR DESCRIPTION
Swap-in servers provide an xpub, that can then be used to derive the public key they'll use for each peer deterministically (based on every peer's `node_id`).