### PR TITLE
Send commit sigs for alternative feerates

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -7,6 +7,7 @@ import fr.acinq.bitcoin.Transaction
 import fr.acinq.lightning.CltvExpiryDelta
 import fr.acinq.lightning.Feature
 import fr.acinq.lightning.NodeParams
+import fr.acinq.lightning.SensitiveTaskEvents
 import fr.acinq.lightning.blockchain.*
 import fr.acinq.lightning.blockchain.fee.OnChainFeerates
 import fr.acinq.lightning.channel.*

--- a/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
@@ -64,7 +64,6 @@
     JsonSerializers.CommitmentChangesSerializer::class,
     JsonSerializers.LocalFundingStatusSerializer::class,
     JsonSerializers.RemoteFundingStatusSerializer::class,
-    JsonSerializers.EncryptedChannelDataSerializer::class,
     JsonSerializers.ShutdownSerializer::class,
     JsonSerializers.ClosingSignedSerializer::class,
     JsonSerializers.UpdateAddHtlcSerializer::class,
@@ -82,6 +81,8 @@
     JsonSerializers.ClosingSignedTlvSerializer::class,
     JsonSerializers.ChannelReestablishTlvSerializer::class,
     JsonSerializers.ChannelReadyTlvSerializer::class,
+    JsonSerializers.CommitSigTlvAlternativeFeerateSigSerializer::class,
+    JsonSerializers.CommitSigTlvAlternativeFeerateSigsSerializer::class,
     JsonSerializers.CommitSigTlvSerializer::class,
     JsonSerializers.UUIDSerializer::class,
     JsonSerializers.ClosingSerializer::class,
@@ -184,6 +185,7 @@ object JsonSerializers {
             }
             polymorphic(Tlv::class) {
                 subclass(ChannelReadyTlv.ShortChannelIdTlv::class, ChannelReadyTlvShortChannelIdTlvSerializer)
+                subclass(CommitSigTlv.AlternativeFeerateSigs::class, CommitSigTlvAlternativeFeerateSigsSerializer)
                 subclass(ShutdownTlv.ChannelData::class, ShutdownTlvChannelDataSerializer)
                 subclass(ClosingSignedTlv.FeeRange::class, ClosingSignedTlvFeeRangeSerializer)
             }
