### PR TITLE
Add a keep-alive mechanism

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -2,7 +2,9 @@ package fr.acinq.lightning.channel.states
 
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.SigHash
-import fr.acinq.lightning.*
+import fr.acinq.lightning.Feature
+import fr.acinq.lightning.Features
+import fr.acinq.lightning.ShortChannelId
 import fr.acinq.lightning.blockchain.BITCOIN_FUNDING_DEPTHOK
 import fr.acinq.lightning.blockchain.WatchConfirmed
 import fr.acinq.lightning.blockchain.WatchEventConfirmed
@@ -375,7 +377,6 @@ data class Normal(
                                     fundingContributions = FundingContributions(emptyList(), emptyList()), // as non-initiator we don't contribute to this splice for now
                                     previousTxs = emptyList()
                                 )
-                                staticParams.nodeParams._nodeEvents.tryEmit(SensitiveTaskEvents.TaskStarted(SensitiveTaskEvents.TaskIdentifier.InteractiveTx(fundingParams)))
                                 val nextState = this@Normal.copy(spliceStatus = SpliceStatus.InProgress(replyTo = null, session, localPushAmount = 0.msat, remotePushAmount = cmd.message.pushAmount, origins = cmd.message.origins))
                                 Pair(nextState, listOf(ChannelAction.Message.Send(spliceAck)))
                             } else {
@@ -434,7 +435,6 @@ data class Normal(
                                     ).send()
                                     when (interactiveTxAction) {
                                         is InteractiveTxSessionAction.SendMessage -> {
-                                            staticParams.nodeParams._nodeEvents.tryEmit(SensitiveTaskEvents.TaskStarted(SensitiveTaskEvents.TaskIdentifier.InteractiveTx(fundingParams)))
                                             val nextState = this@Normal.copy(
                                                 spliceStatus = SpliceStatus.InProgress(
                                                     replyTo = spliceStatus.command.replyTo,
@@ -484,7 +484,6 @@ data class Normal(
                                         is Either.Left -> {
                                             logger.error(signingSession.value) { "cannot initiate interactive-tx splice signing session" }
                                             spliceStatus.replyTo?.complete(ChannelCommand.Commitment.Splice.Response.Failure.CannotCreateCommitTx(signingSession.value))
-                                            staticParams.nodeParams._nodeEvents.tryEmit(SensitiveTaskEvents.TaskEnded(SensitiveTaskEvents.TaskIdentifier.InteractiveTx(spliceStatus.spliceSession.fundingParams)))
                                             Pair(this@Normal.copy(spliceStatus = SpliceStatus.Aborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, signingSession.value.message))))
                                         }
                                         is Either.Right -> {
@@ -515,7 +514,6 @@ data class Normal(
                                 is InteractiveTxSessionAction.RemoteFailure -> {
                                     logger.warning { "interactive-tx failed: $interactiveTxAction" }
                                     spliceStatus.replyTo?.complete(ChannelCommand.Commitment.Splice.Response.Failure.InteractiveTxSessionFailed(interactiveTxAction))
-                                    staticParams.nodeParams._nodeEvents.tryEmit(SensitiveTaskEvents.TaskEnded(SensitiveTaskEvents.TaskIdentifier.InteractiveTx(spliceStatus.spliceSession.fundingParams)))
                                     Pair(this@Normal.copy(spliceStatus = SpliceStatus.Aborted), listOf(ChannelAction.Message.Send(TxAbort(channelId, interactiveTxAction.toString()))))
                                 }
                             }
@@ -584,7 +582,6 @@ data class Normal(
                         is SpliceStatus.InProgress -> {
                             logger.info { "our peer aborted the splice attempt: ascii='${cmd.message.toAscii()}' bin=${cmd.message.data}" }
                             spliceStatus.replyTo?.complete(ChannelCommand.Commitment.Splice.Response.Failure.AbortedByPeer(cmd.message.toAscii()))
-                            staticParams.nodeParams._nodeEvents.tryEmit(SensitiveTaskEvents.TaskEnded(SensitiveTaskEvents.TaskIdentifier.InteractiveTx(spliceStatus.spliceSession.fundingParams)))
                             Pair(
                                 this@Normal.copy(spliceStatus = SpliceStatus.None),
                                 listOf(ChannelAction.Message.Send(TxAbort(channelId, SpliceAborted(channelId).message)))
@@ -592,7 +589,6 @@ data class Normal(
                         }
                         is SpliceStatus.WaitingForSigs -> {
                             logger.info { "our peer aborted the splice attempt: ascii='${cmd.message.toAscii()}' bin=${cmd.message.data}" }
-                            staticParams.nodeParams._nodeEvents.tryEmit(SensitiveTaskEvents.TaskEnded(SensitiveTaskEvents.TaskIdentifier.InteractiveTx(spliceStatus.session.fundingParams)))
                             val nextState = this@Normal.copy(spliceStatus = SpliceStatus.None)
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -736,8 +732,6 @@ data class Normal(
                 add(ChannelAction.Message.Send(spliceLocked))
             }
         }
-        // If we are here, both parties have sent and persisted their commit_sig, so the interactive-tx process will survive a disconnection, even if it may still eventually fail.
-        staticParams.nodeParams._nodeEvents.tryEmit(SensitiveTaskEvents.TaskStarted(SensitiveTaskEvents.TaskIdentifier.InteractiveTx(action.fundingTx.fundingParams)))
         return Pair(nextState, actions)
     }
 


### PR DESCRIPTION
The goal is to make mobile apps (especially on iOS) more robust wrt to disconnections/app switching/background, etc.  by signalling when they need a little bit more uptime to complete some tasks.

~~This is just a proof of concept. In particular:
(a) The callback could take an argument providing more context on the task, for logging purposes. It could also be a `Flow` which maybe would help manage concurrency by integrators. There is no way to indicate when a given task has been completed, the call is stateless and just means "don't kill me just yet". I'm afraid it would be very difficult/impossible to have that level of precision in the general case.
(b) There is only one call to the callback and the location is probably not optimal, it's just an example.~~

~~Pay-to-open is a prime candidate for experimenting, because a disconnection _after_ the parts have been received by Phoenix and _before_ the peer has received the preimage would cause the payment to be aborted by the peer, and stay pending forever on phoenix.~~

@robbiehanson Please advise on a). Is there any limitation or best practice that we should be aware of (should we make frequent requests? or as few as possible?)? That will help addressing b) in an optimal way.~

edit: Following feeback, implementation now uses `NodeEvent`s. Support is limited to interactive-tx in a splice as a proof of concept.