### PR TITLE
Release 1.5.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "fr.acinq.lightning"
-    version = "1.5.8-SNAPSHOT"
+    version = "1.5.8"
 
     repositories {
         // using the local maven repository with Kotlin Multi Platform can lead to build errors that are hard to diagnose.


### PR DESCRIPTION
This PR releases version 1.5.8, which mostly contains a fix (see #544) for version 1.5.7.