### PR TITLE
Add method to recover swap-in transactions

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
@@ -142,13 +142,13 @@ interface KeyManager {
         }
 
         /**
-         * Spend a swap-in transaction
+         * Create a recovery transaction that spends a swap-in transaction after the refund delay has passed
          * @param swapInTx swap-in transaction
          * @param address address to send funds to
          * @param feeRate fee rate for the refund transaction
          * @return a signed transaction that spends our swap-in transaction. It cannot be published until `swapInTx` has enough confirmations
          */
-        fun spendSwapInTransaction(swapInTx: Transaction, address: String, feeRate: FeeratePerKw): Transaction? {
+        fun createRecoveryTransaction(swapInTx: Transaction, address: String, feeRate: FeeratePerKw): Transaction? {
             val utxos = swapInTx.txOut.filter { it.publicKeyScript.contentEquals(Script.write(pubkeyScript)) }
             return if (utxos.isEmpty()) {
                 null

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
@@ -162,15 +162,15 @@ interface KeyManager {
                 )
                 val fees = run {
                     val recoveryTx = utxos.foldIndexed(unsignedTx) { index, tx, utxo ->
-                        val sig = Transaction.signInput(tx, index, redeemScript, SigHash.SIGHASH_ALL, utxo.amount, SigVersion.SIGVERSION_WITNESS_V0, userPrivateKey)
-                        tx.updateWitness(index, ScriptWitness.empty.push(ByteVector.empty).push(sig).push(redeemScript))
+                        val sig = Transactions.signSwapInputUser(tx, index, utxo, userPrivateKey, remoteServerPublicKey, refundDelay)
+                        tx.updateWitness(index, Scripts.witnessSwapIn2of2Refund(sig, userPublicKey,remoteServerPublicKey, refundDelay))
                     }
                     Transactions.weight2fee(feeRate, recoveryTx.weight())
                 }
                 val unsignedTx1 = unsignedTx.copy(txOut = listOf(ourOutput.copy(amount = ourOutput.amount - fees)))
                 val recoveryTx = utxos.foldIndexed(unsignedTx1) { index, tx, utxo ->
-                    val sig = Transaction.signInput(tx, index, redeemScript, SigHash.SIGHASH_ALL, utxo.amount, SigVersion.SIGVERSION_WITNESS_V0, userPrivateKey)
-                    tx.updateWitness(index, ScriptWitness.empty.push(ByteVector.empty).push(sig).push(redeemScript)) // one sig for us, one empty sig for our peer
+                    val sig = Transactions.signSwapInputUser(tx, index, utxo, userPrivateKey, remoteServerPublicKey, refundDelay)
+                    tx.updateWitness(index, Scripts.witnessSwapIn2of2Refund(sig, userPublicKey,remoteServerPublicKey, refundDelay))
                 }
                 // this tx is signed but cannot be published until swapInTx has `refundDelay` confirmations
                 recoveryTx

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
@@ -199,7 +199,7 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
                 TxOut(Satoshi(150000), Bitcoin.addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, TestConstants.Alice.keyManager.swapInOnChainWallet.address))
             ),
             lockTime = 0)
-        val recoveryTx = TestConstants.Alice.keyManager.swapInOnChainWallet.spendSwapInTransaction(swapInTx, TestConstants.Alice.keyManager.finalOnChainWallet.address(0), FeeratePerKw(FeeratePerByte(Satoshi(5))))!!
+        val recoveryTx = TestConstants.Alice.keyManager.swapInOnChainWallet.createRecoveryTransaction(swapInTx, TestConstants.Alice.keyManager.finalOnChainWallet.address(0), FeeratePerKw(FeeratePerByte(Satoshi(5))))!!
         assertEquals(swapInTx.txOut.size, recoveryTx.txIn.size)
         Transaction.correctlySpends(recoveryTx, swapInTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     }


### PR DESCRIPTION
Add a method to create a recovery transaction for swap-in transactions that have not been used and for which the refund delay has passed. 