### PR TITLE
Optionally skip absolute fee check

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -218,7 +218,7 @@ data class NodeParams(
         enableTrampolinePayment = true,
         zeroConfPeers = emptySet(),
         paymentRecipientExpiryParams = RecipientCltvExpiryParams(CltvExpiryDelta(75), CltvExpiryDelta(200)),
-        liquidityPolicy = MutableStateFlow<LiquidityPolicy>(LiquidityPolicy.Auto(maxAbsoluteFee = 2_000.sat, maxRelativeFeeBasisPoints = 3_000 /* 3000 = 30 % */, alwaysAllowPayToOpen = false))
+        liquidityPolicy = MutableStateFlow<LiquidityPolicy>(LiquidityPolicy.Auto(maxAbsoluteFee = 2_000.sat, maxRelativeFeeBasisPoints = 3_000 /* 3000 = 30 % */, skipAbsoluteFeeCheck = false))
     )
 
     sealed class Chain(val name: String, private val genesis: Block) {


### PR DESCRIPTION
Having a more lax policy is useful for pay-to-open, because the sender may not retry payments.

The previous implementation in #487 was a bit too lax though, it created an edge case when amount was less than the pay-the-open fee. The whole payment was eaten by the LSP in that case.