### PR TITLE
Fix `update_fee` reserve requirement mismatch

### DIFF
--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
@@ -1419,7 +1419,8 @@ class NormalTestsCommon : LightningTestSuite() {
         assertEquals(bob.commitments.copy(changes = bob.commitments.changes.copy(remoteChanges = bob.commitments.changes.remoteChanges.copy(proposed = bob.commitments.changes.remoteChanges.proposed + fee2))), bob2.commitments)
     }
 
-    @Test
+    // TODO: restore this test once we take the reserve into account (see canReceiveFee)
+    @Ignore
     fun `recv UpdateFee -- sender cannot afford it`() {
         val (alice, bob) = reachNormal()
         // We put all the balance on Bob's side, so that Alice cannot afford a feerate increase.


### PR DESCRIPTION
The splicing update removed the `channelReserve` field from `LocalParams` and always uses a value of 1% of the channel capacity. But that is incorrect for channels that were created before that update and haven't been migrated.

For such channels, we will use an incorrect channel reserve which can end up force-closing channels when receiving otherwise valid `update_fee` messages. We temporarily ignore the reserve in this computation and will re-enable it once all users have been migrated to use splicing.

We also fix a mismatch between the local and remote dust limit used when computing commit tx fees.