### PR TITLE
Send `batch_size` on `commit_sig` retransmit

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
@@ -88,6 +88,7 @@
     JsonSerializers.ChannelReadyTlvSerializer::class,
     JsonSerializers.CommitSigTlvAlternativeFeerateSigSerializer::class,
     JsonSerializers.CommitSigTlvAlternativeFeerateSigsSerializer::class,
+    JsonSerializers.CommitSigTlvBatchSerializer::class,
     JsonSerializers.CommitSigTlvSerializer::class,
     JsonSerializers.UUIDSerializer::class,
     JsonSerializers.ClosingSerializer::class,
@@ -193,6 +194,7 @@ object JsonSerializers {
             polymorphic(Tlv::class) {
                 subclass(ChannelReadyTlv.ShortChannelIdTlv::class, ChannelReadyTlvShortChannelIdTlvSerializer)
                 subclass(CommitSigTlv.AlternativeFeerateSigs::class, CommitSigTlvAlternativeFeerateSigsSerializer)
+                subclass(CommitSigTlv.Batch::class, CommitSigTlvBatchSerializer)
                 subclass(ShutdownTlv.ChannelData::class, ShutdownTlvChannelDataSerializer)
                 subclass(ClosingSignedTlv.FeeRange::class, ClosingSignedTlvFeeRangeSerializer)
             }
@@ -511,6 +513,9 @@ object JsonSerializers {
 
     @Serializer(forClass = CommitSigTlv.AlternativeFeerateSigs::class)
     object CommitSigTlvAlternativeFeerateSigsSerializer
+
+    @Serializer(forClass = CommitSigTlv.Batch::class)
+    object CommitSigTlvBatchSerializer
 
     @Serializer(forClass = CommitSigTlv::class)
     object CommitSigTlvSerializer


### PR DESCRIPTION
If we get disconnected after sending `commit_sig`, we will retransmit that message when reconnecting if our peer has not received it.

When we have multiple commitments, we need to retransmit one message per commitment, and include the `batch_size` tlv.

We incorrectly stored `commit_sig` without the `batch_size` tlv in the next remote commit field, and thus retransmitted without that tlv.