### PR TITLE
Handle 'unknown segwit' case when checking amounts

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -472,13 +472,14 @@ object Helpers {
          */
         fun checkClosingDustAmounts(closingTx: ClosingTx): Boolean {
             return closingTx.tx.txOut.all { txOut ->
-                val publicKeyScript = txOut.publicKeyScript.toByteArray()
+                val publicKeyScript = Script.parse(txOut.publicKeyScript)
                 when {
                     Script.isPay2pkh(publicKeyScript) -> txOut.amount >= 546.sat
                     Script.isPay2sh(publicKeyScript) -> txOut.amount >= 540.sat
                     Script.isPay2wpkh(publicKeyScript) -> txOut.amount >= 294.sat
                     Script.isPay2wsh(publicKeyScript) -> txOut.amount >= 330.sat
-                    else -> false
+                    Script.isNativeWitnessScript(publicKeyScript) -> txOut.amount >= 354.sat
+                    else -> txOut.amount >= 546.sat
                 }
             }
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/HelpersTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/HelpersTestsCommon.kt
@@ -61,11 +61,13 @@ class HelpersTestsCommon : LightningTestSuite() {
         val p2shBelowDust = listOf(TxOut(539.sat, Script.pay2sh(Hex.decode("0000000000000000000000000000000000000000"))))
         val p2wpkhBelowDust = listOf(TxOut(293.sat, Script.pay2wpkh(randomKey().publicKey())))
         val p2wshBelowDust = listOf(TxOut(329.sat, Script.pay2wsh(Hex.decode("0000000000000000000000000000000000000000"))))
+        val p2trBelowDust = listOf(TxOut(353.sat, Script.pay2tr(randomKey().publicKey().xOnly())))
         val allOutputsAboveDust = listOf(
             TxOut(546.sat, Script.pay2pkh(randomKey().publicKey())),
             TxOut(540.sat, Script.pay2sh(Hex.decode("0000000000000000000000000000000000000000"))),
             TxOut(294.sat, Script.pay2wpkh(randomKey().publicKey())),
             TxOut(330.sat, Script.pay2wsh(Hex.decode("0000000000000000000000000000000000000000"))),
+            TxOut(354.sat, Script.pay2tr(randomKey().publicKey().xOnly()))
         )
 
         fun toClosingTx(txOut: List<TxOut>): Transactions.TransactionWithInputInfo.ClosingTx {
@@ -78,6 +80,7 @@ class HelpersTestsCommon : LightningTestSuite() {
         assertFalse(checkClosingDustAmounts(toClosingTx(p2shBelowDust)))
         assertFalse(checkClosingDustAmounts(toClosingTx(p2wpkhBelowDust)))
         assertFalse(checkClosingDustAmounts(toClosingTx(p2wshBelowDust)))
+        assertFalse(checkClosingDustAmounts(toClosingTx(p2trBelowDust)))
     }
 
 }


### PR DESCRIPTION
As per https://github.com/lightning/bolts/blob/master/03-transactions.md#dust-limits