### PR TITLE
Rework `ElectrumClient`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,3 +65,12 @@ jobs:
       - name: Check without integration
         if: matrix.os == 'macOS-latest'
         run: ./gradlew build -x jvmTest
+
+      # Uncomment the lines below to store test results for debugging failed tests (useful for iOS)
+      # - name: Store test results
+      #   if: always()
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: test results
+      #     path: build/reports
+      #     retention-days: 1

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
@@ -127,7 +127,6 @@ class ElectrumClient(
             // Note that since we synchronously wait for the response, we can safely reuse requestId = 0.
             val ourVersion = ServerVersion()
             socket.send(ourVersion.asJsonRPCRequest(id = 0).encodeToByteArray(), flush = true)
-            delay(1.seconds)
             val theirVersion = parseJsonResponse(ourVersion, handshakeFlow.first())
             require(theirVersion is ServerVersionResponse) { "invalid server version response $theirVersion" }
             logger.info { "server version $theirVersion" }

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
@@ -124,7 +124,7 @@ class ElectrumClient(
             }
         }
 
-        val flow = socket.linesFlow().map { json.decodeFromString(ElectrumResponseDeserializer, it) }
+        val flow = linesFlow(socket).map { json.decodeFromString(ElectrumResponseDeserializer, it) }
         val version = ServerVersion()
         sendRequest(version, 0)
         val rpcFlow = flow.filterIsInstance<Either.Right<Nothing, JsonRPCResponse>>().map { it.value }

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
@@ -53,10 +53,10 @@ class ElectrumClient(
 
     // This channel acts as a queue for messages sent/received to/from the electrum server.
     // It lets us decouple message processing from the connection state (messages will be queued while we're disconnected).
-    // We use a rendezvous channel, which means that writers will simply block until a read operation happens.
+    // We use a rendezvous channel, which means that writers will simply suspend until a read operation happens.
     // When connected, a dedicated coroutine will continuously read from the mailbox, send the corresponding requests to the
     // electrum server, and send the response back when it is received.
-    // When disconnected, callers will block until we reconnect, at which point their messages will be processed.
+    // When disconnected, callers will suspend until we reconnect, at which point their messages will be processed.
     private val mailbox = Channel<Action>()
 
     data class ListenJob(val job: Job, val socket: TcpSocket) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
@@ -14,12 +14,6 @@ import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 import kotlin.time.Duration.Companion.seconds
 
-/** Commands */
-sealed interface ElectrumClientCommand {
-    object Connected : ElectrumClientCommand
-    object Disconnected : ElectrumClientCommand
-}
-
 sealed interface ElectrumConnectionStatus {
     data class Closed(val reason: TcpSocket.IOException?) : ElectrumConnectionStatus
     object Connecting : ElectrumConnectionStatus

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientExtensions.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientExtensions.kt
@@ -10,21 +10,27 @@ import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.MDCLogger
 import fr.acinq.lightning.utils.sat
 
-suspend fun IElectrumClient.getConfirmations(txId: ByteVector32, currentBlockHeight: Int): Int? = getTx(txId)?.let { tx -> getConfirmations(tx, currentBlockHeight) }
+suspend fun IElectrumClient.getConfirmations(txId: ByteVector32): Int? = getTx(txId)?.let { tx -> getConfirmations(tx) }
 
 /**
  * @return the number of confirmations, zero if the transaction is in the mempool, null if the transaction is not found
  */
-suspend fun IElectrumClient.getConfirmations(tx: Transaction, currentBlockHeight: Int): Int? {
-    val scriptHash = ElectrumClient.computeScriptHash(tx.txOut.first().publicKeyScript)
-    val scriptHashHistory = getScriptHashHistory(scriptHash)
-    val item = scriptHashHistory.find { it.txid == tx.txid }
-    return item?.let { if (item.blockHeight > 0) currentBlockHeight - item.blockHeight + 1 else 0 }
+suspend fun IElectrumClient.getConfirmations(tx: Transaction): Int? {
+    return when (val status = connectionStatus.value) {
+        is ElectrumConnectionStatus.Connected -> {
+            val currentBlockHeight = status.height
+            val scriptHash = ElectrumClient.computeScriptHash(tx.txOut.first().publicKeyScript)
+            val scriptHashHistory = getScriptHashHistory(scriptHash)
+            val item = scriptHashHistory.find { it.txid == tx.txid }
+            item?.let { if (item.blockHeight > 0) currentBlockHeight - item.blockHeight + 1 else 0 }
+        }
+        else -> null
+    }
 }
 
-suspend fun IElectrumClient.computeSpliceCpfpFeerate(commitments: Commitments, targetFeerate: FeeratePerKw, spliceWeight: Int, currentBlockHeight: Int, logger: MDCLogger): Pair<FeeratePerKw, Satoshi> {
+suspend fun IElectrumClient.computeSpliceCpfpFeerate(commitments: Commitments, targetFeerate: FeeratePerKw, spliceWeight: Int, logger: MDCLogger): Pair<FeeratePerKw, Satoshi> {
     val (parentsWeight, parentsFees) = commitments.all
-        .takeWhile { getConfirmations(it.fundingTxId, currentBlockHeight).let { confirmations -> confirmations == null || confirmations == 0 } } // we check for null in case the tx has been evicted
+        .takeWhile { getConfirmations(it.fundingTxId).let { confirmations -> confirmations == null || confirmations == 0 } } // we check for null in case the tx has been evicted
         .fold(Pair(0, 0.sat)) { (parentsWeight, parentsFees), commitment ->
             val weight = when (commitment.localFundingStatus) {
                 // weight will be underestimated if the transaction is not fully signed

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientExtensions.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientExtensions.kt
@@ -10,26 +10,21 @@ import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.MDCLogger
 import fr.acinq.lightning.utils.sat
 
-
-suspend fun IElectrumClient.getConfirmations(txId: ByteVector32): Int? {
-    val tx = kotlin.runCatching { getTx(txId) }.getOrNull()
-    return tx?.let { getConfirmations(tx) }
-}
+suspend fun IElectrumClient.getConfirmations(txId: ByteVector32, currentBlockHeight: Int): Int? = getTx(txId)?.let { tx -> getConfirmations(tx, currentBlockHeight) }
 
 /**
- *   @return the number of confirmations, zero if the transaction is in the mempool, null if the transaction is not found
+ * @return the number of confirmations, zero if the transaction is in the mempool, null if the transaction is not found
  */
-suspend fun IElectrumClient.getConfirmations(tx: Transaction): Int? {
+suspend fun IElectrumClient.getConfirmations(tx: Transaction, currentBlockHeight: Int): Int? {
     val scriptHash = ElectrumClient.computeScriptHash(tx.txOut.first().publicKeyScript)
     val scriptHashHistory = getScriptHashHistory(scriptHash)
     val item = scriptHashHistory.find { it.txid == tx.txid }
-    val blockHeight = startHeaderSubscription().blockHeight
-    return item?.let { if (item.blockHeight > 0) blockHeight - item.blockHeight + 1 else 0 }
+    return item?.let { if (item.blockHeight > 0) currentBlockHeight - item.blockHeight + 1 else 0 }
 }
 
-suspend fun IElectrumClient.computeSpliceCpfpFeerate(commitments: Commitments, targetFeerate: FeeratePerKw, spliceWeight: Int, logger: MDCLogger): Pair<FeeratePerKw, Satoshi> {
+suspend fun IElectrumClient.computeSpliceCpfpFeerate(commitments: Commitments, targetFeerate: FeeratePerKw, spliceWeight: Int, currentBlockHeight: Int, logger: MDCLogger): Pair<FeeratePerKw, Satoshi> {
     val (parentsWeight, parentsFees) = commitments.all
-        .takeWhile { getConfirmations(it.fundingTxId).let { confirmations -> confirmations == null || confirmations == 0 } } // we check for null in case the tx has been evicted
+        .takeWhile { getConfirmations(it.fundingTxId, currentBlockHeight).let { confirmations -> confirmations == null || confirmations == 0 } } // we check for null in case the tx has been evicted
         .fold(Pair(0, 0.sat)) { (parentsWeight, parentsFees), commitment ->
             val weight = when (commitment.localFundingStatus) {
                 // weight will be underestimated if the transaction is not fully signed

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumDataTypes.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumDataTypes.kt
@@ -18,7 +18,7 @@ import kotlinx.serialization.json.*
 
 /**
  * Common communication objects between [ElectrumClient] and external ressources (e.g. [ElectrumWatcher])
- * See the documentation for the ElectrumX protocol there: https://electrumx.readthedocs.io
+ * See the documentation for the ElectrumX protocol there: https://electrumx-spesmilo.readthedocs.io
  */
 
 /**

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -178,7 +178,7 @@ class ElectrumMiniWallet(
         job = launch {
             launch {
                 // listen to connection events
-                client.connectionState.filterIsInstance<Connection.ESTABLISHED>().collect { mailbox.send(WalletCommand.Companion.ElectrumConnected) }
+                client.connectionStatus.filterIsInstance<ElectrumConnectionStatus.Connected>().collect { mailbox.send(WalletCommand.Companion.ElectrumConnected) }
             }
             launch {
                 // listen to subscriptions events

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/IElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/IElectrumClient.kt
@@ -1,17 +1,20 @@
 package fr.acinq.lightning.blockchain.electrum
 
+import fr.acinq.bitcoin.BlockHeader
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Transaction
-import fr.acinq.lightning.utils.Connection
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 interface IElectrumClient {
-
-    suspend fun send(request: ElectrumRequest, replyTo: CompletableDeferred<ElectrumResponse>)
+    val notifications: Flow<ElectrumSubscriptionResponse>
+    val connectionStatus: StateFlow<ElectrumConnectionStatus>
 
     suspend fun getTx(txid: ByteVector32): Transaction
+
+    suspend fun getHeader(blockHeight: Int): BlockHeader
+
+    suspend fun getHeaders(startHeight: Int, count: Int): List<BlockHeader>
 
     suspend fun getMerkle(txid: ByteVector32, blockHeight: Int, contextOpt: Transaction? = null): GetMerkleResponse
 
@@ -26,8 +29,4 @@ interface IElectrumClient {
     suspend fun broadcastTransaction(tx: Transaction): BroadcastTransactionResponse
 
     suspend fun estimateFees(confirmations: Int): EstimateFeeResponse
-
-    val notifications: Flow<ElectrumSubscriptionResponse>
-
-    val connectionStatus: StateFlow<ElectrumConnectionStatus>
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/IElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/IElectrumClient.kt
@@ -3,30 +3,47 @@ package fr.acinq.lightning.blockchain.electrum
 import fr.acinq.bitcoin.BlockHeader
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Transaction
+import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
+/** Note to implementers: methods exposed through this interface must *not* throw exceptions. */
 interface IElectrumClient {
     val notifications: Flow<ElectrumSubscriptionResponse>
     val connectionStatus: StateFlow<ElectrumConnectionStatus>
 
-    suspend fun getTx(txid: ByteVector32): Transaction
+    /** Return the transaction matching the txId provided, if it can be found. */
+    suspend fun getTx(txid: ByteVector32): Transaction?
 
-    suspend fun getHeader(blockHeight: Int): BlockHeader
+    /** Return the block header at the given height, if it exists. */
+    suspend fun getHeader(blockHeight: Int): BlockHeader?
 
+    /** Return the block headers starting at the given height, if they exist (empty list otherwise). */
     suspend fun getHeaders(startHeight: Int, count: Int): List<BlockHeader>
 
-    suspend fun getMerkle(txid: ByteVector32, blockHeight: Int, contextOpt: Transaction? = null): GetMerkleResponse
+    /** Return a merkle proof for the given transaction, if it can be found. */
+    suspend fun getMerkle(txid: ByteVector32, blockHeight: Int, contextOpt: Transaction? = null): GetMerkleResponse?
 
+    /** Return the transaction history for a given script, or an empty list if the script is unknown. */
     suspend fun getScriptHashHistory(scriptHash: ByteVector32): List<TransactionHistoryItem>
 
+    /** Return the utxos matching a given script, or an empty list if the script is unknown. */
     suspend fun getScriptHashUnspents(scriptHash: ByteVector32): List<UnspentItem>
 
+    /**
+     * Try broadcasting a transaction: we cannot know whether the remote server really broadcast the transaction,
+     * so we always consider it to be a success. The client should regularly retry transactions that don't confirm.
+     */
+    suspend fun broadcastTransaction(tx: Transaction): ByteVector32
+
+    /** Estimate the feerate required for a transaction to be confirmed in the next [confirmations] blocks. */
+    suspend fun estimateFees(confirmations: Int): FeeratePerKw?
+
+    /******************** Subscriptions ********************/
+
+    /** Subscribe to changes to a given script. */
     suspend fun startScriptHashSubscription(scriptHash: ByteVector32): ScriptHashSubscriptionResponse
 
+    /** Subscribe to headers for new blocks found. */
     suspend fun startHeaderSubscription(): HeaderSubscriptionResponse
-
-    suspend fun broadcastTransaction(tx: Transaction): BroadcastTransactionResponse
-
-    suspend fun estimateFees(confirmations: Int): EstimateFeeResponse
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/IElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/IElectrumClient.kt
@@ -30,6 +30,4 @@ interface IElectrumClient {
     val notifications: Flow<ElectrumSubscriptionResponse>
 
     val connectionStatus: StateFlow<ElectrumConnectionStatus>
-
-    val connectionState: StateFlow<Connection>
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -193,7 +193,7 @@ class Peer(
                 }
         }
         launch {
-            watcher.client.connectionState.filter { it == Connection.ESTABLISHED }.collect {
+            watcher.client.connectionStatus.filter { it is ElectrumConnectionStatus.Connected }.collect {
                 // onchain fees are retrieved punctually, when electrum status moves to Connection.ESTABLISHED
                 // since the application is not running most of the time, and when it is, it will be only for a few minutes, this is good enough.
                 // (for a node that is online most of the time things would be different and we would need to re-evaluate onchain fee estimates on a regular basis)
@@ -256,7 +256,7 @@ class Peer(
     }
 
     private suspend fun updateEstimateFees() {
-        watcher.client.connectionState.filter { it == Connection.ESTABLISHED }.first()
+        watcher.client.connectionStatus.filter { it is ElectrumConnectionStatus.Connected }.first()
         val sortedFees = listOf(
             watcher.client.estimateFees(2),
             watcher.client.estimateFees(6),

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
@@ -1,10 +1,5 @@
 package fr.acinq.lightning.io
 
-import fr.acinq.lightning.utils.decodeToString
-import fr.acinq.lightning.utils.splitByLines
-import fr.acinq.lightning.utils.subArray
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import org.kodein.log.LoggerFactory
 
 interface TcpSocket {
@@ -69,11 +64,3 @@ suspend fun TcpSocket.receiveAvailable(buffer: ByteArray) = receiveAvailable(buf
 internal expect object PlatformSocketBuilder : TcpSocket.Builder
 
 suspend fun TcpSocket.receiveFully(size: Int): ByteArray = ByteArray(size).also { receiveFully(it) }
-
-fun TcpSocket.linesFlow(): Flow<String> = flow {
-    val buffer = ByteArray(8192)
-    while (true) {
-        val size = receiveAvailable(buffer)
-        emit(buffer.subArray(size))
-    }
-}.decodeToString().splitByLines()

--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/strings.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/strings.kt
@@ -1,55 +1,76 @@
 package fr.acinq.lightning.utils
 
+import fr.acinq.lightning.io.TcpSocket
+import fr.acinq.lightning.io.receiveAvailable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 
+/** The first byte of a unicode character tells us how many bytes this character uses. */
+fun utf8ByteCount(firstCodePoint: Byte) = when (firstCodePoint.toUByte().toInt()) {
+    in 0..0x7F -> 1
+    in 0xC0..0xDF -> 2
+    in 0xE0..0xEF -> 3
+    in 0xF0..0xF7 -> 4
+    else -> error("Malformed UTF-8 character (bad first codepoint 0x${firstCodePoint.toUByte().toString(16).padStart(2, '0')})")
+}
 
-fun utf8ByteCount(firstCodePoint: Byte) =
-    when (firstCodePoint.toUByte().toInt()) {
-        in 0..0x7F -> 1
-        in 0xC0..0xDF -> 2
-        in 0xE0..0xEF -> 3
-        in 0xF0..0xF7 -> 4
-        else -> error("Malformed UTF-8 character (bad first codepoint 0x${firstCodePoint.toUByte().toString(16).padStart(2, '0')})")
+/**
+ * When using TCP, the electrum protocol adds a newline character at the end of each message (encoded using JSON-RPC).
+ * This allows multiplexing concurrent, unrelated messages over the same long-lived TCP connection.
+ * This flow extracts individual messages from the TCP socket and returns them one-by-one.
+ *
+ * @param chunkSize we're receiving a potentially infinite stream of bytes on the TCP socket, so we need to read them
+ * by chunks. The caller should provide a value that isn't too high (since we're pre-allocating that memory) while
+ * allowing us to read most messages in a single chunk.
+ */
+fun linesFlow(socket: TcpSocket, chunkSize: Int = 8192): Flow<String> = flow {
+    val buffer = ByteArray(chunkSize)
+    while (true) {
+        val size = socket.receiveAvailable(buffer)
+        emit(buffer.subArray(size))
     }
+}.decodeToString().splitByLines()
 
-fun Flow<ByteArray>.decodeToString(): Flow<String> =
-    flow {
-        val splitBytes = ByteArray(3)
-        var splitBytesSize = 0
-        collect { receivedBytes ->
-            val bytes = splitBytes.subArray(splitBytesSize) concat receivedBytes
+private fun Flow<ByteArray>.decodeToString(): Flow<String> = flow {
+    // We receive chunks of bytes, but a chunk may stop in the middle of a utf8 character.
+    // When that happens, we carry the bytes of the final partial character over to the next chunk of bytes we'll receive.
+    val previousChunkIgnoredBytes = ByteArray(3) // utf8 characters use at most 4 bytes, hence the size of 3
+    var previousChunkIgnoredBytesSize = 0
+    collect { receivedBytes ->
+        val bytes = previousChunkIgnoredBytes.subArray(previousChunkIgnoredBytesSize).concat(receivedBytes)
 
-            var correctSize = 0
-            while (correctSize < bytes.size) {
-                val count = utf8ByteCount(bytes[correctSize])
-                if (correctSize + count > bytes.size) break
-                correctSize += count
-            }
-
-            if (correctSize < bytes.size) {
-                bytes.copyInto(splitBytes, 0, correctSize, bytes.size)
-            }
-            splitBytesSize = bytes.size - correctSize
-
-            emit(bytes.subArray(correctSize).decodeToString())
+        var utf8AlignedSize = 0
+        while (utf8AlignedSize < bytes.size) {
+            val count = utf8ByteCount(bytes[utf8AlignedSize])
+            if (utf8AlignedSize + count > bytes.size) break
+            utf8AlignedSize += count
         }
-        if (splitBytesSize > 0) error("Flow ended with a malformed UTF-8 character")
-    }
 
-fun Flow<String>.splitByLines(): Flow<String> =
-    flow {
-        var buffer = ""
-        val lineEnding = Regex("\\n")
-
-        collect {
-            buffer += it
-            while (true) {
-                val match = lineEnding.find(buffer) ?: break
-                emit(buffer.substring(0, match.range.first))
-                buffer = buffer.substring(match.range.last + 1)
-            }
+        // The chunk ends with a truncated utf8 character: we store that partial character to be processed with the next chunk.
+        if (utf8AlignedSize < bytes.size) {
+            bytes.copyInto(previousChunkIgnoredBytes, 0, utf8AlignedSize, bytes.size)
         }
-        if (buffer.isNotEmpty()) emit(buffer)
+        previousChunkIgnoredBytesSize = bytes.size - utf8AlignedSize
+
+        emit(bytes.subArray(utf8AlignedSize).decodeToString())
     }
+}
+
+private fun Flow<String>.splitByLines(): Flow<String> = flow {
+    // We receive valid utf8 strings, and need to decompose them into individual messages (separated by a newline character).
+    var buffer = ""
+    val lineEnding = Regex("\\n")
+
+    collect {
+        buffer += it
+        while (true) {
+            // If we don't have any newline character, we wait for the next string chunk.
+            val match = lineEnding.find(buffer) ?: break
+            emit(buffer.substring(0, match.range.first))
+            buffer = buffer.substring(match.range.first + 1)
+        }
+    }
+
+    // Our parent flow has been closed. We may have an incomplete message in our buffer, but it doesn't make sense
+    // to emit it, since listeners won't be able to decode it, so we simply silently drop it.
+}

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
@@ -16,8 +16,9 @@ import kotlin.time.Duration.Companion.seconds
 
 class ElectrumClientTest : LightningTestSuite() {
     // this is tx #2690 of block #500000
-    private val referenceTx =
-        Transaction.read("0200000001983c5b32ced1de5ae97d3ce9b7436f8bb0487d15bf81e5cae97b1e238dc395c6000000006a47304402205957c75766e391350eba2c7b752f0056cb34b353648ecd0992a8a81fc9bcfe980220629c286592842d152cdde71177cd83086619744a533f262473298cacf60193500121021b8b51f74dbf0ac1e766d162c8707b5e8d89fc59da0796f3b4505e7c0fb4cf31feffffff0276bd0101000000001976a914219de672ba773aa0bc2e15cdd9d2e69b734138fa88ac3e692001000000001976a914301706dede031e9fb4b60836e073a4761855f6b188ac09a10700")
+    private val referenceTx = Transaction.read(
+        "0200000001983c5b32ced1de5ae97d3ce9b7436f8bb0487d15bf81e5cae97b1e238dc395c6000000006a47304402205957c75766e391350eba2c7b752f0056cb34b353648ecd0992a8a81fc9bcfe980220629c286592842d152cdde71177cd83086619744a533f262473298cacf60193500121021b8b51f74dbf0ac1e766d162c8707b5e8d89fc59da0796f3b4505e7c0fb4cf31feffffff0276bd0101000000001976a914219de672ba773aa0bc2e15cdd9d2e69b734138fa88ac3e692001000000001976a914301706dede031e9fb4b60836e073a4761855f6b188ac09a10700"
+    )
     private val scriptHash = Crypto.sha256(referenceTx.txOut.first().publicKeyScript).toByteVector32().reversed()
     private val height = 500000
     private val position = 2690
@@ -34,8 +35,7 @@ class ElectrumClientTest : LightningTestSuite() {
         Hex.decode("86858812c3837d209110f7ea79de485abdfd22039467a8aa15a8d85856ee7d30"),
         Hex.decode("de20eb85f2e9ad525a6fb5c618682b6bdce2fa83df836a698f31575c4e5b3d38"),
         Hex.decode("98bd1048e04ff1b0af5856d9890cd708d8d67ad6f3a01f777130fbc16810eeb3")
-    )
-        .map { it.toByteVector32() }
+    ).map { it.toByteVector32() }
 
     private fun runTest(test: suspend CoroutineScope.(ElectrumClient) -> Unit) = runSuspendTest(timeout = 15.seconds) {
         val client = connectToMainnetServer()

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
@@ -28,22 +28,6 @@ class ElectrumClientTest : LightningTestSuite() {
         "0200000001983c5b32ced1de5ae97d3ce9b7436f8bb0487d15bf81e5cae97b1e238dc395c6000000006a47304402205957c75766e391350eba2c7b752f0056cb34b353648ecd0992a8a81fc9bcfe980220629c286592842d152cdde71177cd83086619744a533f262473298cacf60193500121021b8b51f74dbf0ac1e766d162c8707b5e8d89fc59da0796f3b4505e7c0fb4cf31feffffff0276bd0101000000001976a914219de672ba773aa0bc2e15cdd9d2e69b734138fa88ac3e692001000000001976a914301706dede031e9fb4b60836e073a4761855f6b188ac09a10700"
     )
     private val scriptHash = Crypto.sha256(referenceTx.txOut.first().publicKeyScript).toByteVector32().reversed()
-    private val height = 500000
-    private val position = 2690
-    private val merkleProof = listOf(
-        Hex.decode("b500cd85cd6c7e0e570b82728dd516646536a477b61cc82056505d84a5820dc3"),
-        Hex.decode("c98798c2e576566a92b23d2405f59d95c506966a6e26fecfb356d6447a199546"),
-        Hex.decode("930d95c428546812fd11f8242904a9a1ba05d2140cd3a83be0e2ed794821c9ec"),
-        Hex.decode("90c97965b12f4262fe9bf95bc37ff7d6362902745eaa822ecf0cf85801fa8b48"),
-        Hex.decode("23792d51fddd6e439ed4c92ad9f19a9b73fc9d5c52bdd69039be70ad6619a1aa"),
-        Hex.decode("4b73075f29a0abdcec2c83c2cfafc5f304d2c19dcacb50a88a023df725468760"),
-        Hex.decode("f80225a32a5ce4ef0703822c6aa29692431a816dec77d9b1baa5b09c3ba29bfb"),
-        Hex.decode("4858ac33f2022383d3b4dd674666a0880557d02a155073be93231a02ecbb81f4"),
-        Hex.decode("eb5b142030ed4e0b55a8ba5a7b5b783a0a24e0c2fd67c1cfa2f7b308db00c38a"),
-        Hex.decode("86858812c3837d209110f7ea79de485abdfd22039467a8aa15a8d85856ee7d30"),
-        Hex.decode("de20eb85f2e9ad525a6fb5c618682b6bdce2fa83df836a698f31575c4e5b3d38"),
-        Hex.decode("98bd1048e04ff1b0af5856d9890cd708d8d67ad6f3a01f777130fbc16810eeb3")
-    ).map { it.toByteVector32() }
 
     private fun runTest(test: suspend CoroutineScope.(ElectrumClient) -> Unit) = runSuspendTest(timeout = 15.seconds) {
         val client = connectToMainnetServer()
@@ -88,20 +72,6 @@ class ElectrumClientTest : LightningTestSuite() {
     }
 
     @Test
-    fun `get transaction id from position`() = runTest { client ->
-        val response = client.rpcCall<GetTransactionIdFromPositionResponse>(GetTransactionIdFromPosition(height, position))
-        assertEquals(GetTransactionIdFromPositionResponse(referenceTx.txid, height, position), response)
-        client.stop()
-    }
-
-    @Test
-    fun `get transaction id from position with merkle proof`() = runTest { client ->
-        val response = client.rpcCall<GetTransactionIdFromPositionResponse>(GetTransactionIdFromPosition(height, position, merkle = true))
-        assertEquals(GetTransactionIdFromPositionResponse(referenceTx.txid, height, position, merkleProof), response)
-        client.stop()
-    }
-
-    @Test
     fun `get transaction`() = runTest { client ->
         val tx = client.getTx(referenceTx.txid)
         assertEquals(referenceTx, tx)
@@ -110,10 +80,10 @@ class ElectrumClientTest : LightningTestSuite() {
 
     @Test
     fun `get header`() = runTest { client ->
-        val response = client.rpcCall<GetHeaderResponse>(GetHeader(100000))
+        val header = client.getHeader(100000)
         assertEquals(
             Hex.decode("000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506").byteVector32(),
-            response.header.blockId
+            header.blockId
         )
         client.stop()
     }
@@ -121,9 +91,8 @@ class ElectrumClientTest : LightningTestSuite() {
     @Test
     fun `get headers`() = runTest { client ->
         val start = (500000 / 2016) * 2016
-        val response = client.rpcCall<GetHeadersResponse>(GetHeaders(start, 2016))
-        assertEquals(start, response.start_height)
-        assertEquals(2016, response.headers.size)
+        val headers = client.getHeaders(start, 2016)
+        assertEquals(2016, headers.size)
         client.stop()
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
@@ -203,9 +203,13 @@ class ElectrumClientTest : LightningTestSuite() {
 
     @Test
     fun `get tx confirmations`() = runTest { client ->
-        val blockHeight = 788_370
-        assertEquals(10, client.getConfirmations(ByteVector32("f1c290880b6fc9355e4f1b1b7d13b9a15babbe096adaf13d01f3a56def793fd5"), blockHeight))
-        assertNull(client.getConfirmations(ByteVector32("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), blockHeight))
+        val confirmedAt = 788_360
+        val currentBlockHeight = when (val status = client.connectionStatus.value) {
+            is ElectrumConnectionStatus.Connected -> status.height
+            else -> null
+        }!!
+        assertEquals(currentBlockHeight - confirmedAt, client.getConfirmations(ByteVector32("f1c290880b6fc9355e4f1b1b7d13b9a15babbe096adaf13d01f3a56def793fd5")))
+        assertNull(client.getConfirmations(ByteVector32("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")))
         client.stop()
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
@@ -163,14 +163,14 @@ class ElectrumClientTest : LightningTestSuite() {
     @Test
     fun `get scripthash history`() = runTest { client ->
         val history = client.getScriptHashHistory(scriptHash)
-        assertTrue { history.contains(TransactionHistoryItem(500000, referenceTx.txid)) }
+        assertTrue(history.contains(TransactionHistoryItem(500_000, referenceTx.txid)))
         client.stop()
     }
 
     @Test
     fun `list script unspents`() = runTest { client ->
         val response = client.getScriptHashUnspents(scriptHash)
-        assertTrue { response.isEmpty() }
+        assertTrue(response.isEmpty())
         client.stop()
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
@@ -43,7 +43,7 @@ class ElectrumClientTest : LightningTestSuite() {
         client.disconnect()
         client.connectionStatus.map { it.toConnectionState() }.first { it is Connection.CLOSED }
         // Try to connect to unreachable server.
-        assertFalse(client.connect(ServerAddress("unknown.electrum.acinq.co", 51002, TcpSocket.TLS.UNSAFE_CERTIFICATES), TcpSocket.Builder()))
+        assertFalse(client.connect(ServerAddress("unknown.electrum.acinq.co", 51002, TcpSocket.TLS.UNSAFE_CERTIFICATES), TcpSocket.Builder(), timeout = 1.seconds))
         assertIs<ElectrumConnectionStatus.Closed>(client.connectionStatus.first())
         // Reconnect to previous valid server.
         assertTrue(client.connect(ElectrumMainnetServerAddress, TcpSocket.Builder()))
@@ -147,7 +147,7 @@ class ElectrumClientTest : LightningTestSuite() {
     @Test
     fun `disconnect from slow servers on subscription attempts`() = runTest { client ->
         // Set a very small timeout that the server won't be able to honor.
-        client.setRpcTimeout(5.milliseconds)
+        client.setRpcTimeout(0.milliseconds)
         val subscriptionJob = async { client.startHeaderSubscription() }
         // We automatically disconnect after timing out on the subscription request.
         client.connectionStatus.first { it is ElectrumConnectionStatus.Closed }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
@@ -72,6 +72,15 @@ class ElectrumClientTest : LightningTestSuite() {
     }
 
     @Test
+    fun `timeout connecting to electrumx server`() = runTest { client ->
+        client.disconnect()
+        client.connectionStatus.map { it.toConnectionState() }.first { it is Connection.CLOSED }
+        assertFalse(client.connect(ElectrumMainnetServerAddress, TcpSocket.Builder(), timeout = 1.milliseconds))
+        client.connectionStatus.map { it.toConnectionState() }.first { it is Connection.CLOSED }
+        client.stop()
+    }
+
+    @Test
     fun `estimate fees`() = runTest { client ->
         val response = client.estimateFees(3)
         assertTrue { response.feerate!! >= FeeratePerKw.MinimumFeeratePerKw }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.joinAll
@@ -50,9 +51,9 @@ class ElectrumClientTest : LightningTestSuite() {
     private fun runTest(test: suspend CoroutineScope.(ElectrumClient) -> Unit) = runSuspendTest(timeout = 15.seconds) {
         val client = connectToMainnetServer()
 
-        client.connectionState.first { it is Connection.CLOSED }
-        client.connectionState.first { it is Connection.ESTABLISHING }
-        client.connectionState.first { it is Connection.ESTABLISHED }
+        client.connectionStatus.map { it.toConnectionState() }.first { it is Connection.CLOSED }
+        client.connectionStatus.map { it.toConnectionState() }.first { it is Connection.ESTABLISHING }
+        client.connectionStatus.map { it.toConnectionState() }.first { it is Connection.ESTABLISHED }
 
         test(client)
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumUtils.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumUtils.kt
@@ -5,11 +5,12 @@ import fr.acinq.lightning.utils.ServerAddress
 import kotlinx.coroutines.CoroutineScope
 import org.kodein.log.LoggerFactory
 
-fun CoroutineScope.connectToElectrumServer(addr: ServerAddress): ElectrumClient =
-    ElectrumClient(this, LoggerFactory.default).apply { connect(addr, TcpSocket.Builder()) }
+val ElectrumTestnetServerAddress = ServerAddress("testnet1.electrum.acinq.co", 51002, TcpSocket.TLS.UNSAFE_CERTIFICATES)
+val ElectrumMainnetServerAddress = ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES)
 
-fun CoroutineScope.connectToTestnetServer(): ElectrumClient =
-    connectToElectrumServer(ServerAddress("testnet1.electrum.acinq.co", 51002, TcpSocket.TLS.UNSAFE_CERTIFICATES))
+suspend fun connectToElectrumServer(scope: CoroutineScope, addr: ServerAddress): ElectrumClient =
+    ElectrumClient(scope, LoggerFactory.default).apply { connect(addr, TcpSocket.Builder()) }
 
-fun CoroutineScope.connectToMainnetServer(): ElectrumClient =
-    connectToElectrumServer(ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES))
+suspend fun CoroutineScope.connectToTestnetServer(): ElectrumClient = connectToElectrumServer(this, ElectrumTestnetServerAddress)
+
+suspend fun CoroutineScope.connectToMainnetServer(): ElectrumClient = connectToElectrumServer(this, ElectrumMainnetServerAddress)

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumUtils.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumUtils.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.CoroutineScope
 import org.kodein.log.LoggerFactory
 
 fun CoroutineScope.connectToElectrumServer(addr: ServerAddress): ElectrumClient =
-    ElectrumClient(TcpSocket.Builder(), this, LoggerFactory.default).apply { connect(addr) }
+    ElectrumClient(this, LoggerFactory.default).apply { connect(addr, TcpSocket.Builder()) }
 
 fun CoroutineScope.connectToTestnetServer(): ElectrumClient =
     connectToElectrumServer(ServerAddress("testnet1.electrum.acinq.co", 51002, TcpSocket.TLS.UNSAFE_CERTIFICATES))

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
@@ -38,7 +38,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `watch for confirmed transactions`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this, LoggerFactory.default).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED)) }
+        val client = ElectrumClient(this, LoggerFactory.default).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED), TcpSocket.Builder()) }
         val watcher = ElectrumWatcher(client, this, LoggerFactory.default)
 
         val (address, _) = bitcoincli.getNewAddress()
@@ -65,7 +65,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `watch for confirmed transactions created while being offline`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this, LoggerFactory.default).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED)) }
+        val client = ElectrumClient(this, LoggerFactory.default).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED), TcpSocket.Builder()) }
         val watcher = ElectrumWatcher(client, this, LoggerFactory.default)
 
         val (address, _) = bitcoincli.getNewAddress()
@@ -93,7 +93,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `watch for spent transactions`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this, LoggerFactory.default).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED)) }
+        val client = ElectrumClient(this, LoggerFactory.default).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED), TcpSocket.Builder()) }
         val watcher = ElectrumWatcher(client, this, LoggerFactory.default)
 
         val (address, privateKey) = bitcoincli.getNewAddress()
@@ -150,7 +150,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `watch for spent transactions before client is connected`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this, LoggerFactory.default)
+        val client = ElectrumClient(this, LoggerFactory.default)
         val watcher = ElectrumWatcher(client, this, LoggerFactory.default)
 
         val (address, privateKey) = bitcoincli.getNewAddress()
@@ -198,7 +198,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
         assertEquals(spendingTx, sentTx)
         bitcoincli.generateBlocks(2)
 
-        client.connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED))
+        client.connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED), TcpSocket.Builder())
 
         val msg = listener.first() as WatchEventSpent
         assertEquals(spendingTx.txid, msg.tx.txid)
@@ -209,7 +209,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `watch for spent transactions while being offline`() = runSuspendTest {
-        val client = ElectrumClient(TcpSocket.Builder(), this, LoggerFactory.default).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED)) }
+        val client = ElectrumClient(this, LoggerFactory.default).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED), TcpSocket.Builder()) }
         val watcher = ElectrumWatcher(client, this, LoggerFactory.default)
 
         val (address, privateKey) = bitcoincli.getNewAddress()
@@ -268,7 +268,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
 
     @Test
     fun `publish transactions with relative and absolute delays`() = runSuspendTest(timeout = 2.minutes) {
-        val client = ElectrumClient(TcpSocket.Builder(), this, LoggerFactory.default).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED)) }
+        val client = ElectrumClient(this, LoggerFactory.default).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED), TcpSocket.Builder()) }
         val watcher = ElectrumWatcher(client, this, LoggerFactory.default)
         val watcherNotifications = watcher.openWatchNotificationsFlow()
 
@@ -391,7 +391,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
     @Test
     fun `notify when ready`() = runSuspendTest(timeout = 50.seconds) {
         // Run on a production server
-        val client = ElectrumClient(TcpSocket.Builder(), this, LoggerFactory.default).apply { connect(ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES)) }
+        val client = ElectrumClient(this, LoggerFactory.default).apply { connect(ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES), TcpSocket.Builder()) }
         val watcher = ElectrumWatcher(client, this, LoggerFactory.default)
         val watcherNotifications = watcher.openWatchNotificationsFlow()
         val readyNotifications = watcher.openUpToDateFlow()

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
@@ -167,7 +167,7 @@ fun buildPeer(
     databases: InMemoryDatabases = InMemoryDatabases(),
     currentTip: Pair<Int, BlockHeader> = 0 to Block.RegtestGenesisBlock.header
 ): Peer {
-    val electrum = ElectrumClient(TcpSocket.Builder(), scope, LoggerFactory.default)
+    val electrum = ElectrumClient(scope, LoggerFactory.default)
     val watcher = ElectrumWatcher(electrum, scope, LoggerFactory.default)
     val peer = Peer(nodeParams, walletParams, watcher, databases, TcpSocket.Builder(), scope)
     peer.currentTipFlow.value = currentTip


### PR DESCRIPTION
Our `ElectrumClient` was poorly documented and had unexpected behavior in various non-trivial edge cases (e.g. disconnections while RPC calls are pending). Since we rely on untrusted electrum servers, we need clearer requirements on what to do in case of failures, and a mechanism to automatically disconnect from malicious-looking or buggy servers.

The architecture of the coroutines spawned by the `ElectrumClient` was also confusing, with for example the `cancel()` method called sometimes on child jobs, sometimes on the main `scope`, which was really hard to reason about since supervision wasn't explicit.

I highly recommend reviewing commits independently, as they are all narrowly scoped to fix a specific issue. We should also spend some time testing this in Phoenix to see how it behaves in practice.

I removed the `CoroutineExceptionHandler` installed on TLS sockets, but that is unfortunately premature. While this new version of the `ElectrumClient` doesn't crash when the socket is remotely closed in unit tests (while the previous version did crash), the behavior is different on Android and the application will still crash: we need https://github.com/ktorio/ktor/pull/3690 to be integrated into `ktor` before we can safely get rid of it. But since it may also have unintended side-effects, I'm not sure yet whether we should keep it or not in this PR.