### PR TITLE
Purge pending incoming payments on disconnection

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -436,7 +436,7 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
             // We also need to filter out htlcs that we already settled and signed (the settlement messages are being retransmitted).
             val alreadySettled = commitments1.changes.localChanges.signed.filterIsInstance<HtlcSettlementMessage>().map { it.id }.toSet()
             val htlcsToReprocess = commitments1.latest.remoteCommit.spec.htlcs.outgoings().filter { !alreadySettled.contains(it.id) }
-            logger.debug { "re-processing signed IN: $htlcsToReprocess" }
+            logger.info { "re-processing signed incoming HTLCs: ${htlcsToReprocess.map { it.id }.joinToString(", ")}" }
             sendQueue.addAll(htlcsToReprocess.map { ChannelAction.ProcessIncomingHtlc(it) })
 
             return Pair(commitments1, sendQueue)

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -1211,7 +1211,6 @@ class Peer(
                         // another instance of the application may resolve them, which would lead to inconsistent
                         // payment handler state (whereas the channel state is kept consistent thanks to the encrypted
                         // channel backup).
-                        logger.info { "purging pending incoming payments from payment handler" }
                         incomingPaymentHandler.purgePendingPayments()
                     }
                 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -1206,7 +1206,13 @@ class Peer(
                             _channels = _channels + (key to state1)
                             processActions(key, peerConnection, actions)
                         }
-                        incomingPaymentHandler.purgePayToOpenRequests()
+                        // We must purge pending incoming payments: incoming HTLCs that aren't settled yet will be
+                        // re-processed on reconnection, and we must not keep HTLCs pending in the payment handler since
+                        // another instance of the application may resolve them, which would lead to inconsistent
+                        // payment handler state (whereas the channel state is kept consistent thanks to the encrypted
+                        // channel backup).
+                        logger.info { "purging pending incoming payments from payment handler" }
+                        incomingPaymentHandler.purgePendingPayments()
                     }
                 }
             }

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -503,7 +503,7 @@ class PeerTest : LightningTestSuite() {
     }
 
     @Test
