### PR TITLE
Fix `invalid_commit_sig` issue when expecting `tx_signatures`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -123,7 +123,7 @@ sealed class LocalFundingStatus {
         override val fee: Satoshi = sharedTx.tx.fees
     }
 
-    data class ConfirmedFundingTx(override val signedTx: Transaction, override val fee: Satoshi) : LocalFundingStatus() {
+    data class ConfirmedFundingTx(override val signedTx: Transaction, override val fee: Satoshi, val localSigs: TxSignatures) : LocalFundingStatus() {
         override val txId: ByteVector32 = signedTx.txid
     }
 }
@@ -832,7 +832,7 @@ data class Commitments(
                 when (c.localFundingStatus) {
                     is LocalFundingStatus.UnconfirmedFundingTx -> {
                         logger.debug { "setting localFundingStatus confirmed for fundingTxId=${fundingTx.txid}" }
-                        c.copy(localFundingStatus = LocalFundingStatus.ConfirmedFundingTx(fundingTx, c.localFundingStatus.sharedTx.tx.fees))
+                        c.copy(localFundingStatus = LocalFundingStatus.ConfirmedFundingTx(fundingTx, c.localFundingStatus.sharedTx.tx.fees, c.localFundingStatus.sharedTx.localSigs))
                     }
                     is LocalFundingStatus.ConfirmedFundingTx -> c
                 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -194,7 +194,7 @@ data class Normal(
                                 is InteractiveTxSigningSessionAction.SendTxSigs -> sendSpliceTxSigs(spliceStatus.origins, action, cmd.message.channelData)
                             }
                         }
-                        commitments.params.channelFeatures.hasFeature(Feature.DualFunding) && ignoreRetransmittedCommitSig(cmd.message) -> {
+                        ignoreRetransmittedCommitSig(cmd.message) -> {
                             // We haven't received our peer's tx_signatures for the latest funding transaction and asked them to resend it on reconnection.
                             // They also resend their corresponding commit_sig, but we have already received it so we should ignore it.
                             // Note that the funding transaction may have confirmed while we were offline.
@@ -738,7 +738,9 @@ data class Normal(
     private fun ignoreRetransmittedCommitSig(commit: CommitSig): Boolean {
         // If we already have a signed commitment transaction containing their signature, we must have previously received that commit_sig.
         val commitTx = commitments.latest.localCommit.publishableTxs.commitTx.tx
-        return commit.batchSize == 1 && commitTx.txIn.first().witness.stack.contains(Scripts.der(commit.signature, SigHash.SIGHASH_ALL))
+        return commitments.params.channelFeatures.hasFeature(Feature.DualFunding) &&
+                commit.batchSize == 1 &&
+                commitTx.txIn.first().witness.stack.contains(Scripts.der(commit.signature, SigHash.SIGHASH_ALL))
     }
 
     /** If we haven't completed the signing steps of an interactive-tx session, we will ask our peer to retransmit signatures for the corresponding transaction. */

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -1,6 +1,7 @@
 package fr.acinq.lightning.channel.states
 
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.SigHash
 import fr.acinq.lightning.Feature
 import fr.acinq.lightning.Features
 import fr.acinq.lightning.ShortChannelId
@@ -9,6 +10,7 @@ import fr.acinq.lightning.blockchain.WatchConfirmed
 import fr.acinq.lightning.blockchain.WatchEventConfirmed
 import fr.acinq.lightning.blockchain.WatchEventSpent
 import fr.acinq.lightning.channel.*
+import fr.acinq.lightning.transactions.Scripts
 import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.*
 import fr.acinq.lightning.wire.*
@@ -192,11 +194,10 @@ data class Normal(
                                 is InteractiveTxSigningSessionAction.SendTxSigs -> sendSpliceTxSigs(spliceStatus.origins, action, cmd.message.channelData)
                             }
                         }
-                        commitments.params.channelFeatures.hasFeature(Feature.DualFunding) && commitments.latest.localFundingStatus.signedTx == null && cmd.message.batchSize == 1 -> {
-                            // The latest funding transaction is unconfirmed and we're missing our peer's tx_signatures: any commit_sig that we receive before that should be ignored,
-                            // it's either a retransmission of a commit_sig we've already received or a bug that will eventually lead to a force-close anyway.
-                            // NB: we check the dual-funding feature, because legacy single-funding unconfirmed channels will have `localFundingStatus=UnconfirmedFundingTx`,
-                            // so we cannot just check on the absence of `signedTx`.
+                        commitments.params.channelFeatures.hasFeature(Feature.DualFunding) && cmd.message.batchSize == 1 && commitSigAlreadyReceived(cmd.message) -> {
+                            // We haven't received our peer's tx_signatures for the latest funding transaction and asked them to resend it on reconnection.
+                            // They also resend their corresponding commit_sig, but we have already received it so we should ignore it.
+                            // Note that the funding transaction may have confirmed while we were offline.
                             logger.info { "ignoring commit_sig, we're still waiting for tx_signatures" }
                             Pair(this@Normal, listOf())
                         }
@@ -731,6 +732,13 @@ data class Normal(
             }
         }
         return Pair(nextState, actions)
+    }
+
+    private fun commitSigAlreadyReceived(commit: CommitSig): Boolean {
+        // If we already have a signed commitment transaction containing their signature,
+        // we must have previously received that commit_sig.
+        val commitTx = commitments.latest.localCommit.publishableTxs.commitTx.tx
+        return commitTx.txIn.first().witness.stack.contains(Scripts.der(commit.signature, SigHash.SIGHASH_ALL))
     }
 
     /** If we haven't completed the signing steps of an interactive-tx session, we will ask our peer to retransmit signatures for the corresponding transaction. */

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -936,7 +936,6 @@ class Peer(
                         }
                     }
                     is HasChannelId -> {
-                        logger.info { "received ${msg::class.simpleName} for channel ${msg.channelId}" }
                         if (msg is Error && msg.channelId == ByteVector32.Zeroes) {
                             logger.error { "connection error: ${msg.toAscii()}" }
                         } else {
@@ -952,7 +951,6 @@ class Peer(
                         }
                     }
                     is ChannelUpdate -> {
-                        logger.info { "received ${msg::class.simpleName} for channel ${msg.shortChannelId}" }
                         _channels.values.filterIsInstance<Normal>().find { it.shortChannelId == msg.shortChannelId }?.let { state ->
                             val event1 = ChannelCommand.MessageReceived(msg)
                             val (state1, actions) = state.process(event1)

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Deserialization.kt
@@ -419,7 +419,16 @@ object Deserialization {
             )
             0x01 -> LocalFundingStatus.ConfirmedFundingTx(
                 signedTx = readTransaction(),
-                fee = readNumber().sat
+                fee = readNumber().sat,
+                // We previously didn't store the tx_signatures after the transaction was confirmed.
+                // It is only used to be retransmitted on reconnection if our peer had not received it.
+                // This happens very rarely in practice, so putting dummy values here shouldn't be an issue.
+                localSigs = TxSignatures(ByteVector32.Zeroes, ByteVector32.Zeroes, listOf())
+            )
+            0x02 -> LocalFundingStatus.ConfirmedFundingTx(
+                signedTx = readTransaction(),
+                fee = readNumber().sat,
+                localSigs = readLightningMessage() as TxSignatures
             )
             else -> error("unknown discriminator $discriminator for class ${LocalFundingStatus::class}")
         },

--- a/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/serialization/v4/Serialization.kt
@@ -464,9 +464,10 @@ object Serialization {
                 writeNumber(localFundingStatus.createdAt)
             }
             is LocalFundingStatus.ConfirmedFundingTx -> {
-                write(0x01)
+                write(0x02)
                 writeBtcObject(localFundingStatus.signedTx)
                 writeNumber(localFundingStatus.fee.toLong())
+                writeLightningMessage(localFundingStatus.localSigs)
             }
         }
         when (remoteFundingStatus) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
@@ -26,6 +26,7 @@ import fr.acinq.lightning.transactions.Scripts
 import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.*
 import fr.acinq.lightning.wire.IncorrectOrUnknownPaymentDetails
+import fr.acinq.lightning.wire.TxSignatures
 import fr.acinq.lightning.wire.UpdateAddHtlc
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
@@ -514,7 +515,7 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
                     Commitment(
                         fundingTxIndex = 0,
                         remoteFundingPubkey = randomKey().publicKey(),
-                        LocalFundingStatus.ConfirmedFundingTx(dummyFundingTx, 500.sat),
+                        LocalFundingStatus.ConfirmedFundingTx(dummyFundingTx, 500.sat, TxSignatures(randomBytes32(), randomBytes32(), listOf())),
                         RemoteFundingStatus.Locked,
                         LocalCommit(0, CommitmentSpec(setOf(), feeRatePerKw, toLocal, toRemote), PublishableTxs(localCommitTx, listOf())),
                         RemoteCommit(0, CommitmentSpec(setOf(), feeRatePerKw, toRemote, toLocal), randomBytes32(), randomKey().publicKey()),
@@ -559,7 +560,7 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
                     Commitment(
                         fundingTxIndex = 0,
                         remoteFundingPubkey = randomKey().publicKey(),
-                        LocalFundingStatus.ConfirmedFundingTx(dummyFundingTx, 500.sat),
+                        LocalFundingStatus.ConfirmedFundingTx(dummyFundingTx, 500.sat, TxSignatures(randomBytes32(), randomBytes32(), listOf())),
                         RemoteFundingStatus.Locked,
                         LocalCommit(0, CommitmentSpec(setOf(), FeeratePerKw(0.sat), toLocal, toRemote), PublishableTxs(localCommitTx, listOf())),
                         RemoteCommit(0, CommitmentSpec(setOf(), FeeratePerKw(0.sat), toRemote, toLocal), randomBytes32(), randomKey().publicKey()),


### PR DESCRIPTION
If we disconnect before receiving our peer's `tx_signatures`, we expect them to re-send it on reconnection (by filling the `next_funding_txid` field in `channel_reestablish`). In that case, our peer may also retransmit their corresponding `commit_sig` first (if they cannot be sure that we've received it). If we've already received that `commit_sig`, we should ignore it. But we must make sure we don't end up ignoring *other* `commit_sig` messages!

Eclair wasn't spec-compliant and wouldn't retransmit their `tx_signatures` if the transaction was already confirmed. We need to fix this on the eclair side (PR incoming). The issue is that `lightning-kmp` ended up ignoring unrelated `commit_sig` messages, which could eventually lead to an `invalid_commit_sig` error and a force-close.