### PR TITLE
Use `TxId` and `TxHash` objects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
 
     val commonMain by sourceSets.getting {
         dependencies {
-            api("fr.acinq.bitcoin:bitcoin-kmp:0.13.0") // when upgrading, keep secp256k1-kmp-jni-jvm in sync below
+            api("fr.acinq.bitcoin:bitcoin-kmp:0.14.0") // when upgrading, keep secp256k1-kmp-jni-jvm in sync below
             api("org.kodein.log:canard:0.18.0")
             api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion")
             api("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
@@ -63,7 +63,7 @@ kotlin {
             api(ktor("client-okhttp"))
             api(ktor("network"))
             api(ktor("network-tls"))
-            implementation("fr.acinq.secp256k1:secp256k1-kmp-jni-jvm:0.10.1")
+            implementation("fr.acinq.secp256k1:secp256k1-kmp-jni-jvm:0.11.0")
             implementation("org.slf4j:slf4j-api:1.7.36")
             api("org.xerial:sqlite-jdbc:3.32.3.2")
         }

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/WatcherTypes.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/WatcherTypes.kt
@@ -23,7 +23,7 @@ sealed class Watch {
 // we need a public key script to use electrum apis
 data class WatchConfirmed(
     override val channelId: ByteVector32,
-    val txId: ByteVector32,
+    val txId: TxId,
     val publicKeyScript: ByteVector,
     val minDepth: Long,
     override val event: BitcoinEvent,
@@ -59,7 +59,7 @@ data class WatchConfirmed(
 
 data class WatchSpent(
     override val channelId: ByteVector32,
-    val txId: ByteVector32,
+    val txId: TxId,
     val outputIndex: Int,
     val publicKeyScript: ByteVector,
     override val event: BitcoinEvent
@@ -83,7 +83,3 @@ sealed class WatchEvent {
 
 data class WatchEventConfirmed(override val channelId: ByteVector32, override val event: BitcoinEvent, val blockHeight: Int, val txIndex: Int, val tx: Transaction) : WatchEvent()
 data class WatchEventSpent(override val channelId: ByteVector32, override val event: BitcoinEvent, val tx: Transaction) : WatchEvent()
-
-data class PublishAsap(val tx: Transaction)
-data class GetTxWithMeta(val channelId: ByteVector32, val txid: ByteVector32)
-data class GetTxWithMetaResponse(val txid: ByteVector32, val tx_opt: Transaction?, val lastBlockTimestamp: Long)

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
@@ -270,19 +270,19 @@ class ElectrumClient(
         }
     }
 
-    override suspend fun getTx(txid: ByteVector32): Transaction? = rpcCall<GetTransactionResponse>(GetTransaction(txid)).right?.tx
+    override suspend fun getTx(txId: TxId): Transaction? = rpcCall<GetTransactionResponse>(GetTransaction(txId)).right?.tx
 
     override suspend fun getHeader(blockHeight: Int): BlockHeader? = rpcCall<GetHeaderResponse>(GetHeader(blockHeight)).right?.header
 
     override suspend fun getHeaders(startHeight: Int, count: Int): List<BlockHeader> = rpcCall<GetHeadersResponse>(GetHeaders(startHeight, count)).right?.headers ?: listOf()
 
-    override suspend fun getMerkle(txid: ByteVector32, blockHeight: Int, contextOpt: Transaction?): GetMerkleResponse? = rpcCall<GetMerkleResponse>(GetMerkle(txid, blockHeight, contextOpt)).right
+    override suspend fun getMerkle(txId: TxId, blockHeight: Int, contextOpt: Transaction?): GetMerkleResponse? = rpcCall<GetMerkleResponse>(GetMerkle(txId, blockHeight, contextOpt)).right
 
     override suspend fun getScriptHashHistory(scriptHash: ByteVector32): List<TransactionHistoryItem> = rpcCall<GetScriptHashHistoryResponse>(GetScriptHashHistory(scriptHash)).right?.history ?: listOf()
 
     override suspend fun getScriptHashUnspents(scriptHash: ByteVector32): List<UnspentItem> = rpcCall<ScriptHashListUnspentResponse>(ScriptHashListUnspent(scriptHash)).right?.unspents ?: listOf()
 
-    override suspend fun broadcastTransaction(tx: Transaction): ByteVector32 = rpcCall<BroadcastTransactionResponse>(BroadcastTransaction(tx)).right?.tx?.txid ?: tx.txid
+    override suspend fun broadcastTransaction(tx: Transaction): TxId = rpcCall<BroadcastTransactionResponse>(BroadcastTransaction(tx)).right?.tx?.txid ?: tx.txid
 
     override suspend fun estimateFees(confirmations: Int): FeeratePerKw? = rpcCall<EstimateFeeResponse>(EstimateFees(confirmations)).right?.feerate
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientExtensions.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientExtensions.kt
@@ -1,8 +1,8 @@
 package fr.acinq.lightning.blockchain.electrum
 
-import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Satoshi
 import fr.acinq.bitcoin.Transaction
+import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.channel.Commitments
 import fr.acinq.lightning.channel.LocalFundingStatus
@@ -10,7 +10,7 @@ import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.MDCLogger
 import fr.acinq.lightning.utils.sat
 
-suspend fun IElectrumClient.getConfirmations(txId: ByteVector32): Int? = getTx(txId)?.let { tx -> getConfirmations(tx) }
+suspend fun IElectrumClient.getConfirmations(txId: TxId): Int? = getTx(txId)?.let { tx -> getConfirmations(tx) }
 
 /**
  * @return the number of confirmations, zero if the transaction is in the mempool, null if the transaction is not found

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -15,7 +15,7 @@ import org.kodein.log.Logger
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 
-data class WalletState(val addresses: Map<String, List<UnspentItem>>, val parentTxs: Map<ByteVector32, Transaction>) {
+data class WalletState(val addresses: Map<String, List<UnspentItem>>, val parentTxs: Map<TxId, Transaction>) {
     /** Electrum sends parent txs separately from utxo outpoints, this boolean indicates when the wallet is consistent */
     val consistent: Boolean = addresses.flatMap { it.value }.all { parentTxs.containsKey(it.txid) }
     val utxos: List<Utxo> = addresses
@@ -96,7 +96,7 @@ private sealed interface WalletCommand {
  * A very simple wallet that only watches one address and publishes its utxos.
  */
 class ElectrumMiniWallet(
-    val chainHash: ByteVector32,
+    val chainHash: BlockHash,
     private val client: IElectrumClient,
     private val scope: CoroutineScope,
     loggerFactory: LoggerFactory,

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
@@ -92,9 +92,9 @@ class ElectrumWatcher(val client: IElectrumClient, val scope: CoroutineScope, lo
                     .filter { state.height - item.blockHeight + 1 >= it.minDepth }
                 triggered.forEach { w ->
                     client.getMerkle(w.txId, item.blockHeight)?.let { merkle ->
-                        val confirmations = state.height - merkle.block_height + 1
-                        logger.info { "txid=${w.txId} had confirmations=$confirmations in block=${merkle.block_height} pos=${merkle.pos}" }
-                        _notificationsFlow.emit(WatchEventConfirmed(w.channelId, w.event, merkle.block_height, merkle.pos, txMap[w.txId]!!))
+                        val confirmations = state.height - merkle.blockHeight + 1
+                        logger.info { "txid=${w.txId} had confirmations=$confirmations in block=${merkle.blockHeight} pos=${merkle.pos}" }
+                        _notificationsFlow.emit(WatchEventConfirmed(w.channelId, w.event, merkle.blockHeight, merkle.pos, txMap[w.txId]!!))
 
                         // check whether we have transactions to publish
                         when (val event = w.event) {
@@ -103,7 +103,7 @@ class ElectrumWatcher(val client: IElectrumClient, val scope: CoroutineScope, lo
                                 logger.info { "parent tx of txid=${tx.txid} has been confirmed" }
                                 val cltvTimeout = Scripts.cltvTimeout(tx)
                                 val csvTimeout = Scripts.csvTimeout(tx)
-                                val absTimeout = max(merkle.block_height + csvTimeout, cltvTimeout)
+                                val absTimeout = max(merkle.blockHeight + csvTimeout, cltvTimeout)
                                 state = if (absTimeout > state.height) {
                                     logger.info { "delaying publication of txid=${tx.txid} until block=$absTimeout (curblock=${state.height})" }
                                     val block2tx = state.block2tx + (absTimeout to state.block2tx.getOrElse(absTimeout) { setOf() } + tx)

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/IElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/IElectrumClient.kt
@@ -3,6 +3,7 @@ package fr.acinq.lightning.blockchain.electrum
 import fr.acinq.bitcoin.BlockHeader
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Transaction
+import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -13,7 +14,7 @@ interface IElectrumClient {
     val connectionStatus: StateFlow<ElectrumConnectionStatus>
 
     /** Return the transaction matching the txId provided, if it can be found. */
-    suspend fun getTx(txid: ByteVector32): Transaction?
+    suspend fun getTx(txId: TxId): Transaction?
 
     /** Return the block header at the given height, if it exists. */
     suspend fun getHeader(blockHeight: Int): BlockHeader?
@@ -22,7 +23,7 @@ interface IElectrumClient {
     suspend fun getHeaders(startHeight: Int, count: Int): List<BlockHeader>
 
     /** Return a merkle proof for the given transaction, if it can be found. */
-    suspend fun getMerkle(txid: ByteVector32, blockHeight: Int, contextOpt: Transaction? = null): GetMerkleResponse?
+    suspend fun getMerkle(txId: TxId, blockHeight: Int, contextOpt: Transaction? = null): GetMerkleResponse?
 
     /** Return the transaction history for a given script, or an empty list if the script is unknown. */
     suspend fun getScriptHashHistory(scriptHash: ByteVector32): List<TransactionHistoryItem>
@@ -34,7 +35,7 @@ interface IElectrumClient {
      * Try broadcasting a transaction: we cannot know whether the remote server really broadcast the transaction,
      * so we always consider it to be a success. The client should regularly retry transactions that don't confirm.
      */
-    suspend fun broadcastTransaction(tx: Transaction): ByteVector32
+    suspend fun broadcastTransaction(tx: Transaction): TxId
 
     /** Estimate the feerate required for a transaction to be confirmed in the next [confirmations] blocks. */
     suspend fun estimateFees(confirmations: Int): FeeratePerKw?

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManager.kt
@@ -1,7 +1,7 @@
 package fr.acinq.lightning.blockchain.electrum
 
-import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.OutPoint
+import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.Lightning
 import fr.acinq.lightning.SwapInParams
 import fr.acinq.lightning.channel.LocalFundingStatus
@@ -14,7 +14,7 @@ import fr.acinq.lightning.utils.MDCLogger
 import fr.acinq.lightning.utils.sat
 
 internal sealed class SwapInCommand {
-    data class TrySwapIn(val currentBlockHeight: Int, val wallet: WalletState, val swapInParams: SwapInParams, val trustedTxs: Set<ByteVector32>) : SwapInCommand()
+    data class TrySwapIn(val currentBlockHeight: Int, val wallet: WalletState, val swapInParams: SwapInParams, val trustedTxs: Set<TxId>) : SwapInCommand()
     data class UnlockWalletInputs(val inputs: Set<OutPoint>) : SwapInCommand()
 }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelAction.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelAction.kt
@@ -72,24 +72,24 @@ sealed class ChannelAction {
         data class RemoveChannel(val data: PersistedChannelState) : Storage()
         data class HtlcInfo(val channelId: ByteVector32, val commitmentNumber: Long, val paymentHash: ByteVector32, val cltvExpiry: CltvExpiry)
         data class StoreHtlcInfos(val htlcs: List<HtlcInfo>) : Storage()
-        data class GetHtlcInfos(val revokedCommitTxId: ByteVector32, val commitmentNumber: Long) : Storage()
+        data class GetHtlcInfos(val revokedCommitTxId: TxId, val commitmentNumber: Long) : Storage()
         /** Payment received through on-chain operations (channel creation or splice-in) */
         sealed class StoreIncomingPayment : Storage() {
             abstract val origin: Origin?
-            abstract val txId: ByteVector32
+            abstract val txId: TxId
             abstract val localInputs: Set<OutPoint>
-            data class ViaNewChannel(val amount: MilliSatoshi, val serviceFee: MilliSatoshi, val miningFee: Satoshi, override val localInputs: Set<OutPoint>, override val txId: ByteVector32, override val origin: Origin?) : StoreIncomingPayment()
-            data class ViaSpliceIn(val amount: MilliSatoshi, val serviceFee: MilliSatoshi, val miningFee: Satoshi, override val localInputs: Set<OutPoint>, override val txId: ByteVector32, override val origin: Origin.PayToOpenOrigin?) : StoreIncomingPayment()
+            data class ViaNewChannel(val amount: MilliSatoshi, val serviceFee: MilliSatoshi, val miningFee: Satoshi, override val localInputs: Set<OutPoint>, override val txId: TxId, override val origin: Origin?) : StoreIncomingPayment()
+            data class ViaSpliceIn(val amount: MilliSatoshi, val serviceFee: MilliSatoshi, val miningFee: Satoshi, override val localInputs: Set<OutPoint>, override val txId: TxId, override val origin: Origin.PayToOpenOrigin?) : StoreIncomingPayment()
         }
         /** Payment sent through on-chain operations (channel close or splice-out) */
         sealed class StoreOutgoingPayment : Storage() {
             abstract val miningFees: Satoshi
-            abstract val txId: ByteVector32
-            data class ViaSpliceOut(val amount: Satoshi, override val miningFees: Satoshi, val address: String, override val txId: ByteVector32) : StoreOutgoingPayment()
-            data class ViaSpliceCpfp(override val miningFees: Satoshi, override val txId: ByteVector32) : StoreOutgoingPayment()
-            data class ViaClose(val amount: Satoshi, override val miningFees: Satoshi, val address: String, override val txId: ByteVector32, val isSentToDefaultAddress: Boolean, val closingType: ChannelClosingType) : StoreOutgoingPayment()
+            abstract val txId: TxId
+            data class ViaSpliceOut(val amount: Satoshi, override val miningFees: Satoshi, val address: String, override val txId: TxId) : StoreOutgoingPayment()
+            data class ViaSpliceCpfp(override val miningFees: Satoshi, override val txId: TxId) : StoreOutgoingPayment()
+            data class ViaClose(val amount: Satoshi, override val miningFees: Satoshi, val address: String, override val txId: TxId, val isSentToDefaultAddress: Boolean, val closingType: ChannelClosingType) : StoreOutgoingPayment()
         }
-        data class SetLocked(val txId: ByteVector32) : Storage()
+        data class SetLocked(val txId: TxId) : Storage()
     }
 
     data class ProcessIncomingHtlc(val add: UpdateAddHtlc) : ChannelAction()

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelCommand.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelCommand.kt
@@ -1,9 +1,6 @@
 package fr.acinq.lightning.channel
 
-import fr.acinq.bitcoin.ByteVector
-import fr.acinq.bitcoin.ByteVector32
-import fr.acinq.bitcoin.Satoshi
-import fr.acinq.bitcoin.TxOut
+import fr.acinq.bitcoin.*
 import fr.acinq.lightning.CltvExpiry
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.blockchain.WatchEvent
@@ -102,7 +99,7 @@ sealed class ChannelCommand {
                 data class Created(
                     val channelId: ByteVector32,
                     val fundingTxIndex: Long,
-                    val fundingTxId: ByteVector32,
+                    val fundingTxId: TxId,
                     val capacity: Satoshi,
                     val balance: MilliSatoshi
                 ) : Response()
@@ -129,7 +126,7 @@ sealed class ChannelCommand {
     }
 
     sealed class Closing : ChannelCommand() {
-        data class GetHtlcInfosResponse(val revokedCommitTxId: ByteVector32, val htlcInfos: List<ChannelAction.Storage.HtlcInfo>) : Closing()
+        data class GetHtlcInfosResponse(val revokedCommitTxId: TxId, val htlcInfos: List<ChannelAction.Storage.HtlcInfo>) : Closing()
     }
     // @formatter:on
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelException.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelException.kt
@@ -1,7 +1,9 @@
 package fr.acinq.lightning.channel
 
+import fr.acinq.bitcoin.BlockHash
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Satoshi
+import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.CltvExpiry
 import fr.acinq.lightning.CltvExpiryDelta
 import fr.acinq.lightning.MilliSatoshi
@@ -14,7 +16,7 @@ open class ChannelException(open val channelId: ByteVector32, override val messa
 }
 
 // @formatter:off
-data class InvalidChainHash                        (override val channelId: ByteVector32, val local: ByteVector32, val remote: ByteVector32) : ChannelException(channelId, "invalid chainHash (local=$local remote=$remote)")
+data class InvalidChainHash                        (override val channelId: ByteVector32, val local: BlockHash, val remote: BlockHash) : ChannelException(channelId, "invalid chainHash (local=$local remote=$remote)")
 data class InvalidFundingAmount                    (override val channelId: ByteVector32, val fundingAmount: Satoshi) : ChannelException(channelId, "invalid funding_amount=$fundingAmount")
 data class InvalidPushAmount                       (override val channelId: ByteVector32, val pushAmount: MilliSatoshi, val max: MilliSatoshi) : ChannelException(channelId, "invalid pushAmount=$pushAmount (max=$max)")
 data class InvalidMaxAcceptedHtlcs                 (override val channelId: ByteVector32, val maxAcceptedHtlcs: Int, val max: Int) : ChannelException(channelId, "invalid max_accepted_htlcs=$maxAcceptedHtlcs (max=$max)")
@@ -30,11 +32,11 @@ data class DualFundingAborted                      (override val channelId: Byte
 data class UnexpectedInteractiveTxMessage          (override val channelId: ByteVector32, val msg: InteractiveTxMessage) : ChannelException(channelId, "unexpected interactive-tx message (${msg::class})")
 data class UnexpectedCommitSig                     (override val channelId: ByteVector32) : ChannelException(channelId, "unexpected commitment signatures (commit_sig)")
 data class UnexpectedFundingSignatures             (override val channelId: ByteVector32) : ChannelException(channelId, "unexpected funding signatures (tx_signatures)")
-data class InvalidFundingSignature                 (override val channelId: ByteVector32, val txId: ByteVector32) : ChannelException(channelId, "invalid funding signature: txId=$txId")
+data class InvalidFundingSignature                 (override val channelId: ByteVector32, val txId: TxId) : ChannelException(channelId, "invalid funding signature: txId=$txId")
 data class InvalidRbfFeerate                       (override val channelId: ByteVector32, val proposed: FeeratePerKw, val expected: FeeratePerKw) : ChannelException(channelId, "invalid rbf attempt: the feerate must be at least $expected, you proposed $proposed")
 data class InvalidRbfAlreadyInProgress             (override val channelId: ByteVector32) : ChannelException(channelId, "invalid rbf attempt: the current rbf attempt must be completed or aborted first")
 data class InvalidRbfTxAbortNotAcked               (override val channelId: ByteVector32) : ChannelException(channelId, "invalid rbf attempt: our previous tx_abort has not been acked")
-data class InvalidRbfTxConfirmed                   (override val channelId: ByteVector32, val txId: ByteVector32) : ChannelException(channelId, "no need to rbf, transaction is already confirmed with txId=$txId")
+data class InvalidRbfTxConfirmed                   (override val channelId: ByteVector32, val txId: TxId) : ChannelException(channelId, "no need to rbf, transaction is already confirmed with txId=$txId")
 data class InvalidRbfNonInitiator                  (override val channelId: ByteVector32) : ChannelException(channelId, "cannot initiate rbf: we're not the initiator of this interactive-tx attempt")
 data class InvalidRbfAttempt                       (override val channelId: ByteVector32) : ChannelException(channelId, "invalid rbf attempt")
 data class InvalidSpliceAlreadyInProgress          (override val channelId: ByteVector32) : ChannelException(channelId, "invalid splice attempt: the current splice attempt must be completed or aborted first")
@@ -46,16 +48,16 @@ data class CannotCloseWithUnsignedOutgoingHtlcs    (override val channelId: Byte
 data class CannotCloseWithUnsignedOutgoingUpdateFee(override val channelId: ByteVector32) : ChannelException(channelId, "cannot close when there is an unsigned fee update")
 data class ChannelUnavailable                      (override val channelId: ByteVector32) : ChannelException(channelId, "channel is unavailable (offline or closing)")
 data class InvalidFinalScript                      (override val channelId: ByteVector32) : ChannelException(channelId, "invalid final script")
-data class FundingTxSpent                          (override val channelId: ByteVector32, val spendingTxId: ByteVector32) : ChannelException(channelId, "funding tx has been spent by txId=$spendingTxId")
+data class FundingTxSpent                          (override val channelId: ByteVector32, val spendingTxId: TxId) : ChannelException(channelId, "funding tx has been spent by txId=$spendingTxId")
 data class HtlcsTimedOutDownstream                 (override val channelId: ByteVector32, val htlcs: Set<UpdateAddHtlc>) : ChannelException(channelId, "one or more htlcs timed out downstream: ids=${htlcs.map { it.id } .joinToString(",")}")
 data class FulfilledHtlcsWillTimeout               (override val channelId: ByteVector32, val htlcs: Set<UpdateAddHtlc>) : ChannelException(channelId, "one or more htlcs that should be fulfilled are close to timing out: ids=${htlcs.map { it.id }.joinToString()}")
 data class HtlcOverriddenByLocalCommit             (override val channelId: ByteVector32, val htlc: UpdateAddHtlc) : ChannelException(channelId, "htlc ${htlc.id} was overridden by local commit")
 data class FeerateTooSmall                         (override val channelId: ByteVector32, val remoteFeeratePerKw: FeeratePerKw) : ChannelException(channelId, "remote fee rate is too small: remoteFeeratePerKw=${remoteFeeratePerKw.toLong()}")
 data class FeerateTooDifferent                     (override val channelId: ByteVector32, val localFeeratePerKw: FeeratePerKw, val remoteFeeratePerKw: FeeratePerKw) : ChannelException(channelId, "local/remote feerates are too different: remoteFeeratePerKw=${remoteFeeratePerKw.toLong()} localFeeratePerKw=${localFeeratePerKw.toLong()}")
-data class InvalidCommitmentSignature              (override val channelId: ByteVector32, val txId: ByteVector32) : ChannelException(channelId, "invalid commitment signature: txId=$txId")
-data class InvalidHtlcSignature                    (override val channelId: ByteVector32, val txId: ByteVector32) : ChannelException(channelId, "invalid htlc signature: txId=$txId")
-data class InvalidCloseSignature                   (override val channelId: ByteVector32, val txId: ByteVector32) : ChannelException(channelId, "invalid close signature: txId=$txId")
-data class InvalidCloseAmountBelowDust             (override val channelId: ByteVector32, val txId: ByteVector32) : ChannelException(channelId, "invalid closing tx: some outputs are below dust: txId=$txId")
+data class InvalidCommitmentSignature              (override val channelId: ByteVector32, val txId: TxId) : ChannelException(channelId, "invalid commitment signature: txId=$txId")
+data class InvalidHtlcSignature                    (override val channelId: ByteVector32, val txId: TxId) : ChannelException(channelId, "invalid htlc signature: txId=$txId")
+data class InvalidCloseSignature                   (override val channelId: ByteVector32, val txId: TxId) : ChannelException(channelId, "invalid close signature: txId=$txId")
+data class InvalidCloseAmountBelowDust             (override val channelId: ByteVector32, val txId: TxId) : ChannelException(channelId, "invalid closing tx: some outputs are below dust: txId=$txId")
 data class CommitSigCountMismatch                  (override val channelId: ByteVector32, val expected: Int, val actual: Int) : ChannelException(channelId, "commit sig count mismatch: expected=$expected actual=$actual")
 data class SwapInSigCountMismatch                  (override val channelId: ByteVector32, val expected: Int, val actual: Int) : ChannelException(channelId, "swap-in sig count mismatch: expected=$expected actual=$actual")
 data class HtlcSigCountMismatch                    (override val channelId: ByteVector32, val expected: Int, val actual: Int) : ChannelException(channelId, "htlc sig count mismatch: expected=$expected actual: $actual")

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -1,9 +1,6 @@
 package fr.acinq.lightning.channel.states
 
-import fr.acinq.bitcoin.ByteVector32
-import fr.acinq.bitcoin.PrivateKey
-import fr.acinq.bitcoin.PublicKey
-import fr.acinq.bitcoin.Transaction
+import fr.acinq.bitcoin.*
 import fr.acinq.lightning.CltvExpiryDelta
 import fr.acinq.lightning.Feature
 import fr.acinq.lightning.NodeParams

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -216,7 +216,7 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
                                         .firstOrNull { staticParams.useZeroConf || it.localFundingStatus is LocalFundingStatus.ConfirmedFundingTx }
                                         ?.let {
                                             logger.debug { "re-sending splice_locked for fundingTxId=${it.fundingTxId}" }
-                                            val spliceLocked = SpliceLocked(channelId, it.fundingTxId.reversed())
+                                            val spliceLocked = SpliceLocked(channelId, it.fundingTxId)
                                             actions.add(ChannelAction.Message.Send(spliceLocked))
                                         }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
@@ -1,6 +1,6 @@
 package fr.acinq.lightning.channel.states
 
-import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.ShortChannelId
 import fr.acinq.lightning.blockchain.BITCOIN_FUNDING_DEPTHOK
@@ -334,7 +334,7 @@ data class WaitForFundingConfirmed(
     }
 
     /** If we haven't completed the signing steps of an interactive-tx session, we will ask our peer to retransmit signatures for the corresponding transaction. */
-    fun getUnsignedFundingTxId(): ByteVector32? {
+    fun getUnsignedFundingTxId(): TxId? {
         return when (rbfStatus) {
             is RbfStatus.WaitingForSigs -> rbfStatus.session.fundingTx.txId
             else -> when (latestFundingTx.sharedTx) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
@@ -138,7 +138,7 @@ data class WaitForFundingSigned(
             // We use part of the funding txid to create a dummy short channel id.
             // This gives us a probability of collisions of 0.1% for 5 0-conf channels and 1% for 20
             // Collisions mean that users may temporarily see incorrect numbers for their 0-conf channels (until they've been confirmed).
-            val shortChannelId = ShortChannelId(0, Pack.int32BE(action.commitment.fundingTxId.slice(0, 16).toByteArray()).absoluteValue, action.commitment.commitInput.outPoint.index.toInt())
+            val shortChannelId = ShortChannelId(0, Pack.int32BE(action.commitment.fundingTxId.value.slice(0, 16).toByteArray()).absoluteValue, action.commitment.commitInput.outPoint.index.toInt())
             val nextState = WaitForChannelReady(commitments, shortChannelId, channelReady)
             val actions = buildList {
                 add(ChannelAction.Storage.StoreState(nextState))

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -29,7 +29,7 @@ interface PaymentsDb : IncomingPaymentsDb, OutgoingPaymentsDb {
      * the transaction is not yet confirmed. In the case of a force-close, the outgoing payment will only be considered confirmed
      * when the channel is closed, meaning that all related transactions have been confirmed.
      */
-    suspend fun setLocked(txId: ByteVector32)
+    suspend fun setLocked(txId: TxId)
 }
 
 interface IncomingPaymentsDb {
@@ -154,7 +154,7 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
         data class SwapIn(val address: String?) : Origin()
 
         /** Trustless swap-in (dual-funding or splice-in) */
-        data class OnChain(val txid: ByteVector32, val localInputs: Set<OutPoint>) : Origin()
+        data class OnChain(val txId: TxId, val localInputs: Set<OutPoint>) : Origin()
     }
 
     data class Received(val receivedWith: List<ReceivedWith>, val receivedAt: Long = currentTimestampMillis()) {
@@ -180,10 +180,9 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
         sealed class OnChainIncomingPayment : ReceivedWith() {
             abstract val serviceFee: MilliSatoshi
             abstract val miningFee: Satoshi
-            override val fees: MilliSatoshi
-                get() = serviceFee + miningFee.toMilliSatoshi()
+            override val fees: MilliSatoshi get() = serviceFee + miningFee.toMilliSatoshi()
             abstract val channelId: ByteVector32
-            abstract val txId: ByteVector32
+            abstract val txId: TxId
             abstract val confirmedAt: Long?
             abstract val lockedAt: Long?
         }
@@ -201,7 +200,7 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
             override val serviceFee: MilliSatoshi,
             override val miningFee: Satoshi,
             override val channelId: ByteVector32,
-            override val txId: ByteVector32,
+            override val txId: TxId,
             override val confirmedAt: Long?,
             override val lockedAt: Long?
         ) : OnChainIncomingPayment()
@@ -211,7 +210,7 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
             override val serviceFee: MilliSatoshi,
             override val miningFee: Satoshi,
             override val channelId: ByteVector32,
-            override val txId: ByteVector32,
+            override val txId: TxId,
             override val confirmedAt: Long?,
             override val lockedAt: Long?
         ) : OnChainIncomingPayment()
@@ -352,7 +351,7 @@ sealed class OnChainOutgoingPayment : OutgoingPayment() {
     abstract override val id: UUID
     abstract val miningFees: Satoshi
     abstract val channelId: ByteVector32
-    abstract val txId: ByteVector32
+    abstract val txId: TxId
     abstract override val createdAt: Long
     abstract val confirmedAt: Long?
     abstract val lockedAt: Long?
@@ -364,7 +363,7 @@ data class SpliceOutgoingPayment(
     val address: String,
     override val miningFees: Satoshi,
     override val channelId: ByteVector32,
-    override val txId: ByteVector32,
+    override val txId: TxId,
     override val createdAt: Long,
     override val confirmedAt: Long?,
     override val lockedAt: Long?,
@@ -378,7 +377,7 @@ data class SpliceCpfpOutgoingPayment(
     override val id: UUID,
     override val miningFees: Satoshi,
     override val channelId: ByteVector32,
-    override val txId: ByteVector32,
+    override val txId: TxId,
     override val createdAt: Long,
     override val confirmedAt: Long?,
     override val lockedAt: Long?,
@@ -403,7 +402,7 @@ data class ChannelCloseOutgoingPayment(
     val isSentToDefaultAddress: Boolean,
     override val miningFees: Satoshi,
     override val channelId: ByteVector32,
-    override val txId: ByteVector32,
+    override val txId: TxId,
     override val createdAt: Long,
     override val confirmedAt: Long?,
     override val lockedAt: Long?,

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -102,7 +102,7 @@ class Peer(
     val db: Databases,
     socketBuilder: TcpSocket.Builder?,
     scope: CoroutineScope,
-    private val trustedSwapInTxs: Set<ByteVector32> = emptySet(),
+    private val trustedSwapInTxs: Set<TxId> = emptySet(),
     private val initTlvStream: TlvStream<InitTlv> = TlvStream.empty()
 ) : CoroutineScope by scope {
     companion object {

--- a/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
@@ -20,8 +20,10 @@
     JsonSerializers.ByteVectorSerializer::class,
     JsonSerializers.ByteVector32Serializer::class,
     JsonSerializers.ByteVector64Serializer::class,
+    JsonSerializers.BlockHashSerializer::class,
     JsonSerializers.PublicKeySerializer::class,
     JsonSerializers.PrivateKeySerializer::class,
+    JsonSerializers.TxIdSerializer::class,
     JsonSerializers.KeyPathSerializer::class,
     JsonSerializers.SatoshiSerializer::class,
     JsonSerializers.MilliSatoshiSerializer::class,
@@ -265,7 +267,7 @@ object JsonSerializers {
     object SignedSharedTransactionSerializer
 
     @Serializable
-    data class InteractiveTxSigningSessionSurrogate(val fundingParams: InteractiveTxParams, val fundingTxId: ByteVector32)
+    data class InteractiveTxSigningSessionSurrogate(val fundingParams: InteractiveTxParams, val fundingTxId: TxId)
     object InteractiveTxSigningSessionSerializer : SurrogateSerializer<InteractiveTxSigningSession, InteractiveTxSigningSessionSurrogate>(
         transform = { s -> InteractiveTxSigningSessionSurrogate(s.fundingParams, s.fundingTx.txId) },
         delegateSerializer = InteractiveTxSigningSessionSurrogate.serializer()
@@ -286,7 +288,7 @@ object JsonSerializers {
     object CommitmentChangesSerializer
 
     @Serializable
-    data class LocalFundingStatusSurrogate(val status: String, val txId: ByteVector32)
+    data class LocalFundingStatusSurrogate(val status: String, val txId: TxId)
     object LocalFundingStatusSerializer : SurrogateSerializer<LocalFundingStatus, LocalFundingStatusSurrogate>(
         transform = { o ->
             when (o) {
@@ -359,7 +361,9 @@ object JsonSerializers {
     object ByteVectorSerializer : StringSerializer<ByteVector>()
     object ByteVector32Serializer : StringSerializer<ByteVector32>()
     object ByteVector64Serializer : StringSerializer<ByteVector64>()
+    object BlockHashSerializer : StringSerializer<BlockHash>()
     object PublicKeySerializer : StringSerializer<PublicKey>()
+    object TxIdSerializer : StringSerializer<TxId>()
     object KeyPathSerializer : StringSerializer<KeyPath>()
     object ShortChannelIdSerializer : StringSerializer<ShortChannelId>()
     object OutPointSerializer : StringSerializer<OutPoint>({ "${it.txid}:${it.index}" })

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/PaymentRequest.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/PaymentRequest.kt
@@ -128,7 +128,7 @@ data class PaymentRequest(
         )
 
         fun create(
-            chainHash: ByteVector32,
+            chainHash: BlockHash,
             amount: MilliSatoshi?,
             paymentHash: ByteVector32,
             privateKey: PrivateKey,

--- a/src/commonMain/kotlin/fr/acinq/lightning/router/Announcements.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/router/Announcements.kt
@@ -31,7 +31,7 @@ object Announcements {
     }
 
     fun makeChannelUpdate(
-        chainHash: ByteVector32,
+        chainHash: BlockHash,
         nodePrivateKey: PrivateKey,
         remoteNodeId: PublicKey,
         shortChannelId: ShortChannelId,
@@ -51,7 +51,7 @@ object Announcements {
     }
 
     private fun channelUpdateWitnessEncode(
-        chainHash: ByteVector32,
+        chainHash: BlockHash,
         shortChannelId: ShortChannelId,
         timestampSeconds: Long,
         messageFlags: Byte,
@@ -64,7 +64,7 @@ object Announcements {
         unknownFields: ByteVector
     ): ByteVector32 {
         val out = ByteArrayOutput()
-        LightningCodecs.writeBytes(chainHash, out)
+        LightningCodecs.writeBytes(chainHash.value, out)
         LightningCodecs.writeU64(shortChannelId.toLong(), out)
         LightningCodecs.writeU32(timestampSeconds.toInt(), out)
         LightningCodecs.writeByte(messageFlags.toInt(), out)

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
@@ -405,7 +405,7 @@ internal data class Commitments(
                     fr.acinq.lightning.channel.PartiallySignedSharedTransaction(
                         fr.acinq.lightning.channel.SharedTransaction(null, InteractiveTxOutput.Shared(0, commitInput.txOut.publicKeyScript, localCommit.spec.toLocal, localCommit.spec.toRemote), listOf(), listOf(), listOf(), listOf(), 0),
                         // We must correctly set the txId here.
-                        TxSignatures(channelId, TxId(commitInput.outPoint.hash), listOf()),
+                        TxSignatures(channelId, commitInput.outPoint.txid, listOf()),
                     ),
                     fr.acinq.lightning.channel.InteractiveTxParams(channelId, localParams.isFunder, commitInput.txOut.amount, commitInput.txOut.amount, remoteParams.fundingPubKey, 0, localParams.dustLimit, localCommit.spec.feerate),
                     0

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/ChannelState.kt
@@ -4,6 +4,7 @@
     EitherSerializer::class,
     ShaChainSerializer::class,
     BlockHeaderKSerializer::class,
+    BlockHashKSerializer::class,
     FundingSignedSerializer::class,
     ChannelUpdateSerializer::class,
     ByteVectorKSerializer::class,
@@ -223,7 +224,7 @@ internal data class RemoteCommit(
     val txid: ByteVector32,
     val remotePerCommitmentPoint: PublicKey
 ) {
-    fun export() = fr.acinq.lightning.channel.RemoteCommit(index, spec.export(), txid, remotePerCommitmentPoint)
+    fun export() = fr.acinq.lightning.channel.RemoteCommit(index, spec.export(), TxId(txid), remotePerCommitmentPoint)
 }
 
 @Serializable
@@ -404,7 +405,7 @@ internal data class Commitments(
                     fr.acinq.lightning.channel.PartiallySignedSharedTransaction(
                         fr.acinq.lightning.channel.SharedTransaction(null, InteractiveTxOutput.Shared(0, commitInput.txOut.publicKeyScript, localCommit.spec.toLocal, localCommit.spec.toRemote), listOf(), listOf(), listOf(), listOf(), 0),
                         // We must correctly set the txId here.
-                        TxSignatures(channelId, commitInput.outPoint.hash, listOf()),
+                        TxSignatures(channelId, TxId(commitInput.outPoint.hash), listOf()),
                     ),
                     fr.acinq.lightning.channel.InteractiveTxParams(channelId, localParams.isFunder, commitInput.txOut.amount, commitInput.txOut.amount, remoteParams.fundingPubKey, 0, localParams.dustLimit, localCommit.spec.feerate),
                     0

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/bitcoinKSerializers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v2/bitcoinKSerializers.kt
@@ -65,6 +65,18 @@ internal object ByteVector64KSerializer : KSerializer<ByteVector64> {
     }
 }
 
+internal object BlockHashKSerializer : KSerializer<BlockHash> {
+    override fun deserialize(decoder: Decoder): BlockHash {
+        return BlockHash(ByteVector32KSerializer.deserialize(decoder))
+    }
+
+    override val descriptor: SerialDescriptor get() = ByteVector32KSerializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: BlockHash) {
+        ByteVector32KSerializer.serialize(encoder, value.value)
+    }
+}
+
 internal object PrivateKeyKSerializer : KSerializer<PrivateKey> {
 
     override fun deserialize(decoder: Decoder): PrivateKey {

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
@@ -398,7 +398,7 @@ internal data class Commitments(
                     fr.acinq.lightning.channel.PartiallySignedSharedTransaction(
                         fr.acinq.lightning.channel.SharedTransaction(null, InteractiveTxOutput.Shared(0, commitInput.txOut.publicKeyScript, localCommit.spec.toLocal, localCommit.spec.toRemote), listOf(), listOf(), listOf(), listOf(), 0),
                         // We must correctly set the txId here.
-                        TxSignatures(channelId, TxId(commitInput.outPoint.hash), listOf()),
+                        TxSignatures(channelId, commitInput.outPoint.txid, listOf()),
                     ),
                     fr.acinq.lightning.channel.InteractiveTxParams(channelId, localParams.isFunder, commitInput.txOut.amount, commitInput.txOut.amount, remoteParams.fundingPubKey, 0, localParams.dustLimit, localCommit.spec.feerate),
                     0

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/ChannelState.kt
@@ -4,6 +4,7 @@
     EitherSerializer::class,
     ShaChainSerializer::class,
     BlockHeaderKSerializer::class,
+    BlockHashKSerializer::class,
     FundingSignedSerializer::class,
     ChannelUpdateSerializer::class,
     ByteVectorKSerializer::class,
@@ -223,7 +224,7 @@ internal data class RemoteCommit(
     val txid: ByteVector32,
     val remotePerCommitmentPoint: PublicKey
 ) {
-    fun export() = fr.acinq.lightning.channel.RemoteCommit(index, spec.export(), txid, remotePerCommitmentPoint)
+    fun export() = fr.acinq.lightning.channel.RemoteCommit(index, spec.export(), TxId(txid), remotePerCommitmentPoint)
 }
 
 @Serializable
@@ -397,7 +398,7 @@ internal data class Commitments(
                     fr.acinq.lightning.channel.PartiallySignedSharedTransaction(
                         fr.acinq.lightning.channel.SharedTransaction(null, InteractiveTxOutput.Shared(0, commitInput.txOut.publicKeyScript, localCommit.spec.toLocal, localCommit.spec.toRemote), listOf(), listOf(), listOf(), listOf(), 0),
                         // We must correctly set the txId here.
-                        TxSignatures(channelId, commitInput.outPoint.hash, listOf()),
+                        TxSignatures(channelId, TxId(commitInput.outPoint.hash), listOf()),
                     ),
                     fr.acinq.lightning.channel.InteractiveTxParams(channelId, localParams.isFunder, commitInput.txOut.amount, commitInput.txOut.amount, remoteParams.fundingPubKey, 0, localParams.dustLimit, localCommit.spec.feerate),
                     0

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/bitcoinKSerializers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v3/bitcoinKSerializers.kt
@@ -65,6 +65,18 @@ internal object ByteVector64KSerializer : KSerializer<ByteVector64> {
     }
 }
 
+internal object BlockHashKSerializer : KSerializer<BlockHash> {
+    override fun deserialize(decoder: Decoder): BlockHash {
+        return BlockHash(ByteVector32KSerializer.deserialize(decoder))
+    }
+
+    override val descriptor: SerialDescriptor get() = ByteVector32KSerializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: BlockHash) {
+        ByteVector32KSerializer.serialize(encoder, value.value)
+    }
+}
+
 internal object PrivateKeyKSerializer : KSerializer<PrivateKey> {
 
     override fun deserialize(decoder: Decoder): PrivateKey {

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
@@ -340,7 +340,7 @@ object Deserialization {
         remoteCommit = RemoteCommit(
             index = readNumber(),
             spec = readCommitmentSpecWithHtlcs(),
-            txid = readByteVector32(),
+            txid = readTxId(),
             remotePerCommitmentPoint = readPublicKey()
         )
     )
@@ -423,7 +423,7 @@ object Deserialization {
                 // We previously didn't store the tx_signatures after the transaction was confirmed.
                 // It is only used to be retransmitted on reconnection if our peer had not received it.
                 // This happens very rarely in practice, so putting dummy values here shouldn't be an issue.
-                localSigs = TxSignatures(ByteVector32.Zeroes, ByteVector32.Zeroes, listOf())
+                localSigs = TxSignatures(ByteVector32.Zeroes, TxId(ByteVector32.Zeroes), listOf())
             )
             0x02 -> LocalFundingStatus.ConfirmedFundingTx(
                 signedTx = readTransaction(),
@@ -454,7 +454,7 @@ object Deserialization {
         remoteCommit = RemoteCommit(
             index = readNumber(),
             spec = readCommitmentSpecWithoutHtlcs(htlcs.map { it.opposite() }.toSet()),
-            txid = readByteVector32(),
+            txid = readTxId(),
             remotePerCommitmentPoint = readPublicKey()
         ),
         nextRemoteCommit = readNullable {
@@ -463,7 +463,7 @@ object Deserialization {
                 commit = RemoteCommit(
                     index = readNumber(),
                     spec = readCommitmentSpecWithoutHtlcs(htlcs.map { it.opposite() }.toSet()),
-                    txid = readByteVector32(),
+                    txid = readTxId(),
                     remotePerCommitmentPoint = readPublicKey()
                 )
             )
@@ -573,6 +573,8 @@ object Deserialization {
     private fun Input.readByteVector64(): ByteVector64 = ByteVector64(ByteArray(64).also { read(it, 0, it.size) })
 
     private fun Input.readPublicKey() = PublicKey(ByteArray(33).also { read(it, 0, it.size) })
+
+    private fun Input.readTxId(): TxId = TxId(readByteVector32())
 
     private fun Input.readDelimitedByteArray(): ByteArray {
         val size = readNumber().toInt()

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
@@ -384,7 +384,7 @@ object Serialization {
         remoteCommit.run {
             writeNumber(index)
             writeCommitmentSpecWithHtlcs(spec)
-            writeByteVector32(txid)
+            writeTxId(txid)
             writePublicKey(remotePerCommitmentPoint)
         }
     }
@@ -489,14 +489,14 @@ object Serialization {
         remoteCommit.run {
             writeNumber(index)
             writeCommitmentSpecWithoutHtlcs(spec)
-            writeByteVector32(txid)
+            writeTxId(txid)
             writePublicKey(remotePerCommitmentPoint)
         }
         writeNullable(nextRemoteCommit) {
             writeLightningMessage(it.sig)
             writeNumber(it.commit.index)
             writeCommitmentSpecWithoutHtlcs(it.commit.spec)
-            writeByteVector32(it.commit.txid)
+            writeTxId(it.commit.txid)
             writePublicKey(it.commit.remotePerCommitmentPoint)
         }
     }
@@ -638,6 +638,8 @@ object Serialization {
     private fun Output.writeByteVector64(o: ByteVector64) = write(o.toByteArray())
 
     private fun Output.writePublicKey(o: PublicKey) = write(o.value.toByteArray())
+
+    private fun Output.writeTxId(o: TxId) = write(o.value.toByteArray())
 
     private fun Output.writeDelimited(o: ByteArray) {
         writeNumber(o.size)

--- a/src/commonMain/kotlin/fr/acinq/lightning/utils/jsonrpc.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/utils/jsonrpc.kt
@@ -2,6 +2,7 @@ package fr.acinq.lightning.utils
 
 import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.Transaction
+import fr.acinq.bitcoin.TxId
 import fr.acinq.secp256k1.Hex
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -32,8 +33,8 @@ fun List<Any>.asJsonRPCParameters(): List<JsonRPCParam> = map {
             it -> 1
             else -> 0
         }.asParam()
-
         is ByteVector -> it.toHex().asParam()
+        is TxId -> it.value.toHex().asParam()
         is Transaction -> Hex.encode(Transaction.write(it)).asParam()
         else -> error("Unsupported type ${it::class} as JSON-RPC parameter")
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
@@ -12,6 +12,7 @@ import fr.acinq.lightning.channel.Origin
 import fr.acinq.lightning.utils.msat
 import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.utils.toByteVector
+import fr.acinq.lightning.utils.toByteVector64
 
 sealed class ChannelTlv : Tlv {
     /** Commitment to where the funds will go in case of a mutual close, which remote node will enforce in case we're compromised. */

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/ChannelTlv.kt
@@ -9,7 +9,9 @@ import fr.acinq.lightning.ShortChannelId
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.channel.ChannelType
 import fr.acinq.lightning.channel.Origin
-import fr.acinq.lightning.utils.*
+import fr.acinq.lightning.utils.msat
+import fr.acinq.lightning.utils.sat
+import fr.acinq.lightning.utils.toByteVector
 
 sealed class ChannelTlv : Tlv {
     /** Commitment to where the funds will go in case of a mutual close, which remote node will enforce in case we're compromised. */
@@ -228,13 +230,13 @@ sealed class RevokeAndAckTlv : Tlv {
 }
 
 sealed class ChannelReestablishTlv : Tlv {
-    data class NextFunding(val txHash: ByteVector32) : ChannelReestablishTlv() {
+    data class NextFunding(val txId: TxId) : ChannelReestablishTlv() {
         override val tag: Long get() = NextFunding.tag
-        override fun write(out: Output) = LightningCodecs.writeBytes(txHash, out)
+        override fun write(out: Output) = LightningCodecs.writeTxHash(TxHash(txId), out)
 
         companion object : TlvValueReader<NextFunding> {
             const val tag: Long = 0
-            override fun read(input: Input): NextFunding = NextFunding(LightningCodecs.bytes(input, 32).toByteVector32())
+            override fun read(input: Input): NextFunding = NextFunding(TxId(LightningCodecs.txHash(input)))
         }
     }
 
@@ -293,7 +295,7 @@ sealed class PleaseOpenChannelTlv : Tlv {
         override val tag: Long get() = GrandParents.tag
         override fun write(out: Output) {
             outpoints.forEach { outpoint ->
-                LightningCodecs.writeBytes(outpoint.hash.toByteArray(), out)
+                LightningCodecs.writeTxHash(outpoint.hash, out)
                 LightningCodecs.writeU64(outpoint.index, out)
             }
         }
@@ -302,7 +304,7 @@ sealed class PleaseOpenChannelTlv : Tlv {
             const val tag: Long = 561
             override fun read(input: Input): GrandParents {
                 val count = input.availableBytes / 40
-                val outpoints = (0 until count).map { OutPoint(LightningCodecs.bytes(input, 32).toByteVector32(), LightningCodecs.u64(input)) }
+                val outpoints = (0 until count).map { OutPoint(LightningCodecs.txHash(input), LightningCodecs.u64(input)) }
                 return GrandParents(outpoints)
             }
         }

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/InteractiveTxTlv.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/InteractiveTxTlv.kt
@@ -5,7 +5,6 @@ import fr.acinq.bitcoin.io.Input
 import fr.acinq.bitcoin.io.Output
 import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.utils.toByteVector
-import fr.acinq.lightning.utils.toByteVector32
 import fr.acinq.lightning.utils.toByteVector64
 
 sealed class TxAddInputTlv : Tlv {
@@ -13,13 +12,13 @@ sealed class TxAddInputTlv : Tlv {
      * When doing a splice, the initiator must provide the previous funding txId instead of the whole transaction.
      * Note that we actually encode this as a tx_hash to be consistent with other lightning messages.
      */
-    data class SharedInputTxId(val txId: ByteVector32) : TxAddInputTlv() {
+    data class SharedInputTxId(val txId: TxId) : TxAddInputTlv() {
         override val tag: Long get() = SharedInputTxId.tag
-        override fun write(out: Output) = LightningCodecs.writeBytes(txId.reversed(), out)
+        override fun write(out: Output) = LightningCodecs.writeTxHash(TxHash(txId), out)
 
         companion object : TlvValueReader<SharedInputTxId> {
             const val tag: Long = 1105
-            override fun read(input: Input): SharedInputTxId = SharedInputTxId(LightningCodecs.bytes(input, 32).toByteVector32().reversed())
+            override fun read(input: Input): SharedInputTxId = SharedInputTxId(TxId(LightningCodecs.txHash(input)))
         }
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningCodecs.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningCodecs.kt
@@ -2,6 +2,8 @@ package fr.acinq.lightning.wire
 
 import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.TxHash
+import fr.acinq.bitcoin.TxId
 import fr.acinq.bitcoin.crypto.Pack
 import fr.acinq.bitcoin.io.ByteArrayOutput
 import fr.acinq.bitcoin.io.Input
@@ -204,6 +206,18 @@ object LightningCodecs {
 
     @JvmStatic
     fun writeBytes(input: ByteVector32, out: Output): Unit = writeBytes(input.toByteArray(), out)
+
+    @JvmStatic
+    fun txId(input: Input): TxId = TxId(bytes(input, 32))
+
+    @JvmStatic
+    fun writeTxId(input: TxId, out: Output): Unit = writeBytes(input.value.toByteArray(), out)
+
+    @JvmStatic
+    fun txHash(input: Input): TxHash = TxHash(bytes(input, 32))
+
+    @JvmStatic
+    fun writeTxHash(input: TxHash, out: Output): Unit = writeBytes(input.value.toByteArray(), out)
 
     @JvmStatic
     fun script(input: Input): ByteArray {

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientTest.kt
@@ -78,7 +78,7 @@ class ElectrumClientTest : LightningTestSuite() {
 
     @Test
     fun `get transaction -- not found`() = runTest { client ->
-        val tx = client.getTx(ByteVector32.Zeroes)
+        val tx = client.getTx(TxId(ByteVector32.Zeroes))
         assertNull(tx)
         client.stop()
     }
@@ -88,7 +88,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val header = client.getHeader(100000)
         assertNotNull(header)
         assertEquals(
-            Hex.decode("000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506").byteVector32(),
+            BlockId(Hex.decode("000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506")),
             header.blockId
         )
         client.stop()
@@ -121,7 +121,7 @@ class ElectrumClientTest : LightningTestSuite() {
         val merkle = client.getMerkle(referenceTx.txid, 500000)
         assertNotNull(merkle)
         assertEquals(referenceTx.txid, merkle.txid)
-        assertEquals(500000, merkle.block_height)
+        assertEquals(500000, merkle.blockHeight)
         assertEquals(2690, merkle.pos)
         assertEquals(
             Hex.decode("1f6231ed3de07345b607ec2a39b2d01bec2fe10dfb7f516ba4958a42691c9531").byteVector32(),
@@ -177,16 +177,16 @@ class ElectrumClientTest : LightningTestSuite() {
     @Test
     fun `client multiplexing`() = runTest { client ->
         val txids = listOf(
-            ByteVector32("c1e943938e0bf2e9e6feefe22af0466514a58e9f7ed0f7ada6fd8e6dbeca0742"),
-            ByteVector32("2cf392ecf573a638f01f72c276c3b097d05eb58f39e165eacc91b8a8df09fbd8"),
-            ByteVector32("149a098d6261b7f9359a572d797c4a41b62378836a14093912618b15644ba402"),
-            ByteVector32("2dd9cb7bcebb74b02efc85570a462f22a54a613235bee11d0a2c791342a26007"),
-            ByteVector32("71b3dbaca67e9f9189dad3617138c19725ab541ef0b49c05a94913e9f28e3f4e"),
-            ByteVector32("21d2eb195736af2a40d42107e6abd59c97eb6cffd4a5a7a7709e86590ae61987"),
-            ByteVector32("74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"),
-            ByteVector32("563ea83f9641d37a36f9294d172fdb4fb86c19b0e9cac45e0b27610331138775"),
-            ByteVector32("971af80218684017722429be08548d1f30a2f1f220abc064380cbca5cabf7623"),
-            ByteVector32("b1ec9c44009147f3cee26caba45abec2610c74df9751fad14074119b5314da21")
+            TxId("c1e943938e0bf2e9e6feefe22af0466514a58e9f7ed0f7ada6fd8e6dbeca0742"),
+            TxId("2cf392ecf573a638f01f72c276c3b097d05eb58f39e165eacc91b8a8df09fbd8"),
+            TxId("149a098d6261b7f9359a572d797c4a41b62378836a14093912618b15644ba402"),
+            TxId("2dd9cb7bcebb74b02efc85570a462f22a54a613235bee11d0a2c791342a26007"),
+            TxId("71b3dbaca67e9f9189dad3617138c19725ab541ef0b49c05a94913e9f28e3f4e"),
+            TxId("21d2eb195736af2a40d42107e6abd59c97eb6cffd4a5a7a7709e86590ae61987"),
+            TxId("74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"),
+            TxId("563ea83f9641d37a36f9294d172fdb4fb86c19b0e9cac45e0b27610331138775"),
+            TxId("971af80218684017722429be08548d1f30a2f1f220abc064380cbca5cabf7623"),
+            TxId("b1ec9c44009147f3cee26caba45abec2610c74df9751fad14074119b5314da21")
         )
 
         // request txids in parallel
@@ -208,8 +208,8 @@ class ElectrumClientTest : LightningTestSuite() {
             is ElectrumConnectionStatus.Connected -> status.height
             else -> null
         }!!
-        assertEquals(currentBlockHeight - confirmedAt, client.getConfirmations(ByteVector32("f1c290880b6fc9355e4f1b1b7d13b9a15babbe096adaf13d01f3a56def793fd5")))
-        assertNull(client.getConfirmations(ByteVector32("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")))
+        assertEquals(currentBlockHeight - confirmedAt, client.getConfirmations(TxId("f1c290880b6fc9355e4f1b1b7d13b9a15babbe096adaf13d01f3a56def793fd5")))
+        assertNull(client.getConfirmations(TxId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")))
         client.stop()
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
@@ -2,8 +2,8 @@ package fr.acinq.lightning.blockchain.electrum
 
 import fr.acinq.bitcoin.Bitcoin
 import fr.acinq.bitcoin.Block
-import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Transaction
+import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.SwapInParams
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.tests.utils.runSuspendTest
@@ -132,17 +132,17 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
 
         assertEquals(
             expected = setOf(
-                Triple("16MmJT8VqW465GEyckWae547jKVfMB14P8", ByteVector32("c1e943938e0bf2e9e6feefe22af0466514a58e9f7ed0f7ada6fd8e6dbeca0742") to 1, 39_000_000.sat),
-                Triple("16MmJT8VqW465GEyckWae547jKVfMB14P8", ByteVector32("2cf392ecf573a638f01f72c276c3b097d05eb58f39e165eacc91b8a8df09fbd8") to 0, 12_000_000.sat),
-                Triple("16MmJT8VqW465GEyckWae547jKVfMB14P8", ByteVector32("149a098d6261b7f9359a572d797c4a41b62378836a14093912618b15644ba402") to 1, 11_000_000.sat),
-                Triple("16MmJT8VqW465GEyckWae547jKVfMB14P8", ByteVector32("2dd9cb7bcebb74b02efc85570a462f22a54a613235bee11d0a2c791342a26007") to 1, 10_000_000.sat),
-                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", ByteVector32("71b3dbaca67e9f9189dad3617138c19725ab541ef0b49c05a94913e9f28e3f4e") to 0, 5_000_000.sat),
-                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", ByteVector32("21d2eb195736af2a40d42107e6abd59c97eb6cffd4a5a7a7709e86590ae61987") to 0, 5_000_000.sat),
-                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", ByteVector32("74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20") to 1, 5_000_000.sat),
-                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", ByteVector32("563ea83f9641d37a36f9294d172fdb4fb86c19b0e9cac45e0b27610331138775") to 0, 5_000_000.sat),
-                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", ByteVector32("971af80218684017722429be08548d1f30a2f1f220abc064380cbca5cabf7623") to 1, 5_000_000.sat),
-                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", ByteVector32("b1ec9c44009147f3cee26caba45abec2610c74df9751fad14074119b5314da21") to 0, 5_000_000.sat),
-                Triple("1NHFyu1uJ1UoDjtPjqZ4Et3wNCyMGCJ1qV", ByteVector32("602839d82ac6c9aafd1a20fff5b23e11a99271e7cc238d2e48b352219b2b87ab") to 1, 2_000_000.sat),
+                Triple("16MmJT8VqW465GEyckWae547jKVfMB14P8", TxId("c1e943938e0bf2e9e6feefe22af0466514a58e9f7ed0f7ada6fd8e6dbeca0742") to 1, 39_000_000.sat),
+                Triple("16MmJT8VqW465GEyckWae547jKVfMB14P8", TxId("2cf392ecf573a638f01f72c276c3b097d05eb58f39e165eacc91b8a8df09fbd8") to 0, 12_000_000.sat),
+                Triple("16MmJT8VqW465GEyckWae547jKVfMB14P8", TxId("149a098d6261b7f9359a572d797c4a41b62378836a14093912618b15644ba402") to 1, 11_000_000.sat),
+                Triple("16MmJT8VqW465GEyckWae547jKVfMB14P8", TxId("2dd9cb7bcebb74b02efc85570a462f22a54a613235bee11d0a2c791342a26007") to 1, 10_000_000.sat),
+                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", TxId("71b3dbaca67e9f9189dad3617138c19725ab541ef0b49c05a94913e9f28e3f4e") to 0, 5_000_000.sat),
+                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", TxId("21d2eb195736af2a40d42107e6abd59c97eb6cffd4a5a7a7709e86590ae61987") to 0, 5_000_000.sat),
+                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", TxId("74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20") to 1, 5_000_000.sat),
+                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", TxId("563ea83f9641d37a36f9294d172fdb4fb86c19b0e9cac45e0b27610331138775") to 0, 5_000_000.sat),
+                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", TxId("971af80218684017722429be08548d1f30a2f1f220abc064380cbca5cabf7623") to 1, 5_000_000.sat),
+                Triple("14xb2HATmkBzrHf4CR2hZczEtjYpTh92d2", TxId("b1ec9c44009147f3cee26caba45abec2610c74df9751fad14074119b5314da21") to 0, 5_000_000.sat),
+                Triple("1NHFyu1uJ1UoDjtPjqZ4Et3wNCyMGCJ1qV", TxId("602839d82ac6c9aafd1a20fff5b23e11a99271e7cc238d2e48b352219b2b87ab") to 1, 2_000_000.sat),
             ),
             actual = walletState.utxos.map {
                 val txOut = it.previousTx.txOut[it.outputIndex]

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumRequestTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumRequestTest.kt
@@ -1,5 +1,6 @@
 package fr.acinq.lightning.blockchain.electrum
 
+import fr.acinq.bitcoin.BlockHash
 import fr.acinq.bitcoin.BlockHeader
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.lightning.tests.utils.LightningTestSuite
@@ -53,7 +54,7 @@ class ElectrumRequestTest : LightningTestSuite() {
         assertEquals(
             Either.Left(HeaderSubscriptionResponse(blockHeight = 520481, BlockHeader(
                 version = 536870912,
-                hashPreviousBlock = ByteVector32.fromValidHex("890208a0ae3a3892aa047c5468725846577cfcd9b512b5000000000000000000"),
+                hashPreviousBlock = BlockHash("890208a0ae3a3892aa047c5468725846577cfcd9b512b5000000000000000000"),
                 hashMerkleRoot = ByteVector32.fromValidHex("5dc2b02f2d297a9064ee103036c14d678f9afc7e3d9409cf53fd58b82e938e8e"),
                 time = 1520495819,
                 bits = 402858285,

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
@@ -284,7 +284,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
                 val mempool = bitcoincli.getRawMempool()
                 if (mempool.isNotEmpty()) {
                     assertEquals(1, mempool.size)
-                    assertEquals(tx.txid.toHex(), mempool.first())
+                    assertEquals(tx.txid.value.toHex(), mempool.first())
                 }
                 delay(1.seconds)
             } while (mempool.isEmpty())

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManagerTestsCommon.kt
@@ -34,8 +34,8 @@ class SwapInManagerTestsCommon : LightningTestSuite() {
         val mgr = SwapInManager(listOf(), logger)
         val wallet = run {
             val parentTxs = listOf(
-                Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 2), 0)), listOf(TxOut(50_000.sat, dummyScript), TxOut(75_000.sat, dummyScript)), 0),
-                Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 0), 0)), listOf(TxOut(25_000.sat, dummyScript)), 0)
+                Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 2), 0)), listOf(TxOut(50_000.sat, dummyScript), TxOut(75_000.sat, dummyScript)), 0),
+                Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 0), 0)), listOf(TxOut(25_000.sat, dummyScript)), 0)
             )
             val unspent = listOf(
                 UnspentItem(parentTxs[0].txid, 0, 50_000, 100), // deeply confirmed
@@ -56,8 +56,8 @@ class SwapInManagerTestsCommon : LightningTestSuite() {
         val mgr = SwapInManager(listOf(), logger)
         val wallet = run {
             val parentTxs = listOf(
-                Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 2), 0)), listOf(TxOut(50_000.sat, dummyScript)), 0),
-                Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 0), 0)), listOf(TxOut(25_000.sat, dummyScript)), 0)
+                Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 2), 0)), listOf(TxOut(50_000.sat, dummyScript)), 0),
+                Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 0), 0)), listOf(TxOut(25_000.sat, dummyScript)), 0)
             )
             val unspent = listOf(
                 UnspentItem(parentTxs[0].txid, 0, 50_000, 100), // recently confirmed
@@ -74,8 +74,8 @@ class SwapInManagerTestsCommon : LightningTestSuite() {
         val mgr = SwapInManager(listOf(), logger)
         val wallet = run {
             val parentTxs = listOf(
-                Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 2), 0)), listOf(TxOut(50_000.sat, dummyScript)), 0),
-                Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 0), 0)), listOf(TxOut(25_000.sat, dummyScript)), 0)
+                Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 2), 0)), listOf(TxOut(50_000.sat, dummyScript)), 0),
+                Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 0), 0)), listOf(TxOut(25_000.sat, dummyScript)), 0)
             )
             val unspent = listOf(
                 UnspentItem(parentTxs[0].txid, 0, 50_000, 100), // exceeds refund delay
@@ -91,9 +91,9 @@ class SwapInManagerTestsCommon : LightningTestSuite() {
     fun `swap funds -- allow unconfirmed in migration`() {
         val mgr = SwapInManager(listOf(), logger)
         val parentTxs = listOf(
-            Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 1), 0)), listOf(TxOut(75_000.sat, dummyScript)), 0),
-            Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 2), 0)), listOf(TxOut(50_000.sat, dummyScript)), 0),
-            Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 0), 0)), listOf(TxOut(25_000.sat, dummyScript)), 0)
+            Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 1), 0)), listOf(TxOut(75_000.sat, dummyScript)), 0),
+            Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 2), 0)), listOf(TxOut(50_000.sat, dummyScript)), 0),
+            Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 0), 0)), listOf(TxOut(25_000.sat, dummyScript)), 0)
         )
         val wallet = run {
             val unspent = listOf(
@@ -114,7 +114,7 @@ class SwapInManagerTestsCommon : LightningTestSuite() {
     fun `swap funds -- previously used inputs`() {
         val mgr = SwapInManager(listOf(), logger)
         val wallet = run {
-            val parentTx = Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 1), 0)), listOf(TxOut(75_000.sat, dummyScript)), 0)
+            val parentTx = Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 1), 0)), listOf(TxOut(75_000.sat, dummyScript)), 0)
             val unspent = UnspentItem(parentTx.txid, 0, 75_000, 100)
             WalletState(mapOf(dummyAddress to listOf(unspent)), mapOf(parentTx.txid to parentTx))
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManagerTestsCommon.kt
@@ -183,7 +183,7 @@ class SwapInManagerTestsCommon : LightningTestSuite() {
         assertEquals(2, inputs.size) // 2 splice inputs
         val spliceTx = alice1.commitments.latest.localFundingStatus.signedTx!!
         val (alice2, _) = alice1.process(ChannelCommand.WatchReceived(WatchEventConfirmed(alice.channelId, BITCOIN_FUNDING_DEPTHOK, 100, 2, spliceTx)))
-        val (alice3, _) = alice2.process(ChannelCommand.MessageReceived(SpliceLocked(alice.channelId, spliceTx.hash)))
+        val (alice3, _) = alice2.process(ChannelCommand.MessageReceived(SpliceLocked(alice.channelId, spliceTx.txid)))
         assertIs<LNChannel<Normal>>(alice3)
         assertEquals(1, alice3.commitments.all.size)
         assertIs<LocalFundingStatus.ConfirmedFundingTx>(alice3.commitments.latest.localFundingStatus)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/ChannelDataTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/ChannelDataTestsCommon.kt
@@ -326,7 +326,7 @@ class ChannelDataTestsCommon : LightningTestSuite(), LoggingContext {
         private fun createClosingTransactions(): Triple<LocalCommitPublished, RemoteCommitPublished, RevokedCommitPublished> {
             val commitTx = Transaction(
                 2,
-                listOf(TxIn(OutPoint(randomBytes32(), 0), 0)),
+                listOf(TxIn(OutPoint(TxId(randomBytes32()), 0), 0)),
                 listOf(
                     TxOut(50_000.sat, ByteVector.empty), // main output Alice
                     TxOut(40_000.sat, ByteVector.empty), // main output Bob

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
@@ -493,7 +493,7 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
             )
             val fundingAmount = (toLocal + toRemote).truncateToSatoshi()
             val dummyFundingScript = Scripts.multiSig2of2(randomKey().publicKey(), randomKey().publicKey())
-            val dummyFundingTx = Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 1), 0)), listOf(TxOut(fundingAmount, Script.pay2wsh(dummyFundingScript))), 0)
+            val dummyFundingTx = Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 1), 0)), listOf(TxOut(fundingAmount, Script.pay2wsh(dummyFundingScript))), 0)
             val commitmentInput = Transactions.InputInfo(OutPoint(dummyFundingTx, 0), dummyFundingTx.txOut[0], dummyFundingScript)
             val localCommitTx = Transactions.TransactionWithInputInfo.CommitTx(commitmentInput, Transaction(2, listOf(), listOf(), 0))
             return Commitments(
@@ -515,10 +515,10 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
                     Commitment(
                         fundingTxIndex = 0,
                         remoteFundingPubkey = randomKey().publicKey(),
-                        LocalFundingStatus.ConfirmedFundingTx(dummyFundingTx, 500.sat, TxSignatures(randomBytes32(), randomBytes32(), listOf())),
+                        LocalFundingStatus.ConfirmedFundingTx(dummyFundingTx, 500.sat, TxSignatures(randomBytes32(), TxId(randomBytes32()), listOf())),
                         RemoteFundingStatus.Locked,
                         LocalCommit(0, CommitmentSpec(setOf(), feeRatePerKw, toLocal, toRemote), PublishableTxs(localCommitTx, listOf())),
-                        RemoteCommit(0, CommitmentSpec(setOf(), feeRatePerKw, toRemote, toLocal), randomBytes32(), randomKey().publicKey()),
+                        RemoteCommit(0, CommitmentSpec(setOf(), feeRatePerKw, toRemote, toLocal), TxId(randomBytes32()), randomKey().publicKey()),
                         nextRemoteCommit = null,
                     )
                 ),
@@ -538,7 +538,7 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
             )
             val fundingAmount = (toLocal + toRemote).truncateToSatoshi()
             val dummyFundingScript = Scripts.multiSig2of2(randomKey().publicKey(), randomKey().publicKey())
-            val dummyFundingTx = Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 1), 0)), listOf(TxOut(fundingAmount, Script.pay2wsh(dummyFundingScript))), 0)
+            val dummyFundingTx = Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 1), 0)), listOf(TxOut(fundingAmount, Script.pay2wsh(dummyFundingScript))), 0)
             val commitmentInput = Transactions.InputInfo(OutPoint(dummyFundingTx, 0), dummyFundingTx.txOut[0], dummyFundingScript)
             val localCommitTx = Transactions.TransactionWithInputInfo.CommitTx(commitmentInput, Transaction(2, listOf(), listOf(), 0))
             return Commitments(
@@ -560,10 +560,10 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
                     Commitment(
                         fundingTxIndex = 0,
                         remoteFundingPubkey = randomKey().publicKey(),
-                        LocalFundingStatus.ConfirmedFundingTx(dummyFundingTx, 500.sat, TxSignatures(randomBytes32(), randomBytes32(), listOf())),
+                        LocalFundingStatus.ConfirmedFundingTx(dummyFundingTx, 500.sat, TxSignatures(randomBytes32(), TxId(randomBytes32()), listOf())),
                         RemoteFundingStatus.Locked,
                         LocalCommit(0, CommitmentSpec(setOf(), FeeratePerKw(0.sat), toLocal, toRemote), PublishableTxs(localCommitTx, listOf())),
-                        RemoteCommit(0, CommitmentSpec(setOf(), FeeratePerKw(0.sat), toRemote, toLocal), randomBytes32(), randomKey().publicKey()),
+                        RemoteCommit(0, CommitmentSpec(setOf(), FeeratePerKw(0.sat), toRemote, toLocal), TxId(randomBytes32()), randomKey().publicKey()),
                         nextRemoteCommit = null
                     )
                 ),

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
@@ -534,7 +534,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             localCommitPublished.commitTx.txIn.first().outPoint,
             localCommitPublished.htlcTimeoutTxs().first().input.outPoint,
         )
