### PR TITLE
Exposed swap-in utxos refund delay

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManager.kt
@@ -3,6 +3,7 @@ package fr.acinq.lightning.blockchain.electrum
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.OutPoint
 import fr.acinq.lightning.Lightning
+import fr.acinq.lightning.SwapInParams
 import fr.acinq.lightning.channel.LocalFundingStatus
 import fr.acinq.lightning.channel.RbfStatus
 import fr.acinq.lightning.channel.SignedSharedTransaction
@@ -13,7 +14,7 @@ import fr.acinq.lightning.utils.MDCLogger
 import fr.acinq.lightning.utils.sat
 
 internal sealed class SwapInCommand {
-    data class TrySwapIn(val currentBlockHeight: Int, val wallet: WalletState, val swapInConfirmations: Int, val trustedTxs: Set<ByteVector32>) : SwapInCommand()
+    data class TrySwapIn(val currentBlockHeight: Int, val wallet: WalletState, val swapInParams: SwapInParams, val trustedTxs: Set<ByteVector32>) : SwapInCommand()
     data class UnlockWalletInputs(val inputs: Set<OutPoint>) : SwapInCommand()
 }
 
@@ -32,7 +33,7 @@ class SwapInManager(private var reservedUtxos: Set<OutPoint>, private val logger
 
     internal fun process(cmd: SwapInCommand): RequestChannelOpen? = when (cmd) {
         is SwapInCommand.TrySwapIn -> {
-            val availableWallet = cmd.wallet.withoutReservedUtxos(reservedUtxos).withConfirmations(cmd.currentBlockHeight, cmd.swapInConfirmations)
+            val availableWallet = cmd.wallet.withoutReservedUtxos(reservedUtxos).withConfirmations(cmd.currentBlockHeight, cmd.swapInParams)
             logger.info { "swap-in wallet balance: deeplyConfirmed=${availableWallet.deeplyConfirmed.balance}, weaklyConfirmed=${availableWallet.weaklyConfirmed.balance}, unconfirmed=${availableWallet.unconfirmed.balance}" }
             val utxos = buildSet {
                 // some utxos may be used for swap-in even if they are not confirmed, for example when migrating from the legacy phoenix android app

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
@@ -3,6 +3,7 @@ package fr.acinq.lightning.crypto
 import fr.acinq.bitcoin.*
 import fr.acinq.bitcoin.DeterministicWallet.hardened
 import fr.acinq.bitcoin.io.ByteArrayInput
+import fr.acinq.lightning.DefaultSwapInParams
 import fr.acinq.lightning.NodeParams
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.transactions.Scripts
@@ -114,7 +115,7 @@ interface KeyManager {
         private val chain: NodeParams.Chain,
         private val master: DeterministicWallet.ExtendedPrivateKey,
         val remoteServerPublicKey: PublicKey,
-        val refundDelay: Int = SwapInRefundDelay
+        val refundDelay: Int = DefaultSwapInParams.RefundDelay
     ) {
         private val userExtendedPrivateKey: DeterministicWallet.ExtendedPrivateKey = DeterministicWallet.derivePrivateKey(master, swapInUserKeyPath(chain))
         val userPrivateKey: PrivateKey = userExtendedPrivateKey.privateKey
@@ -181,9 +182,6 @@ interface KeyManager {
         }
 
         companion object {
-            /** When doing a swap-in, the user's funds are locked in a 2-of-2: they can claim them unilaterally after that delay. */
-            const val SwapInRefundDelay = 144 * 30 * 6 // ~6 months
-
             private fun swapInKeyBasePath(chain: NodeParams.Chain) = when (chain) {
                 NodeParams.Chain.Regtest, NodeParams.Chain.Testnet -> KeyPath.empty / hardened(51) / hardened(0)
                 NodeParams.Chain.Mainnet -> KeyPath.empty / hardened(52) / hardened(0)

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -434,7 +434,7 @@ class Peer(
                         .filterNot { it.commitments.params.channelFeatures.hasFeature(Feature.DualFunding) }
                         .flatMap { state -> state.mutualClosePublished.map { closingTx -> closingTx.tx.txid } }
                     val trustedTxs = trustedSwapInTxs + mutualCloseTxs
-                    swapInCommands.send(SwapInCommand.TrySwapIn(currentBlockHeight, walletState, walletParams.swapInConfirmations, trustedTxs))
+                    swapInCommands.send(SwapInCommand.TrySwapIn(currentBlockHeight, walletState, walletParams.swapInParams, trustedTxs))
                 }
         }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
@@ -30,7 +30,7 @@ import kotlin.test.*
 
 class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
 
-    private val defaultWalletParams = WalletParams(NodeUri(TestConstants.Bob.nodeParams.nodeId, "bob.com", 9735), TestConstants.trampolineFees, InvoiceDefaultRoutingFees(1_000.msat, 100, CltvExpiryDelta(144)), TestConstants.swapInConfirmations)
+    private val defaultWalletParams = WalletParams(NodeUri(TestConstants.Bob.nodeParams.nodeId, "bob.com", 9735), TestConstants.trampolineFees, InvoiceDefaultRoutingFees(1_000.msat, 100, CltvExpiryDelta(144)), TestConstants.swapInParams)
 
     @Test
     fun `invalid payment amount`() = runSuspendTest {

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
@@ -25,7 +25,11 @@ object TestConstants {
     val feeratePerKw = FeeratePerKw(5000.sat) // 20 sat/byte
     val emptyOnionPacket = OnionRoutingPacket(0, ByteVector(ByteArray(33)), ByteVector(ByteArray(OnionRoutingPacket.PaymentPacketLength)), ByteVector32.Zeroes)
 
-    const val swapInConfirmations = 3
+    val swapInParams = SwapInParams(
+        minConfirmations = DefaultSwapInParams.MinConfirmations,
+        maxConfirmations = DefaultSwapInParams.MaxConfirmations,
+        refundDelay = DefaultSwapInParams.RefundDelay,
+    )
     val trampolineFees = listOf(
         TrampolineFees(0.sat, 0, CltvExpiryDelta(576)),
         TrampolineFees(1.sat, 100, CltvExpiryDelta(576)),
@@ -44,7 +48,7 @@ object TestConstants {
         private val seed = MnemonicCode.toSeed(mnemonics, "").toByteVector32()
 
         val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, bobSwapInServerXpub)
-        val walletParams = WalletParams(NodeUri(Bob.keyManager.nodeKeys.nodeKey.publicKey, "bob.com", 9735), trampolineFees, InvoiceDefaultRoutingFees(1_000.msat, 100, CltvExpiryDelta(144)), swapInConfirmations)
+        val walletParams = WalletParams(NodeUri(Bob.keyManager.nodeKeys.nodeKey.publicKey, "bob.com", 9735), trampolineFees, InvoiceDefaultRoutingFees(1_000.msat, 100, CltvExpiryDelta(144)), swapInParams)
         val nodeParams = NodeParams(
             chain = NodeParams.Chain.Regtest,
             loggerFactory = LoggerFactory.default,
@@ -93,7 +97,7 @@ object TestConstants {
         private val seed = MnemonicCode.toSeed(mnemonics, "").toByteVector32()
 
         val keyManager = LocalKeyManager(seed, NodeParams.Chain.Regtest, aliceSwapInServerXpub)
-        val walletParams = WalletParams(NodeUri(Alice.keyManager.nodeKeys.nodeKey.publicKey, "alice.com", 9735), trampolineFees, InvoiceDefaultRoutingFees(1_000.msat, 100, CltvExpiryDelta(144)), swapInConfirmations)
+        val walletParams = WalletParams(NodeUri(Alice.keyManager.nodeKeys.nodeKey.publicKey, "alice.com", 9735), trampolineFees, InvoiceDefaultRoutingFees(1_000.msat, 100, CltvExpiryDelta(144)), swapInParams)
         val nodeParams = NodeParams(
             chain = NodeParams.Chain.Regtest,
             loggerFactory = LoggerFactory.default,


### PR DESCRIPTION
Utxos used for swap-in have an expiry: after a delay the user can spend them unilaterally, which makes them dangerous to accept by the swap provider when we get close to that expiry. We expose these limits so that applications can tell their users to finalize swaps before reaching the expiry, otherwise they'll have to wait before unlocking them.

Fixes #534