### PR TITLE
Unlock utxos when peer is unavailable for splice

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -453,7 +453,6 @@ class Peer(
                 .combine(currentTipFlow.filterNotNull()) { walletState, currentTip -> Pair(walletState, currentTip.first) }
                 .combine(swapInFeeratesFlow.filterNotNull()) { (walletState, currentTip), feerate -> Triple(walletState, currentTip, feerate) }
                 .combine(nodeParams.liquidityPolicy) { (walletState, currentTip, feerate), policy -> TrySwapInFlow(currentTip, walletState, feerate, policy) }
-                .combine(channelsFlow.filter { it.values.all { channel -> channel !is Offline && channel !is Syncing } }) { req, _ -> req } // this is only for synchronization, we discard the channels data
                 .collect { w ->
                     // Local mutual close txs from pre-splice channels can be used as zero-conf inputs for swap-in to facilitate migration
                     val mutualCloseTxs = channels.values

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -453,6 +453,7 @@ class Peer(
                 .combine(currentTipFlow.filterNotNull()) { walletState, currentTip -> Pair(walletState, currentTip.first) }
                 .combine(swapInFeeratesFlow.filterNotNull()) { (walletState, currentTip), feerate -> Triple(walletState, currentTip, feerate) }
                 .combine(nodeParams.liquidityPolicy) { (walletState, currentTip, feerate), policy -> TrySwapInFlow(currentTip, walletState, feerate, policy) }
+                .combine(channelsFlow.filter { it.values.all { channel -> channel !is Offline && channel !is Syncing } }) { req, _ -> req } // this is only for synchronization, we discard the channels data
                 .collect { w ->
                     // Local mutual close txs from pre-splice channels can be used as zero-conf inputs for swap-in to facilitate migration
                     val mutualCloseTxs = channels.values
@@ -1076,6 +1077,7 @@ class Peer(
                         } else {
                             // There are existing channels but not immediately usable (e.g. creating, disconnected), we don't do anything yet
                             logger.info { "ignoring channel request, existing channels are not ready for splice-in: ${channels.values.map { it::class.simpleName }}" }
+                            swapInCommands.trySend(SwapInCommand.UnlockWalletInputs(cmd.walletInputs.map { it.outPoint }.toSet()))
                         }
                     }
                 }


### PR DESCRIPTION
If the peer is offline when the swap-in job requests a splice-in, the request will be ignored, but we weren't unlocking UTXOs, preventing any further attempt.

Also add an optimistic synchronization in the swap-in job, which as a side effect will cause us to retry swaps everytime the peer gets reconnected (vs at every new block or liquidity policy update previously).

cc @dpad85 @robbiehanson 