### PR TITLE
FIX SqliteChannelsDbTestsJvm on Apple m1/m2 machine

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,7 +106,7 @@ kotlin {
                 api(ktor("network-tls"))
                 implementation("fr.acinq.secp256k1:secp256k1-kmp-jni-jvm:$secpJniJvmVersion")
                 implementation("org.slf4j:slf4j-api:1.7.36")
-                api("org.xerial:sqlite-jdbc:3.32.3.2")
+                api("org.xerial:sqlite-jdbc:3.32.3.3")
             }
         }
 


### PR DESCRIPTION
Before sqlite-jdbc version 3.32.3.3 the test would not run on a m1 machine:

```
Error opening connection
java.sql.SQLException: Error opening connection
	at org.sqlite.SQLiteConnection.open(SQLiteConnection.java:239)
	...
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: java.lang.Exception: No native library found for os.name=Mac, os.arch=aarch64, paths=[/Users/<user>/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:.]
	at org.sqlite.SQLiteJDBCLoader.loadSQLiteNativeLibrary(SQLiteJDBCLoader.java:367)
	at org.sqlite.SQLiteJDBCLoader.initialize(SQLiteJDBCLoader.java:67)
	at org.sqlite.core.NativeDB.load(NativeDB.java:63)
	at org.sqlite.SQLiteConnection.open(SQLiteConnection.java:235)
	... 62 more
```

The last version of sqlite-jdbc is 3.41.2.2. One can probably update to this last version but I've just upgraded to the first version solving the issue, namely 3.32.3.3.

See https://github.com/xerial/sqlite-jdbc/releases/tag/3.32.3.3