-        assertEquals(actions1.findWatches<WatchSpent>().map { OutPoint(it.txId.reversed(), it.outputIndex.toLong()) }, watchSpent)
+        assertEquals(actions1.findWatches<WatchSpent>().map { OutPoint(it.txId, it.outputIndex.toLong()) }, watchSpent)
     }
 
     @Test
@@ -859,7 +859,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             remoteCommitPublished.commitTx.txIn.first().outPoint,
             remoteCommitPublished.claimHtlcTimeoutTxs().first().input.outPoint,
         )
-        assertEquals(actions1.findWatches<WatchSpent>().map { OutPoint(it.txId.reversed(), it.outputIndex.toLong()) }, watchSpent)
+        assertEquals(actions1.findWatches<WatchSpent>().map { OutPoint(it.txId, it.outputIndex.toLong()) }, watchSpent)
     }
 
     @Test
@@ -1140,7 +1140,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             remoteCommitPublished.claimHtlcTimeoutTxs().first().input.outPoint,
             remoteCommitPublished.claimHtlcTimeoutTxs().last().input.outPoint,
         )
-        assertEquals(actions1.findWatches<WatchSpent>().map { OutPoint(it.txId.reversed(), it.outputIndex.toLong()) }, watchSpent)
+        assertEquals(actions1.findWatches<WatchSpent>().map { OutPoint(it.txId, it.outputIndex.toLong()) }, watchSpent)
     }
 
     @Test
