### PR TITLE
Fix `tx_signatures` ordering for splices

### DIFF
--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SpliceTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SpliceTestsCommon.kt
@@ -38,6 +38,12 @@ class SpliceTestsCommon : LightningTestSuite() {
     }
 
     @Test
+    fun `splice funds in -- non-initiator`() {
+        val (alice, bob) = reachNormal()
+        spliceIn(bob, alice, listOf(50_000.sat))
+    }
+
+    @Test
     fun `splice funds in -- many utxos`() {
         val (alice, bob) = reachNormal()
         spliceIn(alice, bob, listOf(30_000.sat, 40_000.sat, 25_000.sat))


### PR DESCRIPTION
We were incorrectly splitting the shared input amount based on each peer's balance, but for the signing order the peer that adds the shared input takes credit for the whole amount of that input.