### PR TITLE
Stay in `Offline` and `Syncing` on splice published

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
@@ -96,7 +96,14 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
                             )
                             Pair(nextState, actions)
                         }
-                        else -> state.run { handlePotentialForceClose(watch) }
+                        else -> {
+                            val (nextState, actions) = state.run { handlePotentialForceClose(watch) }
+                            when (nextState) {
+                                is Closing -> Pair(nextState, actions)
+                                is Closed -> Pair(nextState, actions)
+                                else -> Pair(Offline(nextState), actions)
+                            }
+                        }
                     }
                 }
                 is WaitForFundingSigned -> Pair(this@Offline, listOf())

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -299,7 +299,14 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
                             )
                             Pair(nextState, actions)
                         }
-                        else -> state.run { handlePotentialForceClose(watch) }
+                        else -> {
+                            val (nextState, actions) = state.run { handlePotentialForceClose(watch) }
+                            when (nextState) {
+                                is Closing -> Pair(nextState, actions)
+                                is Closed -> Pair(nextState, actions)
+                                else -> Pair(Syncing(nextState, channelReestablishSent), actions)
+                            }
+                        }
                     }
                     is WatchEventConfirmed -> {
                         if (watch.event is BITCOIN_FUNDING_DEPTHOK) {


### PR DESCRIPTION
When a splice transaction is published, it triggers a `BITCOIN_FUNDING_SPENT` event that we should ignore, because this isn't a force-close. If that event is received while we're in `Offline` or `Syncing`, we need to stay in those "wrapper" states.

Ideally, our type system should provide better guarantees here: we should have a different class hierarchy for channel states that can be wrapped in `Offline` and `Syncing` and channel states that don't (e.g. `Closing`). But this is quite a rabbit hole (that we already touched in #480) that deserves its own PR.