### PR TITLE
Correct dust limit for splice inputs

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/transactions/Transactions.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/transactions/Transactions.kt
@@ -181,6 +181,21 @@ object Transactions {
      */
     fun fee2rate(fee: Satoshi, weight: Int): FeeratePerKw = FeeratePerKw((fee * 1000L) / weight.toLong())
 
+    /** As defined in https://github.com/lightning/bolts/blob/master/03-transactions.md#dust-limits */
+    fun dustLimit(scriptPubKey: ByteVector): Satoshi {
+        return runTrying {
+            val script = Script.parse(scriptPubKey)
+            when {
+                Script.isPay2pkh(script) -> 546.sat
+                Script.isPay2sh(script) -> 540.sat
+                Script.isPay2wpkh(script) -> 294.sat
+                Script.isPay2wsh(script) -> 330.sat
+                Script.isNativeWitnessScript(script) -> 354.sat
+                else -> 546.sat
+            }
+        }.getOrElse { 546.sat }
+    }
+
     /** Offered HTLCs below this amount will be trimmed. */
     fun offeredHtlcTrimThreshold(dustLimit: Satoshi, spec: CommitmentSpec): Satoshi = dustLimit + weight2fee(spec.feerate, Commitments.HTLC_TIMEOUT_WEIGHT)
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
@@ -635,7 +635,7 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         val pubKey = privKey.publicKey()
         val fundingParams = InteractiveTxParams(randomBytes32(), true, 150_000.sat, 50_000.sat, pubKey, 0, 660.sat, FeeratePerKw(2500.sat))
         run {
-            val previousTx = Transaction(2, listOf(), listOf(TxOut(650.sat, Script.pay2wpkh(pubKey))), 0)
+            val previousTx = Transaction(2, listOf(), listOf(TxOut(293.sat, Script.pay2wpkh(pubKey))), 0)
             val result = FundingContributions.create(channelKeys, swapInKeys, fundingParams, listOf(WalletState.Utxo(previousTx, 0, 0))).left
             assertNotNull(result)
             assertIs<FundingContributionFailure.InputBelowDust>(result)


### PR DESCRIPTION
When creating a splice transaction, we should filter out inputs that are below the dust limit. But we should apply the dust limit that matches each script type, instead of the using the channel's dust limit (which is used for the outputs of the funding and commitment transactions).