### PR TITLE
Finer grained liquidity rejections

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -30,8 +30,10 @@ sealed interface LiquidityEvents : NodeEvents {
     data class Rejected(override val amount: MilliSatoshi, override val fee: MilliSatoshi, override val source: Source, val reason: Reason) : LiquidityEvents {
         sealed class Reason {
             object PolicySetToDisabled : Reason()
-            object RejectedByUser : Reason()
-            data class TooExpensive(val maxAllowed: MilliSatoshi, val actual: MilliSatoshi) : Reason()
+            sealed class TooExpensive : Reason() {
+                data class OverAbsoluteFee(val maxAbsoluteFee: Satoshi) : TooExpensive()
+                data class OverRelativeFee(val maxRelativeFeeBasisPoints: Int) : TooExpensive()
+            }
             object ChannelInitializing : Reason()
         }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/LiquidityPolicyTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/LiquidityPolicyTestsCommon.kt
@@ -1,0 +1,44 @@
+package fr.acinq.lightning.payment
+
+import fr.acinq.lightning.LiquidityEvents
+import fr.acinq.lightning.tests.utils.LightningTestSuite
+import fr.acinq.lightning.utils.MDCLogger
+import fr.acinq.lightning.utils.msat
+import fr.acinq.lightning.utils.sat
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LiquidityPolicyTestsCommon : LightningTestSuite() {
+
+    private val logger = MDCLogger(LoggerFactory.default.newLogger(this::class))
+
+    @Test
+    fun `policy rejection`() {
+
+        val policy = LiquidityPolicy.Auto(maxAbsoluteFee = 2_000.sat, maxRelativeFeeBasisPoints = 3_000 /* 3000 = 30 % */, skipAbsoluteFeeCheck = false)
+
+        // fee over both absolute and relative
+        assertEquals(
+            expected = LiquidityEvents.Rejected.Reason.TooExpensive.OverRelativeFee(policy.maxRelativeFeeBasisPoints),
+            actual = policy.maybeReject(amount = 4_000_000.msat, fee = 3_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger)?.reason
+        )
+
+        // fee over absolute
+        assertEquals(
+            expected = LiquidityEvents.Rejected.Reason.TooExpensive.OverAbsoluteFee(policy.maxAbsoluteFee),
+            actual = policy.maybeReject(amount = 15_000_000.msat, fee = 3_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger)?.reason
+        )
+
+        // fee over relative
+        assertEquals(
+            expected = LiquidityEvents.Rejected.Reason.TooExpensive.OverRelativeFee(policy.maxRelativeFeeBasisPoints),
+            actual = policy.maybeReject(amount = 4_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger)?.reason
+        )
+
+        assertNull(policy.maybeReject(amount = 10_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger))
+
+    }
+}


### PR DESCRIPTION
This allows for a more informative message to the user.