### PR TITLE
Make swap-in wait for peer ready

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -468,7 +468,7 @@ class Peer(
             channelsFlow.first { it.values.all { channel -> channel !is Offline && channel !is Syncing } }
         }
         if (result == null) {
-            logger.info { "timeout elapsed, not all channels are synced but proceeding anyway" }
+            logger.info { "peer ready timeout elapsed, not all channels are synced but proceeding anyway" }
         }
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -420,7 +420,10 @@ class Peer(
         logger.info { "starting swap-in watch job" }
         if (swapInJob != null) return
         // wait to have a swap-in feerate available
+        logger.info { "waiting for feerates" }
         swapInFeeratesFlow.filterNotNull().first()
+        logger.info { "waiting for peer to be ready" }
+        waitForPeerReady()
         swapInJob = launch {
             swapInWallet.walletStateFlow.combine(currentTipFlow.filterNotNull()) { walletState, currentTip -> currentTip.first to walletState }
                 .filter { (_, walletState) -> walletState.consistent }
@@ -450,6 +453,23 @@ class Peer(
 
     suspend fun send(cmd: PeerCommand) {
         input.send(cmd)
+    }
+
+    /**
+     * This function blocks until the peer is connected and existing channels have been fully reestablished.
+     */
+    private suspend fun waitForPeerReady() {
+        // In theory we would only need to verify that no channel is in state Offline/Syncing, but there is a corner
+        // case where a channel permanently stays in Syncing, because it is only present locally, and the peer will
+        // never send a channel_reestablish (this happens e.g. due to an error at funding). That is why we consider
+        // the peer ready if "all channels are synced" OR "peer has been connected for 10s".
+        connectionState.first { it is Connection.ESTABLISHED }
+        val result = withTimeoutOrNull(10.seconds) {
+            channelsFlow.first { it.values.all { channel -> channel !is Offline && channel !is Syncing } }
+        }
+        if (result == null) {
+            logger.info { "timeout elapsed, not all channels are synced but proceeding anyway" }
+        }
     }
 
     /**
@@ -983,7 +1003,8 @@ class Peer(
             }
             is RequestChannelOpen -> {
                 when (val channel = channels.values.firstOrNull { it is Normal }) {
-                    is ChannelStateWithCommitments -> {
+                    is Normal -> {
+                        // we have a channel and we are connected (otherwise state would be Offline/Syncing)
                         val targetFeerate = swapInFeeratesFlow.filterNotNull().first()
                         val weight = FundingContributions.computeWeightPaid(isInitiator = true, commitment = channel.commitments.active.first(), walletInputs = cmd.walletInputs, localOutputs = emptyList())
                         val (feerate, fee) = watcher.client.computeSpliceCpfpFeerate(channel.commitments, targetFeerate, spliceWeight = weight, logger)


### PR DESCRIPTION
There is a race at startup between the swap-in and the peer connection. If the former wins the race, we reach the following code and drop the message, causing the swap-in to be stuck.
https://github.com/ACINQ/lightning-kmp/blob/d2bc164b52fd2070af3514fa86e512ed981fb492/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt#L1026-L1027


This PR introduces a `waitForPeerReady` helper method which blocks until the peer is fully connected (meaning that existing channels are synced).