### PR TITLE
Simplify and improve typing in `NodeParams`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -206,7 +206,7 @@ data class NodeParams(
         maxAcceptedHtlcs = 6,
         expiryDeltaBlocks = CltvExpiryDelta(144),
         fulfillSafetyBeforeTimeoutBlocks = CltvExpiryDelta(6),
-        checkHtlcTimeoutAfterStartupDelay = 15.seconds,
+        checkHtlcTimeoutAfterStartupDelay = 30.seconds,
         checkHtlcTimeoutInterval = 10.seconds,
         htlcMinimum = 1000.msat,
         minDepthBlocks = 3,

--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -103,7 +103,7 @@ data class RecipientCltvExpiryParams(val min: CltvExpiryDelta, val max: CltvExpi
  * @param maxAcceptedHtlcs cap on the number of pending HTLCs in a channel: this lets us limit our exposure to HTLCs risk.
  * @param expiryDeltaBlocks cltv-expiry-delta used in our channel_update: since our channels are private and we don't relay payments, this will be basically ignored.
  * @param fulfillSafetyBeforeTimeoutBlocks number of blocks necessary to react to a malicious peer that doesn't acknowledge and sign our HTLC preimages.
- * @param checkHtlcTimeoutAfterStartupDelay delay in seconds before we check for timed out HTLCs in our channels after a wallet restart.
+ * @param checkHtlcTimeoutAfterStartupDelay delay before we check for timed out HTLCs in our channels after a wallet restart.
  * @param htlcMinimum minimum accepted htlc value.
  * @param toRemoteDelayBlocks number of blocks our peer will have to wait before they get their main output back in case they force-close a channel.
  * @param maxToLocalDelayBlocks maximum number of blocks we will have to wait before we get our main output back in case we force-close a channel.
@@ -113,8 +113,7 @@ data class RecipientCltvExpiryParams(val min: CltvExpiryDelta, val max: CltvExpi
  * @param pingInterval delay between ping messages.
  * @param initialRandomReconnectDelay delay before which we reconnect to our peers (will be randomized based on this value).
  * @param maxReconnectInterval maximum delay between reconnection attempts.
- * @param paymentRequestExpirySeconds our Bolt 11 invoices will only be valid for this duration.
- * @param multiPartPaymentExpiry number of seconds we will wait to receive all parts of a multi-part payment.
+ * @param mppAggregationWindow amount of time we will wait to receive all parts of a multi-part payment.
  * @param maxPaymentAttempts maximum number of retries when attempting an outgoing payment.
  * @param paymentRecipientExpiryParams configure the expiry delta used for the final node when sending payments.
  * @param zeroConfPeers list of peers with whom we use zero-conf (note that this is a strong trust assumption).
@@ -143,8 +142,7 @@ data class NodeParams(
     val pingInterval: Duration,
     val initialRandomReconnectDelay: Duration,
     val maxReconnectInterval: Duration,
-    val paymentRequestExpirySeconds: Int,
-    val multiPartPaymentExpiry: Duration,
+    val mppAggregationWindow: Duration,
     val maxPaymentAttempts: Int,
     val paymentRecipientExpiryParams: RecipientCltvExpiryParams,
     val zeroConfPeers: Set<PublicKey>,
@@ -217,8 +215,7 @@ data class NodeParams(
         pingInterval = 30.seconds,
         initialRandomReconnectDelay = 5.seconds,
         maxReconnectInterval = 60.minutes,
-        paymentRequestExpirySeconds = 3600,
-        multiPartPaymentExpiry = 60.seconds,
+        mppAggregationWindow = 60.seconds,
         maxPaymentAttempts = 5,
         zeroConfPeers = emptySet(),
         paymentRecipientExpiryParams = RecipientCltvExpiryParams(CltvExpiryDelta(75), CltvExpiryDelta(200)),

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLocked.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLocked.kt
@@ -35,7 +35,7 @@ data class LegacyWaitForFundingLocked(
                         staticParams.nodeParams.expiryDeltaBlocks,
                         commitments.params.remoteParams.htlcMinimum,
                         staticParams.nodeParams.feeBase,
-                        staticParams.nodeParams.feeProportionalMillionth.toLong(),
+                        staticParams.nodeParams.feeProportionalMillionths.toLong(),
                         commitments.latest.fundingAmount.toMilliSatoshi(),
                         enable = Helpers.aboveReserve(commitments)
                     )

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReady.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReady.kt
@@ -68,7 +68,7 @@ data class WaitForChannelReady(
                         staticParams.nodeParams.expiryDeltaBlocks,
                         commitments.params.remoteParams.htlcMinimum,
                         staticParams.nodeParams.feeBase,
-                        staticParams.nodeParams.feeProportionalMillionth.toLong(),
+                        staticParams.nodeParams.feeProportionalMillionths.toLong(),
                         commitments.latest.fundingAmount.toMilliSatoshi(),
                         enable = Helpers.aboveReserve(commitments)
                     )

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -250,7 +250,7 @@ class Peer(
                 // If we have some htlcs that have timed out, we may need to close channels to ensure we don't lose funds.
                 // But maybe we were offline for too long and it is why our peer couldn't settle these htlcs in time.
                 // We give them a bit of time after we reconnect to send us their latest htlc updates.
-                delay(timeMillis = nodeParams.checkHtlcTimeoutAfterStartupDelaySeconds.toLong() * 1000)
+                delay(nodeParams.checkHtlcTimeoutAfterStartupDelay)
                 logger.info { "checking for timed out htlcs for channels: ${channelIds.joinToString(", ")}" }
                 channelIds.forEach { input.send(WrappedChannelCommand(it, ChannelCommand.Commitment.CheckHtlcTimeout)) }
             }
@@ -379,14 +379,14 @@ class Peer(
             suspend fun doPing() {
                 val ping = Ping(10, ByteVector("deadbeef"))
                 while (isActive) {
-                    delay(30.seconds)
+                    delay(nodeParams.pingInterval)
                     peerConnection.send(ping)
                 }
             }
 
             suspend fun checkPaymentsTimeout() {
                 while (isActive) {
-                    delay(10.seconds) // we schedule a check every 10 seconds
+                    delay(nodeParams.checkHtlcTimeoutInterval) // we schedule a check every 10 seconds
                     input.send(CheckPaymentsTimeout)
                 }
             }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -386,7 +386,7 @@ class Peer(
 
             suspend fun checkPaymentsTimeout() {
                 while (isActive) {
-                    delay(nodeParams.checkHtlcTimeoutInterval) // we schedule a check every 10 seconds
+                    delay(nodeParams.checkHtlcTimeoutInterval)
                     input.send(CheckPaymentsTimeout)
                 }
             }

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -375,7 +375,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val db: IncomingPayment
         //   - SHOULD wait for at least 60 seconds after the initial HTLC.
         //   - SHOULD use mpp_timeout for the failure message.
         pending.forEach { (paymentHash, payment) ->
-            val isExpired = currentTimestampSeconds > (payment.startedAtSeconds + nodeParams.multiPartPaymentExpiry.inWholeSeconds)
+            val isExpired = currentTimestampSeconds > (payment.startedAtSeconds + nodeParams.mppAggregationWindow.inWholeSeconds)
             if (isExpired) {
                 keysToRemove += paymentHash
                 payment.parts.forEach { part ->

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -375,7 +375,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val db: IncomingPayment
         //   - SHOULD wait for at least 60 seconds after the initial HTLC.
         //   - SHOULD use mpp_timeout for the failure message.
         pending.forEach { (paymentHash, payment) ->
-            val isExpired = currentTimestampSeconds > (payment.startedAtSeconds + nodeParams.multiPartPaymentExpirySeconds)
+            val isExpired = currentTimestampSeconds > (payment.startedAtSeconds + nodeParams.multiPartPaymentExpiry.inWholeSeconds)
             if (isExpired) {
                 keysToRemove += paymentHash
                 payment.parts.forEach { part ->

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -91,7 +91,7 @@ data class LNChannel<out S : ChannelState>(
 
     fun process(cmd: ChannelCommand): Pair<LNChannel<ChannelState>, List<ChannelAction>> =
         state
-            .run { ctx.copy(logger = ctx.logger.copy(staticMdc = mapOf("alias" to ctx.staticParams.nodeParams.alias) + state.mdc())).process(cmd) }
+            .run { ctx.copy(logger = ctx.logger.copy(staticMdc = state.mdc())).process(cmd) }
             .let { (newState, actions) ->
                 checkSerialization(actions)
                 JsonSerializers.json.encodeToString(newState)

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -31,6 +31,7 @@ import fr.acinq.lightning.wire.*
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
 
 class PeerTest : LightningTestSuite() {
 
@@ -331,7 +332,7 @@ class PeerTest : LightningTestSuite() {
 
         val peer = buildPeer(
             this,
-            alice0.staticParams.nodeParams.copy(checkHtlcTimeoutAfterStartupDelaySeconds = 5),
+            alice0.staticParams.nodeParams.copy(checkHtlcTimeoutAfterStartupDelay = 5.seconds),
             TestConstants.Alice.walletParams,
             databases = InMemoryDatabases().also { it.channels.addOrUpdateChannel(alice1.state) },
             currentTip = htlc.cltvExpiry.toLong().toInt() to Block.RegtestGenesisBlock.header
@@ -401,7 +402,7 @@ class PeerTest : LightningTestSuite() {
 
         val peer = buildPeer(
             this,
-            bob0.staticParams.nodeParams.copy(checkHtlcTimeoutAfterStartupDelaySeconds = 5),
+            bob0.staticParams.nodeParams.copy(checkHtlcTimeoutAfterStartupDelay = 5.seconds),
             TestConstants.Bob.walletParams,
             databases = InMemoryDatabases(), // NB: empty database (Bob has lost its channel state)
             currentTip = htlc.cltvExpiry.toLong().toInt() to Block.RegtestGenesisBlock.header
@@ -431,7 +432,7 @@ class PeerTest : LightningTestSuite() {
 
         val peer = buildPeer(
             this,
-            bob0.staticParams.nodeParams.copy(checkHtlcTimeoutAfterStartupDelaySeconds = 5),
+            bob0.staticParams.nodeParams.copy(checkHtlcTimeoutAfterStartupDelay = 5.seconds),
             TestConstants.Bob.walletParams,
             databases = InMemoryDatabases().also { it.channels.addOrUpdateChannel(bob0.state) }, // NB: outdated channel data
             currentTip = htlc.cltvExpiry.toLong().toInt() to Block.RegtestGenesisBlock.header

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -757,7 +757,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertTrue(result1.actions.isEmpty())
 
         // It expires after a while.
-        val actions1 = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds() + paymentHandler.nodeParams.multiPartPaymentExpiry.inWholeSeconds + 2)
+        val actions1 = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds() + paymentHandler.nodeParams.mppAggregationWindow.inWholeSeconds + 2)
         val addTimeout = ChannelCommand.Htlc.Settlement.Fail(add.id, ChannelCommand.Htlc.Settlement.Fail.Reason.Failure(PaymentTimeout), commit = true)
         assertEquals(listOf(WrappedChannelCommand(add.channelId, addTimeout)), actions1)
 
@@ -767,7 +767,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertTrue(result2.actions.isEmpty())
 
         // It expires again.
-        val actions2 = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds() + paymentHandler.nodeParams.multiPartPaymentExpiry.inWholeSeconds + 2)
+        val actions2 = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds() + paymentHandler.nodeParams.mppAggregationWindow.inWholeSeconds + 2)
         assertEquals(listOf(WrappedChannelCommand(add.channelId, addTimeout)), actions2)
 
         // The channel was offline again, didn't process the failure and retransmits the htlc, but it is now close to its expiry.
@@ -943,7 +943,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         // Step 2 of 3:
         // - don't expire the multipart htlcs too soon.
         run {
-            val currentTimestampSeconds = startTime + paymentHandler.nodeParams.multiPartPaymentExpiry.inWholeSeconds - 2
+            val currentTimestampSeconds = startTime + paymentHandler.nodeParams.mppAggregationWindow.inWholeSeconds - 2
             val actions = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds)
             assertTrue(actions.isEmpty())
         }
@@ -951,7 +951,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         // Step 3 of 3:
         // - expire the htlc-set after configured expiration.
         run {
-            val currentTimestampSeconds = startTime + paymentHandler.nodeParams.multiPartPaymentExpiry.inWholeSeconds + 2
+            val currentTimestampSeconds = startTime + paymentHandler.nodeParams.mppAggregationWindow.inWholeSeconds + 2
             val actions = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds)
             val expected = setOf(
                 WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fail(1, ChannelCommand.Htlc.Settlement.Fail.Reason.Failure(PaymentTimeout), commit = true)),
@@ -981,7 +981,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         // Step 2 of 4:
         // - the MPP set times out
         run {
-            val currentTimestampSeconds = startTime + paymentHandler.nodeParams.multiPartPaymentExpiry.inWholeSeconds + 2
+            val currentTimestampSeconds = startTime + paymentHandler.nodeParams.mppAggregationWindow.inWholeSeconds + 2
             val actions = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds)
             val expected = WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fail(1, ChannelCommand.Htlc.Settlement.Fail.Reason.Failure(PaymentTimeout), commit = true))
             assertEquals(setOf(expected), actions.toSet())

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -757,7 +757,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertTrue(result1.actions.isEmpty())
 
         // It expires after a while.
-        val actions1 = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds() + paymentHandler.nodeParams.multiPartPaymentExpirySeconds + 2)
+        val actions1 = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds() + paymentHandler.nodeParams.multiPartPaymentExpiry.inWholeSeconds + 2)
         val addTimeout = ChannelCommand.Htlc.Settlement.Fail(add.id, ChannelCommand.Htlc.Settlement.Fail.Reason.Failure(PaymentTimeout), commit = true)
         assertEquals(listOf(WrappedChannelCommand(add.channelId, addTimeout)), actions1)
 
@@ -767,7 +767,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertTrue(result2.actions.isEmpty())
 
         // It expires again.
-        val actions2 = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds() + paymentHandler.nodeParams.multiPartPaymentExpirySeconds + 2)
+        val actions2 = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds() + paymentHandler.nodeParams.multiPartPaymentExpiry.inWholeSeconds + 2)
         assertEquals(listOf(WrappedChannelCommand(add.channelId, addTimeout)), actions2)
 
         // The channel was offline again, didn't process the failure and retransmits the htlc, but it is now close to its expiry.
@@ -943,7 +943,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         // Step 2 of 3:
         // - don't expire the multipart htlcs too soon.
         run {
-            val currentTimestampSeconds = startTime + paymentHandler.nodeParams.multiPartPaymentExpirySeconds - 2
+            val currentTimestampSeconds = startTime + paymentHandler.nodeParams.multiPartPaymentExpiry.inWholeSeconds - 2
             val actions = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds)
             assertTrue(actions.isEmpty())
         }
@@ -951,7 +951,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         // Step 3 of 3:
         // - expire the htlc-set after configured expiration.
         run {
-            val currentTimestampSeconds = startTime + paymentHandler.nodeParams.multiPartPaymentExpirySeconds + 2
+            val currentTimestampSeconds = startTime + paymentHandler.nodeParams.multiPartPaymentExpiry.inWholeSeconds + 2
             val actions = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds)
             val expected = setOf(
                 WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fail(1, ChannelCommand.Htlc.Settlement.Fail.Reason.Failure(PaymentTimeout), commit = true)),
@@ -981,7 +981,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         // Step 2 of 4:
         // - the MPP set times out
         run {
-            val currentTimestampSeconds = startTime + paymentHandler.nodeParams.multiPartPaymentExpirySeconds + 2
+            val currentTimestampSeconds = startTime + paymentHandler.nodeParams.multiPartPaymentExpiry.inWholeSeconds + 2
             val actions = paymentHandler.checkPaymentsTimeout(currentTimestampSeconds)
             val expected = WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fail(1, ChannelCommand.Htlc.Settlement.Fail.Reason.Failure(PaymentTimeout), commit = true))
             assertEquals(setOf(expected), actions.toSet())

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
@@ -55,7 +55,6 @@ object TestConstants {
             loggerFactory = testLoggerFactory,
             keyManager = keyManager,
         ).copy(
-            alias = "alice",
             features = Features(
                 Feature.OptionDataLossProtect to FeatureSupport.Optional,
                 Feature.VariableLengthOnion to FeatureSupport.Mandatory,
@@ -85,7 +84,7 @@ object TestConstants {
             toRemoteDelayBlocks = CltvExpiryDelta(144),
             maxToLocalDelayBlocks = CltvExpiryDelta(2048),
             feeBase = 100.msat,
-            feeProportionalMillionth = 10,
+            feeProportionalMillionths = 10,
             paymentRecipientExpiryParams = RecipientCltvExpiryParams(CltvExpiryDelta(0), CltvExpiryDelta(0)),
         )
 
@@ -104,7 +103,6 @@ object TestConstants {
             loggerFactory = testLoggerFactory,
             keyManager = keyManager,
         ).copy(
-            alias = "bob",
             dustLimit = 1_000.sat,
             maxRemoteDustLimit = 1_500.sat,
             onChainFeeConf = OnChainFeeConf(
@@ -117,7 +115,7 @@ object TestConstants {
             toRemoteDelayBlocks = CltvExpiryDelta(144),
             maxToLocalDelayBlocks = CltvExpiryDelta(1024),
             feeBase = 10.msat,
-            feeProportionalMillionth = 10,
+            feeProportionalMillionths = 10,
             paymentRecipientExpiryParams = RecipientCltvExpiryParams(CltvExpiryDelta(0), CltvExpiryDelta(0)),
         )
 


### PR DESCRIPTION
Remove all unused parameters, and use proper type for durations.

Also, increase `checkHtlcTimeoutAfterStartupDelay` to 30s as connecting can be quite long with Tor.