### PR TITLE
Add `fundingTxIndex` to `commitments.isMoreRecent`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -549,7 +549,8 @@ data class Commitments(
     fun isMoreRecent(other: Commitments): Boolean {
         return this.localCommitIndex > other.localCommitIndex ||
                 this.remoteCommitIndex > other.remoteCommitIndex ||
-                (this.remoteCommitIndex == other.remoteCommitIndex && this.remoteNextCommitInfo.isLeft && other.remoteNextCommitInfo.isRight)
+                (this.remoteCommitIndex == other.remoteCommitIndex && this.remoteNextCommitInfo.isLeft && other.remoteNextCommitInfo.isRight) ||
+                this.latest.fundingTxIndex > other.latest.fundingTxIndex
     }
 
     // @formatter:off

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SpliceTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SpliceTestsCommon.kt
@@ -919,6 +919,10 @@ class SpliceTestsCommon : LightningTestSuite() {
 
             assertEquals(alice.commitments.active.size + 1, alice2.commitments.active.size)
             assertEquals(bob.commitments.active.size + 1, bob2.commitments.active.size)
+
+            assertTrue { alice2.commitments.isMoreRecent(alice.commitments) }
+            assertTrue { bob2.commitments.isMoreRecent(bob.commitments) }
+
             assertIs<LNChannel<Normal>>(alice2)
             assertIs<LNChannel<Normal>>(bob2)
             return Pair(alice2, bob2)


### PR DESCRIPTION
We cannot only rely on the commitment index, because splicing doesn't change the commitment index. After a restore we could be on the same commitment index but on a future funding index.