### PR TITLE
Add more improvements to PeerConnection

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -343,7 +343,7 @@ class Peer(
             val ping = Ping(10, ByteVector("deadbeef"))
             while (isActive) {
                 delay(30.seconds)
-                sendToPeer(ping)
+                peerConnection.output.trySend(ping)
             }
         }
 
@@ -513,17 +513,16 @@ class Peer(
         return incomingPaymentHandler.createInvoice(paymentPreimage, amount, description, extraHops, expirySeconds)
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
-    suspend fun sendToPeer(msg: LightningMessage) {
-        peerConnection?.output?.run { if (!isClosedForSend) send(msg) }
+    private fun sendToPeer(msg: LightningMessage) {
+        // We can safely use trySend because we use unlimited channel buffers.
+        peerConnection?.output?.run { trySend(msg) }
     }
 
     // The (node_id, fcm_token) tuple only needs to be registered once.
     // And after that, only if the tuple changes (e.g. different fcm_token).
     fun registerFcmToken(token: String?) {
-        launch {
-            sendToPeer(if (token == null) UnsetFCMToken else FCMToken(token))
-        }
+        val message = if (token == null) UnsetFCMToken else FCMToken(token)
+        sendToPeer(message)
     }
 
     private suspend fun processActions(channelId: ByteVector32, actions: List<ChannelAction>) {
@@ -724,7 +723,7 @@ class Peer(
     }
 
     // MUST ONLY BE SET BY processEvent()
-    var peerConnection: PeerConnection? = null
+    private var peerConnection: PeerConnection? = null
 
     private suspend fun processEvent(cmd: PeerCommand) {
         when (cmd) {
@@ -735,7 +734,7 @@ class Peer(
             }
             is MessageReceived -> {
                 if (cmd.connectionId != peerConnection?.id) {
-                    logger.warning { "ignoring ${cmd.msg} for connectionId=${cmd.connectionId}"}
+                    logger.warning { "ignoring ${cmd.msg} for connectionId=${cmd.connectionId}" }
                     return
                 }
                 val msg = cmd.msg

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -676,7 +676,11 @@ class Peer(
             else -> throw RuntimeException("invalid state")
         }
 
-        val writer = makeWriter(ourKeys, theirPubkey)
+        val writer = HandshakeState.initializeWriter(
+            handshakePatternXK, prologue,
+            ourKeys, Pair(ByteArray(0), ByteArray(0)), theirPubkey, ByteArray(0),
+            Secp256k1DHFunctions, Chacha20Poly1305CipherFunctions, SHA256HashFunctions
+        )
         val (state1, message, _) = writer.write(ByteArray(0))
         w(byteArrayOf(prefix) + message)
 
@@ -689,18 +693,6 @@ class Peer(
         w(byteArrayOf(prefix) + message1)
         return Triple(enc, dec, ck)
     }
-
-    private fun makeWriter(localStatic: Pair<ByteArray, ByteArray>, remoteStatic: ByteArray) = HandshakeState.initializeWriter(
-        handshakePatternXK, prologue,
-        localStatic, Pair(ByteArray(0), ByteArray(0)), remoteStatic, ByteArray(0),
-        Secp256k1DHFunctions, Chacha20Poly1305CipherFunctions, SHA256HashFunctions
-    )
-
-    private fun makeReader(localStatic: Pair<ByteArray, ByteArray>) = HandshakeState.initializeReader(
-        handshakePatternXK, prologue,
-        localStatic, Pair(ByteArray(0), ByteArray(0)), ByteArray(0), ByteArray(0),
-        Secp256k1DHFunctions, Chacha20Poly1305CipherFunctions, SHA256HashFunctions
-    )
 
     private suspend fun run() {
         logger.info { "peer is active" }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -272,8 +272,12 @@ class Peer(
     }
 
     fun connect() {
-        if (connectionState.value is Connection.CLOSED) establishConnection()
-        else logger.warning { "Peer is already connecting / connected" }
+        if (connectionState.value is Connection.CLOSED) {
+            _connectionState.value = Connection.ESTABLISHING
+            establishConnection()
+        } else {
+            logger.warning { "Peer is already connecting / connected" }
+        }
     }
 
     fun disconnect() {
@@ -289,7 +293,6 @@ class Peer(
     private lateinit var socket: TcpSocket
     private fun establishConnection() = launch {
         logger.info { "connecting to ${walletParams.trampolineNode.host}" }
-        _connectionState.value = Connection.ESTABLISHING
         socket = try {
             socketBuilder?.connect(
                 host = walletParams.trampolineNode.host,

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -283,12 +283,11 @@ class Peer(
     fun disconnect() {
         if (this::socket.isInitialized) socket.close()
         _connectionState.value = Connection.CLOSED(null)
-        // TODO in exception handler? output.close()
     }
 
     // Warning : lateinit vars have to be used AFTER their init to avoid any crashes
     //
-    // This shouldn't be used outside the establishedConnection() function
+    // This shouldn't be used outside the establishConnection() function
     // Except from the disconnect() one that check if the lateinit var has been initialized
     private lateinit var socket: TcpSocket
     private fun establishConnection() = launch {
@@ -370,6 +369,8 @@ class Peer(
             } catch (ex: TcpSocket.IOException) {
                 logger.warning { "TCP receive: ${ex.message}" }
                 closeSocket(ex)
+            } finally {
+                peerConnection.output.close()
             }
         }
 
@@ -384,6 +385,8 @@ class Peer(
             } catch (ex: TcpSocket.IOException) {
                 logger.warning { "TCP send: ${ex.message}" }
                 closeSocket(ex)
+            } finally {
+                peerConnection.output.close()
             }
         }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -49,7 +49,7 @@ data class OpenChannel(
 
 data class PeerConnection(val id: Long, val output: Channel<LightningMessage>)
 data class Connected(val peerConnection: PeerConnection) : PeerCommand()
-data class MessageReceived(val msg: LightningMessage, val connectionId: Long = 0) : PeerCommand()
+data class MessageReceived(val msg: LightningMessage, val connectionId: Long) : PeerCommand()
 data class WatchReceived(val watch: WatchEvent) : PeerCommand()
 data class WrappedChannelCommand(val channelId: ByteVector32, val channelCommand: ChannelCommand) : PeerCommand()
 object Disconnected : PeerCommand()

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -62,9 +62,9 @@ class PeerTest : LightningTestSuite() {
         val bob = buildPeer(this, TestConstants.Bob.nodeParams, TestConstants.Bob.walletParams)
 
         // start Init for Alice
-        alice.send(MessageReceived(Init(features = TestConstants.Bob.nodeParams.features)))
+        alice.send(MessageReceived(Init(features = TestConstants.Bob.nodeParams.features), connectionId = 0))
         // start Init for Bob
-        bob.send(MessageReceived(Init(features = TestConstants.Alice.nodeParams.features)))
+        bob.send(MessageReceived(Init(features = TestConstants.Alice.nodeParams.features), connectionId = 0))
 
         // Wait until the Peer is ready
         alice.expectStatus(Connection.ESTABLISHED)
@@ -343,7 +343,7 @@ class PeerTest : LightningTestSuite() {
 
         // send Init from remote node
         val theirInit = Init(features = bob0.staticParams.nodeParams.features)
-        peer.send(MessageReceived(theirInit))
+        peer.send(MessageReceived(theirInit, connectionId = 0))
         // Wait until the Peer is ready
         peer.expectStatus(Connection.ESTABLISHED)
 
@@ -367,7 +367,7 @@ class PeerTest : LightningTestSuite() {
             myCurrentPerCommitmentPoint = myCurrentPerCommitmentPoint
         ).withChannelData(commitments.remoteChannelData)
 
-        peer.send(MessageReceived(channelReestablish))
+        peer.send(MessageReceived(channelReestablish, connectionId = 0))
 
         // Wait until the channels are Reestablished(=Normal)
         val reestablishChannels = peer.channelsFlow.first { it.values.isNotEmpty() && it.values.all { channelState -> channelState is Normal } }
@@ -388,7 +388,7 @@ class PeerTest : LightningTestSuite() {
     fun `restore channel -- unknown channel`() = runSuspendTest {
         val (alice, _, alice2bob) = newPeers(this, Pair(TestConstants.Alice.nodeParams, TestConstants.Bob.nodeParams), Pair(TestConstants.Alice.walletParams, TestConstants.Bob.walletParams))
         val unknownChannelReestablish = ChannelReestablish(randomBytes32(), 1, 0, randomKey(), randomKey().publicKey())
-        alice.send(MessageReceived(unknownChannelReestablish))
+        alice.send(MessageReceived(unknownChannelReestablish, connectionId = 0))
         alice2bob.expect<Error>()
     }
 
@@ -407,11 +407,11 @@ class PeerTest : LightningTestSuite() {
         )
 
         // Simulate a reconnection with Alice.
-        peer.send(MessageReceived(Init(features = alice0.staticParams.nodeParams.features)))
+        peer.send(MessageReceived(Init(features = alice0.staticParams.nodeParams.features), connectionId = 0))
         peer.expectStatus(Connection.ESTABLISHED)
         val aliceReestablish = alice1.state.run { alice1.ctx.createChannelReestablish() }
         assertFalse(aliceReestablish.channelData.isEmpty())
-        peer.send(MessageReceived(aliceReestablish))
+        peer.send(MessageReceived(aliceReestablish, connectionId = 0))
 
         // Wait until the channels are Syncing
         val restoredChannel = peer.channelsFlow
@@ -437,11 +437,11 @@ class PeerTest : LightningTestSuite() {
         )
 
         // Simulate a reconnection with Alice.
-        peer.send(MessageReceived(Init(features = alice0.staticParams.nodeParams.features)))
+        peer.send(MessageReceived(Init(features = alice0.staticParams.nodeParams.features), connectionId = 0))
         peer.expectStatus(Connection.ESTABLISHED)
         val aliceReestablish = alice1.state.run { alice1.ctx.createChannelReestablish() }
         assertFalse(aliceReestablish.channelData.isEmpty())
-        peer.send(MessageReceived(aliceReestablish))
+        peer.send(MessageReceived(aliceReestablish, connectionId = 0))
 
         // Wait until the channels are Syncing
         val restoredChannel = peer.channelsFlow

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.mapNotNull
 
 suspend inline fun <reified M : LightningMessage> Flow<LightningMessage>.expect(): M = first { it is M } as M
 
-suspend inline fun Peer.forward(message: LightningMessage) = send((MessageReceived(message)))
+suspend inline fun Peer.forward(message: LightningMessage) = send((MessageReceived(message, connectionId = 0)))
 
 suspend inline fun Peer.expectStatus(await: Connection) = connectionState.first {
     when (await) {


### PR DESCRIPTION
Builds on top of #526 to fully fix the race conditions in peer connections (:crossed_fingers:).

The most important and subtle commits are https://github.com/ACINQ/lightning-kmp/pull/527/commits/c75939296d56dfee65593ba84983af923b2e5298 and https://github.com/ACINQ/lightning-kmp/pull/527/commits/9eb5c43c8c4006696c9ea39a9ce4b13d73838c86

I wanted to refactor that code to make sure that event processing could not access the `input` channel, and provide an overall better encapsulation, but this was quite a rabbit hole so I chose to keep the number of changes minimal for this PR. A follow-up PR can work on pure refactoring to split the `Peer` into smaller classes.