### PR TITLE
Filter `LegacyWaitForFundingConfirmed` on startup

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -225,7 +225,7 @@ class Peer(
         }
         launch {
             // we don't restore closed channels
-            val bootChannels = db.channels.listLocalChannels().filterNot { it is Closed }
+            val bootChannels = db.channels.listLocalChannels().filterNot { it is Closed || it is LegacyWaitForFundingConfirmed }
             _bootChannelsFlow.value = bootChannels.associateBy { it.channelId }
             val channelIds = bootChannels.map {
                 logger.info { "restoring channel ${it.channelId} from local storage" }


### PR DESCRIPTION
There are two reasons why a channel would be in this state:
  a) The peer was shut down during channel creation. The funding tx got published but the peer hasn't been started since.
  b) The channel creation was actually aborted, and not only will the funding tx never be published, the channel was forgotten altogether by the counterparty. In this case, the channel stays permanently in the state `Syncing(LegacyWaitForFundingConfirmed)` because the counterparty never sends `channel_reestablish` and lightning-kmp will not send his when the remote backup is enabled.

There are some users in the b) case, it caused them to be stuck during migration (because we were checking that all states were either synced or closed). We published a patch, but then the same users are stuck with the swap-in, because we do the same kind of check.

I fail to see why we even stored channels in that state in the first place: either the channel was actually created and it would be restored upon reconnection, or the channel creation was aborted and it's better to forget about it.