### PR TITLE
Release v1.5.12

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "fr.acinq.lightning"
-    version = "1.5.12-SNAPSHOT"
+    version = "1.5.12"
 
     repositories {
         // using the local maven repository with Kotlin Multi Platform can lead to build errors that are hard to diagnose.


### PR DESCRIPTION
This PR tags version 1.5.12 which is a bug fix release, along with an improvement on the peer connection.

See diff: https://github.com/ACINQ/lightning-kmp/compare/v1.5.11...2261535b18a232680d0cf575cefa868b1c3d2d0e