### PR TITLE
Fix race condition in connection to Peer

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -282,12 +282,11 @@ class Peer(
     fun disconnect() {
         if (this::socket.isInitialized) socket.close()
         _connectionState.value = Connection.CLOSED(null)
-        // TODO in exception handler? output.close()
     }
 
     // Warning : lateinit vars have to be used AFTER their init to avoid any crashes
     //
-    // This shouldn't be used outside the establishedConnection() function
+    // This shouldn't be used outside the establishConnection() function
     // Except from the disconnect() one that check if the lateinit var has been initialized
     private lateinit var socket: TcpSocket
     private fun establishConnection() = launch {
@@ -369,6 +368,8 @@ class Peer(
             } catch (ex: TcpSocket.IOException) {
                 logger.warning { "TCP receive: ${ex.message}" }
                 closeSocket(ex)
+            } finally {
+                peerConnection.output.close()
             }
         }
 
@@ -383,6 +384,8 @@ class Peer(
             } catch (ex: TcpSocket.IOException) {
                 logger.warning { "TCP send: ${ex.message}" }
                 closeSocket(ex)
+            } finally {
+                peerConnection.output.close()
             }
         }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -271,8 +271,12 @@ class Peer(
     }
 
     fun connect() {
-        if (connectionState.value is Connection.CLOSED) establishConnection()
-        else logger.warning { "Peer is already connecting / connected" }
+        if (connectionState.value is Connection.CLOSED) {
+            _connectionState.value = Connection.ESTABLISHING
+            establishConnection()
+        } else {
+            logger.warning { "Peer is already connecting / connected" }
+        }
     }
 
     fun disconnect() {
@@ -288,7 +292,6 @@ class Peer(
     private lateinit var socket: TcpSocket
     private fun establishConnection() = launch {
         logger.info { "connecting to ${walletParams.trampolineNode.host}" }
-        _connectionState.value = Connection.ESTABLISHING
         socket = try {
             socketBuilder?.connect(
                 host = walletParams.trampolineNode.host,

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
-import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.*
 import org.kodein.log.newLogger
 import kotlin.time.Duration.Companion.seconds
@@ -51,7 +50,7 @@ data class OpenChannel(
 
 data class PeerConnection(val id: Long, val output: Channel<ByteArray>)
 data class Connected(val peerConnection: PeerConnection) : PeerCommand()
-data class BytesReceived(val data: ByteArray) : PeerCommand()
+data class BytesReceived(val data: ByteArray, val connectionId: Long = 0) : PeerCommand()
 data class WatchReceived(val watch: WatchEvent) : PeerCommand()
 data class WrappedChannelCommand(val channelId: ByteVector32, val channelCommand: ChannelCommand) : PeerCommand()
 object Disconnected : PeerCommand()
@@ -116,8 +115,6 @@ class Peer(
     // We use unlimited buffers, otherwise we may end up in a deadlock since we're both
     // receiving *and* sending to those channels in the same coroutine.
     private val input = Channel<PeerCommand>(UNLIMITED)
-    private var output = Channel<ByteArray>(UNLIMITED)
-    val outputLightningMessages: ReceiveChannel<ByteArray> get() = output
 
     private val swapInCommands = Channel<SwapInCommand>(Channel.UNLIMITED)
 
@@ -282,7 +279,7 @@ class Peer(
     fun disconnect() {
         if (this::socket.isInitialized) socket.close()
         _connectionState.value = Connection.CLOSED(null)
-        output.close()
+        // TODO in exception handler? output.close()
     }
 
     // Warning : lateinit vars have to be used AFTER their init to avoid any crashes
@@ -336,7 +333,7 @@ class Peer(
         val session = LightningSession(enc, dec, ck)
 
         // TODO use atomic counter instead
-        val peerConnection = PeerConnection(id = currentTimestampMillis(), output)
+        val peerConnection = PeerConnection(id = currentTimestampMillis(), output = Channel(UNLIMITED))
         // inform the peer about the new connection
         input.send(Connected(peerConnection))
 
@@ -359,7 +356,7 @@ class Peer(
             try {
                 while (isActive) {
                     val received = session.receive { size -> socket.receiveFully(size) }
-                    input.send(BytesReceived(received))
+                    input.send(BytesReceived(received, peerConnection.id))
                 }
                 closeSocket(null)
             } catch (ex: TcpSocket.IOException) {
@@ -369,10 +366,8 @@ class Peer(
         }
 
         suspend fun respond() {
-            // Reset the output channel to avoid sending obsolete messages
-            output = Channel(UNLIMITED)
             try {
-                for (msg in output) session.send(message) { data, flush -> socket.send(data, flush) }
+                for (msg in peerConnection.output) session.send(msg) { data, flush -> socket.send(data, flush) }
             } catch (ex: TcpSocket.IOException) {
                 logger.warning { "TCP send: ${ex.message}" }
                 closeSocket(ex)
@@ -527,7 +522,7 @@ class Peer(
         val encoded = LightningMessage.encode(msg)
         // Avoids polluting the logs with pings/pongs
         if (msg !is Ping && msg !is Pong) logger.info { "sending $msg" }
-        if (!output.isClosedForSend) output.send(encoded)
+        peerConnection?.output?.run { if (!isClosedForSend) send(encoded) }
     }
 
     // The (node_id, fcm_token) tuple only needs to be registered once.
@@ -735,13 +730,21 @@ class Peer(
         }
     }
 
+    // MUST ONLY BE SET BY processEvent()
+    var peerConnection: PeerConnection? = null
+
     private suspend fun processEvent(cmd: PeerCommand) {
         when (cmd) {
             is Connected -> {
-                logger.info { "sending init $ourInit" }
+                logger.info { "new connection with id=${cmd.peerConnection.id}, sending init $ourInit" }
+                peerConnection = cmd.peerConnection
                 sendToPeer(ourInit)
             }
             is BytesReceived -> {
+                if (cmd.connectionId != peerConnection?.id) {
+                    logger.warning { "ignoring ${cmd.data} for connectionId=${cmd.connectionId}"}
+                    return
+                }
                 val msg = try {
                     LightningMessage.decode(cmd.data)
                 } catch (e: Throwable) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -351,7 +351,7 @@ class Peer(
             }
         }
 
-        suspend fun listen() {
+        suspend fun receiveLoop() {
             try {
                 while (isActive) {
                     val received = session.receive { size -> socket.receiveFully(size) }
@@ -369,7 +369,7 @@ class Peer(
             }
         }
 
-        suspend fun respond() {
+        suspend fun sendLoop() {
             try {
                 for (msg in peerConnection.output) {
                     // Avoids polluting the logs with pings/pongs
@@ -385,9 +385,9 @@ class Peer(
 
         launch { doPing() }
         launch { checkPaymentsTimeout() }
-        launch { respond() }
+        launch { sendLoop() }
 
-        listen() // This suspends until the coroutines is cancelled or the socket is closed
+        receiveLoop() // This suspends until the coroutines is cancelled or the socket is closed
     }
 
     /**

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -49,7 +49,7 @@ data class OpenChannel(
 
 data class PeerConnection(val id: Long, val output: Channel<LightningMessage>)
 data class Connected(val peerConnection: PeerConnection) : PeerCommand()
-data class BytesReceived(val msg: LightningMessage, val connectionId: Long = 0) : PeerCommand()
+data class MessageReceived(val msg: LightningMessage, val connectionId: Long = 0) : PeerCommand()
 data class WatchReceived(val watch: WatchEvent) : PeerCommand()
 data class WrappedChannelCommand(val channelId: ByteVector32, val channelCommand: ChannelCommand) : PeerCommand()
 object Disconnected : PeerCommand()
@@ -357,7 +357,7 @@ class Peer(
                     val received = session.receive { size -> socket.receiveFully(size) }
                     try {
                         val msg = LightningMessage.decode(received)
-                        input.send(BytesReceived(msg, peerConnection.id))
+                        input.send(MessageReceived(msg, peerConnection.id))
                     } catch (e: Throwable) {
                         logger.warning { "cannot deserialized message: ${received.byteVector().toHex()}" }
                     }
@@ -746,7 +746,7 @@ class Peer(
                 peerConnection = cmd.peerConnection
                 sendToPeer(ourInit)
             }
-            is BytesReceived -> {
+            is MessageReceived -> {
                 if (cmd.connectionId != peerConnection?.id) {
                     logger.warning { "ignoring ${cmd.msg} for connectionId=${cmd.connectionId}"}
                     return

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -55,7 +55,7 @@ data class PeerConnection(val id: Long, val output: Channel<LightningMessage>) {
     }
 }
 data class Connected(val peerConnection: PeerConnection) : PeerCommand()
-data class MessageReceived(val msg: LightningMessage, val connectionId: Long) : PeerCommand()
+data class MessageReceived(val connectionId: Long, val msg: LightningMessage) : PeerCommand()
 data class WatchReceived(val watch: WatchEvent) : PeerCommand()
 data class WrappedChannelCommand(val channelId: ByteVector32, val channelCommand: ChannelCommand) : PeerCommand()
 object Disconnected : PeerCommand()
@@ -368,7 +368,7 @@ class Peer(
                     val received = session.receive { size -> socket.receiveFully(size) }
                     try {
                         val msg = LightningMessage.decode(received)
-                        input.send(MessageReceived(msg, peerConnection.id))
+                        input.send(MessageReceived(peerConnection.id, msg))
                     } catch (e: Throwable) {
                         logger.warning { "cannot deserialized message: ${received.byteVector().toHex()}" }
                     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -49,7 +49,7 @@ data class OpenChannel(
 
 data class PeerConnection(val id: Long, val output: Channel<LightningMessage>)
 data class Connected(val peerConnection: PeerConnection) : PeerCommand()
-data class MessageReceived(val msg: LightningMessage, val connectionId: Long = 0) : PeerCommand()
+data class MessageReceived(val msg: LightningMessage, val connectionId: Long) : PeerCommand()
 data class WatchReceived(val watch: WatchEvent) : PeerCommand()
 data class WrappedChannelCommand(val channelId: ByteVector32, val channelCommand: ChannelCommand) : PeerCommand()
 object Disconnected : PeerCommand()

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -708,7 +708,11 @@ class Peer(
             else -> throw RuntimeException("invalid state")
         }
 
-        val writer = makeWriter(ourKeys, theirPubkey)
+        val writer = HandshakeState.initializeWriter(
+            handshakePatternXK, prologue,
+            ourKeys, Pair(ByteArray(0), ByteArray(0)), theirPubkey, ByteArray(0),
+            Secp256k1DHFunctions, Chacha20Poly1305CipherFunctions, SHA256HashFunctions
+        )
         val (state1, message, _) = writer.write(ByteArray(0))
         w(byteArrayOf(prefix) + message)
 
@@ -721,18 +725,6 @@ class Peer(
         w(byteArrayOf(prefix) + message1)
         return Triple(enc, dec, ck)
     }
-
-    private fun makeWriter(localStatic: Pair<ByteArray, ByteArray>, remoteStatic: ByteArray) = HandshakeState.initializeWriter(
-        handshakePatternXK, prologue,
-        localStatic, Pair(ByteArray(0), ByteArray(0)), remoteStatic, ByteArray(0),
-        Secp256k1DHFunctions, Chacha20Poly1305CipherFunctions, SHA256HashFunctions
-    )
-
-    private fun makeReader(localStatic: Pair<ByteArray, ByteArray>) = HandshakeState.initializeReader(
-        handshakePatternXK, prologue,
-        localStatic, Pair(ByteArray(0), ByteArray(0)), ByteArray(0), ByteArray(0),
-        Secp256k1DHFunctions, Chacha20Poly1305CipherFunctions, SHA256HashFunctions
-    )
 
     private suspend fun run() {
         logger.info { "peer is active" }

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -62,9 +62,9 @@ class PeerTest : LightningTestSuite() {
         val bob = buildPeer(this, TestConstants.Bob.nodeParams, TestConstants.Bob.walletParams)
 
         // start Init for Alice
-        alice.send(MessageReceived(Init(features = TestConstants.Bob.nodeParams.features)))
+        alice.send(MessageReceived(Init(features = TestConstants.Bob.nodeParams.features), connectionId = 0))
         // start Init for Bob
-        bob.send(MessageReceived(Init(features = TestConstants.Alice.nodeParams.features)))
+        bob.send(MessageReceived(Init(features = TestConstants.Alice.nodeParams.features), connectionId = 0))
 
         // Wait until the Peer is ready
         alice.expectStatus(Connection.ESTABLISHED)
@@ -343,7 +343,7 @@ class PeerTest : LightningTestSuite() {
 
         // send Init from remote node
         val theirInit = Init(features = bob0.staticParams.nodeParams.features)
-        peer.send(MessageReceived(theirInit))
+        peer.send(MessageReceived(theirInit, connectionId = 0))
         // Wait until the Peer is ready
         peer.expectStatus(Connection.ESTABLISHED)
 
@@ -367,7 +367,7 @@ class PeerTest : LightningTestSuite() {
             myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint
         ).withChannelData(commitments.remoteChannelData)
 
-        peer.send(MessageReceived(channelReestablish))
+        peer.send(MessageReceived(channelReestablish, connectionId = 0))
 
         // Wait until the channels are Reestablished(=Normal)
         val reestablishChannels = peer.channelsFlow.first { it.values.isNotEmpty() && it.values.all { channelState -> channelState is Normal } }
@@ -388,7 +388,7 @@ class PeerTest : LightningTestSuite() {
     fun `restore channel -- unknown channel`() = runSuspendTest {
         val (alice, _, alice2bob) = newPeers(this, Pair(TestConstants.Alice.nodeParams, TestConstants.Bob.nodeParams), Pair(TestConstants.Alice.walletParams, TestConstants.Bob.walletParams))
         val unknownChannelReestablish = ChannelReestablish(randomBytes32(), 1, 0, randomKey(), randomKey().publicKey())
-        alice.send(MessageReceived(unknownChannelReestablish))
+        alice.send(MessageReceived(unknownChannelReestablish, connectionId = 0))
         alice2bob.expect<Error>()
     }
 
@@ -407,11 +407,11 @@ class PeerTest : LightningTestSuite() {
         )
 
         // Simulate a reconnection with Alice.
-        peer.send(MessageReceived(Init(features = alice0.staticParams.nodeParams.features)))
+        peer.send(MessageReceived(Init(features = alice0.staticParams.nodeParams.features), connectionId = 0))
         peer.expectStatus(Connection.ESTABLISHED)
         val aliceReestablish = alice1.state.run { alice1.ctx.createChannelReestablish() }
         assertFalse(aliceReestablish.channelData.isEmpty())
-        peer.send(MessageReceived(aliceReestablish))
+        peer.send(MessageReceived(aliceReestablish, connectionId = 0))
 
         // Wait until the channels are Syncing
         val restoredChannel = peer.channelsFlow
@@ -437,11 +437,11 @@ class PeerTest : LightningTestSuite() {
         )
 
         // Simulate a reconnection with Alice.
-        peer.send(MessageReceived(Init(features = alice0.staticParams.nodeParams.features)))
+        peer.send(MessageReceived(Init(features = alice0.staticParams.nodeParams.features), connectionId = 0))
         peer.expectStatus(Connection.ESTABLISHED)
         val aliceReestablish = alice1.state.run { alice1.ctx.createChannelReestablish() }
         assertFalse(aliceReestablish.channelData.isEmpty())
-        peer.send(MessageReceived(aliceReestablish))
+        peer.send(MessageReceived(aliceReestablish, connectionId = 0))
 
         // Wait until the channels are Syncing
         val restoredChannel = peer.channelsFlow

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -62,9 +62,9 @@ class PeerTest : LightningTestSuite() {
         val bob = buildPeer(this, TestConstants.Bob.nodeParams, TestConstants.Bob.walletParams)
 
         // start Init for Alice
-        alice.send(BytesReceived(Init(features = TestConstants.Bob.nodeParams.features)))
+        alice.send(MessageReceived(Init(features = TestConstants.Bob.nodeParams.features)))
         // start Init for Bob
-        bob.send(BytesReceived(Init(features = TestConstants.Alice.nodeParams.features)))
+        bob.send(MessageReceived(Init(features = TestConstants.Alice.nodeParams.features)))
 
         // Wait until the Peer is ready
         alice.expectStatus(Connection.ESTABLISHED)
@@ -343,7 +343,7 @@ class PeerTest : LightningTestSuite() {
 
         // send Init from remote node
         val theirInit = Init(features = bob0.staticParams.nodeParams.features)
-        peer.send(BytesReceived(theirInit))
+        peer.send(MessageReceived(theirInit))
         // Wait until the Peer is ready
         peer.expectStatus(Connection.ESTABLISHED)
 
@@ -367,7 +367,7 @@ class PeerTest : LightningTestSuite() {
             myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint
         ).withChannelData(commitments.remoteChannelData)
 
-        peer.send(BytesReceived(channelReestablish))
+        peer.send(MessageReceived(channelReestablish))
 
         // Wait until the channels are Reestablished(=Normal)
         val reestablishChannels = peer.channelsFlow.first { it.values.isNotEmpty() && it.values.all { channelState -> channelState is Normal } }
@@ -388,7 +388,7 @@ class PeerTest : LightningTestSuite() {
     fun `restore channel -- unknown channel`() = runSuspendTest {
         val (alice, _, alice2bob) = newPeers(this, Pair(TestConstants.Alice.nodeParams, TestConstants.Bob.nodeParams), Pair(TestConstants.Alice.walletParams, TestConstants.Bob.walletParams))
         val unknownChannelReestablish = ChannelReestablish(randomBytes32(), 1, 0, randomKey(), randomKey().publicKey())
-        alice.send(BytesReceived(unknownChannelReestablish))
+        alice.send(MessageReceived(unknownChannelReestablish))
         alice2bob.expect<Error>()
     }
 
@@ -407,11 +407,11 @@ class PeerTest : LightningTestSuite() {
         )
 
         // Simulate a reconnection with Alice.
-        peer.send(BytesReceived(Init(features = alice0.staticParams.nodeParams.features)))
+        peer.send(MessageReceived(Init(features = alice0.staticParams.nodeParams.features)))
         peer.expectStatus(Connection.ESTABLISHED)
         val aliceReestablish = alice1.state.run { alice1.ctx.createChannelReestablish() }
         assertFalse(aliceReestablish.channelData.isEmpty())
-        peer.send(BytesReceived(aliceReestablish))
+        peer.send(MessageReceived(aliceReestablish))
 
         // Wait until the channels are Syncing
         val restoredChannel = peer.channelsFlow
@@ -437,11 +437,11 @@ class PeerTest : LightningTestSuite() {
         )
 
         // Simulate a reconnection with Alice.
-        peer.send(BytesReceived(Init(features = alice0.staticParams.nodeParams.features)))
+        peer.send(MessageReceived(Init(features = alice0.staticParams.nodeParams.features)))
         peer.expectStatus(Connection.ESTABLISHED)
         val aliceReestablish = alice1.state.run { alice1.ctx.createChannelReestablish() }
         assertFalse(aliceReestablish.channelData.isEmpty())
-        peer.send(BytesReceived(aliceReestablish))
+        peer.send(MessageReceived(aliceReestablish))
 
         // Wait until the channels are Syncing
         val restoredChannel = peer.channelsFlow

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -12,12 +12,14 @@ import fr.acinq.lightning.blockchain.BITCOIN_FUNDING_DEPTHOK
 import fr.acinq.lightning.blockchain.WatchEventConfirmed
 import fr.acinq.lightning.blockchain.electrum.balance
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
-import fr.acinq.lightning.channel.*
+import fr.acinq.lightning.channel.ChannelType
+import fr.acinq.lightning.channel.LNChannel
+import fr.acinq.lightning.channel.Origin
+import fr.acinq.lightning.channel.TestsHelper
 import fr.acinq.lightning.channel.TestsHelper.createWallet
 import fr.acinq.lightning.channel.states.*
 import fr.acinq.lightning.db.InMemoryDatabases
 import fr.acinq.lightning.io.*
-import fr.acinq.lightning.payment.PaymentRequest
 import fr.acinq.lightning.router.Announcements
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.io.peer.*
@@ -25,7 +27,6 @@ import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.tests.utils.runSuspendTest
 import fr.acinq.lightning.utils.*
 import fr.acinq.lightning.wire.*
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlin.test.*
@@ -61,9 +62,9 @@ class PeerTest : LightningTestSuite() {
         val bob = buildPeer(this, TestConstants.Bob.nodeParams, TestConstants.Bob.walletParams)
 
         // start Init for Alice
-        alice.send(BytesReceived(LightningMessage.encode(Init(features = TestConstants.Bob.nodeParams.features))))
+        alice.send(BytesReceived(Init(features = TestConstants.Bob.nodeParams.features)))
         // start Init for Bob
-        bob.send(BytesReceived(LightningMessage.encode(Init(features = TestConstants.Alice.nodeParams.features))))
+        bob.send(BytesReceived(Init(features = TestConstants.Alice.nodeParams.features)))
 
         // Wait until the Peer is ready
         alice.expectStatus(Connection.ESTABLISHED)
@@ -342,8 +343,7 @@ class PeerTest : LightningTestSuite() {
 
         // send Init from remote node
         val theirInit = Init(features = bob0.staticParams.nodeParams.features)
-        val initMsg = LightningMessage.encode(theirInit)
-        peer.send(BytesReceived(initMsg))
+        peer.send(BytesReceived(theirInit))
         // Wait until the Peer is ready
         peer.expectStatus(Connection.ESTABLISHED)
 
@@ -367,8 +367,7 @@ class PeerTest : LightningTestSuite() {
             myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint
         ).withChannelData(commitments.remoteChannelData)
 
-        val reestablishMsg = LightningMessage.encode(channelReestablish)
-        peer.send(BytesReceived(reestablishMsg))
+        peer.send(BytesReceived(channelReestablish))
 
         // Wait until the channels are Reestablished(=Normal)
         val reestablishChannels = peer.channelsFlow.first { it.values.isNotEmpty() && it.values.all { channelState -> channelState is Normal } }
@@ -389,7 +388,7 @@ class PeerTest : LightningTestSuite() {
     fun `restore channel -- unknown channel`() = runSuspendTest {
         val (alice, _, alice2bob) = newPeers(this, Pair(TestConstants.Alice.nodeParams, TestConstants.Bob.nodeParams), Pair(TestConstants.Alice.walletParams, TestConstants.Bob.walletParams))
         val unknownChannelReestablish = ChannelReestablish(randomBytes32(), 1, 0, randomKey(), randomKey().publicKey())
-        alice.send(BytesReceived(LightningMessage.encode(unknownChannelReestablish)))
+        alice.send(BytesReceived(unknownChannelReestablish))
         alice2bob.expect<Error>()
     }
 
@@ -408,11 +407,11 @@ class PeerTest : LightningTestSuite() {
         )
 
         // Simulate a reconnection with Alice.
-        peer.send(BytesReceived(LightningMessage.encode(Init(features = alice0.staticParams.nodeParams.features))))
+        peer.send(BytesReceived(Init(features = alice0.staticParams.nodeParams.features)))
         peer.expectStatus(Connection.ESTABLISHED)
         val aliceReestablish = alice1.state.run { alice1.ctx.createChannelReestablish() }
         assertFalse(aliceReestablish.channelData.isEmpty())
-        peer.send(BytesReceived(LightningMessage.encode(aliceReestablish)))
+        peer.send(BytesReceived(aliceReestablish))
 
         // Wait until the channels are Syncing
         val restoredChannel = peer.channelsFlow
@@ -438,11 +437,11 @@ class PeerTest : LightningTestSuite() {
         )
 
         // Simulate a reconnection with Alice.
-        peer.send(BytesReceived(LightningMessage.encode(Init(features = alice0.staticParams.nodeParams.features))))
+        peer.send(BytesReceived(Init(features = alice0.staticParams.nodeParams.features)))
         peer.expectStatus(Connection.ESTABLISHED)
         val aliceReestablish = alice1.state.run { alice1.ctx.createChannelReestablish() }
         assertFalse(aliceReestablish.channelData.isEmpty())
-        peer.send(BytesReceived(LightningMessage.encode(aliceReestablish)))
+        peer.send(BytesReceived(aliceReestablish))
 
         // Wait until the channels are Syncing
         val restoredChannel = peer.channelsFlow

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -62,9 +62,9 @@ class PeerTest : LightningTestSuite() {
         val bob = buildPeer(this, TestConstants.Bob.nodeParams, TestConstants.Bob.walletParams)
 
         // start Init for Alice
-        alice.send(MessageReceived(Init(features = TestConstants.Bob.nodeParams.features), connectionId = 0))
+        alice.send(MessageReceived(connectionId = 0, Init(features = TestConstants.Bob.nodeParams.features)))
         // start Init for Bob
-        bob.send(MessageReceived(Init(features = TestConstants.Alice.nodeParams.features), connectionId = 0))
+        bob.send(MessageReceived(connectionId = 0, Init(features = TestConstants.Alice.nodeParams.features)))
 
         // Wait until the Peer is ready
         alice.expectStatus(Connection.ESTABLISHED)
@@ -343,7 +343,7 @@ class PeerTest : LightningTestSuite() {
 
         // send Init from remote node
         val theirInit = Init(features = bob0.staticParams.nodeParams.features)
-        peer.send(MessageReceived(theirInit, connectionId = 0))
+        peer.send(MessageReceived(connectionId = 0, theirInit))
         // Wait until the Peer is ready
         peer.expectStatus(Connection.ESTABLISHED)
 
@@ -367,7 +367,7 @@ class PeerTest : LightningTestSuite() {
             myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint
         ).withChannelData(commitments.remoteChannelData)
 
-        peer.send(MessageReceived(channelReestablish, connectionId = 0))
+        peer.send(MessageReceived(connectionId = 0, channelReestablish))
 
         // Wait until the channels are Reestablished(=Normal)
         val reestablishChannels = peer.channelsFlow.first { it.values.isNotEmpty() && it.values.all { channelState -> channelState is Normal } }
@@ -388,7 +388,7 @@ class PeerTest : LightningTestSuite() {
     fun `restore channel -- unknown channel`() = runSuspendTest {
         val (alice, _, alice2bob) = newPeers(this, Pair(TestConstants.Alice.nodeParams, TestConstants.Bob.nodeParams), Pair(TestConstants.Alice.walletParams, TestConstants.Bob.walletParams))
         val unknownChannelReestablish = ChannelReestablish(randomBytes32(), 1, 0, randomKey(), randomKey().publicKey())
-        alice.send(MessageReceived(unknownChannelReestablish, connectionId = 0))
+        alice.send(MessageReceived(connectionId = 0, unknownChannelReestablish))
         alice2bob.expect<Error>()
     }
 
@@ -407,11 +407,11 @@ class PeerTest : LightningTestSuite() {
         )
 
         // Simulate a reconnection with Alice.
-        peer.send(MessageReceived(Init(features = alice0.staticParams.nodeParams.features), connectionId = 0))
+        peer.send(MessageReceived(connectionId = 0, Init(features = alice0.staticParams.nodeParams.features)))
         peer.expectStatus(Connection.ESTABLISHED)
         val aliceReestablish = alice1.state.run { alice1.ctx.createChannelReestablish() }
         assertFalse(aliceReestablish.channelData.isEmpty())
-        peer.send(MessageReceived(aliceReestablish, connectionId = 0))
+        peer.send(MessageReceived(connectionId = 0, aliceReestablish))
 
         // Wait until the channels are Syncing
         val restoredChannel = peer.channelsFlow
@@ -437,11 +437,11 @@ class PeerTest : LightningTestSuite() {
         )
 
         // Simulate a reconnection with Alice.
-        peer.send(MessageReceived(Init(features = alice0.staticParams.nodeParams.features), connectionId = 0))
+        peer.send(MessageReceived(connectionId = 0, Init(features = alice0.staticParams.nodeParams.features)))
         peer.expectStatus(Connection.ESTABLISHED)
         val aliceReestablish = alice1.state.run { alice1.ctx.createChannelReestablish() }
         assertFalse(aliceReestablish.channelData.isEmpty())
-        peer.send(MessageReceived(aliceReestablish, connectionId = 0))
+        peer.send(MessageReceived(connectionId = 0, aliceReestablish))
 
         // Wait until the channels are Syncing
         val restoredChannel = peer.channelsFlow

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
@@ -70,9 +70,9 @@ suspend fun newPeers(
     }
 
     // Initialize Bob with Alice's features
-    bob.send(MessageReceived(Init(features = nodeParams.first.features.initFeatures()), bobConnection.id))
+    bob.send(MessageReceived(bobConnection.id, Init(features = nodeParams.first.features.initFeatures())))
     // Initialize Alice with Bob's features
-    alice.send(MessageReceived(Init(features = nodeParams.second.features.initFeatures()), aliceConnection.id))
+    alice.send(MessageReceived(aliceConnection.id, Init(features = nodeParams.second.features.initFeatures())))
 
     // TODO update to depend on the initChannels size
     if (initChannels.isNotEmpty()) {
@@ -103,12 +103,12 @@ suspend fun newPeers(
     if (automateMessaging) {
         scope.launch {
             bob2alice.collect {
-                alice.send(MessageReceived(it, bobConnection.id))
+                alice.send(MessageReceived(bobConnection.id, it))
             }
         }
         scope.launch {
             alice2bob.collect {
-                bob.send(MessageReceived(it, aliceConnection.id))
+                bob.send(MessageReceived(aliceConnection.id, it))
             }
         }
     }
@@ -133,7 +133,7 @@ suspend fun CoroutineScope.newPeer(
         // send Init from remote node
         val theirInit = Init(features = state.ctx.staticParams.nodeParams.features.initFeatures())
 
-        peer.send(MessageReceived(theirInit, connection.id))
+        peer.send(MessageReceived(connection.id, theirInit))
         peer.expectStatus(Connection.ESTABLISHED)
 
         peer.channelsFlow.first {
@@ -152,7 +152,7 @@ suspend fun CoroutineScope.newPeer(
             myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint
         ).withChannelData(state.commitments.remoteChannelData)
 
-        peer.send(MessageReceived(channelReestablish, connection.id))
+        peer.send(MessageReceived(connection.id, channelReestablish))
     }
 
     peer.channelsFlow.first {

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
@@ -70,9 +70,9 @@ suspend fun newPeers(
     }
 
     // Initialize Bob with Alice's features
-    bob.send(BytesReceived(Init(features = nodeParams.first.features.initFeatures())))
+    bob.send(MessageReceived(Init(features = nodeParams.first.features.initFeatures())))
     // Initialize Alice with Bob's features
-    alice.send(BytesReceived(Init(features = nodeParams.second.features.initFeatures())))
+    alice.send(MessageReceived(Init(features = nodeParams.second.features.initFeatures())))
 
     // TODO update to depend on the initChannels size
     if (initChannels.isNotEmpty()) {
@@ -103,12 +103,12 @@ suspend fun newPeers(
     if (automateMessaging) {
         scope.launch {
             bob2alice.collect {
-                alice.send(BytesReceived(it))
+                alice.send(MessageReceived(it))
             }
         }
         scope.launch {
             alice2bob.collect {
-                bob.send(BytesReceived(it))
+                bob.send(MessageReceived(it))
             }
         }
     }
@@ -133,7 +133,7 @@ suspend fun CoroutineScope.newPeer(
         // send Init from remote node
         val theirInit = Init(features = state.ctx.staticParams.nodeParams.features.initFeatures())
 
-        peer.send(BytesReceived(theirInit))
+        peer.send(MessageReceived(theirInit))
         peer.expectStatus(Connection.ESTABLISHED)
 
         peer.channelsFlow.first {
@@ -152,7 +152,7 @@ suspend fun CoroutineScope.newPeer(
             myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint
         ).withChannelData(state.commitments.remoteChannelData)
 
-        peer.send(BytesReceived(channelReestablish))
+        peer.send(MessageReceived(channelReestablish))
     }
 
     peer.channelsFlow.first {

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
@@ -19,6 +19,7 @@ import fr.acinq.lightning.channel.states.Syncing
 import fr.acinq.lightning.db.InMemoryDatabases
 import fr.acinq.lightning.io.*
 import fr.acinq.lightning.utils.Connection
+import fr.acinq.lightning.utils.MDCLogger
 import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.wire.ChannelReady
 import fr.acinq.lightning.wire.ChannelReestablish
@@ -32,6 +33,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 
 suspend fun newPeers(
     scope: CoroutineScope,
@@ -48,8 +50,8 @@ suspend fun newPeers(
         initChannels.forEach { channels.addOrUpdateChannel(it.second.state) }
     })
 
-    val aliceConnection = PeerConnection(0, Channel(Channel.UNLIMITED))
-    val bobConnection = PeerConnection(0, Channel(Channel.UNLIMITED))
+    val aliceConnection = PeerConnection(0, Channel(Channel.UNLIMITED), MDCLogger(LoggerFactory.default.newLogger(PeerConnection::class)))
+    val bobConnection = PeerConnection(0, Channel(Channel.UNLIMITED), MDCLogger(LoggerFactory.default.newLogger(PeerConnection::class)))
     alice.send(Connected(aliceConnection))
     bob.send(Connected(bobConnection))
 
@@ -126,7 +128,7 @@ suspend fun CoroutineScope.newPeer(
 
     val peer = buildPeer(this, nodeParams, walletParams, db)
 
-    val connection = PeerConnection(0, Channel(Channel.UNLIMITED))
+    val connection = PeerConnection(0, Channel(Channel.UNLIMITED), MDCLogger(LoggerFactory.default.newLogger(PeerConnection::class)))
     peer.send(Connected(connection))
 
     remotedNodeChannelState?.let { state ->
@@ -180,7 +182,7 @@ suspend fun buildPeer(
         claimMainFeerate = FeeratePerKw(FeeratePerByte(20.sat)),
         fastFeerate = FeeratePerKw(FeeratePerByte(50.sat))
     )
-    val connection = PeerConnection(0, Channel(Channel.UNLIMITED))
+    val connection = PeerConnection(0, Channel(Channel.UNLIMITED), MDCLogger(LoggerFactory.default.newLogger(PeerConnection::class)))
     peer.send(Connected(connection))
 
     return peer

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.mapNotNull
 
 suspend inline fun <reified M : LightningMessage> Flow<LightningMessage>.expect(): M = first { it is M } as M
 
-suspend inline fun Peer.forward(message: LightningMessage) = send((MessageReceived(message, connectionId = 0)))
+suspend inline fun Peer.forward(message: LightningMessage) = send((MessageReceived(connectionId = 0, message)))
 
 suspend inline fun Peer.expectStatus(await: Connection) = connectionState.first {
     when (await) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
@@ -2,7 +2,7 @@ package fr.acinq.lightning.tests.io.peer
 
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.lightning.channel.states.ChannelState
-import fr.acinq.lightning.io.BytesReceived
+import fr.acinq.lightning.io.MessageReceived
 import fr.acinq.lightning.io.Peer
 import fr.acinq.lightning.utils.Connection
 import fr.acinq.lightning.wire.LightningMessage
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.mapNotNull
 
 suspend inline fun <reified M : LightningMessage> Flow<LightningMessage>.expect(): M = first { it is M } as M
 
-suspend inline fun Peer.forward(message: LightningMessage) = send((BytesReceived(message)))
+suspend inline fun Peer.forward(message: LightningMessage) = send((MessageReceived(message)))
 
 suspend inline fun Peer.expectStatus(await: Connection) = connectionState.first {
     when (await) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.mapNotNull
 
 suspend inline fun <reified M : LightningMessage> Flow<LightningMessage>.expect(): M = first { it is M } as M
 
-suspend inline fun Peer.forward(message: LightningMessage) = send((MessageReceived(message)))
+suspend inline fun Peer.forward(message: LightningMessage) = send((MessageReceived(message, connectionId = 0)))
 
 suspend inline fun Peer.expectStatus(await: Connection) = connectionState.first {
     when (await) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.mapNotNull
 
 suspend inline fun <reified M : LightningMessage> Flow<LightningMessage>.expect(): M = first { it is M } as M
 
-suspend inline fun Peer.forward(message: LightningMessage) = send((BytesReceived(LightningMessage.encode(message))))
+suspend inline fun Peer.forward(message: LightningMessage) = send((BytesReceived(message)))
 
 suspend inline fun Peer.expectStatus(await: Connection) = connectionState.first {
     when (await) {


### PR DESCRIPTION
The fix is in two parts:
- First we clean up the connection logic, introduce connection ids and make the main peer loop responsible for switching between connections (see [bafb425](https://github.com/ACINQ/lightning-kmp/pull/526/commits/bafb4253e243d6762c3a04e7b638a318749015d1))
- Then we fix `processActions` to make sure that we always use the connection that the `Channel` FSM was using when it asked to send messages (see [61446b4](https://github.com/ACINQ/lightning-kmp/pull/526/commits/61446b46cb2aa9d4c94a8ae5ec1292764b5df611))