### PR TITLE
Add `Job.mkTree` extension method

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/coroutines.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/coroutines.kt
@@ -1,0 +1,32 @@
+package fr.acinq.lightning.utils
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.job
+
+private fun Job.print(buffer: StringBuilder, prefix: String, childrenPrefix: String) {
+    buffer.append(prefix)
+    buffer.append(job.toString())
+    buffer.append('\n')
+    val it = job.children.iterator()
+    while (it.hasNext()) {
+        val child = it.next()
+        if (it.hasNext()) {
+            child.print(buffer, "$childrenPrefix├── ", "$childrenPrefix│   ")
+        } else {
+            child.print(buffer, "$childrenPrefix└── ", "$childrenPrefix    ")
+        }
+    }
+}
+
+/**
+ * Extension method to print a hierarchy of coroutines for debug purposes.
+ * Usage:
+ * ```
+ *    println(scope.coroutineContext.job.mkTree())
+ * ```
+ */
+fun Job.mkTree(): String {
+    val sb = StringBuilder()
+    job.print(sb, "", "")
+    return sb.toString()
+}

--- a/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
+++ b/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
@@ -31,8 +31,8 @@ class JvmTcpSocket(val socket: Socket, val loggerFactory: LoggerFactory) : TcpSo
 
     override suspend fun send(bytes: ByteArray?, offset: Int, length: Int, flush: Boolean) =
         withContext(Dispatchers.IO) {
+            ensureActive()
             try {
-                ensureActive()
                 if (bytes != null) connection.output.writeFully(bytes, offset, length)
                 if (flush) connection.output.flush()
             } catch (ex: ClosedSendChannelException) {


### PR DESCRIPTION
 It can be useful to print a hierarchy of coroutines for debug purposes:

```
JobImpl{Active}@3e2059ae
├── "foo#2":StandaloneCoroutine{Cancelling}@2609b277
│   ├── "foo#4":StandaloneCoroutine{Cancelling}@1fd14d74
│   │   ├── "foo#6":StandaloneCoroutine{Cancelling}@563e4951
│   │   └── "foo#7":StandaloneCoroutine{Cancelling}@4066c471
│   │       ├── "baz#8":StandaloneCoroutine{Cancelling}@2b175c00
│   │       │   └── "baz#11":StandaloneCoroutine{Cancelling}@3eb81efb
│   │       └── "foo#10":StandaloneCoroutine{Cancelling}@1ae8bcbc
│   └── "foo#5":StandaloneCoroutine{Cancelling}@6cdba6dc
│       └── "foo#9":StandaloneCoroutine{Cancelling}@7d3d101b
│           └── "foo#12":StandaloneCoroutine{Cancelling}@30c8681
└── "bar#3":StandaloneCoroutine{Cancelling}@5cdec700
```