### PR TITLE
Remove reserve checks for splice if contribution is positive

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "fr.acinq.lightning"
-    version = "1.5.3"
+    version = "1.5.4-SNAPSHOT"
 
     repositories {
         // using the local maven repository with Kotlin Multi Platform can lead to build errors that are hard to diagnose.

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -105,7 +105,7 @@ data class Normal(
                             localOutputs = cmd.spliceOutputs,
                             targetFeerate = cmd.feerate
                         )
-                        if (parentCommitment.localCommit.spec.toLocal + fundingContribution.toMilliSatoshi() < 0.msat) {
+                        if (fundingContribution < 0.sat && parentCommitment.localCommit.spec.toLocal + fundingContribution.toMilliSatoshi() < parentCommitment.localChannelReserve(commitments.params)) {
                             logger.warning { "cannot do splice: insufficient funds" }
                             cmd.replyTo.complete(ChannelCommand.Commitment.Splice.Response.Failure.InsufficientFunds)
                             Pair(this@Normal, emptyList())


### PR DESCRIPTION
If the contribution is positive, we should skip the reserve requirement, because the splice will increase the reserve, even if the post-splice level stays below the target (it may actually worsens if the other side is adding funds at the same time, but that's not remote's fault).

This applies to both local and remote.