### PR TITLE
Include `paymentHash` in `LiquidityEvent.Source`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -26,7 +26,11 @@ sealed interface LiquidityEvents : NodeEvents {
     val fee: MilliSatoshi
     val source: Source
 
-    enum class Source { OnChainWallet, OffChainPayment }
+    sealed class Source {
+        data class OffChainPayment(val paymentHash: ByteVector32) : Source()
+        object OnChainWallet : Source()
+    }
+
     data class Rejected(override val amount: MilliSatoshi, override val fee: MilliSatoshi, override val source: Source, val reason: Reason) : LiquidityEvents {
         sealed class Reason {
             object PolicySetToDisabled : Reason()

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -969,7 +969,7 @@ class Peer(
                                 && !_channels.values.any { it is Normal } // we don't have a channel that can be spliced
                                 && _channels.values.any { it is WaitForFundingSigned || it is WaitForFundingConfirmed || it is WaitForChannelReady } // but we will have one soon
                         if (channelInitializing) {
-                            val rejected = LiquidityEvents.Rejected(msg.amountMsat, msg.payToOpenFeeSatoshis.toMilliSatoshi(), LiquidityEvents.Source.OffChainPayment, LiquidityEvents.Rejected.Reason.ChannelInitializing)
+                            val rejected = LiquidityEvents.Rejected(msg.amountMsat, msg.payToOpenFeeSatoshis.toMilliSatoshi(), LiquidityEvents.Source.OffChainPayment(msg.paymentHash), LiquidityEvents.Rejected.Reason.ChannelInitializing)
                             logger.info { "rejecting pay-to-open: reason=${rejected.reason}" }
                             nodeParams._nodeEvents.emit(rejected)
                             val action = IncomingPaymentHandler.actionForPayToOpenFailure(nodeParams.nodePrivateKey, TemporaryNodeFailure, msg)

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -250,7 +250,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val db: IncomingPayment
                             if (payment.parts.filterIsInstance<PayToOpenPart>().isNotEmpty()) {
                                 // We consider the total amount received (not only the pay-to-open parts) to evaluate whether or not to accept the payment
                                 val payToOpenFee = payment.parts.filterIsInstance<PayToOpenPart>().map { it.payToOpenRequest.payToOpenFeeSatoshis }.sum()
-                                nodeParams.liquidityPolicy.value.maybeReject(payment.amountReceived, payToOpenFee.toMilliSatoshi(), LiquidityEvents.Source.OffChainPayment, logger)?.let { rejected ->
+                                nodeParams.liquidityPolicy.value.maybeReject(payment.amountReceived, payToOpenFee.toMilliSatoshi(), LiquidityEvents.Source.OffChainPayment(paymentPart.paymentHash), logger)?.let { rejected ->
                                     logger.info { "rejecting pay-to-open: reason=${rejected.reason}" }
                                     nodeParams._nodeEvents.emit(rejected)
                                     val actions = payment.parts.map { part ->

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/LiquidityPolicy.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/LiquidityPolicy.kt
@@ -25,7 +25,7 @@ sealed class LiquidityPolicy {
         return when (this) {
             is Disable -> LiquidityEvents.Rejected.Reason.PolicySetToDisabled
             is Auto -> {
-                val maxAbsoluteFee = if (skipAbsoluteFeeCheck && source == LiquidityEvents.Source.OffChainPayment) Long.MAX_VALUE.msat else this.maxAbsoluteFee.toMilliSatoshi()
+                val maxAbsoluteFee = if (skipAbsoluteFeeCheck && source is LiquidityEvents.Source.OffChainPayment) Long.MAX_VALUE.msat else this.maxAbsoluteFee.toMilliSatoshi()
                 val maxRelativeFee = amount * maxRelativeFeeBasisPoints / 10_000
                 logger.info { "liquidity policy check: fee=$fee maxAbsoluteFee=$maxAbsoluteFee maxRelativeFee=$maxRelativeFee policy=$this" }
                 if (fee > maxRelativeFee) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/LiquidityPolicyTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/LiquidityPolicyTestsCommon.kt
@@ -1,5 +1,6 @@
 package fr.acinq.lightning.payment
 
+import fr.acinq.lightning.Lightning.randomBytes32
 import fr.acinq.lightning.LiquidityEvents
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.utils.MDCLogger
@@ -23,22 +24,22 @@ class LiquidityPolicyTestsCommon : LightningTestSuite() {
         // fee over both absolute and relative
         assertEquals(
             expected = LiquidityEvents.Rejected.Reason.TooExpensive.OverRelativeFee(policy.maxRelativeFeeBasisPoints),
-            actual = policy.maybeReject(amount = 4_000_000.msat, fee = 3_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger)?.reason
+            actual = policy.maybeReject(amount = 4_000_000.msat, fee = 3_000_000.msat, source = LiquidityEvents.Source.OffChainPayment(randomBytes32()), logger)?.reason
         )
 
         // fee over absolute
         assertEquals(
             expected = LiquidityEvents.Rejected.Reason.TooExpensive.OverAbsoluteFee(policy.maxAbsoluteFee),
-            actual = policy.maybeReject(amount = 15_000_000.msat, fee = 3_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger)?.reason
+            actual = policy.maybeReject(amount = 15_000_000.msat, fee = 3_000_000.msat, source = LiquidityEvents.Source.OffChainPayment(randomBytes32()), logger)?.reason
         )
 
         // fee over relative
         assertEquals(
             expected = LiquidityEvents.Rejected.Reason.TooExpensive.OverRelativeFee(policy.maxRelativeFeeBasisPoints),
-            actual = policy.maybeReject(amount = 4_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger)?.reason
+            actual = policy.maybeReject(amount = 4_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment(randomBytes32()), logger)?.reason
         )
 
-        assertNull(policy.maybeReject(amount = 10_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger))
+        assertNull(policy.maybeReject(amount = 10_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment(randomBytes32()), logger))
 
     }
 
@@ -48,7 +49,7 @@ class LiquidityPolicyTestsCommon : LightningTestSuite() {
         val policy = LiquidityPolicy.Auto(maxAbsoluteFee = 1_000.sat, maxRelativeFeeBasisPoints = 5_000 /* 3000 = 30 % */, skipAbsoluteFeeCheck = true)
 
         // fee is over absolute, and it's an offchain payment so the check passes
-        assertNull(policy.maybeReject(amount = 4_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger))
+        assertNull(policy.maybeReject(amount = 4_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment(randomBytes32()), logger))
 
         // fee is over absolute, but it's an on-chain payment so the check fails
         assertEquals(


### PR DESCRIPTION
This allows integrators to easily map events to payments.