-    fun `payment test between two phoenix nodes -- manual mode`() = runSuspendTest {
+    fun `payment between two nodes -- manual mode`() = runSuspendTest {
         val (alice0, bob0) = TestsHelper.reachNormal()
         val nodeParams = Pair(alice0.staticParams.nodeParams, bob0.staticParams.nodeParams)
         val walletParams = Pair(
@@ -547,7 +547,108 @@ class PeerTest : LightningTestSuite() {
     }
 
     @Test
-    fun `payment test between two phoenix nodes -- automated messaging`() = runSuspendTest {
+    fun `payment between two nodes -- with disconnection`() = runSuspendTest {
+        // We create two channels between Alice and Bob to ensure that the payment is split in two parts.
+        val (aliceChan1, bobChan1) = TestsHelper.reachNormal(aliceFundingAmount = 100_000.sat, bobFundingAmount = 100_000.sat, alicePushAmount = 0.msat, bobPushAmount = 0.msat)
+        val (aliceChan2, bobChan2) = TestsHelper.reachNormal(aliceFundingAmount = 100_000.sat, bobFundingAmount = 100_000.sat, alicePushAmount = 0.msat, bobPushAmount = 0.msat)
+        val nodeParams = Pair(aliceChan1.staticParams.nodeParams, bobChan1.staticParams.nodeParams)
+        val walletParams = Pair(
+            // Alice must declare Bob as her trampoline node to enable direct payments.
+            TestConstants.Alice.walletParams.copy(trampolineNode = NodeUri(nodeParams.second.nodeId, "bob.com", 9735)),
+            TestConstants.Bob.walletParams
+        )
+        // Bob sends a multipart payment to Alice.
+        val (alice, bob, alice2bob1, bob2alice1) = newPeers(this, nodeParams, walletParams, listOf(aliceChan1 to bobChan1, aliceChan2 to bobChan2), automateMessaging = false)
+        val invoice = alice.createInvoice(randomBytes32(), 150_000_000.msat, Either.Left("test invoice"), null)
+        bob.send(SendPayment(UUID.randomUUID(), invoice.amount!!, alice.nodeParams.nodeId, invoice))
+
+        // Bob sends one HTLC on each channel.
+        val htlcs = listOf(
+            bob2alice1.expect<UpdateAddHtlc>(),
+            bob2alice1.expect<UpdateAddHtlc>(),
+        )
+        assertEquals(2, htlcs.map { it.channelId }.toSet().size)
+        val commitSigsBob = listOf(
+            bob2alice1.expect<CommitSig>(),
+            bob2alice1.expect<CommitSig>(),
+        )
+
+        // We cross-sign the HTLC on the first channel.
+        run {
+            val htlc = htlcs.find { it.channelId == aliceChan1.channelId }
+            assertNotNull(htlc)
+            alice.forward(htlc)
+            val commitSigBob = commitSigsBob.find { it.channelId == aliceChan1.channelId }
+            assertNotNull(commitSigBob)
+            alice.forward(commitSigBob)
+            bob.forward(alice2bob1.expect<RevokeAndAck>())
+            bob.forward(alice2bob1.expect<CommitSig>())
+            alice.forward(bob2alice1.expect<RevokeAndAck>())
+        }
+        // We start cross-signing the HTLC on the second channel.
+        run {
+            val htlc = htlcs.find { it.channelId == aliceChan2.channelId }
+            assertNotNull(htlc)
+            alice.forward(htlc)
+            val commitSigBob = commitSigsBob.find { it.channelId == aliceChan2.channelId }
+            assertNotNull(commitSigBob)
+            alice.forward(commitSigBob)
+            bob.forward(alice2bob1.expect<RevokeAndAck>())
+            bob.forward(alice2bob1.expect<CommitSig>())
+            bob2alice1.expect<RevokeAndAck>() // Alice doesn't receive Bob's revocation.
+        }
+
+        // We disconnect before Alice receives Bob's revocation on the second channel.
+        alice.disconnect()
+        alice.send(Disconnected)
+        bob.disconnect()
+        bob.send(Disconnected)
+
+        // On reconnection, Bob retransmits its revocation.
+        val (_, _, alice2bob2, bob2alice2) = connect(this, connectionId = 1, alice, bob, channelsCount = 2, expectChannelReady = false, automateMessaging = false)
+        alice.forward(bob2alice2.expect<RevokeAndAck>(), connectionId = 1)
+
+        // Alice has now received the complete payment and fulfills it.
+        val fulfills = listOf(
+            alice2bob2.expect<UpdateFulfillHtlc>(),
+            alice2bob2.expect<UpdateFulfillHtlc>(),
+        )
+        val commitSigsAlice = listOf(
+            alice2bob2.expect<CommitSig>(),
+            alice2bob2.expect<CommitSig>(),
+        )
+
+        // We fulfill the first HTLC.
+        run {
+            val fulfill = fulfills.find { it.channelId == aliceChan1.channelId }
+            assertNotNull(fulfill)
+            bob.forward(fulfill, connectionId = 1)
+            val commitSigAlice = commitSigsAlice.find { it.channelId == aliceChan1.channelId }
+            assertNotNull(commitSigAlice)
+            bob.forward(commitSigAlice, connectionId = 1)
+            alice.forward(bob2alice2.expect<RevokeAndAck>(), connectionId = 1)
+            alice.forward(bob2alice2.expect<CommitSig>(), connectionId = 1)
+            bob.forward(alice2bob2.expect<RevokeAndAck>(), connectionId = 1)
+        }
+
+        // We fulfill the second HTLC.
+        run {
+            val fulfill = fulfills.find { it.channelId == aliceChan2.channelId }
+            assertNotNull(fulfill)
+            bob.forward(fulfill, connectionId = 1)
+            val commitSigAlice = commitSigsAlice.find { it.channelId == aliceChan2.channelId }
+            assertNotNull(commitSigAlice)
+            bob.forward(commitSigAlice, connectionId = 1)
+            alice.forward(bob2alice2.expect<RevokeAndAck>(), connectionId = 1)
+            alice.forward(bob2alice2.expect<CommitSig>(), connectionId = 1)
+            bob.forward(alice2bob2.expect<RevokeAndAck>(), connectionId = 1)
+        }
+
+        assertEquals(invoice.amount, alice.db.payments.getIncomingPayment(invoice.paymentHash)?.received?.amount)
+    }
+
+    @Test
+    fun `payment between two nodes -- automated messaging`() = runSuspendTest {
         val (alice0, bob0) = TestsHelper.reachNormal()
         val nodeParams = Pair(alice0.staticParams.nodeParams, bob0.staticParams.nodeParams)
         val walletParams = Pair(
@@ -563,4 +664,5 @@ class PeerTest : LightningTestSuite() {
 
         alice.expectState<Normal> { commitments.availableBalanceForReceive() > alice0.commitments.availableBalanceForReceive() }
     }
+
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/helpers.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.mapNotNull
 
 suspend inline fun <reified M : LightningMessage> Flow<LightningMessage>.expect(): M = first { it is M } as M
 
-suspend inline fun Peer.forward(message: LightningMessage) = send((MessageReceived(connectionId = 0, message)))
+suspend inline fun Peer.forward(message: LightningMessage, connectionId: Long = 0) = send((MessageReceived(connectionId, message)))
 
 suspend inline fun Peer.expectStatus(await: Connection) = connectionState.first {
     when (await) {


### PR DESCRIPTION
We were keeping pending incoming payments in the internal state of the `IncomingPaymentHandler` even when disconnected. This could lead to inconsistencies with the channel state: if an HTLC that was added to the `IncomingPaymentHandler` was failed by another instance of the app (for example a background task), that failure wouldn't propagate to the state of the `IncomingPaymentHandler`. This can lead to partially fulfilled payments, where we think we have received the complete payment, but one of the part was actually failed so we shouldn't release the preimage.