### PR TITLE
More consistent JvmTcpSocket

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ allprojects {
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
 kotlin {
-    val ktorVersion: String by extra { "2.0.3" }
+    val ktorVersion: String by extra { "2.3.2" }
     fun ktor(module: String) = "io.ktor:ktor-$module:$ktorVersion"
     val serializationVersion = "1.5.1"
     val coroutineVersion = "1.7.1"

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
@@ -108,7 +108,7 @@ class ElectrumClient(
             logger.info { "attempting connection to electrumx instance [host=$host, port=$port, tls=$tls]" }
             socketBuilder?.connect(host, port, tls, loggerFactory) ?: error("socket builder is null.")
         } catch (ex: Throwable) {
-            logger.warning { "TCP connect: ${ex.message}" }
+            logger.warning(ex) { "TCP connect: ${ex.message}" }
             val ioException = when (ex) {
                 is TcpSocket.IOException -> ex
                 else -> TcpSocket.IOException.ConnectionRefused(ex)

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
@@ -26,7 +26,6 @@ sealed interface ElectrumConnectionStatus {
     data class Connected(val version: ServerVersionResponse, val height: Int, val header: BlockHeader) : ElectrumConnectionStatus
 }
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class ElectrumClient(
     socketBuilder: TcpSocket.Builder?,
     scope: CoroutineScope,
@@ -100,7 +99,7 @@ class ElectrumClient(
     }
 
     private fun establishConnection(serverAddress: ServerAddress) = launch(CoroutineExceptionHandler { _, exception ->
-        logger.error(exception) { "error starting electrum client" }
+        logger.error(exception) { "error starting electrum client: " }
     }) {
         _connectionStatus.value = ElectrumConnectionStatus.Connecting
         val socket: TcpSocket = try {
@@ -108,7 +107,7 @@ class ElectrumClient(
             logger.info { "attempting connection to electrumx instance [host=$host, port=$port, tls=$tls]" }
             socketBuilder?.connect(host, port, tls, loggerFactory) ?: error("socket builder is null.")
         } catch (ex: Throwable) {
-            logger.warning(ex) { "TCP connect: ${ex.message}" }
+            logger.warning(ex) { "TCP connect: ${ex.message}: " }
             val ioException = when (ex) {
                 is TcpSocket.IOException -> ex
                 else -> TcpSocket.IOException.ConnectionRefused(ex)
@@ -121,7 +120,7 @@ class ElectrumClient(
 
         fun closeSocket(ex: TcpSocket.IOException?) {
             if (_connectionStatus.value is ElectrumConnectionStatus.Closed) return
-            logger.warning { "closing TCP socket." }
+            logger.warning(ex) { "closing TCP socket: " }
             socket.close()
             _connectionStatus.value = ElectrumConnectionStatus.Closed(ex)
             mailbox.close(ex)
@@ -133,7 +132,7 @@ class ElectrumClient(
             try {
                 socket.send(bytes, flush = true)
             } catch (ex: TcpSocket.IOException) {
-                logger.warning(ex) { "cannot send to electrum server" }
+                logger.warning { "cannot send to electrum server" }
                 closeSocket(ex)
             }
         }
@@ -203,7 +202,7 @@ class ElectrumClient(
         launch { ping() }
         launch { respond() }
 
-        listen() // This suspends until the coroutines is cancelled or the socket is closed
+        listen() // This suspends until the coroutine is cancelled or the socket is closed
     }
 
     override suspend fun send(request: ElectrumRequest, replyTo: CompletableDeferred<ElectrumResponse>) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -300,7 +300,7 @@ class Peer(
                 loggerFactory = nodeParams.loggerFactory
             ) ?: error("socket builder is null.")
         } catch (ex: Throwable) {
-            logger.warning(ex) { "TCP connect: ${ex.message}" }
+            logger.warning(ex) { "TCP connect: ${ex.message}: " }
             val ioException = when (ex) {
                 is TcpSocket.IOException -> ex
                 else -> TcpSocket.IOException.ConnectionRefused(ex)
@@ -311,7 +311,7 @@ class Peer(
 
         fun closeSocket(ex: TcpSocket.IOException?) {
             if (_connectionState.value is Connection.CLOSED) return
-            logger.warning { "closing TCP socket." }
+            logger.warning(ex) { "closing TCP socket: " }
             socket.close()
             _connectionState.value = Connection.CLOSED(ex)
             cancel()

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -300,7 +300,7 @@ class Peer(
                 loggerFactory = nodeParams.loggerFactory
             ) ?: error("socket builder is null.")
         } catch (ex: Throwable) {
-            logger.warning { "TCP connect: ${ex.message}" }
+            logger.warning(ex) { "TCP connect: ${ex.message}" }
             val ioException = when (ex) {
                 is TcpSocket.IOException -> ex
                 else -> TcpSocket.IOException.ConnectionRefused(ex)

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import org.kodein.log.LoggerFactory
 
-
 interface TcpSocket {
 
     sealed class IOException(override val message: String, cause: Throwable? = null) : Exception(message, cause) {
@@ -69,16 +68,12 @@ suspend fun TcpSocket.receiveAvailable(buffer: ByteArray) = receiveAvailable(buf
 
 internal expect object PlatformSocketBuilder : TcpSocket.Builder
 
-suspend fun TcpSocket.receiveFully(size: Int): ByteArray =
-    ByteArray(size).also { receiveFully(it) }
+suspend fun TcpSocket.receiveFully(size: Int): ByteArray = ByteArray(size).also { receiveFully(it) }
 
-fun TcpSocket.linesFlow(): Flow<String> =
-    flow {
-        val buffer = ByteArray(8192)
-        while (true) {
-            val size = receiveAvailable(buffer)
-            emit(buffer.subArray(size))
-        }
+fun TcpSocket.linesFlow(): Flow<String> = flow {
+    val buffer = ByteArray(8192)
+    while (true) {
+        val size = receiveAvailable(buffer)
+        emit(buffer.subArray(size))
     }
-        .decodeToString()
-        .splitByLines()
+}.decodeToString().splitByLines()


### PR DESCRIPTION
- check for coroutine cancellation in `send` and `receive`
- use Dispatchers.IO context in `receiveAvailable`
- don't catch `Throwable`, let it bubble up
- add `CoroutineExceptionHandler` for low-level TLS coroutines
