### PR TITLE
Fix liquidity ads purchase completion time

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -400,7 +400,7 @@ data class InboundLiquidityOutgoingPayment(
 ) : OnChainOutgoingPayment() {
     override val fees: MilliSatoshi = (miningFees + lease.fees.serviceFee).toMilliSatoshi()
     override val amount: MilliSatoshi = fees
-    override val completedAt: Long? = confirmedAt
+    override val completedAt: Long? = lockedAt
 }
 
 enum class ChannelClosingType {


### PR DESCRIPTION
The inbound liquidity is available as soon as the splice has been locked, not when it has been confirmed.