@@ -1222,7 +1222,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             assertEquals(alice3, alice4)
             assertEquals(actions4.findPublishTxs(), listOf(futureRemoteCommitPublished.claimMainOutputTx!!.tx))
             assertEquals(actions4.findWatches<WatchConfirmed>().map { it.txId }, listOf(bobCommitTx.txid, futureRemoteCommitPublished.claimMainOutputTx!!.tx.txid))
-            assertEquals(actions4.findWatches<WatchSpent>().map { OutPoint(it.txId.reversed(), it.outputIndex.toLong()) }, listOf(bobCommitTx.txIn.first().outPoint))
+            assertEquals(actions4.findWatches<WatchSpent>().map { OutPoint(it.txId, it.outputIndex.toLong()) }, listOf(bobCommitTx.txIn.first().outPoint))
             actions4.doesNotHave<ChannelAction.Storage.StoreOutgoingPayment.ViaClose>()
         }
 
@@ -1308,7 +1308,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             addAll(revokedCommitPublished.htlcPenaltyTxs.map { it.input.outPoint })
         }
         assertEquals(3, outputsToWatch.size)
-        assertEquals(outputsToWatch, aliceActions2.findWatches<WatchSpent>().map { OutPoint(it.txId.reversed(), it.outputIndex.toLong()) }.toSet())
+        assertEquals(outputsToWatch, aliceActions2.findWatches<WatchSpent>().map { OutPoint(it.txId, it.outputIndex.toLong()) }.toSet())
 
         // simulate a wallet restart
         run {
@@ -1322,7 +1322,7 @@ class ClosingTestsCommon : LightningTestSuite() {
             assertEquals(aliceTxs, actions3.findPublishTxs().toSet())
             assertEquals(setOf(bobRevokedTx.txid, revokedCommitPublished.claimMainOutputTx!!.tx.txid), actions3.findWatches<WatchConfirmed>().map { it.txId }.toSet())
             val watchSpent = outputsToWatch + alice3.commitments.latest.commitInput.outPoint
-            assertEquals(watchSpent, actions3.findWatches<WatchSpent>().map { OutPoint(it.txId.reversed(), it.outputIndex.toLong()) }.toSet())
+            assertEquals(watchSpent, actions3.findWatches<WatchSpent>().map { OutPoint(it.txId, it.outputIndex.toLong()) }.toSet())
         }
 
         val watchConfirmed = listOf(
@@ -1642,7 +1642,7 @@ class ClosingTestsCommon : LightningTestSuite() {
         val bobHtlcTx = Transaction(
             2,
             listOf(
-                TxIn(OutPoint(Lightning.randomBytes32(), 4), listOf(), 1), // unrelated utxo (maybe used for fee bumping)
+                TxIn(OutPoint(TxId(Lightning.randomBytes32()), 4), listOf(), 1), // unrelated utxo (maybe used for fee bumping)
                 bobRevokedTx.htlcTxsAndSigs[0].txinfo.tx.txIn.first(),
                 bobRevokedTx.htlcTxsAndSigs[1].txinfo.tx.txIn.first(),
                 bobRevokedTx.htlcTxsAndSigs[2].txinfo.tx.txIn.first(),

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
@@ -1996,7 +1996,7 @@ class NormalTestsCommon : LightningTestSuite() {
         val htlcInputs = htlcPenaltyTxs.map { it.txIn.first().outPoint }.toSet()
         assertEquals(4, htlcInputs.size) // each htlc-penalty tx spends a different output
         assertEquals(5, actions2.findWatches<WatchSpent>().count { it.event is BITCOIN_OUTPUT_SPENT })
-        assertEquals(htlcInputs + mainPenaltyTx.txIn.first().outPoint, actions2.findWatches<WatchSpent>().map { OutPoint(it.txId.reversed(), it.outputIndex.toLong()) }.toSet())
+        assertEquals(htlcInputs + mainPenaltyTx.txIn.first().outPoint, actions2.findWatches<WatchSpent>().map { OutPoint(it.txId, it.outputIndex.toLong()) }.toSet())
 
         // two main outputs are 760 000 and 200 000 (minus fees)
         assertEquals(748_070.sat, mainOutputTx.txOut[0].amount)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SpliceTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SpliceTestsCommon.kt
@@ -261,7 +261,7 @@ class SpliceTestsCommon : LightningTestSuite() {
         val (alice1, bob1) = spliceOut(alice, bob, 60_000.sat)
         val spliceTx = alice1.commitments.latest.localFundingStatus.signedTx!!
 
-        val (alice2, actionsAlice2) = alice1.process(ChannelCommand.MessageReceived(SpliceLocked(alice.channelId, spliceTx.hash)))
+        val (alice2, actionsAlice2) = alice1.process(ChannelCommand.MessageReceived(SpliceLocked(alice.channelId, spliceTx.txid)))
         assertEquals(actionsAlice2.size, 2)
         actionsAlice2.has<ChannelAction.Storage.StoreState>()
         actionsAlice2.has<ChannelAction.Storage.SetLocked>()
@@ -269,7 +269,7 @@ class SpliceTestsCommon : LightningTestSuite() {
         assertNotEquals(alice2.commitments.latest.fundingTxId, alice.commitments.latest.fundingTxId)
         assertIs<LocalFundingStatus.UnconfirmedFundingTx>(alice2.commitments.latest.localFundingStatus)
 
-        val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(SpliceLocked(bob.channelId, spliceTx.hash)))
+        val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(SpliceLocked(bob.channelId, spliceTx.txid)))
         assertEquals(actionsBob2.size, 2)
         actionsBob2.has<ChannelAction.Storage.StoreState>()
         actionsBob2.has<ChannelAction.Storage.SetLocked>()
@@ -286,7 +286,7 @@ class SpliceTestsCommon : LightningTestSuite() {
         val (alice2, _) = spliceOut(alice1, bob1, 60_000.sat)
         val spliceTx2 = alice2.commitments.latest.localFundingStatus.signedTx!!
 
-        val (_, actionsAlice3) = alice2.process(ChannelCommand.MessageReceived(SpliceLocked(alice.channelId, spliceTx2.hash)))
+        val (_, actionsAlice3) = alice2.process(ChannelCommand.MessageReceived(SpliceLocked(alice.channelId, spliceTx2.txid)))
         assertEquals(3, actionsAlice3.size)
         actionsAlice3.has<ChannelAction.Storage.StoreState>()
         assertContains(actionsAlice3, ChannelAction.Storage.SetLocked(spliceTx1.txid))
@@ -304,10 +304,10 @@ class SpliceTestsCommon : LightningTestSuite() {
         val (nodes2, preimage, htlc) = addHtlc(15_000_000.msat, alice1, bob1)
         val (alice3, bob3) = crossSign(nodes2.first, nodes2.second, commitmentsCount = 2)
 
-        val (alice4, actionsAlice4) = alice3.process(ChannelCommand.MessageReceived(SpliceLocked(alice.channelId, spliceTx.hash)))
+        val (alice4, actionsAlice4) = alice3.process(ChannelCommand.MessageReceived(SpliceLocked(alice.channelId, spliceTx.txid)))
         actionsAlice4.has<ChannelAction.Storage.StoreState>()
         assertEquals(alice4.commitments.active.size, 1)
-        val (bob4, actionsBob4) = bob3.process(ChannelCommand.MessageReceived(SpliceLocked(bob.channelId, spliceTx.hash)))
+        val (bob4, actionsBob4) = bob3.process(ChannelCommand.MessageReceived(SpliceLocked(bob.channelId, spliceTx.txid)))
         actionsBob4.has<ChannelAction.Storage.StoreState>()
         assertEquals(bob4.commitments.active.size, 1)
 
@@ -333,7 +333,7 @@ class SpliceTestsCommon : LightningTestSuite() {
         assertEquals(alice2.commitments.active.size, 3)
         assertEquals(bob2.commitments.active.size, 3)
         val spliceTx = alice2.commitments.latest.localFundingStatus.signedTx!!
-        val spliceLocked = SpliceLocked(alice.channelId, spliceTx.hash)
+        val spliceLocked = SpliceLocked(alice.channelId, spliceTx.txid)
 
         // Alice adds a new HTLC, and sends commit_sigs before receiving Bob's splice_locked.
         //
@@ -870,10 +870,10 @@ class SpliceTestsCommon : LightningTestSuite() {
         val (alice, bob) = reachNormalWithConfirmedFundingTx(zeroConf = true)
         val (alice1, bob1) = spliceOut(alice, bob, 50_000.sat)
         val spliceTx = alice1.commitments.latest.localFundingStatus.signedTx!!
-        val (alice2, _) = alice1.process(ChannelCommand.MessageReceived(SpliceLocked(alice.channelId, spliceTx.hash)))
+        val (alice2, _) = alice1.process(ChannelCommand.MessageReceived(SpliceLocked(alice.channelId, spliceTx.txid)))
         assertEquals(alice2.commitments.active.size, 1)
         assertEquals(alice2.commitments.inactive.size, 1)
-        val (bob2, _) = bob1.process(ChannelCommand.MessageReceived(SpliceLocked(bob.channelId, spliceTx.hash)))
+        val (bob2, _) = bob1.process(ChannelCommand.MessageReceived(SpliceLocked(bob.channelId, spliceTx.txid)))
         assertEquals(bob2.commitments.active.size, 1)
         assertEquals(bob2.commitments.inactive.size, 1)
 
@@ -939,11 +939,11 @@ class SpliceTestsCommon : LightningTestSuite() {
         val (alice, bob) = reachNormalWithConfirmedFundingTx(zeroConf = true)
         val (alice1, bob1) = spliceOut(alice, bob, 50_000.sat)
         val spliceTx = alice1.commitments.latest.localFundingStatus.signedTx!!
-        val (alice2, _) = alice1.process(ChannelCommand.MessageReceived(SpliceLocked(alice.channelId, spliceTx.hash)))
+        val (alice2, _) = alice1.process(ChannelCommand.MessageReceived(SpliceLocked(alice.channelId, spliceTx.txid)))
         assertIs<LNChannel<Normal>>(alice2)
         assertEquals(alice2.commitments.active.size, 1)
         assertEquals(alice2.commitments.inactive.size, 1)
-        val (bob2, _) = bob1.process(ChannelCommand.MessageReceived(SpliceLocked(bob.channelId, spliceTx.hash)))
+        val (bob2, _) = bob1.process(ChannelCommand.MessageReceived(SpliceLocked(bob.channelId, spliceTx.txid)))
         assertIs<LNChannel<Normal>>(bob2)
         assertEquals(bob2.commitments.active.size, 1)
         assertEquals(bob2.commitments.inactive.size, 1)
@@ -1092,7 +1092,7 @@ class SpliceTestsCommon : LightningTestSuite() {
             return exchangeSpliceSigs(alice4, commitSigAlice, bob4, commitSigBob)
         }
 
-        private fun checkCommandResponse(replyTo: CompletableDeferred<ChannelCommand.Commitment.Splice.Response>, parentCommitment: Commitment, spliceInit: SpliceInit): ByteVector32 = runBlocking {
+        private fun checkCommandResponse(replyTo: CompletableDeferred<ChannelCommand.Commitment.Splice.Response>, parentCommitment: Commitment, spliceInit: SpliceInit): TxId = runBlocking {
             val response = replyTo.await()
             assertIs<ChannelCommand.Commitment.Splice.Response.Created>(response)
             assertEquals(response.capacity, parentCommitment.fundingAmount + spliceInit.fundingContribution)
@@ -1160,7 +1160,7 @@ class SpliceTestsCommon : LightningTestSuite() {
         private fun createWalletWithFunds(keyManager: KeyManager, amounts: List<Satoshi>): List<WalletState.Utxo> {
             val script = keyManager.swapInOnChainWallet.pubkeyScript
             return amounts.map { amount ->
-                val txIn = listOf(TxIn(OutPoint(Lightning.randomBytes32(), 2), 0))
+                val txIn = listOf(TxIn(OutPoint(TxId(Lightning.randomBytes32()), 2), 0))
                 val txOut = listOf(TxOut(amount, script), TxOut(150.sat, Script.pay2wpkh(randomKey().publicKey())))
                 val parentTx = Transaction(2, txIn, txOut, 0)
                 WalletState.Utxo(parentTx, 0, 42)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SyncingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SyncingTestsCommon.kt
@@ -1,12 +1,11 @@
 package fr.acinq.lightning.channel.states
 
-import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.ScriptFlags
 import fr.acinq.bitcoin.Transaction
+import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.Feature
 import fr.acinq.lightning.blockchain.*
 import fr.acinq.lightning.channel.*
-
 import fr.acinq.lightning.channel.TestsHelper.reachNormal
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
@@ -339,7 +338,7 @@ class SyncingTestsCommon : LightningTestSuite() {
             return Pair(alice, bob)
         }
 
-        data class UnsignedRbfFixture(val alice: LNChannel<WaitForFundingConfirmed>, val commitSigAlice: CommitSig, val bob: LNChannel<WaitForFundingConfirmed>, val commitSigBob: CommitSig, val rbfFundingTxId: ByteVector32)
+        data class UnsignedRbfFixture(val alice: LNChannel<WaitForFundingConfirmed>, val commitSigAlice: CommitSig, val bob: LNChannel<WaitForFundingConfirmed>, val commitSigBob: CommitSig, val rbfFundingTxId: TxId)
 
         fun createUnsignedRbf(): UnsignedRbfFixture {
             val (alice, bob, _, wallet) = WaitForFundingConfirmedTestsCommon.init()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
@@ -10,7 +10,6 @@ import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.utils.msat
-import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.utils.toMilliSatoshi
 import fr.acinq.lightning.wire.*
 import kotlin.test.*
@@ -44,7 +43,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
     @Test
     fun `recv TxSignatures -- duplicate`() {
         val (alice, _, _, _) = init()
-        val (alice1, actions1) = alice.process(ChannelCommand.MessageReceived(TxSignatures(alice.channelId, alice.commitments.latest.fundingTxId.reversed(), listOf())))
+        val (alice1, actions1) = alice.process(ChannelCommand.MessageReceived(TxSignatures(alice.channelId, alice.commitments.latest.fundingTxId, listOf())))
         assertEquals(alice1, alice)
         assertTrue(actions1.isEmpty())
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
@@ -444,7 +444,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
             assertIs<FullySignedSharedTransaction>(previousFundingTx)
             // Alice adds a new input that increases her contribution and covers the additional fees.
             val script = alice.staticParams.nodeParams.keyManager.swapInOnChainWallet.pubkeyScript
-            val parentTx = Transaction(2, listOf(TxIn(OutPoint(randomBytes32(), 1), 0)), listOf(TxOut(30_000.sat, script)), 0)
+            val parentTx = Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 1), 0)), listOf(TxOut(30_000.sat, script)), 0)
             val wallet1 = wallet + listOf(WalletState.Utxo(parentTx, 0, 42))
             return ChannelCommand.Funding.BumpFundingFee(previousFundingTx.feerate * 1.1, previousFundingParams.localContribution + 20_000.sat, wallet1, previousFundingTx.tx.lockTime + 1)
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreatedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreatedTestsCommon.kt
@@ -1,9 +1,6 @@
 package fr.acinq.lightning.channel.states
 
-import fr.acinq.bitcoin.ByteVector32
-import fr.acinq.bitcoin.ByteVector64
-import fr.acinq.bitcoin.Satoshi
-import fr.acinq.bitcoin.Script
+import fr.acinq.bitcoin.*
 import fr.acinq.lightning.Feature
 import fr.acinq.lightning.Features
 import fr.acinq.lightning.Lightning.randomBytes32
@@ -205,12 +202,12 @@ class WaitForFundingCreatedTestsCommon : LightningTestSuite() {
     fun `recv TxSignatures`() {
         val (alice, bob, _) = init(ChannelType.SupportedChannelType.AnchorOutputs, bobFundingAmount = 0.sat, alicePushAmount = 0.msat)
         run {
-            val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(TxSignatures(alice.channelId, randomBytes32(), listOf())))
+            val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(TxSignatures(alice.channelId, TxId(randomBytes32()), listOf())))
             assertEquals(actionsAlice1.findOutgoingMessage<Error>().toAscii(), UnexpectedFundingSignatures(alice.channelId).message)
             assertIs<Aborted>(alice1.state)
         }
         run {
-            val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(TxSignatures(bob.channelId, randomBytes32(), listOf())))
+            val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(TxSignatures(bob.channelId, TxId(randomBytes32()), listOf())))
             assertEquals(actionsBob1.findOutgoingMessage<Error>().toAscii(), UnexpectedFundingSignatures(bob.channelId).message)
             assertIs<Aborted>(bob1.state)
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
@@ -182,12 +182,12 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
     fun `recv TxSignatures -- before CommitSig`() {
         val (alice, _, bob, _) = init()
         run {
-            val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(TxSignatures(alice.channelId, randomBytes32(), listOf())))
+            val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(TxSignatures(alice.channelId, TxId(randomBytes32()), listOf())))
             assertEquals(actionsAlice1.findOutgoingMessage<Error>().toAscii(), UnexpectedFundingSignatures(alice.channelId).message)
             assertIs<Aborted>(alice1.state)
         }
         run {
-            val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(TxSignatures(bob.channelId, randomBytes32(), listOf())))
+            val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(TxSignatures(bob.channelId, TxId(randomBytes32()), listOf())))
             assertEquals(actionsBob1.findOutgoingMessage<Error>().toAscii(), UnexpectedFundingSignatures(bob.channelId).message)
             assertIs<Aborted>(bob1.state)
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
@@ -2,7 +2,7 @@ package fr.acinq.lightning.db
 
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto
-import fr.acinq.lightning.MilliSatoshi
+import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.channel.ChannelException
 import fr.acinq.lightning.payment.FinalFailure
 import fr.acinq.lightning.payment.OutgoingPaymentFailure
@@ -15,7 +15,7 @@ class InMemoryPaymentsDb : PaymentsDb {
     private val incoming = mutableMapOf<ByteVector32, IncomingPayment>()
     private val outgoing = mutableMapOf<UUID, LightningOutgoingPayment>()
     private val outgoingParts = mutableMapOf<UUID, Pair<UUID, LightningOutgoingPayment.Part>>()
-    override suspend fun setLocked(txId: ByteVector32) {}
+    override suspend fun setLocked(txId: TxId) {}
 
     override suspend fun addIncomingPayment(preimage: ByteVector32, origin: IncomingPayment.Origin, createdAt: Long): IncomingPayment {
         val paymentHash = Crypto.sha256(preimage).toByteVector32()
@@ -68,7 +68,7 @@ class InMemoryPaymentsDb : PaymentsDb {
 
     override suspend fun addOutgoingPayment(outgoingPayment: OutgoingPayment) {
         require(!outgoing.contains(outgoingPayment.id)) { "an outgoing payment with id=${outgoingPayment.id} already exists" }
-        when(outgoingPayment) {
+        when (outgoingPayment) {
             is LightningOutgoingPayment -> {
                 outgoingPayment.parts.forEach { require(!outgoingParts.contains(it.id)) { "an outgoing payment part with id=${it.id} already exists" } }
                 outgoing[outgoingPayment.id] = outgoingPayment.copy(parts = listOf())

--- a/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
@@ -70,7 +70,7 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
             pr.paymentHash, listOf(
                 IncomingPayment.ReceivedWith.LightningPayment(amount = 57_000.msat, channelId = channelId1, htlcId = 1L),
                 IncomingPayment.ReceivedWith.LightningPayment(amount = 43_000.msat, channelId = channelId2, htlcId = 54L),
-                IncomingPayment.ReceivedWith.NewChannel(amount = 99_000.msat, channelId = channelId3, serviceFee = 1_000.msat, miningFee = 0.sat, txId = randomBytes32(), confirmedAt = null, lockedAt = null)
+                IncomingPayment.ReceivedWith.NewChannel(amount = 99_000.msat, channelId = channelId3, serviceFee = 1_000.msat, miningFee = 0.sat, txId = TxId(randomBytes32()), confirmedAt = null, lockedAt = null)
             ), 110
         )
         val received = db.getIncomingPayment(pr.paymentHash)
@@ -146,7 +146,7 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
                     serviceFee = 15_000.msat,
                     miningFee = 0.sat,
                     channelId = randomBytes32(),
-                    txId = randomBytes32(),
+                    txId = TxId(randomBytes32()),
                     confirmedAt = null,
                     lockedAt = null
                 )

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -7,8 +7,6 @@ import fr.acinq.lightning.Lightning.randomBytes32
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.ShortChannelId
 import fr.acinq.lightning.channel.*
-import fr.acinq.lightning.channel.ChannelAction
-import fr.acinq.lightning.channel.ChannelCommand
 import fr.acinq.lightning.crypto.sphinx.Sphinx
 import fr.acinq.lightning.db.InMemoryPaymentsDb
 import fr.acinq.lightning.db.IncomingPayment
@@ -175,7 +173,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             serviceFee = payToOpenRequest.payToOpenFeeSatoshis.toMilliSatoshi(),
             miningFee = 0.sat,
             localInputs = emptySet(),
-            txId = randomBytes32(),
+            txId = TxId(randomBytes32()),
             origin = Origin.PayToOpenOrigin(amount = payToOpenRequest.amountMsat, paymentHash = payToOpenRequest.paymentHash, serviceFee = 0.msat, miningFee = payToOpenRequest.payToOpenFeeSatoshis)
         )
         paymentHandler.process(channelId, amountOrigin)
@@ -242,7 +240,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
     fun `receive pay-to-open payment with an unknown payment hash`() = runSuspendTest {
         val (paymentHandler, _, _) = createFixture(defaultAmount)
         val payToOpenRequest = PayToOpenRequest(
-            chainHash = ByteVector32.Zeroes,
+            chainHash = BlockHash(ByteVector32.Zeroes),
             fundingSatoshis = 100_000.sat,
             amountMsat = defaultAmount,
             payToOpenMinAmountMsat = 1_000_000.msat,
@@ -337,7 +335,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             NodeHop(TestConstants.Alice.nodeParams.nodeId, TestConstants.Bob.nodeParams.nodeId, CltvExpiryDelta(144), 0.msat)
         )
         val payToOpenRequest = PayToOpenRequest(
-            chainHash = ByteVector32.Zeroes,
+            chainHash = BlockHash(ByteVector32.Zeroes),
             fundingSatoshis = 100_000.sat,
             amountMsat = defaultAmount,
             payToOpenMinAmountMsat = 1_000_000.msat,
@@ -1067,7 +1065,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         )
         paymentHandler.db.receivePayment(
             paidInvoice.paymentHash,
-            receivedWith = listOf(IncomingPayment.ReceivedWith.NewChannel(amount = 15_000_000.msat, serviceFee = 1_000_000.msat, miningFee = 0.sat, channelId = randomBytes32(), txId = randomBytes32(), confirmedAt = null, lockedAt = null)),
+            receivedWith = listOf(IncomingPayment.ReceivedWith.NewChannel(amount = 15_000_000.msat, serviceFee = 1_000_000.msat, miningFee = 0.sat, channelId = randomBytes32(), txId = TxId(randomBytes32()), confirmedAt = null, lockedAt = null)),
             receivedAt = 101
         ) // simulate incoming payment being paid before it expired
 
@@ -1097,7 +1095,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val dummyKey = PrivateKey(ByteVector32("0101010101010101010101010101010101010101010101010101010101010101")).publicKey()
             val dummyUpdate = ChannelUpdate(
                 signature = ByteVector64.Zeroes,
-                chainHash = ByteVector32.Zeroes,
+                chainHash = BlockHash(ByteVector32.Zeroes),
                 shortChannelId = ShortChannelId(144, 0, 0),
                 timestampSeconds = 0,
                 messageFlags = 0,
@@ -1160,7 +1158,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
 
         private fun makeReceivedWithNewChannel(payToOpen: PayToOpenRequest, feeRatio: Double = 0.1): IncomingPayment.ReceivedWith.NewChannel {
             val fee = payToOpen.amountMsat * feeRatio
-            return IncomingPayment.ReceivedWith.NewChannel(amount = payToOpen.amountMsat - fee, serviceFee = fee, miningFee = 0.sat, channelId = randomBytes32(), txId = randomBytes32(), confirmedAt = null, lockedAt = null)
+            return IncomingPayment.ReceivedWith.NewChannel(amount = payToOpen.amountMsat - fee, serviceFee = fee, miningFee = 0.sat, channelId = randomBytes32(), txId = TxId(randomBytes32()), confirmedAt = null, lockedAt = null)
         }
 
         private suspend fun checkDbPayment(incomingPayment: IncomingPayment, db: IncomingPaymentsDb) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
@@ -67,7 +67,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
     private val remotePaymentPriv = PrivateKey(randomBytes32())
     private val localHtlcPriv = PrivateKey(randomBytes32())
     private val remoteHtlcPriv = PrivateKey(randomBytes32())
-    private val commitInput = Funding.makeFundingInputInfo(randomBytes32(), 0, 1.btc, localFundingPriv.publicKey(), remoteFundingPriv.publicKey())
+    private val commitInput = Funding.makeFundingInputInfo(TxId(randomBytes32()), 0, 1.btc, localFundingPriv.publicKey(), remoteFundingPriv.publicKey())
     private val toLocalDelay = CltvExpiryDelta(144)
     private val localDustLimit = 546.sat
     private val feerate = FeeratePerKw(22_000.sat)
@@ -120,7 +120,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             // ClaimHtlcDelayedTx
             // first we create a fake htlcSuccessOrTimeoutTx tx, containing only the output that will be spent by the ClaimDelayedOutputTx
             val pubKeyScript = write(pay2wsh(toLocalDelayed(localRevocationPriv.publicKey(), toLocalDelay, localPaymentPriv.publicKey())))
-            val htlcSuccessOrTimeoutTx = Transaction(version = 0, txIn = listOf(TxIn(OutPoint(ByteVector32.Zeroes, 0), TxIn.SEQUENCE_FINAL)), txOut = listOf(TxOut(20000.sat, pubKeyScript)), lockTime = 0)
+            val htlcSuccessOrTimeoutTx = Transaction(version = 0, txIn = listOf(TxIn(OutPoint(TxId(ByteVector32.Zeroes), 0), TxIn.SEQUENCE_FINAL)), txOut = listOf(TxOut(20000.sat, pubKeyScript)), lockTime = 0)
             val claimHtlcDelayedTx = makeClaimLocalDelayedOutputTx(htlcSuccessOrTimeoutTx, localDustLimit, localRevocationPriv.publicKey(), toLocalDelay, localPaymentPriv.publicKey(), finalPubKeyScript, feeratePerKw)
             assertTrue(claimHtlcDelayedTx is Success, "is $claimHtlcDelayedTx")
             // we use dummy signatures to compute the weight
@@ -132,7 +132,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             // MainPenaltyTx
             // first we create a fake commitTx tx, containing only the output that will be spent by the MainPenaltyTx
             val pubKeyScript = write(pay2wsh(toLocalDelayed(localRevocationPriv.publicKey(), toLocalDelay, localPaymentPriv.publicKey())))
-            val commitTx = Transaction(version = 0, txIn = listOf(TxIn(OutPoint(ByteVector32.Zeroes, 0), TxIn.SEQUENCE_FINAL)), txOut = listOf(TxOut(20000.sat, pubKeyScript)), lockTime = 0)
+            val commitTx = Transaction(version = 0, txIn = listOf(TxIn(OutPoint(TxId(ByteVector32.Zeroes), 0), TxIn.SEQUENCE_FINAL)), txOut = listOf(TxOut(20000.sat, pubKeyScript)), lockTime = 0)
             val mainPenaltyTx = makeMainPenaltyTx(commitTx, localDustLimit, localRevocationPriv.publicKey(), finalPubKeyScript, toLocalDelay, localPaymentPriv.publicKey(), feeratePerKw)
             assertTrue(mainPenaltyTx is Success, "is $mainPenaltyTx")
             // we use dummy signatures to compute the weight
@@ -147,7 +147,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             val htlc = UpdateAddHtlc(ByteVector32.Zeroes, 0, (20000 * 1000).msat, ByteVector32(sha256(paymentPreimage)), CltvExpiryDelta(144).toCltvExpiry(blockHeight.toLong()), TestConstants.emptyOnionPacket)
             val redeemScript = htlcReceived(localHtlcPriv.publicKey(), remoteHtlcPriv.publicKey(), localRevocationPriv.publicKey(), ripemd160(htlc.paymentHash), htlc.cltvExpiry)
             val pubKeyScript = write(pay2wsh(redeemScript))
-            val commitTx = Transaction(version = 0, txIn = listOf(TxIn(OutPoint(ByteVector32.Zeroes, 0), TxIn.SEQUENCE_FINAL)), txOut = listOf(TxOut(htlc.amountMsat.truncateToSatoshi(), pubKeyScript)), lockTime = 0)
+            val commitTx = Transaction(version = 0, txIn = listOf(TxIn(OutPoint(TxId(ByteVector32.Zeroes), 0), TxIn.SEQUENCE_FINAL)), txOut = listOf(TxOut(htlc.amountMsat.truncateToSatoshi(), pubKeyScript)), lockTime = 0)
             val htlcPenaltyTx = makeHtlcPenaltyTx(commitTx, 0, write(redeemScript), localDustLimit, finalPubKeyScript, feeratePerKw)
             assertTrue(htlcPenaltyTx is Success, "is $htlcPenaltyTx")
             // we use dummy signatures to compute the weight
@@ -175,7 +175,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
                     remoteHtlcPriv.publicKey(),
                     spec
                 )
-            val commitTx = Transaction(version = 0, txIn = listOf(TxIn(OutPoint(ByteVector32.Zeroes, 0), TxIn.SEQUENCE_FINAL)), txOut = outputs.map { it.output }, lockTime = 0)
+            val commitTx = Transaction(version = 0, txIn = listOf(TxIn(OutPoint(TxId(ByteVector32.Zeroes), 0), TxIn.SEQUENCE_FINAL)), txOut = outputs.map { it.output }, lockTime = 0)
             val claimHtlcSuccessTx =
                 makeClaimHtlcSuccessTx(commitTx, outputs, localDustLimit, remoteHtlcPriv.publicKey(), localHtlcPriv.publicKey(), localRevocationPriv.publicKey(), finalPubKeyScript, htlc, feeratePerKw)
             assertTrue(claimHtlcSuccessTx is Success, "is $claimHtlcSuccessTx")
@@ -204,7 +204,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
                     remoteHtlcPriv.publicKey(),
                     spec
                 )
-            val commitTx = Transaction(version = 0, txIn = listOf(TxIn(OutPoint(ByteVector32.Zeroes, 0), TxIn.SEQUENCE_FINAL)), txOut = outputs.map { it.output }, lockTime = 0)
+            val commitTx = Transaction(version = 0, txIn = listOf(TxIn(OutPoint(TxId(ByteVector32.Zeroes), 0), TxIn.SEQUENCE_FINAL)), txOut = outputs.map { it.output }, lockTime = 0)
             val claimHtlcTimeoutTx =
                 makeClaimHtlcTimeoutTx(commitTx, outputs, localDustLimit, remoteHtlcPriv.publicKey(), localHtlcPriv.publicKey(), localRevocationPriv.publicKey(), finalPubKeyScript, htlc, feeratePerKw)
             assertTrue(claimHtlcTimeoutTx is Success, "is $claimHtlcTimeoutTx")
@@ -218,7 +218,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
     @Test
     fun `generate valid commitment and htlc transactions`() {
         val finalPubKeyScript = write(pay2wpkh(PrivateKey(ByteVector32("01".repeat(32))).publicKey()))
-        val commitInput = Funding.makeFundingInputInfo(ByteVector32("02".repeat(32)), 0, 1.btc, localFundingPriv.publicKey(), remoteFundingPriv.publicKey())
+        val commitInput = Funding.makeFundingInputInfo(TxId(ByteVector32("02".repeat(32))), 0, 1.btc, localFundingPriv.publicKey(), remoteFundingPriv.publicKey())
 
         // htlc1 and htlc2 are regular IN/OUT htlcs
         val paymentPreimage1 = ByteVector32("03".repeat(32))
@@ -446,7 +446,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
         val userWallet = TestConstants.Alice.keyManager.swapInOnChainWallet
         val swapInTx = Transaction(
             version = 2,
-            txIn = listOf(TxIn(OutPoint(randomBytes32(), 2), 0)),
+            txIn = listOf(TxIn(OutPoint(TxId(randomBytes32()), 2), 0)),
             txOut = listOf(TxOut(100_000.sat, userWallet.pubkeyScript)),
             lockTime = 0
         )
@@ -485,10 +485,10 @@ class TransactionsTestsCommon : LightningTestSuite() {
         val pubkey = randomKey().publicKey()
         // DER-encoded ECDSA signatures usually take up to 72 bytes.
         val sig = randomBytes(72).toByteVector()
-        val tx = Transaction(2, listOf(TxIn(OutPoint(ByteVector32.Zeroes, 2), 0)), listOf(TxOut(50_000.sat, pay2wpkh(pubkey))), 0)
+        val tx = Transaction(2, listOf(TxIn(OutPoint(TxId(ByteVector32.Zeroes), 2), 0)), listOf(TxOut(50_000.sat, pay2wpkh(pubkey))), 0)
         val redeemScript = Scripts.swapIn2of2(pubkey, pubkey, 144)
         val witness = ScriptWitness(listOf(sig, sig, write(redeemScript).byteVector()))
-        val swapInput = TxIn(OutPoint(ByteVector32.Zeroes, 3), ByteVector.empty, 0, witness)
+        val swapInput = TxIn(OutPoint(TxId(ByteVector32.Zeroes), 3), ByteVector.empty, 0, witness)
         val txWithAdditionalInput = tx.copy(txIn = tx.txIn + listOf(swapInput))
         val inputWeight = txWithAdditionalInput.weight() - tx.weight()
         assertEquals(inputWeight, swapInputWeight)
@@ -504,7 +504,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
         val remotePaymentPriv = PrivateKey.fromHex("a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6a6")
         val localHtlcPriv = PrivateKey.fromHex("a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7")
         val remoteHtlcPriv = PrivateKey.fromHex("a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8")
-        val commitInput = Funding.makeFundingInputInfo(ByteVector32.fromValidHex("a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"), 0, 1.btc, localFundingPriv.publicKey(), remoteFundingPriv.publicKey())
+        val commitInput = Funding.makeFundingInputInfo(TxId("a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"), 0, 1.btc, localFundingPriv.publicKey(), remoteFundingPriv.publicKey())
 
         // htlc1 and htlc2 are two regular incoming HTLCs with different amounts.
         // htlc2 and htlc3 have the same amounts and should be sorted according to their scriptPubKey

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -277,7 +277,7 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
     @Test
     fun `encode - decode open_channel`() {
         // @formatter:off
-        val defaultOpen = OpenDualFundedChannel(ByteVector32.Zeroes, ByteVector32.One, FeeratePerKw(5000.sat), FeeratePerKw(4000.sat), 250_000.sat, 500.sat, 50_000, 15.msat, CltvExpiryDelta(144), 483, 650_000, publicKey(1), publicKey(2), publicKey(3), publicKey(4), publicKey(5), publicKey(6), publicKey(7), 1.toByte())
+        val defaultOpen = OpenDualFundedChannel(BlockHash(ByteVector32.Zeroes), ByteVector32.One, FeeratePerKw(5000.sat), FeeratePerKw(4000.sat), 250_000.sat, 500.sat, 50_000, 15.msat, CltvExpiryDelta(144), 483, 650_000, publicKey(1), publicKey(2), publicKey(3), publicKey(4), publicKey(5), publicKey(6), publicKey(7), 1.toByte())
         val defaultEncoded = ByteVector("0040 0000000000000000000000000000000000000000000000000000000000000000 0100000000000000000000000000000000000000000000000000000000000000 00001388 00000fa0 000000000003d090 00000000000001f4 000000000000c350 000000000000000f 0090 01e3 0009eb10 031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f 024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766 02531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337 03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b 0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f7 03f006a18d5653c4edf5391ff23a61f03ff83d237e880ee61187fa9f379a028e0a 02989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f 01")
         val testCases = listOf(
             defaultOpen to defaultEncoded,
@@ -427,7 +427,7 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
     @Test
     fun `encode - decode splice messages`() {
         val channelId = ByteVector32("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-        val fundingTxHash = ByteVector32("24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566")
+        val fundingTxId = TxId(TxHash("24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566"))
         val fundingPubkey = PublicKey(ByteVector.fromHex("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"))
         val testCases = listOf(
             // @formatter:off
@@ -439,7 +439,7 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
             SpliceAck(channelId, 40_000.sat, 10_000_000.msat, fundingPubkey) to ByteVector("908a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0000000000009c40 0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798 fe4700000703989680"),
             SpliceAck(channelId, 0.sat, fundingPubkey) to ByteVector("908a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0000000000000000 0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"),
             SpliceAck(channelId, (-25_000).sat, fundingPubkey) to ByteVector("908a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ffffffffffff9e58 0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"),
-            SpliceLocked(channelId, fundingTxHash) to ByteVector("908c aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566"),
+            SpliceLocked(channelId, fundingTxId) to ByteVector("908c aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566"),
             // @formatter:on
         )
         testCases.forEach { (message, bin) ->
@@ -456,11 +456,11 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
         val channelId = ByteVector32("c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c")
         val commitmentSecret = PrivateKey.fromHex("34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55")
         val commitmentPoint = PublicKey.fromHex("02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867")
-        val fundingTxHash = ByteVector32("24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566")
+        val fundingTxId = TxId(TxHash("24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566"))
         val testCases = listOf(
             // @formatter:off
             ChannelReestablish(channelId, 242842, 42, commitmentSecret, commitmentPoint) to ByteVector("0088 c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c 000000000003b49a 000000000000002a 34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55 02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867"),
-            ChannelReestablish(channelId, 242842, 42, commitmentSecret, commitmentPoint, TlvStream(ChannelReestablishTlv.NextFunding(fundingTxHash))) to ByteVector("0088 c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c 000000000003b49a 000000000000002a 34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55 02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867 00 20 24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566")
+            ChannelReestablish(channelId, 242842, 42, commitmentSecret, commitmentPoint, TlvStream(ChannelReestablishTlv.NextFunding(fundingTxId))) to ByteVector("0088 c11b8fbd682b3c6ee11f9d7268e22bb5887cd4d3bf3338bfcc340583f685733c 000000000003b49a 000000000000002a 34f159d37cf7b5de52ec0adc3968886232f90d272e8c82e8b6f7fcb7e57c4b55 02bf050efff417efc09eb211ca9e4e845920e2503740800e88505b25e6f0e1e867 00 20 24e1b2c94c4e734dd5b9c5f3c910fbb6b3b436ced6382c7186056a5a23f14566")
             // @formatter:on
         )
         testCases.forEach { (message, bin) ->
@@ -476,7 +476,7 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
     fun `encode - decode channel_update`() {
         val channelUpdate = ChannelUpdate(
             randomBytes64(),
-            randomBytes32(),
+            BlockHash(randomBytes32()),
             ShortChannelId(561),
             1105,
             0,
@@ -500,7 +500,7 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
         val decoded = LightningMessage.decode(encoded.toByteArray())
         val expected = ChannelUpdate(
             ByteVector64("58fff7d0e987e2cdd560e3bb5a046b4efe7b26c969c2f51da1dceec7bcb8ae1b634790503d5290c1a6c51d681cf8f4211d27ed33a257dcc1102862571bf17923"),
-            ByteVector32("06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f"),
+            BlockHash("06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f"),
             ShortChannelId(0x5a10000020000L),
             1539791129,
             1,
@@ -520,7 +520,7 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
     fun `encode - decode channel_update with unknown trailing bytes`() {
         val channelUpdate = ChannelUpdate(
             randomBytes64(),
-            randomBytes32(),
+            BlockHash(randomBytes32()),
             ShortChannelId(561),
             1105,
             0,
@@ -546,7 +546,7 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
                 randomBytes64(),
                 randomBytes64(),
                 Features(Hex.decode("09004200")),
-                randomBytes32(),
+                BlockHash(randomBytes32()),
                 ShortChannelId(42),
                 randomKey().publicKey(),
                 randomKey().publicKey(),
@@ -559,7 +559,7 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
                 randomBytes64(),
                 randomBytes64(),
                 Features(mapOf()),
-                randomBytes32(),
+                BlockHash(randomBytes32()),
                 ShortChannelId(42),
                 randomKey().publicKey(),
                 randomKey().publicKey(),
@@ -628,7 +628,7 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
     @Test
     fun `nonreg backup channel data`() {
         val channelId = randomBytes32()
-        val txHash = randomBytes32()
+        val txHash = TxHash(randomBytes32())
         val signature = randomBytes64()
         val key = randomKey()
         val point = randomKey().publicKey()
@@ -644,10 +644,10 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
             Hex.decode("0088") + channelId.toByteArray() + Hex.decode("0001020304050607 0809aabbccddeeff") + key.value.toByteArray() + point.value.toByteArray() + Hex.decode("fe47010000 07 bbbbbbbbbbbbbb") to ChannelReestablish(channelId, 0x01020304050607L, 0x0809aabbccddeeffL, key, point).withChannelData(ByteVector("bbbbbbbbbbbbbb")),
             Hex.decode("0088") + channelId.toByteArray() + Hex.decode("0001020304050607 0809aabbccddeeff") + key.value.toByteArray() + point.value.toByteArray() + Hex.decode("01 02 0102") + Hex.decode("fe47010000 07 bbbbbbbbbbbbbb") to ChannelReestablish(channelId, 0x01020304050607L, 0x0809aabbccddeeffL, key, point, TlvStream(setOf(ChannelReestablishTlv.ChannelData(EncryptedChannelData(ByteVector("bbbbbbbbbbbbbb")))), setOf(GenericTlv(1, ByteVector("0102"))))),
             // tx_signatures
-            Hex.decode("0047") + channelId.toByteArray() + txHash.toByteArray() + Hex.decode("0000") to TxSignatures(channelId, txHash, listOf()),
-            Hex.decode("0047") + channelId.toByteArray() + txHash.toByteArray() + Hex.decode("0000 fe47010000 00") to TxSignatures(channelId, txHash, listOf(), TlvStream(TxSignaturesTlv.ChannelData(EncryptedChannelData.empty))),
-            Hex.decode("0047") + channelId.toByteArray() + txHash.toByteArray() + Hex.decode("0000 fe47010000 04 deadbeef") to TxSignatures(channelId, txHash, listOf(), TlvStream(TxSignaturesTlv.ChannelData(EncryptedChannelData(ByteVector("deadbeef"))))),
-            Hex.decode("0047") + channelId.toByteArray() + txHash.toByteArray() + Hex.decode("0000 2b012a fe47010000 04 deadbeef") to TxSignatures(channelId, txHash, listOf(), TlvStream(setOf(TxSignaturesTlv.ChannelData(EncryptedChannelData(ByteVector("deadbeef")))), setOf(GenericTlv(43, ByteVector("2a"))))),
+            Hex.decode("0047") + channelId.toByteArray() + txHash.value.toByteArray() + Hex.decode("0000") to TxSignatures(channelId, TxId(txHash), listOf()),
+            Hex.decode("0047") + channelId.toByteArray() + txHash.value.toByteArray() + Hex.decode("0000 fe47010000 00") to TxSignatures(channelId, TxId(txHash), listOf(), TlvStream(TxSignaturesTlv.ChannelData(EncryptedChannelData.empty))),
+            Hex.decode("0047") + channelId.toByteArray() + txHash.value.toByteArray() + Hex.decode("0000 fe47010000 04 deadbeef") to TxSignatures(channelId, TxId(txHash), listOf(), TlvStream(TxSignaturesTlv.ChannelData(EncryptedChannelData(ByteVector("deadbeef"))))),
+            Hex.decode("0047") + channelId.toByteArray() + txHash.value.toByteArray() + Hex.decode("0000 2b012a fe47010000 04 deadbeef") to TxSignatures(channelId, TxId(txHash), listOf(), TlvStream(setOf(TxSignaturesTlv.ChannelData(EncryptedChannelData(ByteVector("deadbeef")))), setOf(GenericTlv(43, ByteVector("2a"))))),
             // commit_sig
             Hex.decode("0084") + channelId.toByteArray() + signature.toByteArray() + Hex.decode("0000") to CommitSig(channelId, signature, listOf()),
             Hex.decode("0084") + channelId.toByteArray() + signature.toByteArray() + Hex.decode("0000") + Hex.decode("01 02 0102") to CommitSig(channelId, signature, listOf(), TlvStream(setOf(), setOf(GenericTlv(1, ByteVector("0102"))))),
@@ -694,7 +694,7 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
         val aboveLimit = EncryptedChannelData(ByteVector(ByteArray(60000) { 42 }))
         val messages = listOf(
             ChannelReestablish(randomBytes32(), 0, 0, randomKey(), randomKey().publicKey()),
-            TxSignatures(randomBytes32(), randomBytes32(), listOf()),
+            TxSignatures(randomBytes32(), TxId(randomBytes32()), listOf()),
             CommitSig(randomBytes32(), randomBytes64(), listOf()),
             RevokeAndAck(randomBytes32(), randomKey(), randomKey().publicKey()),
             Shutdown(randomBytes32(), ByteVector("deadbeef")),
@@ -718,10 +718,10 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
     @Test
     fun `encode - decode pay-to-open messages`() {
         val testCases = listOf(
-            PayToOpenRequest(randomBytes32(), 10_000.sat, 5_000.msat, 100.msat, 10.sat, randomBytes32(), 100, OnionRoutingPacket(0, randomKey().publicKey().value, ByteVector("0102030405"), randomBytes32())),
-            PayToOpenResponse(randomBytes32(), randomBytes32(), PayToOpenResponse.Result.Success(randomBytes32())),
-            PayToOpenResponse(randomBytes32(), randomBytes32(), PayToOpenResponse.Result.Failure(null)),
-            PayToOpenResponse(randomBytes32(), randomBytes32(), PayToOpenResponse.Result.Failure(ByteVector("deadbeef"))),
+            PayToOpenRequest(BlockHash(randomBytes32()), 10_000.sat, 5_000.msat, 100.msat, 10.sat, randomBytes32(), 100, OnionRoutingPacket(0, randomKey().publicKey().value, ByteVector("0102030405"), randomBytes32())),
+            PayToOpenResponse(BlockHash(randomBytes32()), randomBytes32(), PayToOpenResponse.Result.Success(randomBytes32())),
+            PayToOpenResponse(BlockHash(randomBytes32()), randomBytes32(), PayToOpenResponse.Result.Failure(null)),
+            PayToOpenResponse(BlockHash(randomBytes32()), randomBytes32(), PayToOpenResponse.Result.Failure(ByteVector("deadbeef"))),
         )
 
         testCases.forEach {
@@ -738,8 +738,8 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
             // @formatter:off
             PleaseOpenChannel(Block.RegtestGenesisBlock.hash, ByteVector32("2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25"), 123_456.sat, 2, 522_000) to Hex.decode("8ca1 06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f 2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25 000000000001e240 0002 0007f710"),
             PleaseOpenChannel(Block.RegtestGenesisBlock.hash, ByteVector32("2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25"), 123_456.sat, 2, 522_000, TlvStream(PleaseOpenChannelTlv.GrandParents(listOf()))) to Hex.decode("8ca1 06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f 2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25 000000000001e240 0002 0007f710 fd023100"),
-            PleaseOpenChannel(Block.RegtestGenesisBlock.hash, ByteVector32("2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25"), 123_456.sat, 2, 522_000, TlvStream(PleaseOpenChannelTlv.GrandParents(listOf(OutPoint(ByteVector32("d0556c8cc004933f40b9ca5e87e18cb549298fb02d7e64b0c0ee95303485145a"), 5))))) to Hex.decode("8ca1 06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f 2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25 000000000001e240 0002 0007f710 fd023128d0556c8cc004933f40b9ca5e87e18cb549298fb02d7e64b0c0ee95303485145a0000000000000005"),
-            PleaseOpenChannel(Block.RegtestGenesisBlock.hash, ByteVector32("2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25"), 123_456.sat, 2, 522_000, TlvStream(PleaseOpenChannelTlv.GrandParents(listOf(OutPoint(ByteVector32("572b045edb5f0e3ff667e914e368273b11a874fae56a735b332b54048b7978c2"), 0), OutPoint(ByteVector32("cd6ac843158a1c317021de1323cdd2071f0f59744f79b298a8a45fda2dd7989f"), 1105))))) to Hex.decode("8ca1 06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f 2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25 000000000001e240 0002 0007f710 fd023150572b045edb5f0e3ff667e914e368273b11a874fae56a735b332b54048b7978c20000000000000000cd6ac843158a1c317021de1323cdd2071f0f59744f79b298a8a45fda2dd7989f0000000000000451"),
+            PleaseOpenChannel(Block.RegtestGenesisBlock.hash, ByteVector32("2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25"), 123_456.sat, 2, 522_000, TlvStream(PleaseOpenChannelTlv.GrandParents(listOf(OutPoint(TxHash("d0556c8cc004933f40b9ca5e87e18cb549298fb02d7e64b0c0ee95303485145a"), 5))))) to Hex.decode("8ca1 06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f 2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25 000000000001e240 0002 0007f710 fd023128d0556c8cc004933f40b9ca5e87e18cb549298fb02d7e64b0c0ee95303485145a0000000000000005"),
+            PleaseOpenChannel(Block.RegtestGenesisBlock.hash, ByteVector32("2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25"), 123_456.sat, 2, 522_000, TlvStream(PleaseOpenChannelTlv.GrandParents(listOf(OutPoint(TxHash("572b045edb5f0e3ff667e914e368273b11a874fae56a735b332b54048b7978c2"), 0), OutPoint(TxHash("cd6ac843158a1c317021de1323cdd2071f0f59744f79b298a8a45fda2dd7989f"), 1105))))) to Hex.decode("8ca1 06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f 2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25 000000000001e240 0002 0007f710 fd023150572b045edb5f0e3ff667e914e368273b11a874fae56a735b332b54048b7978c20000000000000000cd6ac843158a1c317021de1323cdd2071f0f59744f79b298a8a45fda2dd7989f0000000000000451"),
             // @formatter:on
         )
 


### PR DESCRIPTION
This helps disambiguate when each is used. Even though confusingly, Electrum calls its field `tx_hash` while actually returning the `txid`.

This is mostly a trivial replacement from `ByteVector32` to `TxId` and removing a lot of calls to `reversed()`. The only subtle parts are in the `wire` package, where we now only expose `TxId` but in most cases actually encode/decode a `tx_hash`.