### PR TITLE
Provide a set of trusted txids for swap-in

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -86,7 +86,7 @@ data class PhoenixAndroidLegacyInfoEvent(val info: PhoenixAndroidLegacyInfo) : P
  * @param watcher Watches events from the Electrum client and publishes transactions and events.
  * @param db Wraps the various databases persisting the channels and payments data related to the Peer.
  * @param socketBuilder Builds the TCP socket used to connect to the Peer.
- * @param isMigrationFromLegacyApp true if we're migrating from the legacy phoenix android app.
+ * @param trustedSwapInTxs a set of txids that can be used for swap-in even if they are zeroconf (useful when migrating from the legacy phoenix android app).
  * @param initTlvStream Optional stream of TLV for the [Init] message we send to this Peer after connection. Empty by default.
  */
 @OptIn(ExperimentalStdlibApi::class)
@@ -97,7 +97,7 @@ class Peer(
     val db: Databases,
     socketBuilder: TcpSocket.Builder?,
     scope: CoroutineScope,
-    private val isMigrationFromLegacyApp: Boolean = false,
+    private val trustedSwapInTxs: Set<ByteVector32> = emptySet(),
     private val initTlvStream: TlvStream<InitTlv> = TlvStream.empty()
 ) : CoroutineScope by scope {
     companion object {
@@ -394,7 +394,7 @@ class Peer(
             .filter { it.consistent }
             .collect {
                 val currentBlockHeight = currentTipFlow.filterNotNull().first().first
-                swapInCommands.send(SwapInCommand.TrySwapIn(currentBlockHeight, it, walletParams.swapInConfirmations, isMigrationFromLegacyApp))
+                swapInCommands.send(SwapInCommand.TrySwapIn(currentBlockHeight, it, walletParams.swapInConfirmations, trustedSwapInTxs))
             }
     }
 


### PR DESCRIPTION
Instead of a `isMigrationFromLegacyApp` boolean, we provide a set of txids that can be considered safe for swap-in even if they are not confirmed.

This is not more complicated than relying on a boolean to implement zeroconf migration, and much more robust.