### PR TITLE
Refactor peer connection establishment

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
@@ -243,7 +243,11 @@ class ElectrumClient(
             ?: ServerError(request, JsonRPCError(0, "timeout"))
         return when (result) {
             is ServerError -> {
-                logger.warning { "received error for ${request.method}: ${result.error.message}" }
+                when (request) {
+                    // Some electrum servers don't seem to respond to ping requests, even though they keep the connection alive.
+                    is Ping -> logger.debug { "received error for ${request.method}: ${result.error.message}" }
+                    else -> logger.warning { "received error for ${request.method}: ${result.error.message}" }
+                }
                 Either.Left(result)
             }
             else -> Either.Right(result as T)


### PR DESCRIPTION
Use the same pattern as the `ElectrumClient`, with an explicit job and timeouts. The `connect` function now suspends, which makes it easier to handle from the caller's point of view.

We don't have an easy way of unit testing that in `lightning-kmp`, so this will deserve some e2e tests.

Fixes #531
