### PR TITLE
Fix build warnings 

### DIFF
--- a/PhoenixCrypto/build.gradle.kts
+++ b/PhoenixCrypto/build.gradle.kts
@@ -1,5 +1,5 @@
-listOf("iphoneos", "iphonesimulator").forEach { sdk ->
-    tasks.create<Exec>("buildCrypto${sdk.capitalize()}") {
+listOf("Iphoneos", "Iphonesimulator").forEach { sdk ->
+    tasks.create<Exec>("buildCrypto$sdk") {
         group = "build"
 
         commandLine(
@@ -7,7 +7,7 @@ listOf("iphoneos", "iphonesimulator").forEach { sdk ->
             "-quiet",
             "-project", "PhoenixCrypto.xcodeproj",
             "-target", "PhoenixCrypto",
-            "-sdk", sdk
+            "-sdk", sdk.lowercase()
         )
         workingDir(projectDir)
 
@@ -16,7 +16,7 @@ listOf("iphoneos", "iphonesimulator").forEach { sdk ->
             fileTree("$projectDir/PhoenixCrypto")
         )
         outputs.files(
-            fileTree("$projectDir/build/Release-${sdk}")
+            fileTree("$projectDir/build/Release-${sdk.lowercase()}")
         )
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -156,18 +156,12 @@ kotlin {
     }
 }
 
-val dokkaOutputDir = buildDir.resolve("dokka")
+val dokkaOutputDir = layout.buildDirectory.dir("dokka")
 tasks.dokkaHtml {
     outputDirectory.set(file(dokkaOutputDir))
     dokkaSourceSets {
         configureEach {
-            val platformName = when (platform.get()) {
-                Platform.jvm -> "jvm"
-                Platform.js -> "js"
-                Platform.native -> "native"
-                Platform.common -> "common"
-                Platform.wasm -> "wasm"
-            }
+            val platformName = platform.get().name
             displayName.set(platformName)
 
             perPackageOption {
@@ -231,7 +225,7 @@ afterEvaluate {
     configure(targets) {
         compilations.all {
             cinterops.all { tasks[interopProcessingTaskName].enabled = false }
-            compileKotlinTask.enabled = false
+            compileTaskProvider.get().enabled = false
             tasks[processResourcesTaskName].enabled = false
         }
         binaries.all { linkTask.enabled = false }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,28 +48,28 @@ kotlin {
     if (currentOs.isMacOsX) {
         iosX64 { // ios simulator on intel devices
             compilations["main"].cinterops.create("PhoenixCrypto") {
-                val platform = "iphonesimulator"
+                val platform = "Iphonesimulator"
                 val interopTask = tasks[interopProcessingTaskName]
-                interopTask.dependsOn(":PhoenixCrypto:buildCrypto${platform.capitalize()}")
-                includeDirs.headerFilterOnly("$rootDir/PhoenixCrypto/build/Release-$platform/include")
+                interopTask.dependsOn(":PhoenixCrypto:buildCrypto$platform")
+                includeDirs.headerFilterOnly("$rootDir/PhoenixCrypto/build/Release-${platform.lowercase()}/include")
             }
         }
 
         iosArm64 { // actual ios devices
             compilations["main"].cinterops.create("PhoenixCrypto") {
-                val platform = "iphoneos"
+                val platform = "Iphoneos"
                 val interopTask = tasks[interopProcessingTaskName]
-                interopTask.dependsOn(":PhoenixCrypto:buildCrypto${platform.capitalize()}")
-                includeDirs.headerFilterOnly("$rootDir/PhoenixCrypto/build/Release-$platform/include")
+                interopTask.dependsOn(":PhoenixCrypto:buildCrypto$platform")
+                includeDirs.headerFilterOnly("$rootDir/PhoenixCrypto/build/Release-${platform.lowercase()}/include")
             }
         }
 
         iosSimulatorArm64 { // actual ios devices
             compilations["main"].cinterops.create("PhoenixCrypto") {
-                val platform = "iphonesimulator"
+                val platform = "Iphonesimulator"
                 val interopTask = tasks[interopProcessingTaskName]
-                interopTask.dependsOn(":PhoenixCrypto:buildCrypto${platform.capitalize()}")
-                includeDirs.headerFilterOnly("$rootDir/PhoenixCrypto/build/Release-$platform/include")
+                interopTask.dependsOn(":PhoenixCrypto:buildCrypto$platform")
+                includeDirs.headerFilterOnly("$rootDir/PhoenixCrypto/build/Release-${platform.lowercase()}/include")
             }
         }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
@@ -249,6 +249,7 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
     }
 
     @Ignore
+    @Test
     fun `perf test generator`() = runSuspendTest(timeout = 45.seconds) {
         val client = connectToMainnetServer()
         val wallet = ElectrumMiniWallet(Block.LivenetGenesisBlock.hash, client, this, logger)


### PR DESCRIPTION
Follow up to #594 which introduced deprecation warnings.

I'm quite happy with the replacement of `buildFinished` with `finalizedBy`, it looks much cleaner.

Best reviewed commit by commit.