### PR TITLE
Strip witnesses of interactive tx parents

### DIFF
--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
@@ -641,8 +641,8 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
             assertIs<FundingContributionFailure.InputBelowDust>(result)
         }
         run {
-            val txIn = (1..400).map { TxIn(OutPoint(randomBytes32(), 3), ByteVector.empty, 0, Script.witnessPay2wpkh(pubKey, Transactions.PlaceHolderSig)) }
-            val txOut = (1..400).map { i -> TxOut(1000.sat * i, Script.pay2wpkh(pubKey)) }
+            val txIn = (1..1000).map { TxIn(OutPoint(randomBytes32(), 3), ByteVector.empty, 0, Script.witnessPay2wpkh(pubKey, Transactions.PlaceHolderSig)) }
+            val txOut = (1..1000).map { i -> TxOut(1000.sat * i, Script.pay2wpkh(pubKey)) }
             val previousTx = Transaction(2, txIn, txOut, 0)
             val result = FundingContributions.create(channelKeys, swapInKeys, fundingParams, listOf(WalletState.Utxo(previousTx, 53, 0))).left
             assertNotNull(result)


### PR DESCRIPTION
We can safely remove the witness data, it doesn't affect txid and saves space. There is a max size on transactions due to lightning message limits.