### PR TITLE
Refactor swap-in trigger mechanism

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManager.kt
@@ -1,0 +1,85 @@
+package fr.acinq.lightning.blockchain.electrum
+
+import fr.acinq.bitcoin.OutPoint
+import fr.acinq.lightning.Lightning
+import fr.acinq.lightning.channel.LocalFundingStatus
+import fr.acinq.lightning.channel.RbfStatus
+import fr.acinq.lightning.channel.SignedSharedTransaction
+import fr.acinq.lightning.channel.SpliceStatus
+import fr.acinq.lightning.channel.states.*
+import fr.acinq.lightning.io.RequestChannelOpen
+import fr.acinq.lightning.utils.MDCLogger
+import fr.acinq.lightning.utils.sat
+
+internal sealed class SwapInCommand {
+    data class TrySwapIn(val currentBlockHeight: Int, val wallet: WalletState, val swapInConfirmations: Int, val isMigrationFromLegacyApp: Boolean) : SwapInCommand()
+    data class UnlockWalletInputs(val inputs: Set<OutPoint>) : SwapInCommand()
+}
+
+/**
+ * This object selects inputs that are ready to be used for swaps and keeps track of those that are currently used in channel funding attempts.
+ * Those inputs should not be reused, otherwise we would double-spend ourselves.
+ * If the electrum server we connect to has our channel funding attempts in their mempool, those inputs wouldn't be added to our wallet at all.
+ * But we cannot rely only on that, since we may connect to a different electrum server after a restart, or transactions may be evicted from their mempool.
+ * Since we don't have an easy way of asking electrum to check for double-spends, we would end up with channels that are stuck waiting for confirmations.
+ * This generally wouldn't be a security issue (only one of the funding attempts would succeed), unless 0-conf is used and our LSP is malicious.
+ *
+ * Note: this object is *not* thread-safe and should be used in a dedicated coroutine.
+ */
+class SwapInManager(private var reservedUtxos: Set<OutPoint>, private val logger: MDCLogger) {
+    constructor(bootChannels: List<PersistedChannelState>, logger: MDCLogger) : this(reservedWalletInputs(bootChannels), logger)
+
+    internal fun process(cmd: SwapInCommand): RequestChannelOpen? = when (cmd) {
+        is SwapInCommand.TrySwapIn -> {
+            val availableWallet = cmd.wallet.withoutReservedUtxos(reservedUtxos).withConfirmations(cmd.currentBlockHeight, cmd.swapInConfirmations)
+            logger.info { "swap-in wallet balance (migration=${cmd.isMigrationFromLegacyApp}): deeplyConfirmed=${availableWallet.deeplyConfirmed.balance}, weaklyConfirmed=${availableWallet.weaklyConfirmed.balance}, unconfirmed=${availableWallet.unconfirmed.balance}" }
+            val utxos = when {
+                // When migrating from the legacy android app, we use all utxos, even unconfirmed ones.
+                cmd.isMigrationFromLegacyApp -> availableWallet.all
+                else -> availableWallet.deeplyConfirmed
+            }
+            if (utxos.balance > 0.sat) {
+                logger.info { "swap-in wallet: requesting channel using ${utxos.size} utxos with balance=${utxos.balance}" }
+                reservedUtxos = reservedUtxos.union(utxos.map { it.outPoint })
+                RequestChannelOpen(Lightning.randomBytes32(), utxos)
+            } else {
+                null
+            }
+        }
+        is SwapInCommand.UnlockWalletInputs -> {
+            logger.debug { "releasing ${cmd.inputs.size} utxos" }
+            reservedUtxos = reservedUtxos - cmd.inputs
+            null
+        }
+    }
+
+    companion object {
+        /**
+         * Return the list of wallet inputs used in pending unconfirmed channel funding attempts.
+         * These inputs should not be reused in other funding attempts, otherwise we would double-spend ourselves.
+         */
+        fun reservedWalletInputs(channels: List<PersistedChannelState>): Set<OutPoint> {
+            val unconfirmedFundingTxs: List<SignedSharedTransaction> = buildList {
+                for (channel in channels) {
+                    // Add all unsigned inputs currently used to build a funding tx that isn't broadcast yet (creation, rbf, splice).
+                    when {
+                        channel is WaitForFundingSigned -> add(channel.signingSession.fundingTx)
+                        channel is WaitForFundingConfirmed && channel.rbfStatus is RbfStatus.WaitingForSigs -> add(channel.rbfStatus.session.fundingTx)
+                        channel is Normal && channel.spliceStatus is SpliceStatus.WaitingForSigs -> add(channel.spliceStatus.session.fundingTx)
+                        else -> {}
+                    }
+                    // Add all inputs in unconfirmed funding txs (utxos spent by confirmed transactions will never appear in our wallet).
+                    when (channel) {
+                        is ChannelStateWithCommitments -> channel.commitments.all
+                            .map { it.localFundingStatus }
+                            .filterIsInstance<LocalFundingStatus.UnconfirmedFundingTx>()
+                            .forEach { add(it.sharedTx) }
+                        else -> {}
+                    }
+                }
+            }
+            val localInputs = unconfirmedFundingTxs.flatMap { fundingTx -> fundingTx.tx.localInputs.map { it.outPoint } }
+            return localInputs.toSet()
+        }
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -17,7 +17,9 @@ import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.blockchain.fee.FeerateTolerance
 import fr.acinq.lightning.blockchain.fee.OnChainFeerates
 import fr.acinq.lightning.channel.Helpers.Closing.inputsAlreadySpent
-import fr.acinq.lightning.channel.states.*
+import fr.acinq.lightning.channel.states.Channel
+import fr.acinq.lightning.channel.states.ClosingFeerates
+import fr.acinq.lightning.channel.states.ClosingFees
 import fr.acinq.lightning.crypto.Bolt3Derivation.deriveForCommitment
 import fr.acinq.lightning.crypto.Bolt3Derivation.deriveForRevocation
 import fr.acinq.lightning.crypto.KeyManager
@@ -242,34 +244,6 @@ object Helpers {
             require(output.txid == parentTx.txid) { "output doesn't belong to the given parentTx: txid=${output.txid} but expected txid=${parentTx.txid}" }
             ChannelAction.Blockchain.SendWatch(WatchSpent(channelId, parentTx, output.index.toInt(), BITCOIN_OUTPUT_SPENT))
         }
-    }
-
-    /**
-     * Return the list of wallet inputs used in pending unconfirmed channel funding attempts.
-     * These inputs should not be reused in other funding attempts, otherwise we would double-spend ourselves.
-     */
-    fun reservedWalletInputs(channels: List<PersistedChannelState>): Set<OutPoint> {
-        val unconfirmedFundingTxs: List<SignedSharedTransaction> = buildList {
-            for (channel in channels) {
-                // Add all unsigned inputs currently used to build a funding tx that isn't broadcast yet (creation, rbf, splice).
-                when {
-                    channel is WaitForFundingSigned -> add(channel.signingSession.fundingTx)
-                    channel is WaitForFundingConfirmed && channel.rbfStatus is RbfStatus.WaitingForSigs -> add(channel.rbfStatus.session.fundingTx)
-                    channel is Normal && channel.spliceStatus is SpliceStatus.WaitingForSigs -> add(channel.spliceStatus.session.fundingTx)
-                    else -> {}
-                }
-                // Add all inputs in unconfirmed funding txs (utxos spent by confirmed transactions will never appear in our wallet).
-                when (channel) {
-                    is ChannelStateWithCommitments -> channel.commitments.all
-                        .map { it.localFundingStatus }
-                        .filterIsInstance<LocalFundingStatus.UnconfirmedFundingTx>()
-                        .forEach { add(it.sharedTx) }
-                    else -> {}
-                }
-            }
-        }
-        val localInputs = unconfirmedFundingTxs.flatMap { fundingTx -> fundingTx.tx.localInputs.map { it.outPoint } }
-        return localInputs.toSet()
     }
 
     object Funding {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -230,11 +230,11 @@ class Peer(
             logger.info { "restored ${channelIds.size} channels" }
             launch {
                 val swapInManager = SwapInManager(bootChannels, logger)
-                // wait to have a swap-in feerate available
-                swapInFeeratesFlow.filterNotNull().first()
                 processSwapInCommands(swapInManager)
             }
             launch {
+                // wait to have a swap-in feerate available
+                swapInFeeratesFlow.filterNotNull().first()
                 watchSwapInWallet()
             }
             launch {

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManagerTestsCommon.kt
@@ -1,0 +1,154 @@
+package fr.acinq.lightning.blockchain.electrum
+
+import fr.acinq.bitcoin.*
+import fr.acinq.lightning.Lightning.randomBytes32
+import fr.acinq.lightning.NodeParams
+import fr.acinq.lightning.channel.LocalFundingStatus
+import fr.acinq.lightning.channel.TestsHelper
+import fr.acinq.lightning.channel.states.SpliceTestsCommon
+import fr.acinq.lightning.channel.states.WaitForFundingSignedTestsCommon
+import fr.acinq.lightning.tests.utils.LightningTestSuite
+import fr.acinq.lightning.utils.MDCLogger
+import fr.acinq.lightning.utils.sat
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class SwapInManagerTestsCommon : LightningTestSuite() {
+
+    private val logger = MDCLogger(LoggerFactory.default.newLogger(SwapInManager::class))
+
+    private val dummyPubkey = PublicKey.fromHex("02eae982c8563a1c256ee9b4655af7d4c0dc545d1e5c350a68c5f8902cd4cf3021")
+    private val dummyScript = Script.pay2wpkh(dummyPubkey)
+    private val dummyAddress = Bitcoin.computeP2WpkhAddress(dummyPubkey, NodeParams.Chain.Regtest.chainHash)
+
+    @Test
+    fun `swap funds`() {
+        val mgr = SwapInManager(listOf(), logger)
+        val wallet = run {
+            val parentTxs = listOf(
+                Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 2), 0)), listOf(TxOut(50_000.sat, dummyScript), TxOut(75_000.sat, dummyScript)), 0),
+                Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 0), 0)), listOf(TxOut(25_000.sat, dummyScript)), 0)
+            )
+            val unspent = listOf(
+                UnspentItem(parentTxs[0].txid, 0, 50_000, 100), // deeply confirmed
+                UnspentItem(parentTxs[0].txid, 1, 75_000, 100), // deeply confirmed
+                UnspentItem(parentTxs[1].txid, 0, 25_000, 149), // recently confirmed
+            )
+            WalletState(mapOf(dummyAddress to unspent), parentTxs.associateBy { it.txid })
+        }
+        val cmd = SwapInCommand.TrySwapIn(currentBlockHeight = 150, wallet = wallet, swapInConfirmations = 3, isMigrationFromLegacyApp = false)
+        mgr.process(cmd).also { result ->
+            assertNotNull(result)
+            assertEquals(result.walletInputs.map { it.amount }.toSet(), setOf(50_000.sat, 75_000.sat))
+        }
+    }
+
+    @Test
+    fun `swap funds -- not deeply confirmed`() {
+        val mgr = SwapInManager(listOf(), logger)
+        val wallet = run {
+            val parentTxs = listOf(
+                Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 2), 0)), listOf(TxOut(50_000.sat, dummyScript)), 0),
+                Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 0), 0)), listOf(TxOut(25_000.sat, dummyScript)), 0)
+            )
+            val unspent = listOf(
+                UnspentItem(parentTxs[0].txid, 0, 50_000, 100), // recently confirmed
+                UnspentItem(parentTxs[1].txid, 0, 25_000, 0), // unconfirmed
+            )
+            WalletState(mapOf(dummyAddress to unspent), parentTxs.associateBy { it.txid })
+        }
+        val cmd = SwapInCommand.TrySwapIn(currentBlockHeight = 101, wallet = wallet, swapInConfirmations = 3, isMigrationFromLegacyApp = false)
+        mgr.process(cmd).also { assertNull(it) }
+    }
+
+    @Test
+    fun `swap funds -- allow unconfirmed in migration`() {
+        val mgr = SwapInManager(listOf(), logger)
+        val wallet = run {
+            val parentTxs = listOf(
+                Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 1), 0)), listOf(TxOut(75_000.sat, dummyScript)), 0),
+                Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 2), 0)), listOf(TxOut(50_000.sat, dummyScript)), 0),
+                Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 0), 0)), listOf(TxOut(25_000.sat, dummyScript)), 0)
+            )
+            val unspent = listOf(
+                UnspentItem(parentTxs[0].txid, 0, 75_000, 100), // deeply confirmed
+                UnspentItem(parentTxs[1].txid, 0, 50_000, 150), // recently confirmed
+                UnspentItem(parentTxs[2].txid, 0, 25_000, 0), // unconfirmed
+            )
+            WalletState(mapOf(dummyAddress to unspent), parentTxs.associateBy { it.txid })
+        }
+        val cmd = SwapInCommand.TrySwapIn(currentBlockHeight = 150, wallet = wallet, swapInConfirmations = 5, isMigrationFromLegacyApp = true)
+        mgr.process(cmd).also { result ->
+            assertNotNull(result)
+            assertEquals(result.walletInputs.map { it.amount }.toSet(), setOf(25_000.sat, 50_000.sat, 75_000.sat))
+        }
+    }
+
+    @Test
+    fun `swap funds -- previously used inputs`() {
+        val mgr = SwapInManager(listOf(), logger)
+        val wallet = run {
+            val parentTx = Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 1), 0)), listOf(TxOut(75_000.sat, dummyScript)), 0)
+            val unspent = UnspentItem(parentTx.txid, 0, 75_000, 100)
+            WalletState(mapOf(dummyAddress to listOf(unspent)), mapOf(parentTx.txid to parentTx))
+        }
+        val cmd = SwapInCommand.TrySwapIn(currentBlockHeight = 150, wallet = wallet, swapInConfirmations = 5, isMigrationFromLegacyApp = false)
+        mgr.process(cmd).also { assertNotNull(it) }
+
+        // We cannot reuse the same inputs.
+        mgr.process(cmd.copy(currentBlockHeight = 151)).also { assertNull(it) }
+
+        // The channel funding attempts fails: we can now reuse those inputs.
+        mgr.process(SwapInCommand.UnlockWalletInputs(wallet.utxos.map { it.outPoint }.toSet()))
+        mgr.process(cmd.copy(currentBlockHeight = 152)).also { result ->
+            assertNotNull(result)
+            assertEquals(result.walletInputs.map { it.amount }.toSet(), setOf(75_000.sat))
+        }
+    }
+
+    @Test
+    fun `swap funds -- ignore inputs from pending channel`() {
+        val (waitForFundingSigned, _) = WaitForFundingSignedTestsCommon.init()
+        val wallet = run {
+            val parentTxs = waitForFundingSigned.state.signingSession.fundingTx.tx.localInputs.map { it.previousTx }
+            val unspent = waitForFundingSigned.state.signingSession.fundingTx.tx.localInputs.map { i -> UnspentItem(i.outPoint.txid, i.outPoint.index.toInt(), i.txOut.amount.toLong(), 100) }
+            WalletState(mapOf(dummyAddress to unspent), parentTxs.associateBy { it.txid })
+        }
+        val mgr = SwapInManager(listOf(waitForFundingSigned.state), logger)
+        val cmd = SwapInCommand.TrySwapIn(currentBlockHeight = 150, wallet = wallet, swapInConfirmations = 5, isMigrationFromLegacyApp = false)
+        mgr.process(cmd).also { assertNull(it) }
+
+        // The pending channel is aborted: we can reuse those inputs.
+        mgr.process(SwapInCommand.UnlockWalletInputs(wallet.utxos.map { it.outPoint }.toSet()))
+        mgr.process(cmd).also { assertNotNull(it) }
+    }
+
+    @Test
+    fun `swap funds -- ignore inputs from pending splices`() {
+        val (alice, bob) = TestsHelper.reachNormal(zeroConf = true)
+        val (alice1, _) = SpliceTestsCommon.spliceIn(alice, bob, listOf(50_000.sat, 75_000.sat))
+        assertEquals(2, alice1.commitments.active.size)
+        val inputs = alice1.commitments.active.map { it.localFundingStatus }.filterIsInstance<LocalFundingStatus.UnconfirmedFundingTx>().flatMap { it.sharedTx.tx.localInputs }
+        assertEquals(3, inputs.size) // 1 initial funding input and 2 splice inputs
+        val wallet = run {
+            val parentTxs = inputs.map { it.previousTx }
+            val unspent = inputs.map { i -> UnspentItem(i.outPoint.txid, i.outPoint.index.toInt(), i.txOut.amount.toLong(), 100) }
+            WalletState(mapOf(dummyAddress to unspent), parentTxs.associateBy { it.txid })
+        }
+        val mgr = SwapInManager(listOf(alice1.state), logger)
+        val cmd = SwapInCommand.TrySwapIn(currentBlockHeight = 150, wallet = wallet, swapInConfirmations = 5, isMigrationFromLegacyApp = false)
+        mgr.process(cmd).also { assertNull(it) }
+
+        // The channel is aborted: we can reuse those inputs.
+        mgr.process(SwapInCommand.UnlockWalletInputs(wallet.utxos.map { it.outPoint }.toSet()))
+        mgr.process(cmd).also { result ->
+            assertNotNull(result)
+            assertEquals(3, result.walletInputs.size)
+        }
+    }
+
+}

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SpliceTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SpliceTestsCommon.kt
@@ -32,21 +32,13 @@ class SpliceTestsCommon : LightningTestSuite() {
     @Test
     fun `splice funds in`() {
         val (alice, bob) = reachNormal()
-        assertTrue(Helpers.reservedWalletInputs(listOf(alice.state)).isEmpty())
-        assertTrue(Helpers.reservedWalletInputs(listOf(bob.state)).isEmpty())
-        val (alice1, bob1) = spliceIn(alice, bob, listOf(50_000.sat))
-        assertEquals(1, Helpers.reservedWalletInputs(listOf(alice1.state)).size)
-        assertTrue(Helpers.reservedWalletInputs(listOf(bob1.state)).isEmpty())
+        spliceIn(alice, bob, listOf(50_000.sat))
     }
 
     @Test
     fun `splice funds in -- many utxos`() {
         val (alice, bob) = reachNormal()
-        assertTrue(Helpers.reservedWalletInputs(listOf(alice.state)).isEmpty())
-        assertTrue(Helpers.reservedWalletInputs(listOf(bob.state)).isEmpty())
-        val (alice1, bob1) = spliceIn(alice, bob, listOf(30_000.sat, 40_000.sat, 25_000.sat))
-        assertEquals(3, Helpers.reservedWalletInputs(listOf(alice1.state)).size)
-        assertTrue(Helpers.reservedWalletInputs(listOf(bob1.state)).isEmpty())
+        spliceIn(alice, bob, listOf(30_000.sat, 40_000.sat, 25_000.sat))
     }
 
     @Test
@@ -764,7 +756,7 @@ class SpliceTestsCommon : LightningTestSuite() {
             return UnsignedSpliceFixture(alice5, commitSigAlice, bob5, commitSigBob)
         }
 
-        private fun spliceIn(alice: LNChannel<Normal>, bob: LNChannel<Normal>, amounts: List<Satoshi>): Pair<LNChannel<Normal>, LNChannel<Normal>> {
+        fun spliceIn(alice: LNChannel<Normal>, bob: LNChannel<Normal>, amounts: List<Satoshi>): Pair<LNChannel<Normal>, LNChannel<Normal>> {
             val parentCommitment = alice.commitments.active.first()
             val cmd = ChannelCommand.Commitment.Splice.Request(
                 replyTo = CompletableDeferred(),

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
@@ -328,7 +328,6 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
                 assertFalse(commitSigBob.channelData.isEmpty())
             }
             actionsBob3.has<ChannelAction.Storage.StoreState>()
-            assertEquals(setOf(OutPoint(inputAlice.previousTx!!, inputAlice.previousTxOutput)), Helpers.reservedWalletInputs(listOf(alice2.state)))
             return Fixture(alice2, commitSigAlice, bob3, commitSigBob, walletAlice)
         }
     }


### PR DESCRIPTION
We create a new `SwapInManager` that checks the wallet state and decides whether to initiate a channel funding attempt, while keeping track of utxos that are currently being used.

We allow unlocking those utxos once a channel funding attempt fails because of a liquidity policy restriction.