### PR TITLE
Keep using 400 bytes trampoline payloads

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentPacket.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentPacket.kt
@@ -85,7 +85,7 @@ object OutgoingPaymentPacket {
             Triple(amount + hop.fee(amount), expiry + hop.cltvExpiryDelta, listOf(payload) + payloads)
         }
         val nodes = hops.map { it.nextNodeId }
-        val onion = buildOnion(nodes, payloads, invoice.paymentHash, null)
+        val onion = buildOnion(nodes, payloads, invoice.paymentHash, 400) // TODO: remove the fixed payload length once eclair supports it
         return Triple(firstAmount, firstExpiry, onion)
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/PaymentPacketTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/PaymentPacketTestsCommon.kt
@@ -365,8 +365,6 @@ class PaymentPacketTestsCommon : LightningTestSuite() {
         //             .--.
         //            /    \
         // a -> b -> c      d -> e
-
-
         val features = Features(Feature.BasicMultiPartPayment to FeatureSupport.Optional)
         val offer = OfferTypes.Offer(finalAmount, "test offer", e, features, Block.LivenetGenesisBlock.hash)
         val payerKey = randomKey()


### PR DESCRIPTION
Eclair has support for variable size payloads, but it's not deployed on our node yet.