### PR TITLE
Emit sensitive task event for mpp

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -49,6 +49,7 @@ sealed interface SensitiveTaskEvents : NodeEvents {
         data class InteractiveTx(val channelId: ByteVector32, val fundingTxIndex: Long) : TaskIdentifier() {
             constructor(fundingParams: InteractiveTxParams) : this(fundingParams.channelId, (fundingParams.sharedInput as? SharedFundingInput.Multisig2of2)?.fundingTxIndex?.let { it + 1 } ?: 0)
         }
+        data class IncomingMultiPartPayment(val paymentHash: ByteVector32) : TaskIdentifier()
     }
     data class TaskStarted(val id: TaskIdentifier) : SensitiveTaskEvents
     data class TaskEnded(val id: TaskIdentifier) : SensitiveTaskEvents


### PR DESCRIPTION
When the first part of a multi-part payment is received, we emit a `SensitiveTaskEvents.TaskStarted` hoping that iOS will let the app running long enough for subsequent parts to arrive.

@robbiehanson we discussed providing some metadata on the payment within this mechanism (amount/total received, etc.), it doesn't seem to work as only the first part triggers a `TaskStarted`. This implementation doesn't have any metadata aside from the `paymentHash`.