### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,11 +29,11 @@ kotlin {
     val ktorVersion: String by extra { "2.0.3" }
     fun ktor(module: String) = "io.ktor:ktor-$module:$ktorVersion"
     val serializationVersion = "1.5.1"
-    val coroutineVersion = "1.7.1"
+    val coroutineVersion = "1.7.2"
 
     val commonMain by sourceSets.getting {
         dependencies {
-            api("fr.acinq.bitcoin:bitcoin-kmp:0.12.0") // when upgrading, keep secp256k1-kmp-jni-jvm in sync below
+            api("fr.acinq.bitcoin:bitcoin-kmp:0.13.0") // when upgrading, keep secp256k1-kmp-jni-jvm in sync below
             api("org.kodein.log:canard:0.18.0")
             api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion")
             api("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
@@ -63,7 +63,7 @@ kotlin {
             api(ktor("client-okhttp"))
             api(ktor("network"))
             api(ktor("network-tls"))
-            implementation("fr.acinq.secp256k1:secp256k1-kmp-jni-jvm:0.10.0")
+            implementation("fr.acinq.secp256k1:secp256k1-kmp-jni-jvm:0.10.1")
             implementation("org.slf4j:slf4j-api:1.7.36")
             api("org.xerial:sqlite-jdbc:3.32.3.2")
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
@@ -111,7 +111,7 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
             ),
             actual = walletState.utxos.map {
                 val txOut = it.previousTx.txOut[it.outputIndex]
-                val address = Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, txOut.publicKeyScript.toByteArray())
+                val address = Bitcoin.addressFromPublicKeyScript(Block.LivenetGenesisBlock.hash, txOut.publicKeyScript.toByteArray()).result!!
                 Triple(address, it.previousTx.txid to it.outputIndex, txOut.amount)
             }.toSet()
         )

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
@@ -195,8 +195,8 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         val swapInTx = Transaction(version = 2,
             txIn = listOf(),
             txOut = listOf(
-                TxOut(Satoshi(100000), Bitcoin.addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, TestConstants.Alice.keyManager.swapInOnChainWallet.address)),
-                TxOut(Satoshi(150000), Bitcoin.addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, TestConstants.Alice.keyManager.swapInOnChainWallet.address))
+                TxOut(Satoshi(100000), Bitcoin.addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, TestConstants.Alice.keyManager.swapInOnChainWallet.address).result!!),
+                TxOut(Satoshi(150000), Bitcoin.addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, TestConstants.Alice.keyManager.swapInOnChainWallet.address).result!!)
             ),
             lockTime = 0)
         val recoveryTx = TestConstants.Alice.keyManager.swapInOnChainWallet.createRecoveryTransaction(swapInTx, TestConstants.Alice.keyManager.finalOnChainWallet.address(0), FeeratePerKw(FeeratePerByte(Satoshi(5))))!!


### PR DESCRIPTION
Use bitcoin-kmp 0.13.0 which includes improvements to address/script conversions methods that make them easier to use from Phoenix. bitcoin-kmp 0.13.0 uses secp256k1-kmp 0.10.1 which is based on secp256k1 0.3.2

Use kotlinx coroutines 1.7.2 (a bugfix release, see https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.7.2)