### PR TITLE
Truncate public key of pinned servers in logs

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
@@ -47,7 +47,7 @@ interface TcpSocket {
             val pubKey: String
         ) : TLS() {
             override fun toString(): String {
-                return "PINNED_PUBLIC_KEY(pubKey=${pubKey.take(15)}...${pubKey.takeLast(15)}"
+                return "PINNED_PUBLIC_KEY(pubKey=${pubKey.take(64)}...}"
             }
         }
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/TcpSocket.kt
@@ -45,7 +45,11 @@ interface TcpSocket {
              * (I.e. same as PEM format, without BEGIN/END header/footer)
              */
             val pubKey: String
-        ) : TLS()
+        ) : TLS() {
+            override fun toString(): String {
+                return "PINNED_PUBLIC_KEY(pubKey=${pubKey.take(15)}...${pubKey.takeLast(15)}"
+            }
+        }
     }
 
     interface Builder {


### PR DESCRIPTION
This key is logged multiple times, especially when connecting to [Electrum server](https://github.com/ACINQ/phoenix/blob/master/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/ElectrumServers.kt) and is very large. Truncating `pubKey` will make logs more readable.