@@ -485,6 +487,12 @@ object JsonSerializers {
 
     @Serializer(forClass = ShutdownTlv::class)
     object ShutdownTlvSerializer
+
+    @Serializer(forClass = CommitSigTlv.AlternativeFeerateSig::class)
+    object CommitSigTlvAlternativeFeerateSigSerializer
+
+    @Serializer(forClass = CommitSigTlv.AlternativeFeerateSigs::class)
+    object CommitSigTlvAlternativeFeerateSigsSerializer
 
     @Serializer(forClass = CommitSigTlv::class)
     object CommitSigTlvSerializer

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -1101,6 +1101,7 @@ data class CommitSig(
     override val channelData: EncryptedChannelData get() = tlvStream.get<CommitSigTlv.ChannelData>()?.ecb ?: EncryptedChannelData.empty
     override fun withNonEmptyChannelData(ecd: EncryptedChannelData): CommitSig = copy(tlvStream = tlvStream.addOrUpdate(CommitSigTlv.ChannelData(ecd)))
 
+    val alternativeFeerateSigs: List<CommitSigTlv.AlternativeFeerateSig> = tlvStream.get<CommitSigTlv.AlternativeFeerateSigs>()?.sigs ?: listOf()
     val batchSize: Int = tlvStream.get<CommitSigTlv.Batch>()?.size ?: 1
 
     override fun write(out: Output) {
@@ -1117,6 +1118,7 @@ data class CommitSig(
         @Suppress("UNCHECKED_CAST")
         val readers = mapOf(
             CommitSigTlv.ChannelData.tag to CommitSigTlv.ChannelData.Companion as TlvValueReader<CommitSigTlv>,
+            CommitSigTlv.AlternativeFeerateSigs.tag to CommitSigTlv.AlternativeFeerateSigs.Companion as TlvValueReader<CommitSigTlv>,
             CommitSigTlv.Batch.tag to CommitSigTlv.Batch.Companion as TlvValueReader<CommitSigTlv>,
         )
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
@@ -20,7 +20,6 @@ import fr.acinq.lightning.channel.TestsHelper.localClose
 import fr.acinq.lightning.channel.TestsHelper.makeCmdAdd
 import fr.acinq.lightning.channel.TestsHelper.mutualCloseAlice
 import fr.acinq.lightning.channel.TestsHelper.mutualCloseBob
-
 import fr.acinq.lightning.channel.TestsHelper.reachNormal
 import fr.acinq.lightning.channel.TestsHelper.remoteClose
 import fr.acinq.lightning.db.ChannelClosingType
@@ -708,6 +707,62 @@ class ClosingTestsCommon : LightningTestSuite() {
         confirmWatchedTxs(aliceFulfill, watchConfirmed)
     }
 
+    private fun useAlternativeSig(s: LNChannel<ChannelState>, alternative: CommitSigTlv.AlternativeFeerateSig): Transaction {
+        val channelKeys = s.commitments.params.localParams.channelKeys(s.ctx.keyManager)
+        val alternativeSpec = s.commitments.latest.localCommit.spec.copy(feerate = alternative.feerate)
+        val fundingTxIndex = s.commitments.latest.fundingTxIndex
+        val commitInput = s.commitments.latest.commitInput
+        val remoteFundingPubKey = s.commitments.latest.remoteFundingPubkey
+        val localPerCommitmentPoint = channelKeys.commitmentPoint(s.commitments.localCommitIndex)
+        val (localCommitTx, _) = Commitments.makeLocalTxs(
+            channelKeys,
+            s.commitments.localCommitIndex,
+            s.commitments.params.localParams,
+            s.commitments.params.remoteParams,
+            fundingTxIndex,
+            remoteFundingPubKey,
+            commitInput,
+            localPerCommitmentPoint,
+            alternativeSpec
+        )
+        val localSig = Transactions.sign(localCommitTx, channelKeys.fundingKey(fundingTxIndex))
+        val signedCommitTx = Transactions.addSigs(localCommitTx, channelKeys.fundingPubKey(fundingTxIndex), remoteFundingPubKey, localSig, alternative.sig)
+        assertTrue(Transactions.checkSpendable(signedCommitTx).isSuccess)
+        return signedCommitTx.tx
+    }
+
+    @Test
+    fun `recv BITCOIN_TX_CONFIRMED -- remote commit -- alternative feerate`() {
+        val (alice0, bob0) = reachNormal()
+        val (bobClosing, remoteCommitPublished) = run {
+            val (nodes1, r, htlc) = addHtlc(75_000_000.msat, alice0, bob0)
+            val (alice1, bob1) = nodes1
+            val (alice2, bob2) = crossSign(alice1, bob1)
+            val (alice3, bob3) = fulfillHtlc(htlc.id, r, alice2, bob2)
+            val (bob4, actionsBob4) = bob3.process(ChannelCommand.Commitment.Sign)
+            val commitSigBob = actionsBob4.hasOutgoingMessage<CommitSig>()
+            val (alice4, actionsAlice4) = alice3.process(ChannelCommand.MessageReceived(commitSigBob))
+            val revAlice = actionsAlice4.hasOutgoingMessage<RevokeAndAck>()
+            val (alice5, actionsAlice5) = alice4.process(ChannelCommand.Commitment.Sign)
+            val commitSigAlice = actionsAlice5.hasOutgoingMessage<CommitSig>()
+            val (bob5, _) = bob4.process(ChannelCommand.MessageReceived(revAlice))
+            val (bob6, actionsBob6) = bob5.process(ChannelCommand.MessageReceived(commitSigAlice))
+            val revBob = actionsBob6.hasOutgoingMessage<RevokeAndAck>()
+            val (alice6, _) = alice5.process(ChannelCommand.MessageReceived(revBob))
+            val alternativeCommitTx = useAlternativeSig(alice6, commitSigBob.alternativeFeerateSigs.first())
+            remoteClose(alternativeCommitTx, bob6)
+        }
+
+        assertNotNull(remoteCommitPublished.claimMainOutputTx)
+        val claimMain = remoteCommitPublished.claimMainOutputTx!!.tx
+        Transaction.correctlySpends(claimMain, remoteCommitPublished.commitTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+
+        val (bobClosing1, _) = bobClosing.process(ChannelCommand.WatchReceived(WatchEventConfirmed(bob0.channelId, BITCOIN_TX_CONFIRMED(remoteCommitPublished.commitTx), 42, 0, remoteCommitPublished.commitTx)))
+        val (bobClosed, actions) = bobClosing1.process(ChannelCommand.WatchReceived(WatchEventConfirmed(bob0.channelId, BITCOIN_TX_CONFIRMED(claimMain), 43, 0, claimMain)))
+        assertIs<Closed>(bobClosed.state)
+        assertTrue(actions.contains(ChannelAction.Storage.StoreState(bobClosed.state)))
+    }
+
     @Test
     fun `recv BITCOIN_OUTPUT_SPENT -- remote commit`() {
         val (alice0, bob0) = reachNormal()
@@ -898,7 +953,7 @@ class ClosingTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `recv BITCOIN_TX_CONFIRMED -- next remote commit --  followed by CMD_FULFILL_HTLC`() {
+    fun `recv BITCOIN_TX_CONFIRMED -- next remote commit -- followed by CMD_FULFILL_HTLC`() {
         val (alice0, bob0) = reachNormal()
         val (aliceClosing, remoteCommitPublished, fulfill) = run {
             // An HTLC Bob -> Alice is cross-signed that will be fulfilled later.
@@ -947,6 +1002,31 @@ class ClosingTestsCommon : LightningTestSuite() {
             WatchEventConfirmed(alice0.channelId, BITCOIN_TX_CONFIRMED(remoteCommitPublished.claimMainOutputTx!!.tx), 250, 0, remoteCommitPublished.claimMainOutputTx!!.tx)
         )
         confirmWatchedTxs(aliceFulfill, watchConfirmed)
+    }
+
+    @Test
+    fun `recv BITCOIN_TX_CONFIRMED -- next remote commit -- alternative feerate`() {
+        val (alice0, bob0) = reachNormal()
+        val (bobClosing, remoteCommitPublished) = run {
+            val (nodes1, r, htlc) = addHtlc(75_000_000.msat, alice0, bob0)
+            val (alice1, bob1) = nodes1
+            val (alice2, bob2) = crossSign(alice1, bob1)
+            val (alice3, bob3) = fulfillHtlc(htlc.id, r, alice2, bob2)
+            val (bob4, actionsBob4) = bob3.process(ChannelCommand.Commitment.Sign)
+            val commitSigBob = actionsBob4.hasOutgoingMessage<CommitSig>()
+            val (alice4, _) = alice3.process(ChannelCommand.MessageReceived(commitSigBob))
+            val alternativeCommitTx = useAlternativeSig(alice4, commitSigBob.alternativeFeerateSigs.first())
+            remoteClose(alternativeCommitTx, bob4)
+        }
+
+        assertNotNull(remoteCommitPublished.claimMainOutputTx)
+        val claimMain = remoteCommitPublished.claimMainOutputTx!!.tx
+        Transaction.correctlySpends(claimMain, remoteCommitPublished.commitTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+
+        val (bobClosing1, _) = bobClosing.process(ChannelCommand.WatchReceived(WatchEventConfirmed(bob0.channelId, BITCOIN_TX_CONFIRMED(remoteCommitPublished.commitTx), 42, 0, remoteCommitPublished.commitTx)))
+        val (bobClosed, actions) = bobClosing1.process(ChannelCommand.WatchReceived(WatchEventConfirmed(bob0.channelId, BITCOIN_TX_CONFIRMED(claimMain), 43, 0, claimMain)))
+        assertIs<Closed>(bobClosed.state)
+        assertTrue(actions.contains(ChannelAction.Storage.StoreState(bobClosed.state)))
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -338,6 +338,32 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
     }
 
     @Test
+    fun `encode - decode commit_sig`() {
+        val channelId = ByteVector32.fromValidHex("2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db25")
+        val signature = ByteVector64.fromValidHex("05e06d9a8fdfbb3625051ff2e3cdf82679cc2268beee6905941d6dd8a067cd62711e04b119a836aa0eebe07545172cefb228860fea6c797178453a319169bed7")
+        val alternateSigs = listOf(
+            CommitSigTlv.AlternativeFeerateSig(FeeratePerKw(253.sat), ByteVector64.fromValidHex("c49269a9baa73a5ec44b63bdcaabf9c7c6477f72866b822f8502e5c989aa3562fe69d72bec62025d3474b9c2d947ec6d68f9f577be5fab8ee80503cefd8846c3")),
+            CommitSigTlv.AlternativeFeerateSig(FeeratePerKw(500.sat), ByteVector64.fromValidHex("2dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db252a2f914ea1fcbd580b80cdea60226f63288cd44bd84a8850c9189a24f08c7cc5")),
+            CommitSigTlv.AlternativeFeerateSig(FeeratePerKw(750.sat), ByteVector64.fromValidHex("83a7a1a04141ac8ab2818f4a872ea86716ef9aac0852146bcdbc2cc49aecc985899a63513f41ed2502a321a4945689239d12bdab778c1a2e8bf7c3f19ec53b58")),
+        )
+        val backup = EncryptedChannelData(ByteVector.fromHex("fe69d72bec62025d3474b9c2d947ec6d68f9f577be5fab8ee80503cefd8846c303a6680e79e30f050d4f32f1fb9d046cc6efb5ed4cc99eeedba6b2e89cbf838691"))
+        val testCases = listOf(
+            // @formatter:off
+            CommitSig(channelId, signature, listOf(), TlvStream(CommitSigTlv.ChannelData(backup))) to "00842dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db2505e06d9a8fdfbb3625051ff2e3cdf82679cc2268beee6905941d6dd8a067cd62711e04b119a836aa0eebe07545172cefb228860fea6c797178453a319169bed70000fe4701000041fe69d72bec62025d3474b9c2d947ec6d68f9f577be5fab8ee80503cefd8846c303a6680e79e30f050d4f32f1fb9d046cc6efb5ed4cc99eeedba6b2e89cbf838691",
+            CommitSig(channelId, signature, listOf(), TlvStream(CommitSigTlv.ChannelData(backup), CommitSigTlv.AlternativeFeerateSigs(listOf()))) to "00842dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db2505e06d9a8fdfbb3625051ff2e3cdf82679cc2268beee6905941d6dd8a067cd62711e04b119a836aa0eebe07545172cefb228860fea6c797178453a319169bed70000fe4701000041fe69d72bec62025d3474b9c2d947ec6d68f9f577be5fab8ee80503cefd8846c303a6680e79e30f050d4f32f1fb9d046cc6efb5ed4cc99eeedba6b2e89cbf838691fe470100010100",
+            CommitSig(channelId, signature, listOf(), TlvStream(CommitSigTlv.AlternativeFeerateSigs(alternateSigs))) to "00842dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db2505e06d9a8fdfbb3625051ff2e3cdf82679cc2268beee6905941d6dd8a067cd62711e04b119a836aa0eebe07545172cefb228860fea6c797178453a319169bed70000fe47010001cd03000000fdc49269a9baa73a5ec44b63bdcaabf9c7c6477f72866b822f8502e5c989aa3562fe69d72bec62025d3474b9c2d947ec6d68f9f577be5fab8ee80503cefd8846c3000001f42dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db252a2f914ea1fcbd580b80cdea60226f63288cd44bd84a8850c9189a24f08c7cc5000002ee83a7a1a04141ac8ab2818f4a872ea86716ef9aac0852146bcdbc2cc49aecc985899a63513f41ed2502a321a4945689239d12bdab778c1a2e8bf7c3f19ec53b58",
+            CommitSig(channelId, signature, listOf(), TlvStream(CommitSigTlv.ChannelData(backup), CommitSigTlv.AlternativeFeerateSigs(alternateSigs))) to "00842dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db2505e06d9a8fdfbb3625051ff2e3cdf82679cc2268beee6905941d6dd8a067cd62711e04b119a836aa0eebe07545172cefb228860fea6c797178453a319169bed70000fe4701000041fe69d72bec62025d3474b9c2d947ec6d68f9f577be5fab8ee80503cefd8846c303a6680e79e30f050d4f32f1fb9d046cc6efb5ed4cc99eeedba6b2e89cbf838691fe47010001cd03000000fdc49269a9baa73a5ec44b63bdcaabf9c7c6477f72866b822f8502e5c989aa3562fe69d72bec62025d3474b9c2d947ec6d68f9f577be5fab8ee80503cefd8846c3000001f42dadacd65b585e4061421b5265ff543e2a7bdc4d4a7fea932727426bdc53db252a2f914ea1fcbd580b80cdea60226f63288cd44bd84a8850c9189a24f08c7cc5000002ee83a7a1a04141ac8ab2818f4a872ea86716ef9aac0852146bcdbc2cc49aecc985899a63513f41ed2502a321a4945689239d12bdab778c1a2e8bf7c3f19ec53b58",
+            // @formatter:on
+        )
+        testCases.forEach { (commitSig, bin) ->
+            val decoded = LightningMessage.decode(Hex.decode(bin))
+            assertEquals(decoded, commitSig)
+            val encoded = LightningMessage.encode(commitSig)
+            assertEquals(Hex.encode(encoded), bin)
+        }
+    }
+
+    @Test
     fun `encode - decode interactive-tx messages`() {
         val channelId1 = ByteVector32("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
         val channelId2 = ByteVector32("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")


### PR DESCRIPTION
When the commitment transaction doesn't contain any HTLC, we send additional signatures for alternative feerates. This lets the wallet provider force-close with a more interesting feerate when the wallet user disappears without closing their channels.