### PR TITLE
Refactor key management

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -126,7 +126,7 @@ data class LocalCommit(val index: Long, val spec: CommitmentSpec, val publishabl
             if (commit.htlcSignatures.size != sortedHtlcTxs.size) {
                 return Either.Left(HtlcSigCountMismatch(params.channelId, sortedHtlcTxs.size, commit.htlcSignatures.size))
             }
-            val htlcSigs = sortedHtlcTxs.map { Transactions.sign(it, keyManager.htlcKey.deriveForCommitment(localPerCommitmentPoint), SigHash.SIGHASH_ALL) }
+            val htlcSigs = sortedHtlcTxs.map { Transactions.sign2(it, keyManager.htlcKey.deriveForCommitment(localPerCommitmentPoint), SigHash.SIGHASH_ALL) }
             val remoteHtlcPubkey = params.remoteParams.htlcBasepoint.deriveForCommitment(localPerCommitmentPoint)
             // combine the sigs to make signed txs
             val htlcTxsAndSigs = Triple(sortedHtlcTxs, htlcSigs, commit.htlcSignatures).zipped().map { (htlcTx, localSig, remoteSig) ->
@@ -168,7 +168,7 @@ data class RemoteCommit(val index: Long, val spec: CommitmentSpec, val txid: TxI
         )
         val sig = Transactions.sign2(remoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
         // we sign our peer's HTLC txs with SIGHASH_SINGLE || SIGHASH_ANYONECANPAY
-        val htlcSigs = sortedHtlcsTxs.map { Transactions.sign(it, channelKeys.htlcKey.deriveForCommitment(remotePerCommitmentPoint), SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
+        val htlcSigs = sortedHtlcsTxs.map { Transactions.sign2(it, channelKeys.htlcKey.deriveForCommitment(remotePerCommitmentPoint), SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
         return CommitSig(params.channelId, sig, htlcSigs.toList())
     }
 
@@ -479,7 +479,7 @@ data class Commitment(
         val sig = Transactions.sign2(remoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
 
         // we sign our peer's HTLC txs with SIGHASH_SINGLE || SIGHASH_ANYONECANPAY
-        val htlcSigs = sortedHtlcTxs.map { Transactions.sign(it, channelKeys.htlcKey.deriveForCommitment(remoteNextPerCommitmentPoint), SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
+        val htlcSigs = sortedHtlcTxs.map { Transactions.sign2(it, channelKeys.htlcKey.deriveForCommitment(remoteNextPerCommitmentPoint),  SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
 
         // NB: IN/OUT htlcs are inverted because this is the remote commit
         log.info {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -112,7 +112,7 @@ data class LocalCommit(val index: Long, val spec: CommitmentSpec, val publishabl
                 localPerCommitmentPoint = localPerCommitmentPoint,
                 spec
             )
-            val sig = Transactions.sign(localCommitTx, keyManager.fundingKey(fundingTxIndex))
+            val sig = Transactions.sign2(localCommitTx, keyManager.fundingKey(fundingTxIndex))
 
             // no need to compute htlc sigs if commit sig doesn't check out
             val signedCommitTx = Transactions.addSigs(localCommitTx, keyManager.fundingPubKey(fundingTxIndex), remoteFundingPubKey, sig, commit.signature)
@@ -166,7 +166,7 @@ data class RemoteCommit(val index: Long, val spec: CommitmentSpec, val txid: TxI
             remotePerCommitmentPoint = remotePerCommitmentPoint,
             spec
         )
-        val sig = Transactions.sign(remoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
+        val sig = Transactions.sign2(remoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
         // we sign our peer's HTLC txs with SIGHASH_SINGLE || SIGHASH_ANYONECANPAY
         val htlcSigs = sortedHtlcsTxs.map { Transactions.sign(it, channelKeys.htlcKey.deriveForCommitment(remotePerCommitmentPoint), SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
         return CommitSig(params.channelId, sig, htlcSigs.toList())
@@ -476,7 +476,7 @@ data class Commitment(
             remotePerCommitmentPoint = remoteNextPerCommitmentPoint,
             spec
         )
-        val sig = Transactions.sign(remoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
+        val sig = Transactions.sign2(remoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
 
         // we sign our peer's HTLC txs with SIGHASH_SINGLE || SIGHASH_ANYONECANPAY
         val htlcSigs = sortedHtlcTxs.map { Transactions.sign(it, channelKeys.htlcKey.deriveForCommitment(remoteNextPerCommitmentPoint), SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
@@ -493,7 +493,7 @@ data class Commitment(
                 val alternativeSigs = Commitments.alternativeFeerates.map { feerate ->
                     val alternativeSpec = spec.copy(feerate = feerate)
                     val (alternativeRemoteCommitTx, _) = Commitments.makeRemoteTxs(channelKeys, commitTxNumber = remoteCommit.index + 1, params.localParams, params.remoteParams, fundingTxIndex = fundingTxIndex, remoteFundingPubKey = remoteFundingPubkey, commitInput, remotePerCommitmentPoint = remoteNextPerCommitmentPoint, alternativeSpec)
-                    val alternativeSig = Transactions.sign(alternativeRemoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
+                    val alternativeSig = Transactions.sign2(alternativeRemoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
                     CommitSigTlv.AlternativeFeerateSig(feerate, alternativeSig)
                 }
                 add(CommitSigTlv.AlternativeFeerateSigs(alternativeSigs))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -112,7 +112,7 @@ data class LocalCommit(val index: Long, val spec: CommitmentSpec, val publishabl
                 localPerCommitmentPoint = localPerCommitmentPoint,
                 spec
             )
-            val sig = Transactions.sign(localCommitTx, keyManager.fundingKey(fundingTxIndex))
+            val sig = keyManager.fundingKey(fundingTxIndex).sign(localCommitTx)
 
             // no need to compute htlc sigs if commit sig doesn't check out
             val signedCommitTx = Transactions.addSigs(localCommitTx, keyManager.fundingPubKey(fundingTxIndex), remoteFundingPubKey, sig, commit.signature)
@@ -126,7 +126,7 @@ data class LocalCommit(val index: Long, val spec: CommitmentSpec, val publishabl
             if (commit.htlcSignatures.size != sortedHtlcTxs.size) {
                 return Either.Left(HtlcSigCountMismatch(params.channelId, sortedHtlcTxs.size, commit.htlcSignatures.size))
             }
-            val htlcSigs = sortedHtlcTxs.map { Transactions.sign(it, keyManager.htlcKey.deriveForCommitment(localPerCommitmentPoint), SigHash.SIGHASH_ALL) }
+            val htlcSigs = sortedHtlcTxs.map { keyManager.htlcKey.deriveForCommitment(localPerCommitmentPoint).sign(it, SigHash.SIGHASH_ALL) }
             val remoteHtlcPubkey = params.remoteParams.htlcBasepoint.deriveForCommitment(localPerCommitmentPoint)
             // combine the sigs to make signed txs
             val htlcTxsAndSigs = Triple(sortedHtlcTxs, htlcSigs, commit.htlcSignatures).zipped().map { (htlcTx, localSig, remoteSig) ->
@@ -166,9 +166,9 @@ data class RemoteCommit(val index: Long, val spec: CommitmentSpec, val txid: TxI
             remotePerCommitmentPoint = remotePerCommitmentPoint,
             spec
         )
-        val sig = Transactions.sign(remoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
+        val sig = channelKeys.fundingKey(fundingTxIndex).sign(remoteCommitTx)
         // we sign our peer's HTLC txs with SIGHASH_SINGLE || SIGHASH_ANYONECANPAY
-        val htlcSigs = sortedHtlcsTxs.map { Transactions.sign(it, channelKeys.htlcKey.deriveForCommitment(remotePerCommitmentPoint), SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
+        val htlcSigs = sortedHtlcsTxs.map { channelKeys.htlcKey.deriveForCommitment(remotePerCommitmentPoint).sign(it, SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
         return CommitSig(params.channelId, sig, htlcSigs.toList())
     }
 
@@ -476,10 +476,10 @@ data class Commitment(
             remotePerCommitmentPoint = remoteNextPerCommitmentPoint,
             spec
         )
-        val sig = Transactions.sign(remoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
+        val sig = channelKeys.fundingKey(fundingTxIndex).sign(remoteCommitTx)
 
         // we sign our peer's HTLC txs with SIGHASH_SINGLE || SIGHASH_ANYONECANPAY
-        val htlcSigs = sortedHtlcTxs.map { Transactions.sign(it, channelKeys.htlcKey.deriveForCommitment(remoteNextPerCommitmentPoint),  SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
+        val htlcSigs = sortedHtlcTxs.map { channelKeys.htlcKey.deriveForCommitment(remoteNextPerCommitmentPoint).sign(it,  SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
 
         // NB: IN/OUT htlcs are inverted because this is the remote commit
         log.info {
@@ -493,7 +493,7 @@ data class Commitment(
                 val alternativeSigs = Commitments.alternativeFeerates.map { feerate ->
                     val alternativeSpec = spec.copy(feerate = feerate)
                     val (alternativeRemoteCommitTx, _) = Commitments.makeRemoteTxs(channelKeys, commitTxNumber = remoteCommit.index + 1, params.localParams, params.remoteParams, fundingTxIndex = fundingTxIndex, remoteFundingPubKey = remoteFundingPubkey, commitInput, remotePerCommitmentPoint = remoteNextPerCommitmentPoint, alternativeSpec)
-                    val alternativeSig = Transactions.sign(alternativeRemoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
+                    val alternativeSig = channelKeys.fundingKey(fundingTxIndex).sign(alternativeRemoteCommitTx)
                     CommitSigTlv.AlternativeFeerateSig(feerate, alternativeSig)
                 }
                 add(CommitSigTlv.AlternativeFeerateSigs(alternativeSigs))

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -479,7 +479,7 @@ object Helpers {
                     feerateDelayed
                 )
             }?.let {
-                val sig = Transactions.sign(it, channelKeys.delayedPaymentKey.deriveForCommitment(localPerCommitmentPoint), SigHash.SIGHASH_ALL)
+                val sig = Transactions.sign2(it, channelKeys.delayedPaymentKey.deriveForCommitment(localPerCommitmentPoint), SigHash.SIGHASH_ALL)
                 Transactions.addSigs(it, sig)
             }
 
@@ -513,7 +513,7 @@ object Helpers {
                         feerateDelayed
                     )
                 }?.let {
-                    val sig = Transactions.sign(it, channelKeys.delayedPaymentKey.deriveForCommitment(localPerCommitmentPoint), SigHash.SIGHASH_ALL)
+                    val sig = Transactions.sign2(it, channelKeys.delayedPaymentKey.deriveForCommitment(localPerCommitmentPoint), SigHash.SIGHASH_ALL)
                     Transactions.addSigs(it, sig)
                 }
             }
@@ -601,7 +601,7 @@ object Helpers {
                                 null -> Pair(claimHtlcTx.input.outPoint, null)
                                 // incoming htlc for which we have the preimage: we can spend it directly
                                 else -> {
-                                    val sig = Transactions.sign(claimHtlcTx, channelKeys.htlcKey.deriveForCommitment(remoteCommit.remotePerCommitmentPoint), SigHash.SIGHASH_ALL)
+                                    val sig = Transactions.sign2(claimHtlcTx, channelKeys.htlcKey.deriveForCommitment(remoteCommit.remotePerCommitmentPoint), SigHash.SIGHASH_ALL)
                                     Pair(claimHtlcTx.input.outPoint, Transactions.addSigs(claimHtlcTx, sig, preimage))
                                 }
                             }
@@ -622,7 +622,7 @@ object Helpers {
                                 feerateClaimHtlc
                             )
                         }?.let { claimHtlcTx ->
-                            val sig = Transactions.sign(claimHtlcTx, channelKeys.htlcKey.deriveForCommitment(remoteCommit.remotePerCommitmentPoint), SigHash.SIGHASH_ALL)
+                            val sig = Transactions.sign2(claimHtlcTx, channelKeys.htlcKey.deriveForCommitment(remoteCommit.remotePerCommitmentPoint), SigHash.SIGHASH_ALL)
                             Pair(claimHtlcTx.input.outPoint, Transactions.addSigs(claimHtlcTx, sig))
                         }
                     }
@@ -725,7 +725,7 @@ object Helpers {
                     feeratePenalty
                 )
             }?.let {
-                val sig = Transactions.sign(it, channelKeys.revocationKey.deriveForRevocation(remotePerCommitmentSecret))
+                val sig = Transactions.sign2(it, channelKeys.revocationKey.deriveForRevocation(remotePerCommitmentSecret))
                 Transactions.addSigs(it, sig)
             }
 
@@ -770,7 +770,7 @@ object Helpers {
                             feeratePenalty
                         )
                     }?.let { htlcPenaltyTx ->
-                        val sig = Transactions.sign(htlcPenaltyTx, channelKeys.revocationKey.deriveForRevocation(revokedCommitPublished.remotePerCommitmentSecret))
+                        val sig = Transactions.sign2(htlcPenaltyTx, channelKeys.revocationKey.deriveForRevocation(revokedCommitPublished.remotePerCommitmentSecret))
                         Transactions.addSigs(htlcPenaltyTx, sig, remoteRevocationPubkey)
                     }
                 }
@@ -827,7 +827,7 @@ object Helpers {
                     generateTx("claim-htlc-delayed-penalty") {
                         claimDelayedOutputPenaltyTx
                     }?.let {
-                        val sig = Transactions.sign(it, channelKeys.revocationKey.deriveForRevocation(revokedCommitPublished.remotePerCommitmentSecret))
+                        val sig = Transactions.sign2(it, channelKeys.revocationKey.deriveForRevocation(revokedCommitPublished.remotePerCommitmentSecret))
                         val signedTx = Transactions.addSigs(it, sig)
                         // we need to make sure that the tx is indeed valid
                         when (runTrying { Transaction.correctlySpends(signedTx.tx, listOf(htlcTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS) }) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -408,7 +408,7 @@ object Helpers {
             require(isValidFinalScriptPubkey(remoteScriptPubkey, allowAnySegwit)) { "invalid remoteScriptPubkey" }
             val dustLimit = commitment.params.localParams.dustLimit.max(commitment.params.remoteParams.dustLimit)
             val closingTx = Transactions.makeClosingTx(commitment.commitInput, localScriptPubkey, remoteScriptPubkey, commitment.params.localParams.isInitiator, dustLimit, closingFees.preferred, commitment.localCommit.spec)
-            val localClosingSig = Transactions.sign2(closingTx, channelKeys.fundingKey(commitment.fundingTxIndex))
+            val localClosingSig = Transactions.sign(closingTx, channelKeys.fundingKey(commitment.fundingTxIndex))
             val closingSigned = ClosingSigned(commitment.channelId, closingFees.preferred, localClosingSig, TlvStream(ClosingSignedTlv.FeeRange(closingFees.min, closingFees.max)))
             return Pair(closingTx, closingSigned)
         }
@@ -479,7 +479,7 @@ object Helpers {
                     feerateDelayed
                 )
             }?.let {
-                val sig = Transactions.sign2(it, channelKeys.delayedPaymentKey.deriveForCommitment(localPerCommitmentPoint), SigHash.SIGHASH_ALL)
+                val sig = Transactions.sign(it, channelKeys.delayedPaymentKey.deriveForCommitment(localPerCommitmentPoint), SigHash.SIGHASH_ALL)
                 Transactions.addSigs(it, sig)
             }
 
@@ -513,7 +513,7 @@ object Helpers {
                         feerateDelayed
                     )
                 }?.let {
-                    val sig = Transactions.sign2(it, channelKeys.delayedPaymentKey.deriveForCommitment(localPerCommitmentPoint), SigHash.SIGHASH_ALL)
+                    val sig = Transactions.sign(it, channelKeys.delayedPaymentKey.deriveForCommitment(localPerCommitmentPoint), SigHash.SIGHASH_ALL)
                     Transactions.addSigs(it, sig)
                 }
             }
@@ -601,7 +601,7 @@ object Helpers {
                                 null -> Pair(claimHtlcTx.input.outPoint, null)
                                 // incoming htlc for which we have the preimage: we can spend it directly
                                 else -> {
-                                    val sig = Transactions.sign2(claimHtlcTx, channelKeys.htlcKey.deriveForCommitment(remoteCommit.remotePerCommitmentPoint), SigHash.SIGHASH_ALL)
+                                    val sig = Transactions.sign(claimHtlcTx, channelKeys.htlcKey.deriveForCommitment(remoteCommit.remotePerCommitmentPoint), SigHash.SIGHASH_ALL)
                                     Pair(claimHtlcTx.input.outPoint, Transactions.addSigs(claimHtlcTx, sig, preimage))
                                 }
                             }
@@ -622,7 +622,7 @@ object Helpers {
                                 feerateClaimHtlc
                             )
                         }?.let { claimHtlcTx ->
-                            val sig = Transactions.sign2(claimHtlcTx, channelKeys.htlcKey.deriveForCommitment(remoteCommit.remotePerCommitmentPoint), SigHash.SIGHASH_ALL)
+                            val sig = Transactions.sign(claimHtlcTx, channelKeys.htlcKey.deriveForCommitment(remoteCommit.remotePerCommitmentPoint), SigHash.SIGHASH_ALL)
                             Pair(claimHtlcTx.input.outPoint, Transactions.addSigs(claimHtlcTx, sig))
                         }
                     }
@@ -651,7 +651,7 @@ object Helpers {
                     claimMainFeerate
                 )
             }?.let {
-                val sig = Transactions.sign2(it, channelKeys.paymentKey)
+                val sig = Transactions.sign(it, channelKeys.paymentKey)
                 Transactions.addSigs(it, sig)
             }
 
@@ -709,7 +709,7 @@ object Helpers {
                     feerateMain
                 )
             }?.let {
-                val sig = Transactions.sign2(it, channelKeys.paymentKey)
+                val sig = Transactions.sign(it, channelKeys.paymentKey)
                 Transactions.addSigs(it, sig)
             }
 
@@ -725,7 +725,7 @@ object Helpers {
                     feeratePenalty
                 )
             }?.let {
-                val sig = Transactions.sign2(it, channelKeys.revocationKey.deriveForRevocation(remotePerCommitmentSecret))
+                val sig = Transactions.sign(it, channelKeys.revocationKey.deriveForRevocation(remotePerCommitmentSecret))
                 Transactions.addSigs(it, sig)
             }
 
@@ -770,7 +770,7 @@ object Helpers {
                             feeratePenalty
                         )
                     }?.let { htlcPenaltyTx ->
-                        val sig = Transactions.sign2(htlcPenaltyTx, channelKeys.revocationKey.deriveForRevocation(revokedCommitPublished.remotePerCommitmentSecret))
+                        val sig = Transactions.sign(htlcPenaltyTx, channelKeys.revocationKey.deriveForRevocation(revokedCommitPublished.remotePerCommitmentSecret))
                         Transactions.addSigs(htlcPenaltyTx, sig, remoteRevocationPubkey)
                     }
                 }
@@ -827,7 +827,7 @@ object Helpers {
                     generateTx("claim-htlc-delayed-penalty") {
                         claimDelayedOutputPenaltyTx
                     }?.let {
-                        val sig = Transactions.sign2(it, channelKeys.revocationKey.deriveForRevocation(revokedCommitPublished.remotePerCommitmentSecret))
+                        val sig = Transactions.sign(it, channelKeys.revocationKey.deriveForRevocation(revokedCommitPublished.remotePerCommitmentSecret))
                         val signedTx = Transactions.addSigs(it, sig)
                         // we need to make sure that the tx is indeed valid
                         when (runTrying { Transaction.correctlySpends(signedTx.tx, listOf(htlcTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS) }) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -408,7 +408,7 @@ object Helpers {
             require(isValidFinalScriptPubkey(remoteScriptPubkey, allowAnySegwit)) { "invalid remoteScriptPubkey" }
             val dustLimit = commitment.params.localParams.dustLimit.max(commitment.params.remoteParams.dustLimit)
             val closingTx = Transactions.makeClosingTx(commitment.commitInput, localScriptPubkey, remoteScriptPubkey, commitment.params.localParams.isInitiator, dustLimit, closingFees.preferred, commitment.localCommit.spec)
-            val localClosingSig = Transactions.sign(closingTx, channelKeys.fundingKey(commitment.fundingTxIndex))
+            val localClosingSig = Transactions.sign2(closingTx, channelKeys.fundingKey(commitment.fundingTxIndex))
             val closingSigned = ClosingSigned(commitment.channelId, closingFees.preferred, localClosingSig, TlvStream(ClosingSignedTlv.FeeRange(closingFees.min, closingFees.max)))
             return Pair(closingTx, closingSigned)
         }
@@ -651,7 +651,7 @@ object Helpers {
                     claimMainFeerate
                 )
             }?.let {
-                val sig = Transactions.sign(it, channelKeys.paymentKey)
+                val sig = Transactions.sign2(it, channelKeys.paymentKey)
                 Transactions.addSigs(it, sig)
             }
 
@@ -709,7 +709,7 @@ object Helpers {
                     feerateMain
                 )
             }?.let {
-                val sig = Transactions.sign(it, channelKeys.paymentKey)
+                val sig = Transactions.sign2(it, channelKeys.paymentKey)
                 Transactions.addSigs(it, sig)
             }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
@@ -3,7 +3,6 @@ package fr.acinq.lightning.channel
 import fr.acinq.bitcoin.*
 import fr.acinq.bitcoin.Script.tail
 import fr.acinq.bitcoin.crypto.musig2.IndividualNonce
-import fr.acinq.bitcoin.crypto.musig2.Musig2
 import fr.acinq.bitcoin.crypto.musig2.SecretNonce
 import fr.acinq.bitcoin.utils.getOrDefault
 import fr.acinq.lightning.Lightning.randomBytes32
@@ -710,7 +709,7 @@ data class InteractiveTxSession(
                     // Generate a secret nonce for this input if we don't already have one.
                     is InteractiveTxInput.LocalSwapIn -> when (secretNonces[inputOutgoing.serialId]) {
                         null -> {
-                            val secretNonce = Musig2.generateNonce(randomBytes32(), swapInKeys.userPrivateKey.instantiate(), listOf(swapInKeys.userPublicKey, swapInKeys.remoteServerPublicKey))
+                            val secretNonce = swapInKeys.userPrivateKey.generateMusig2Nonce(randomBytes32(), listOf(swapInKeys.userPublicKey, swapInKeys.remoteServerPublicKey))
                             secretNonces + (inputOutgoing.serialId to secretNonce)
                         }
                         else -> secretNonces
@@ -796,7 +795,7 @@ data class InteractiveTxSession(
             // Generate a secret nonce for this input if we don't already have one.
             is InteractiveTxInput.RemoteSwapIn -> when (secretNonces[input.serialId]) {
                 null -> {
-                    val secretNonce = Musig2.generateNonce(randomBytes32(), swapInKeys.localServerPrivateKey(remoteNodeId).instantiate(), listOf(input.userKey, input.serverKey))
+                    val secretNonce = swapInKeys.localServerPrivateKey(remoteNodeId).generateMusig2Nonce(randomBytes32(), listOf(input.userKey, input.serverKey))
                     secretNonces + (input.serialId to secretNonce)
                 }
                 else -> secretNonces

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
@@ -710,7 +710,7 @@ data class InteractiveTxSession(
                     // Generate a secret nonce for this input if we don't already have one.
                     is InteractiveTxInput.LocalSwapIn -> when (secretNonces[inputOutgoing.serialId]) {
                         null -> {
-                            val secretNonce = Musig2.generateNonce(randomBytes32(), swapInKeys.userPrivateKey, listOf(swapInKeys.userPublicKey, swapInKeys.remoteServerPublicKey))
+                            val secretNonce = Musig2.generateNonce(randomBytes32(), swapInKeys.userPrivateKey.instantiate(), listOf(swapInKeys.userPublicKey, swapInKeys.remoteServerPublicKey))
                             secretNonces + (inputOutgoing.serialId to secretNonce)
                         }
                         else -> secretNonces
@@ -796,7 +796,7 @@ data class InteractiveTxSession(
             // Generate a secret nonce for this input if we don't already have one.
             is InteractiveTxInput.RemoteSwapIn -> when (secretNonces[input.serialId]) {
                 null -> {
-                    val secretNonce = Musig2.generateNonce(randomBytes32(), swapInKeys.localServerPrivateKey(remoteNodeId), listOf(input.userKey, input.serverKey))
+                    val secretNonce = Musig2.generateNonce(randomBytes32(), swapInKeys.localServerPrivateKey(remoteNodeId).instantiate(), listOf(input.userKey, input.serverKey))
                     secretNonces + (input.serialId to secretNonce)
                 }
                 else -> secretNonces

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
@@ -49,7 +49,7 @@ sealed class SharedFundingInput {
 
         override fun sign(channelKeys: KeyManager.ChannelKeys, tx: Transaction): ByteVector64 {
             val fundingKey = channelKeys.fundingKey(fundingTxIndex)
-            return Transactions.sign(Transactions.TransactionWithInputInfo.SpliceTx(info, tx), fundingKey)
+            return Transactions.sign2(Transactions.TransactionWithInputInfo.SpliceTx(info, tx), fundingKey)
         }
 
         companion object {
@@ -1013,7 +1013,7 @@ data class InteractiveTxSigningSession(
                 when (val signedLocalCommit = LocalCommit.fromCommitSig(channelKeys, channelParams, fundingTxIndex, fundingParams.remoteFundingPubkey, commitInput, remoteCommitSig, localCommitIndex, localCommit.value.spec, localPerCommitmentPoint, logger)) {
                     is Either.Left -> {
                         val fundingKey = channelKeys.fundingKey(fundingTxIndex)
-                        val localSigOfLocalTx = Transactions.sign(localCommit.value.commitTx, fundingKey)
+                        val localSigOfLocalTx = Transactions.sign2(localCommit.value.commitTx, fundingKey)
                         val signedLocalCommitTx = Transactions.addSigs(localCommit.value.commitTx, fundingKey.publicKey(), fundingParams.remoteFundingPubkey, localSigOfLocalTx, remoteCommitSig.signature)
                         logger.info { "interactiveTxSession=$this" }
                         logger.info { "channelParams=$channelParams" }
@@ -1091,7 +1091,7 @@ data class InteractiveTxSigningSession(
                 remoteFundingPubkey = fundingParams.remoteFundingPubkey,
                 remotePerCommitmentPoint = remotePerCommitmentPoint
             ).map { firstCommitTx ->
-                val localSigOfRemoteCommitTx = Transactions.sign(firstCommitTx.remoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
+                val localSigOfRemoteCommitTx = Transactions.sign2(firstCommitTx.remoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
                 val localSigsOfRemoteHtlcTxs = firstCommitTx.remoteHtlcTxs.map { Transactions.sign(it, channelKeys.htlcKey.deriveForCommitment(remotePerCommitmentPoint), SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
 
                 val alternativeSigs = if (firstCommitTx.remoteHtlcTxs.isEmpty()) {
@@ -1108,7 +1108,7 @@ data class InteractiveTxSigningSession(
                             remotePerCommitmentPoint,
                             alternativeSpec
                         )
-                        val sig = Transactions.sign(alternativeRemoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
+                        val sig = Transactions.sign2(alternativeRemoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
                         CommitSigTlv.AlternativeFeerateSig(feerate, sig)
                     }
                     TlvStream(CommitSigTlv.AlternativeFeerateSigs(commitSigTlvs) as CommitSigTlv)

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
@@ -49,7 +49,7 @@ sealed class SharedFundingInput {
 
         override fun sign(channelKeys: KeyManager.ChannelKeys, tx: Transaction): ByteVector64 {
             val fundingKey = channelKeys.fundingKey(fundingTxIndex)
-            return Transactions.sign2(Transactions.TransactionWithInputInfo.SpliceTx(info, tx), fundingKey)
+            return Transactions.sign(Transactions.TransactionWithInputInfo.SpliceTx(info, tx), fundingKey)
         }
 
         companion object {
@@ -1013,7 +1013,7 @@ data class InteractiveTxSigningSession(
                 when (val signedLocalCommit = LocalCommit.fromCommitSig(channelKeys, channelParams, fundingTxIndex, fundingParams.remoteFundingPubkey, commitInput, remoteCommitSig, localCommitIndex, localCommit.value.spec, localPerCommitmentPoint, logger)) {
                     is Either.Left -> {
                         val fundingKey = channelKeys.fundingKey(fundingTxIndex)
-                        val localSigOfLocalTx = Transactions.sign2(localCommit.value.commitTx, fundingKey)
+                        val localSigOfLocalTx = Transactions.sign(localCommit.value.commitTx, fundingKey)
                         val signedLocalCommitTx = Transactions.addSigs(localCommit.value.commitTx, fundingKey.publicKey(), fundingParams.remoteFundingPubkey, localSigOfLocalTx, remoteCommitSig.signature)
                         logger.info { "interactiveTxSession=$this" }
                         logger.info { "channelParams=$channelParams" }
@@ -1091,8 +1091,8 @@ data class InteractiveTxSigningSession(
                 remoteFundingPubkey = fundingParams.remoteFundingPubkey,
                 remotePerCommitmentPoint = remotePerCommitmentPoint
             ).map { firstCommitTx ->
-                val localSigOfRemoteCommitTx = Transactions.sign2(firstCommitTx.remoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
-                val localSigsOfRemoteHtlcTxs = firstCommitTx.remoteHtlcTxs.map { Transactions.sign2(it, channelKeys.htlcKey.deriveForCommitment(remotePerCommitmentPoint), SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
+                val localSigOfRemoteCommitTx = Transactions.sign(firstCommitTx.remoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
+                val localSigsOfRemoteHtlcTxs = firstCommitTx.remoteHtlcTxs.map { Transactions.sign(it, channelKeys.htlcKey.deriveForCommitment(remotePerCommitmentPoint), SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
 
                 val alternativeSigs = if (firstCommitTx.remoteHtlcTxs.isEmpty()) {
                     val commitSigTlvs = Commitments.alternativeFeerates.map { feerate ->
@@ -1108,7 +1108,7 @@ data class InteractiveTxSigningSession(
                             remotePerCommitmentPoint,
                             alternativeSpec
                         )
-                        val sig = Transactions.sign2(alternativeRemoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
+                        val sig = Transactions.sign(alternativeRemoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
                         CommitSigTlv.AlternativeFeerateSig(feerate, sig)
                     }
                     TlvStream(CommitSigTlv.AlternativeFeerateSigs(commitSigTlvs) as CommitSigTlv)

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
@@ -1092,7 +1092,7 @@ data class InteractiveTxSigningSession(
                 remotePerCommitmentPoint = remotePerCommitmentPoint
             ).map { firstCommitTx ->
                 val localSigOfRemoteCommitTx = Transactions.sign2(firstCommitTx.remoteCommitTx, channelKeys.fundingKey(fundingTxIndex))
-                val localSigsOfRemoteHtlcTxs = firstCommitTx.remoteHtlcTxs.map { Transactions.sign(it, channelKeys.htlcKey.deriveForCommitment(remotePerCommitmentPoint), SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
+                val localSigsOfRemoteHtlcTxs = firstCommitTx.remoteHtlcTxs.map { Transactions.sign2(it, channelKeys.htlcKey.deriveForCommitment(remotePerCommitmentPoint), SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY) }
 
                 val alternativeSigs = if (firstCommitTx.remoteHtlcTxs.isEmpty()) {
                     val commitSigTlvs = Commitments.alternativeFeerates.map { feerate ->

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/Bolt3Derivation.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/Bolt3Derivation.kt
@@ -14,13 +14,6 @@ object Bolt3Derivation {
 
     fun perCommitPoint(seed: ByteVector32, index: Long): PublicKey = perCommitSecret(seed, index).publicKey()
 
-    private fun derivePrivKey(secret: PrivateKey, perCommitPoint: PublicKey): PrivateKey {
-        // secretkey = basepoint-secret + SHA256(per-commitment-point || basepoint)
-        return secret + (PrivateKey(sha256(perCommitPoint.value + secret.publicKey().value)))
-    }
-
-    fun PrivateKeyDescriptor.deriveForCommitment(perCommitPoint: PublicKey): PrivateKeyDescriptor = Bolt3CommitmentKeyDescriptor(this, perCommitPoint)
-
     private fun derivePubKey(basePoint: PublicKey, perCommitPoint: PublicKey): PublicKey {
         //pubkey = basepoint + SHA256(per-commitment-point || basepoint)*G
         val a = PrivateKey(sha256(perCommitPoint.value + basePoint.value))
@@ -36,38 +29,4 @@ object Bolt3Derivation {
     }
 
     fun PublicKey.deriveForRevocation(perCommitPoint: PublicKey): PublicKey = revocationPubKey(this, perCommitPoint)
-
-    private fun revocationPrivKey(secret: PrivateKey, perCommitSecret: PrivateKey): PrivateKey {
-        val a = PrivateKey(sha256(secret.publicKey().value + perCommitSecret.publicKey().value))
-        val b = PrivateKey(sha256(perCommitSecret.publicKey().value + secret.publicKey().value))
-        return (secret * a) + (perCommitSecret * b)
-    }
-
-    fun PrivateKeyDescriptor.deriveForRevocation(perCommitSecret: PrivateKey): PrivateKeyDescriptor = Bolt3RevocationKeyDescriptor(this, perCommitSecret)
-
-    class Bolt3RevocationKeyDescriptor(
-        private val parent: PrivateKeyDescriptor,
-        private val perCommitSecret: PrivateKey
-    ) : PrivateKeyDescriptor {
-        override fun instantiate(): PrivateKey {
-            return revocationPrivKey(parent.instantiate(), perCommitSecret)
-        }
-
-        override fun publicKey(): PublicKey {
-            return instantiate().publicKey()
-        }
-    }
-
-    class Bolt3CommitmentKeyDescriptor(
-        private val parent: PrivateKeyDescriptor,
-        private val perCommitPoint: PublicKey
-    ) : PrivateKeyDescriptor {
-        override fun instantiate(): PrivateKey {
-            return derivePrivKey(parent.instantiate(), perCommitPoint)
-        }
-
-        override fun publicKey(): PublicKey {
-            return instantiate().publicKey()
-        }
-    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/ExtendedPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/ExtendedPrivateKeyDescriptor.kt
@@ -1,0 +1,16 @@
+package fr.acinq.lightning.crypto
+
+import fr.acinq.bitcoin.DeterministicWallet
+import fr.acinq.bitcoin.PrivateKey
+
+interface ExtendedPrivateKeyDescriptor {
+    // TODO: instantiate function should be removed from this interface
+    //  and become private at some point. Only the keymanager that supports
+    //  a given type of keys should be able to manipulate them to sign with.
+    //  But for now, we keep it public as its needed in different places.
+    fun instantiate(): DeterministicWallet.ExtendedPrivateKey
+
+    fun publicKey(): DeterministicWallet.ExtendedPublicKey
+
+    fun derivePrivateKey(index: Long): PrivateKeyDescriptor
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/ExtendedPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/ExtendedPrivateKeyDescriptor.kt
@@ -1,16 +1,18 @@
 package fr.acinq.lightning.crypto
 
 import fr.acinq.bitcoin.DeterministicWallet
+import fr.acinq.bitcoin.KeyPath
 import fr.acinq.bitcoin.PrivateKey
 
 interface ExtendedPrivateKeyDescriptor {
-    // TODO: instantiate function should be removed from this interface
-    //  and become private at some point. Only the keymanager that supports
-    //  a given type of keys should be able to manipulate them to sign with.
-    //  But for now, we keep it public as its needed in different places.
-    fun instantiate(): DeterministicWallet.ExtendedPrivateKey
+
+    fun privateKey(): PrivateKeyDescriptor
 
     fun publicKey(): DeterministicWallet.ExtendedPublicKey
 
+    fun derive(path: KeyPath): ExtendedPrivateKeyDescriptor
+
     fun derivePrivateKey(index: Long): PrivateKeyDescriptor
+
+    fun derivePrivateKey(path: KeyPath): PrivateKeyDescriptor
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
@@ -71,21 +71,21 @@ interface KeyManager {
 
     data class Bip84OnChainKeys(
         private val chain: Chain,
-        private val master: DeterministicWallet.ExtendedPrivateKey,
+        private val master: ExtendedPrivateKeyDescriptor,
         val account: Long
     ) {
-        private val xpriv = DeterministicWallet.derivePrivateKey(master, bip84BasePath(chain) / hardened(account))
+        private val xpriv = LocalKeyManager.DerivedExtendedPrivateKeyDescriptor(master, bip84BasePath(chain) / hardened(account))
 
         val xpub: String = DeterministicWallet.encode(
-            input = DeterministicWallet.publicKey(xpriv),
+            input = xpriv.publicKey(),
             prefix = when (chain) {
                 Chain.Testnet, Chain.Regtest, Chain.Signet -> DeterministicWallet.vpub
                 Chain.Mainnet -> DeterministicWallet.zpub
             }
         )
 
-        fun privateKey(addressIndex: Long): PrivateKey {
-            return DeterministicWallet.derivePrivateKey(xpriv, KeyPath.empty / 0 / addressIndex).privateKey
+        fun privateKey(addressIndex: Long): PrivateKeyDescriptor {
+            return LocalKeyManager.FromExtendedPrivateKeyDescriptor(xpriv, KeyPath.empty / 0 / addressIndex)
         }
 
         fun pubkeyScript(addressIndex: Long): ByteVector {

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
@@ -8,6 +8,8 @@ import fr.acinq.bitcoin.io.ByteArrayInput
 import fr.acinq.bitcoin.utils.Either
 import fr.acinq.lightning.DefaultSwapInParams
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
+import fr.acinq.lightning.crypto.local.DerivedExtendedPrivateKeyDescriptor
+import fr.acinq.lightning.crypto.local.FromExtendedPrivateKeyDescriptor
 import fr.acinq.lightning.transactions.SwapInProtocol
 import fr.acinq.lightning.transactions.SwapInProtocolLegacy
 import fr.acinq.lightning.transactions.Transactions
@@ -74,7 +76,7 @@ interface KeyManager {
         private val master: ExtendedPrivateKeyDescriptor,
         val account: Long
     ) {
-        private val xpriv = LocalKeyManager.DerivedExtendedPrivateKeyDescriptor(master, bip84BasePath(chain) / hardened(account))
+        private val xpriv = DerivedExtendedPrivateKeyDescriptor(master, bip84BasePath(chain) / hardened(account))
 
         val xpub: String = DeterministicWallet.encode(
             input = xpriv.publicKey(),
@@ -85,7 +87,7 @@ interface KeyManager {
         )
 
         fun privateKey(addressIndex: Long): PrivateKeyDescriptor {
-            return LocalKeyManager.FromExtendedPrivateKeyDescriptor(xpriv, KeyPath.empty / 0 / addressIndex)
+            return FromExtendedPrivateKeyDescriptor(xpriv, KeyPath.empty / 0 / addressIndex)
         }
 
         fun pubkeyScript(addressIndex: Long): ByteVector {
@@ -121,15 +123,15 @@ interface KeyManager {
         val refundDelay: Int = DefaultSwapInParams.RefundDelay
     ) {
         private val userExtendedPrivateKey: ExtendedPrivateKeyDescriptor =
-            LocalKeyManager.DerivedExtendedPrivateKeyDescriptor(master, swapInUserKeyPath(chain))
-        private val userRefundExtendedPrivateKey: ExtendedPrivateKeyDescriptor = LocalKeyManager.DerivedExtendedPrivateKeyDescriptor(master, swapInUserRefundKeyPath(chain))
+            DerivedExtendedPrivateKeyDescriptor(master, swapInUserKeyPath(chain))
+        private val userRefundExtendedPrivateKey: ExtendedPrivateKeyDescriptor = DerivedExtendedPrivateKeyDescriptor(master, swapInUserRefundKeyPath(chain))
 
-        val userPrivateKey: PrivateKeyDescriptor = LocalKeyManager.FromExtendedPrivateKeyDescriptor(userExtendedPrivateKey)
+        val userPrivateKey: PrivateKeyDescriptor = FromExtendedPrivateKeyDescriptor(userExtendedPrivateKey)
 
         val userPublicKey: PublicKey = userPrivateKey.publicKey()
 
-        private val localServerExtendedPrivateKey: ExtendedPrivateKeyDescriptor = LocalKeyManager.DerivedExtendedPrivateKeyDescriptor(master, swapInLocalServerKeyPath(chain))
-        fun localServerPrivateKey(remoteNodeId: PublicKey): PrivateKeyDescriptor = LocalKeyManager.FromExtendedPrivateKeyDescriptor(localServerExtendedPrivateKey, perUserPath(remoteNodeId))
+        private val localServerExtendedPrivateKey: ExtendedPrivateKeyDescriptor = DerivedExtendedPrivateKeyDescriptor(master, swapInLocalServerKeyPath(chain))
+        fun localServerPrivateKey(remoteNodeId: PublicKey): PrivateKeyDescriptor = FromExtendedPrivateKeyDescriptor(localServerExtendedPrivateKey, perUserPath(remoteNodeId))
 
         // legacy p2wsh-based swap-in protocol, with a fixed on-chain address
         val legacySwapInProtocol = SwapInProtocolLegacy(userPublicKey, remoteServerPublicKey, refundDelay)

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
@@ -54,9 +54,9 @@ interface KeyManager {
         val fundingKeyPath: KeyPath,
         val fundingKey: (Long) -> PrivateKeyDescriptor,
         val paymentKey: PrivateKeyDescriptor,
-        val delayedPaymentKey: PrivateKey,
-        val htlcKey: PrivateKey,
-        val revocationKey: PrivateKey,
+        val delayedPaymentKey: PrivateKeyDescriptor,
+        val htlcKey: PrivateKeyDescriptor,
+        val revocationKey: PrivateKeyDescriptor,
         val shaSeed: ByteVector32,
     ) {
         fun fundingPubKey(index: Long): PublicKey = fundingKey(index).publicKey()

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
@@ -32,6 +32,28 @@ interface KeyManager {
      */
     fun channelKeys(fundingKeyPath: KeyPath): ChannelKeys
 
+
+    /**
+     * This method offers direct access to the master key derivation. It should only be used for some advanced usage
+     * like (LNURL-auth, data encryption).
+     */
+    fun derivePrivateKey(keyPath: KeyPath): PrivateKeyDescriptor
+
+    /**
+     * Deterministically generate key material from a given KeyPath.
+     * It could be used if the client needs to cipher some data and
+     * want to rely on this keyManager to ensure it can recover its
+     * key when needed.
+     * The choice of how to generate the key material is left to the KeyManager
+     * implementer. They must only ensure that it is a deterministic process
+     * and that it will always return the same key material for the same KeyPath.
+     * Diversification parameter is a KeyPath for practical and historical reason
+     * but the caller should not suppose that any standard path derivation will be
+     * applied to any master key of the wallet. And, as a matter of fact this
+     * should be discouraged to prevent key materiel extraction.
+     */
+    fun deterministicKeyMaterial(keyPath: KeyPath): ByteVector32
+
     val finalOnChainWallet: Bip84OnChainKeys
 
     val swapInOnChainWallet: SwapInOnChainKeys

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
@@ -52,8 +52,8 @@ interface KeyManager {
      */
     data class ChannelKeys(
         val fundingKeyPath: KeyPath,
-        val fundingKey: (Long) -> PrivateKey,
-        val paymentKey: PrivateKey,
+        val fundingKey: (Long) -> PrivateKeyDescriptor,
+        val paymentKey: PrivateKeyDescriptor,
         val delayedPaymentKey: PrivateKey,
         val htlcKey: PrivateKey,
         val revocationKey: PrivateKey,

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/KeyManager.kt
@@ -141,11 +141,6 @@ interface KeyManager {
             return legacySwapInProtocol.signSwapInputUser(fundingTx, index, parentTxOuts[fundingTx.txIn[index].outPoint.index.toInt()], userPrivateKey)
         }
 
-        // this is a private descriptor that can be used as-is to recover swap-in funds once the refund delay has passed
-        // it is compatible with address rotation as long as refund keys are derived directly from userRefundExtendedPrivateKey
-        // README: it includes the user's master refund private key and is not safe to share !!
-        val privateDescriptor = SwapInProtocol.privateDescriptor(chain, userPublicKey, remoteServerPublicKey, refundDelay, userRefundExtendedPrivateKey.instantiate())
-
         // this is the public version of the above descriptor. It can be used to monitor a user's swap-in transaction
         // README: it cannot be used to derive private keys, but it can be used to derive swap-in addresses
         val publicDescriptor = SwapInProtocol.publicDescriptor(chain, userPublicKey, remoteServerPublicKey, refundDelay, DeterministicWallet.publicKey(userRefundExtendedPrivateKey.instantiate()))

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
@@ -43,7 +43,7 @@ data class LocalKeyManager(val seed: ByteVector, val chain: Chain, val remoteSwa
         nodeKey = derivePrivateKey(master, nodeKeyBasePath(chain)),
     )
 
-    override val finalOnChainWallet: KeyManager.Bip84OnChainKeys = KeyManager.Bip84OnChainKeys(chain, master, account = 0)
+    override val finalOnChainWallet: KeyManager.Bip84OnChainKeys = KeyManager.Bip84OnChainKeys(chain, masterDescriptor,  account = 0)
     override val swapInOnChainWallet: KeyManager.SwapInOnChainKeys = run {
         val (prefix, xpub) = DeterministicWallet.ExtendedPublicKey.decode(remoteSwapInExtendedPublicKey)
         val expectedPrefix = when (chain) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
@@ -6,6 +6,8 @@ import fr.acinq.bitcoin.DeterministicWallet.hardened
 import fr.acinq.bitcoin.crypto.Pack
 import fr.acinq.lightning.Lightning.secureRandom
 import fr.acinq.lightning.crypto.LocalKeyManager.Companion.channelKeyPath
+import fr.acinq.lightning.crypto.local.FromExtendedPrivateKeyDescriptor
+import fr.acinq.lightning.crypto.local.RootExtendedPrivateKeyDescriptor
 
 /**
  * An implementation of [KeyManager] that supports deterministic derivation for [KeyManager.ChannelKeys] based
@@ -168,51 +170,6 @@ data class LocalKeyManager(val seed: ByteVector, val chain: Chain, val remoteSwa
         }
     }
 
-    class FromExtendedPrivateKeyDescriptor(private val parent: ExtendedPrivateKeyDescriptor, private val path: KeyPath) :
-        PrivateKeyDescriptor {
-
-        constructor(parent: ExtendedPrivateKeyDescriptor, index: Long): this(parent, KeyPath(listOf(index)))
-
-        constructor(parent: ExtendedPrivateKeyDescriptor): this(parent, KeyPath(listOf()))
-
-        override fun instantiate(): PrivateKey {
-            return DeterministicWallet.derivePrivateKey(parent.instantiate(), path).privateKey
-        }
-
-        override fun publicKey(): PublicKey {
-            return instantiate().publicKey()
-        }
-    }
-
-    class RootExtendedPrivateKeyDescriptor(val master: DeterministicWallet.ExtendedPrivateKey) : ExtendedPrivateKeyDescriptor{
-        override fun instantiate(): DeterministicWallet.ExtendedPrivateKey {
-            return master
-        }
-        override fun publicKey(): DeterministicWallet.ExtendedPublicKey {
-            return DeterministicWallet.publicKey(instantiate())
-        }
-
-        override fun derivePrivateKey(index: Long): PrivateKeyDescriptor {
-            return FromExtendedPrivateKeyDescriptor(this, index)
-        }
-    }
-
-    class DerivedExtendedPrivateKeyDescriptor(
-        private val parent: ExtendedPrivateKeyDescriptor,
-        private val keyPath: KeyPath
-    ) : ExtendedPrivateKeyDescriptor {
-        override fun instantiate(): DeterministicWallet.ExtendedPrivateKey {
-            return DeterministicWallet.derivePrivateKey(parent.instantiate(), keyPath)
-        }
-
-        override fun publicKey(): DeterministicWallet.ExtendedPublicKey {
-            return DeterministicWallet.publicKey(instantiate())
-        }
-
-        override fun derivePrivateKey(index: Long): PrivateKeyDescriptor {
-            return FromExtendedPrivateKeyDescriptor(this, index)
-        }
-    }
 }
 
 infix operator fun KeyPath.div(index: Long): KeyPath = this.append(index)

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
@@ -98,9 +98,9 @@ data class LocalKeyManager(val seed: ByteVector, val chain: Chain, val remoteSwa
         return RecoveredChannelKeys(
             fundingPubKey,
             paymentKey = LocalPrivateKeyDescriptor(this, channelKeyPrefix / hardened(2)),
-            delayedPaymentKey = privateKey(channelKeyPrefix / hardened(3)),
-            htlcKey = privateKey(channelKeyPrefix / hardened(4)),
-            revocationKey = privateKey(channelKeyPrefix / hardened(1)),
+            delayedPaymentKey = LocalPrivateKeyDescriptor(this, channelKeyPrefix / hardened(3)),
+            htlcKey = LocalPrivateKeyDescriptor(this, channelKeyPrefix / hardened(4)),
+            revocationKey = LocalPrivateKeyDescriptor(this, channelKeyPrefix / hardened(1)),
             shaSeed = privateKey(channelKeyPrefix / hardened(5)).value.concat(1).sha256()
         )
     }
@@ -113,9 +113,9 @@ data class LocalKeyManager(val seed: ByteVector, val chain: Chain, val remoteSwa
     data class RecoveredChannelKeys(
         val fundingPubKey: PublicKey,
         val paymentKey: PrivateKeyDescriptor,
-        val delayedPaymentKey: PrivateKey,
-        val htlcKey: PrivateKey,
-        val revocationKey: PrivateKey,
+        val delayedPaymentKey: PrivateKeyDescriptor,
+        val htlcKey: PrivateKeyDescriptor,
+        val revocationKey: PrivateKeyDescriptor,
         val shaSeed: ByteVector32
     ) {
         val htlcBasepoint: PublicKey = htlcKey.publicKey()

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
@@ -72,8 +72,6 @@ data class LocalKeyManager(val seed: ByteVector, val chain: Chain, val remoteSwa
         return (master.derivePrivateKey(keyPath) as LocalPrivateKeyDescriptor).instantiate().value
     }
 
-    fun privateKey(keyPath: KeyPath): PrivateKey = (master.derivePrivateKey(keyPath) as LocalPrivateKeyDescriptor).instantiate()
-
     override fun newFundingKeyPath(isInitiator: Boolean): KeyPath {
         val last = hardened(if (isInitiator) 1 else 0)
         fun next() = secureRandom.nextInt().toLong() and 0xFFFFFFFF
@@ -111,7 +109,8 @@ data class LocalKeyManager(val seed: ByteVector, val chain: Chain, val remoteSwa
             delayedPaymentKey = master.derivePrivateKey(channelKeyPrefix / hardened(3)),
             htlcKey = master.derivePrivateKey(channelKeyPrefix / hardened(4)),
             revocationKey = master.derivePrivateKey(channelKeyPrefix / hardened(1)),
-            shaSeed = privateKey(channelKeyPrefix / hardened(5)).value.concat(1).sha256()
+            shaSeed = (master.derivePrivateKey(channelKeyPrefix / hardened(5)) as LocalPrivateKeyDescriptor)
+                .instantiate().value.concat(1).sha256()
         )
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/LocalKeyManager.kt
@@ -63,7 +63,14 @@ data class LocalKeyManager(val seed: ByteVector, val chain: Chain, val remoteSwa
      * This method offers direct access to the master key derivation. It should only be used for some advanced usage
      * like (LNURL-auth, data encryption).
      */
-    fun derivePrivateKey(keyPath: KeyPath): DeterministicWallet.ExtendedPrivateKey = (master.derive(keyPath) as LocalExtendedPrivateKeyDescriptor).instantiate()
+    override fun derivePrivateKey(keyPath: KeyPath): PrivateKeyDescriptor = master.derivePrivateKey(keyPath)
+
+    override fun deterministicKeyMaterial(keyPath: KeyPath): ByteVector32 {
+        // This implementation ensures backward compatibility with Phoenix
+        // (see LocalKeyManager.cloudKey())... but it also allows one to extract
+        // any key from this key manager given they know its derivation path.
+        return (master.derivePrivateKey(keyPath) as LocalPrivateKeyDescriptor).instantiate().value
+    }
 
     fun privateKey(keyPath: KeyPath): PrivateKey = (master.derivePrivateKey(keyPath) as LocalPrivateKeyDescriptor).instantiate()
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
@@ -1,0 +1,15 @@
+package fr.acinq.lightning.crypto
+
+import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.bitcoin.PublicKey
+
+interface PrivateKeyDescriptor {
+    // TODO: instantiate function should be removed from this interface
+    //  and become private at some point. Only the keymanager that supports
+    //  a given type of keys should be able to manipulate them to sign with.
+    //  But for now, we keep it public as the signing is done directly in
+    //  Transactions.kt
+    abstract fun instantiate(): PrivateKey
+
+    fun publicKey(): PublicKey
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
@@ -12,4 +12,14 @@ interface PrivateKeyDescriptor {
     abstract fun instantiate(): PrivateKey
 
     fun publicKey(): PublicKey
+
+    // TODO: this function is only used for keys generated from revocation
+    //       derivation so, maybe, we could make it so that only this type
+    //       of keys can be derived that way.
+    fun deriveForRevocation(perCommitSecret: PrivateKey): PrivateKeyDescriptor
+
+    // TODO: this function is only used for htlc and delayed payment keys
+    //       so, maybe, we could make it so that only this type of keys can
+    //       be derived that way.
+    fun deriveForCommitment(perCommitPoint: PublicKey): PrivateKeyDescriptor
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
@@ -1,7 +1,14 @@
 package fr.acinq.lightning.crypto
 
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.ByteVector64
 import fr.acinq.bitcoin.PrivateKey
 import fr.acinq.bitcoin.PublicKey
+import fr.acinq.bitcoin.Satoshi
+import fr.acinq.bitcoin.SigHash
+import fr.acinq.bitcoin.Transaction
+import fr.acinq.bitcoin.TxOut
+import fr.acinq.lightning.transactions.Transactions
 
 interface PrivateKeyDescriptor {
     // TODO: instantiate function should be removed from this interface
@@ -22,4 +29,39 @@ interface PrivateKeyDescriptor {
     //       so, maybe, we could make it so that only this type of keys can
     //       be derived that way.
     fun deriveForCommitment(perCommitPoint: PublicKey): PrivateKeyDescriptor
+
+    /**
+     * sign a tx input
+     *
+     * @param tx                   input transaction
+     * @param inputIndex           index of the tx input that is being processed
+     * @param redeemScript         public key script of the output claimed by this tx input
+     * @param amount               amount of the output claimed by this tx input
+     * @param sighash              signature hash type, which will be appended to the signature
+     * @return the encoded signature of this tx for this specific tx input
+     */
+    fun sign(tx: Transaction, inputIndex: Int, redeemScript: ByteArray, amount: Satoshi, sighash: Int = SigHash.SIGHASH_ALL): ByteVector64
+
+    /**
+     * sign a tx input
+     *
+     * transaction must spend the input to sign
+     *
+     * @param txInfo               input transaction
+     * @param sighash              signature hash type, which will be appended to the signature
+     * @return the encoded signature of this tx
+     */
+    fun sign(txInfo: Transactions.TransactionWithInputInfo, sighash: Int = SigHash.SIGHASH_ALL): ByteVector64
+
+    /**
+     * Sign a taproot tx input, using one of its script paths.
+     *
+     * @param tx input transaction.
+     * @param inputIndex index of the tx input that is being signed.
+     * @param inputs list of all UTXOs spent by this transaction.
+     * @param sighash signature hash type, which will be appended to the signature (if not default).
+     * @param tapleaf tapscript leaf hash of the script that is being spent.
+     * @return the schnorr signature of this tx for this specific tx input and the given script leaf.
+     */
+    fun signInputTaprootScriptPath(tx: Transaction, inputIndex: Int, inputs: List<TxOut>, sigHash: Int, tapleaf: ByteVector32): ByteVector64
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
@@ -5,9 +5,13 @@ import fr.acinq.bitcoin.ByteVector64
 import fr.acinq.bitcoin.PrivateKey
 import fr.acinq.bitcoin.PublicKey
 import fr.acinq.bitcoin.Satoshi
+import fr.acinq.bitcoin.ScriptTree
 import fr.acinq.bitcoin.SigHash
 import fr.acinq.bitcoin.Transaction
 import fr.acinq.bitcoin.TxOut
+import fr.acinq.bitcoin.crypto.musig2.IndividualNonce
+import fr.acinq.bitcoin.crypto.musig2.SecretNonce
+import fr.acinq.bitcoin.utils.Either
 import fr.acinq.lightning.transactions.Transactions
 
 interface PrivateKeyDescriptor {
@@ -64,4 +68,18 @@ interface PrivateKeyDescriptor {
      * @return the schnorr signature of this tx for this specific tx input and the given script leaf.
      */
     fun signInputTaprootScriptPath(tx: Transaction, inputIndex: Int, inputs: List<TxOut>, sigHash: Int, tapleaf: ByteVector32): ByteVector64
+
+    /**
+     * Create a partial musig2 signature for the given taproot input key path.
+     *
+     * @param tx transaction spending the target taproot input.
+     * @param index index of the taproot input to spend.
+     * @param inputs all inputs of the spending transaction.
+     * @param publicKeys public keys of all participants of the musig2 session: callers must verify that all public keys are valid.
+     * @param secretNonce secret nonce of the signing participant.
+     * @param publicNonces public nonces of all participants of the musig2 session.
+     * @param scriptTree tapscript tree of the taproot input, if it has script paths.
+     */
+    fun signMusig2TaprootInput(tx: Transaction, index: Int, inputs: List<TxOut>, publicKeys: List<PublicKey>, secretNonce: SecretNonce, publicNonces: List<IndividualNonce>, scriptTree: ScriptTree.Leaf): Either<Throwable, ByteVector32>
+
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
@@ -15,12 +15,6 @@ import fr.acinq.bitcoin.utils.Either
 import fr.acinq.lightning.transactions.Transactions
 
 interface PrivateKeyDescriptor {
-    // TODO: instantiate function should be removed from this interface
-    //  and become private at some point. Only the keymanager that supports
-    //  a given type of keys should be able to manipulate them to sign with.
-    //  But for now, we keep it public as the signing is done directly in
-    //  Transactions.kt
-    abstract fun instantiate(): PrivateKey
 
     fun publicKey(): PublicKey
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
@@ -82,4 +82,9 @@ interface PrivateKeyDescriptor {
      */
     fun signMusig2TaprootInput(tx: Transaction, index: Int, inputs: List<TxOut>, publicKeys: List<PublicKey>, secretNonce: SecretNonce, publicNonces: List<IndividualNonce>, scriptTree: ScriptTree.Leaf): Either<Throwable, ByteVector32>
 
+    /**
+     * @param sessionId a random, unique session ID.
+     * @param publicKeys public keys of all participants: callers must verify that all public keys are valid.
+     */
+    fun generateMusig2Nonce(sessionId: ByteVector32, publicKeys: List<PublicKey>): Pair<SecretNonce, IndividualNonce>
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/PrivateKeyDescriptor.kt
@@ -1,5 +1,6 @@
 package fr.acinq.lightning.crypto
 
+import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.ByteVector64
 import fr.acinq.bitcoin.PrivateKey
@@ -27,6 +28,14 @@ interface PrivateKeyDescriptor {
     //       so, maybe, we could make it so that only this type of keys can
     //       be derived that way.
     fun deriveForCommitment(perCommitPoint: PublicKey): PrivateKeyDescriptor
+
+    /**
+     * Sign data with this private key, using RCF6979 deterministic signatures
+     *
+     * @param data       data to sign
+     * @return a (r, s) ECDSA signature pair
+     */
+    fun sign(data: ByteVector32): ByteVector
 
     /**
      * sign a tx input

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/Bolt3CommitmentKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/Bolt3CommitmentKeyDescriptor.kt
@@ -1,0 +1,20 @@
+package fr.acinq.lightning.crypto.local
+
+import fr.acinq.bitcoin.Crypto
+import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.bitcoin.PublicKey
+import fr.acinq.lightning.crypto.PrivateKeyDescriptor
+
+class Bolt3CommitmentKeyDescriptor(
+    private val parent: PrivateKeyDescriptor,
+    private val perCommitPoint: PublicKey
+) : LocalPrivateKeyDescriptor {
+    override fun instantiate(): PrivateKey {
+        return derivePrivKey(parent.instantiate(), perCommitPoint)
+    }
+
+    private fun derivePrivKey(secret: PrivateKey, perCommitPoint: PublicKey): PrivateKey {
+        // secretkey = basepoint-secret + SHA256(per-commitment-point || basepoint)
+        return secret + (PrivateKey(Crypto.sha256(perCommitPoint.value + secret.publicKey().value)))
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/Bolt3CommitmentKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/Bolt3CommitmentKeyDescriptor.kt
@@ -6,7 +6,7 @@ import fr.acinq.bitcoin.PublicKey
 import fr.acinq.lightning.crypto.PrivateKeyDescriptor
 
 class Bolt3CommitmentKeyDescriptor(
-    private val parent: PrivateKeyDescriptor,
+    private val parent: LocalPrivateKeyDescriptor,
     private val perCommitPoint: PublicKey
 ) : LocalPrivateKeyDescriptor {
     override fun instantiate(): PrivateKey {

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/Bolt3CommitmentKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/Bolt3CommitmentKeyDescriptor.kt
@@ -3,7 +3,6 @@ package fr.acinq.lightning.crypto.local
 import fr.acinq.bitcoin.Crypto
 import fr.acinq.bitcoin.PrivateKey
 import fr.acinq.bitcoin.PublicKey
-import fr.acinq.lightning.crypto.PrivateKeyDescriptor
 
 class Bolt3CommitmentKeyDescriptor(
     private val parent: LocalPrivateKeyDescriptor,

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/Bolt3RevocationKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/Bolt3RevocationKeyDescriptor.kt
@@ -5,7 +5,7 @@ import fr.acinq.bitcoin.PrivateKey
 import fr.acinq.lightning.crypto.PrivateKeyDescriptor
 
 class Bolt3RevocationKeyDescriptor(
-    private val parent: PrivateKeyDescriptor,
+    private val parent: LocalPrivateKeyDescriptor,
     private val perCommitSecret: PrivateKey
 ) : LocalPrivateKeyDescriptor {
     override fun instantiate(): PrivateKey {

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/Bolt3RevocationKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/Bolt3RevocationKeyDescriptor.kt
@@ -1,0 +1,20 @@
+package fr.acinq.lightning.crypto.local
+
+import fr.acinq.bitcoin.Crypto
+import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.lightning.crypto.PrivateKeyDescriptor
+
+class Bolt3RevocationKeyDescriptor(
+    private val parent: PrivateKeyDescriptor,
+    private val perCommitSecret: PrivateKey
+) : LocalPrivateKeyDescriptor {
+    override fun instantiate(): PrivateKey {
+        return revocationPrivKey(parent.instantiate(), perCommitSecret)
+    }
+
+    private fun revocationPrivKey(secret: PrivateKey, perCommitSecret: PrivateKey): PrivateKey {
+        val a = PrivateKey(Crypto.sha256(secret.publicKey().value + perCommitSecret.publicKey().value))
+        val b = PrivateKey(Crypto.sha256(perCommitSecret.publicKey().value + secret.publicKey().value))
+        return (secret * a) + (perCommitSecret * b)
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/DerivedExtendedPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/DerivedExtendedPrivateKeyDescriptor.kt
@@ -6,7 +6,7 @@ import fr.acinq.lightning.crypto.ExtendedPrivateKeyDescriptor
 import fr.acinq.lightning.crypto.PrivateKeyDescriptor
 
 class DerivedExtendedPrivateKeyDescriptor(
-    private val parent: ExtendedPrivateKeyDescriptor,
+    private val parent: LocalExtendedPrivateKeyDescriptor,
     private val keyPath: KeyPath
 ) : LocalExtendedPrivateKeyDescriptor {
     override fun instantiate(): DeterministicWallet.ExtendedPrivateKey {

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/DerivedExtendedPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/DerivedExtendedPrivateKeyDescriptor.kt
@@ -1,0 +1,15 @@
+package fr.acinq.lightning.crypto.local
+
+import fr.acinq.bitcoin.DeterministicWallet
+import fr.acinq.bitcoin.KeyPath
+import fr.acinq.lightning.crypto.ExtendedPrivateKeyDescriptor
+import fr.acinq.lightning.crypto.PrivateKeyDescriptor
+
+class DerivedExtendedPrivateKeyDescriptor(
+    private val parent: ExtendedPrivateKeyDescriptor,
+    private val keyPath: KeyPath
+) : LocalExtendedPrivateKeyDescriptor {
+    override fun instantiate(): DeterministicWallet.ExtendedPrivateKey {
+        return DeterministicWallet.derivePrivateKey(parent.instantiate(), keyPath)
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/FromExtendedPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/FromExtendedPrivateKeyDescriptor.kt
@@ -7,14 +7,14 @@ import fr.acinq.bitcoin.PublicKey
 import fr.acinq.lightning.crypto.ExtendedPrivateKeyDescriptor
 import fr.acinq.lightning.crypto.PrivateKeyDescriptor
 
-class FromExtendedPrivateKeyDescriptor(private val parent: ExtendedPrivateKeyDescriptor, private val path: KeyPath) :
+class FromExtendedPrivateKeyDescriptor(private val parent: LocalExtendedPrivateKeyDescriptor, private val path: KeyPath) :
     LocalPrivateKeyDescriptor {
 
-    constructor(parent: ExtendedPrivateKeyDescriptor, index: Long): this(parent,
+    constructor(parent: LocalExtendedPrivateKeyDescriptor, index: Long): this(parent,
         KeyPath(listOf(index))
     )
 
-    constructor(parent: ExtendedPrivateKeyDescriptor): this(parent, KeyPath(listOf()))
+    constructor(parent: LocalExtendedPrivateKeyDescriptor): this(parent, KeyPath(listOf()))
 
     override fun instantiate(): PrivateKey {
         return DeterministicWallet.derivePrivateKey(parent.instantiate(), path).privateKey

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/FromExtendedPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/FromExtendedPrivateKeyDescriptor.kt
@@ -1,0 +1,22 @@
+package fr.acinq.lightning.crypto.local
+
+import fr.acinq.bitcoin.DeterministicWallet
+import fr.acinq.bitcoin.KeyPath
+import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.bitcoin.PublicKey
+import fr.acinq.lightning.crypto.ExtendedPrivateKeyDescriptor
+import fr.acinq.lightning.crypto.PrivateKeyDescriptor
+
+class FromExtendedPrivateKeyDescriptor(private val parent: ExtendedPrivateKeyDescriptor, private val path: KeyPath) :
+    LocalPrivateKeyDescriptor {
+
+    constructor(parent: ExtendedPrivateKeyDescriptor, index: Long): this(parent,
+        KeyPath(listOf(index))
+    )
+
+    constructor(parent: ExtendedPrivateKeyDescriptor): this(parent, KeyPath(listOf()))
+
+    override fun instantiate(): PrivateKey {
+        return DeterministicWallet.derivePrivateKey(parent.instantiate(), path).privateKey
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalExtendedPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalExtendedPrivateKeyDescriptor.kt
@@ -1,15 +1,30 @@
 package fr.acinq.lightning.crypto.local
 
 import fr.acinq.bitcoin.DeterministicWallet
+import fr.acinq.bitcoin.KeyPath
 import fr.acinq.lightning.crypto.ExtendedPrivateKeyDescriptor
 import fr.acinq.lightning.crypto.PrivateKeyDescriptor
 
 interface LocalExtendedPrivateKeyDescriptor : ExtendedPrivateKeyDescriptor {
+    fun instantiate(): DeterministicWallet.ExtendedPrivateKey
+
+    override fun privateKey(): PrivateKeyDescriptor {
+        return FromExtendedPrivateKeyDescriptor(this)
+    }
+
     override fun publicKey(): DeterministicWallet.ExtendedPublicKey {
         return DeterministicWallet.publicKey(instantiate())
     }
 
+    override fun derive(path: KeyPath): ExtendedPrivateKeyDescriptor {
+        return DerivedExtendedPrivateKeyDescriptor(this, path)
+    }
+
     override fun derivePrivateKey(index: Long): PrivateKeyDescriptor {
         return FromExtendedPrivateKeyDescriptor(this, index)
+    }
+
+    override fun derivePrivateKey(path: KeyPath): PrivateKeyDescriptor {
+        return FromExtendedPrivateKeyDescriptor(this, path)
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalExtendedPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalExtendedPrivateKeyDescriptor.kt
@@ -1,0 +1,15 @@
+package fr.acinq.lightning.crypto.local
+
+import fr.acinq.bitcoin.DeterministicWallet
+import fr.acinq.lightning.crypto.ExtendedPrivateKeyDescriptor
+import fr.acinq.lightning.crypto.PrivateKeyDescriptor
+
+interface LocalExtendedPrivateKeyDescriptor : ExtendedPrivateKeyDescriptor {
+    override fun publicKey(): DeterministicWallet.ExtendedPublicKey {
+        return DeterministicWallet.publicKey(instantiate())
+    }
+
+    override fun derivePrivateKey(index: Long): PrivateKeyDescriptor {
+        return FromExtendedPrivateKeyDescriptor(this, index)
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalPrivateKeyDescriptor.kt
@@ -1,8 +1,17 @@
 package fr.acinq.lightning.crypto.local
 
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.ByteVector64
+import fr.acinq.bitcoin.Crypto
 import fr.acinq.bitcoin.PrivateKey
 import fr.acinq.bitcoin.PublicKey
+import fr.acinq.bitcoin.Satoshi
+import fr.acinq.bitcoin.SigHash
+import fr.acinq.bitcoin.SigVersion
+import fr.acinq.bitcoin.Transaction
+import fr.acinq.bitcoin.TxOut
 import fr.acinq.lightning.crypto.PrivateKeyDescriptor
+import fr.acinq.lightning.transactions.Transactions
 
 interface LocalPrivateKeyDescriptor : PrivateKeyDescriptor {
 
@@ -15,4 +24,20 @@ interface LocalPrivateKeyDescriptor : PrivateKeyDescriptor {
 
     override fun deriveForCommitment(perCommitPoint: PublicKey): PrivateKeyDescriptor =
         Bolt3CommitmentKeyDescriptor(this, perCommitPoint)
+
+    override fun sign(tx: Transaction, inputIndex: Int, redeemScript: ByteArray, amount: Satoshi, sighash: Int): ByteVector64 {
+        val key = instantiate()
+        val sigDER = Transaction.signInput(tx, inputIndex, redeemScript, sighash, amount, SigVersion.SIGVERSION_WITNESS_V0, key)
+        return Crypto.der2compact(sigDER)
+    }
+
+    override fun sign(txInfo: Transactions.TransactionWithInputInfo, sighash: Int): ByteVector64 {
+        val inputIndex = txInfo.tx.txIn.indexOfFirst { it.outPoint == txInfo.input.outPoint }
+        require(inputIndex >= 0) { "transaction doesn't spend the input to sign" }
+        return sign(txInfo.tx, inputIndex, txInfo.input.redeemScript.toByteArray(), txInfo.input.txOut.amount, sighash)
+    }
+
+    override fun signInputTaprootScriptPath(tx: Transaction, inputIndex: Int, inputs: List<TxOut>, sigHash: Int, tapleaf: ByteVector32): ByteVector64 {
+        return Transaction.signInputTaprootScriptPath(instantiate(), tx, inputIndex, inputs, SigHash.SIGHASH_DEFAULT, tapleaf)
+    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalPrivateKeyDescriptor.kt
@@ -1,5 +1,6 @@
 package fr.acinq.lightning.crypto.local
 
+import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.ByteVector64
 import fr.acinq.bitcoin.Crypto
@@ -31,6 +32,10 @@ interface LocalPrivateKeyDescriptor : PrivateKeyDescriptor {
 
     override fun deriveForCommitment(perCommitPoint: PublicKey): PrivateKeyDescriptor =
         Bolt3CommitmentKeyDescriptor(this, perCommitPoint)
+
+    override fun sign(data: ByteVector32): ByteVector {
+        return Crypto.compact2der(Crypto.sign(data, instantiate()))
+    }
 
     override fun sign(tx: Transaction, inputIndex: Int, redeemScript: ByteArray, amount: Satoshi, sighash: Int): ByteVector64 {
         val key = instantiate()

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalPrivateKeyDescriptor.kt
@@ -20,6 +20,8 @@ import fr.acinq.lightning.transactions.Transactions
 
 interface LocalPrivateKeyDescriptor : PrivateKeyDescriptor {
 
+    fun instantiate(): PrivateKey
+
     override fun publicKey(): PublicKey {
         return instantiate().publicKey()
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalPrivateKeyDescriptor.kt
@@ -6,10 +6,15 @@ import fr.acinq.bitcoin.Crypto
 import fr.acinq.bitcoin.PrivateKey
 import fr.acinq.bitcoin.PublicKey
 import fr.acinq.bitcoin.Satoshi
+import fr.acinq.bitcoin.ScriptTree
 import fr.acinq.bitcoin.SigHash
 import fr.acinq.bitcoin.SigVersion
 import fr.acinq.bitcoin.Transaction
 import fr.acinq.bitcoin.TxOut
+import fr.acinq.bitcoin.crypto.musig2.IndividualNonce
+import fr.acinq.bitcoin.crypto.musig2.Musig2
+import fr.acinq.bitcoin.crypto.musig2.SecretNonce
+import fr.acinq.bitcoin.utils.Either
 import fr.acinq.lightning.crypto.PrivateKeyDescriptor
 import fr.acinq.lightning.transactions.Transactions
 
@@ -39,5 +44,9 @@ interface LocalPrivateKeyDescriptor : PrivateKeyDescriptor {
 
     override fun signInputTaprootScriptPath(tx: Transaction, inputIndex: Int, inputs: List<TxOut>, sigHash: Int, tapleaf: ByteVector32): ByteVector64 {
         return Transaction.signInputTaprootScriptPath(instantiate(), tx, inputIndex, inputs, SigHash.SIGHASH_DEFAULT, tapleaf)
+    }
+
+    override fun signMusig2TaprootInput(tx: Transaction, index: Int, inputs: List<TxOut>, publicKeys: List<PublicKey>, secretNonce: SecretNonce, publicNonces: List<IndividualNonce>, scriptTree: ScriptTree.Leaf): Either<Throwable, ByteVector32> {
+        return Musig2.signTaprootInput(instantiate(), tx, index, inputs, publicKeys, secretNonce, publicNonces, scriptTree)
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalPrivateKeyDescriptor.kt
@@ -1,0 +1,18 @@
+package fr.acinq.lightning.crypto.local
+
+import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.bitcoin.PublicKey
+import fr.acinq.lightning.crypto.PrivateKeyDescriptor
+
+interface LocalPrivateKeyDescriptor : PrivateKeyDescriptor {
+
+    override fun publicKey(): PublicKey {
+        return instantiate().publicKey()
+    }
+
+    override fun deriveForRevocation(perCommitSecret: PrivateKey): PrivateKeyDescriptor =
+        Bolt3RevocationKeyDescriptor(this, perCommitSecret)
+
+    override fun deriveForCommitment(perCommitPoint: PublicKey): PrivateKeyDescriptor =
+        Bolt3CommitmentKeyDescriptor(this, perCommitPoint)
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/LocalPrivateKeyDescriptor.kt
@@ -49,4 +49,8 @@ interface LocalPrivateKeyDescriptor : PrivateKeyDescriptor {
     override fun signMusig2TaprootInput(tx: Transaction, index: Int, inputs: List<TxOut>, publicKeys: List<PublicKey>, secretNonce: SecretNonce, publicNonces: List<IndividualNonce>, scriptTree: ScriptTree.Leaf): Either<Throwable, ByteVector32> {
         return Musig2.signTaprootInput(instantiate(), tx, index, inputs, publicKeys, secretNonce, publicNonces, scriptTree)
     }
+
+    override fun generateMusig2Nonce(sessionId: ByteVector32, publicKeys: List<PublicKey>): Pair<SecretNonce, IndividualNonce> {
+        return Musig2.generateNonce(sessionId, instantiate(), publicKeys)
+    }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/RootExtendedPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/RootExtendedPrivateKeyDescriptor.kt
@@ -1,0 +1,12 @@
+package fr.acinq.lightning.crypto.local
+
+import fr.acinq.bitcoin.DeterministicWallet
+import fr.acinq.lightning.crypto.ExtendedPrivateKeyDescriptor
+import fr.acinq.lightning.crypto.PrivateKeyDescriptor
+
+class RootExtendedPrivateKeyDescriptor(val master: DeterministicWallet.ExtendedPrivateKey) :
+    LocalExtendedPrivateKeyDescriptor {
+    override fun instantiate(): DeterministicWallet.ExtendedPrivateKey {
+        return master
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/RootExtendedPrivateKeyDescriptor.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/crypto/local/RootExtendedPrivateKeyDescriptor.kt
@@ -1,8 +1,6 @@
 package fr.acinq.lightning.crypto.local
 
 import fr.acinq.bitcoin.DeterministicWallet
-import fr.acinq.lightning.crypto.ExtendedPrivateKeyDescriptor
-import fr.acinq.lightning.crypto.PrivateKeyDescriptor
 
 class RootExtendedPrivateKeyDescriptor(val master: DeterministicWallet.ExtendedPrivateKey) :
     LocalExtendedPrivateKeyDescriptor {

--- a/src/commonMain/kotlin/fr/acinq/lightning/transactions/SwapInProtocol.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/transactions/SwapInProtocol.kt
@@ -47,7 +47,7 @@ data class SwapInProtocol(val userPublicKey: PublicKey, val serverPublicKey: Pub
 
     fun signSwapInputRefund(fundingTx: Transaction, index: Int, parentTxOuts: List<TxOut>, userPrivateKey: PrivateKeyDescriptor): ByteVector64 {
         require(userPrivateKey.publicKey() == userRefundKey) { "refund private key does not match expected public key: are you using the user key instead of the refund key?" }
-        return Transaction.signInputTaprootScriptPath(userPrivateKey.instantiate(), fundingTx, index, parentTxOuts, SigHash.SIGHASH_DEFAULT, scriptTree.hash())
+        return userPrivateKey.signInputTaprootScriptPath(fundingTx, index, parentTxOuts, SigHash.SIGHASH_DEFAULT, scriptTree.hash())
     }
 
     fun signSwapInputServer(fundingTx: Transaction, index: Int, parentTxOuts: List<TxOut>, serverPrivateKey: PrivateKeyDescriptor, privateNonce: SecretNonce, userNonce: IndividualNonce, serverNonce: IndividualNonce): Either<Throwable, ByteVector32> {
@@ -112,11 +112,11 @@ data class SwapInProtocolLegacy(val userPublicKey: PublicKey, val serverPublicKe
 
     fun signSwapInputUser(fundingTx: Transaction, index: Int, parentTxOut: TxOut, userKey: PrivateKeyDescriptor): ByteVector64 {
         require(userKey.publicKey() == userPublicKey) { "user private key does not match expected public key: are you using the refund key instead of the user key?" }
-        return Transactions.sign(fundingTx, index, Script.write(redeemScript), parentTxOut.amount, userKey)
+        return userKey.sign(fundingTx, index, Script.write(redeemScript), parentTxOut.amount)
     }
 
     fun signSwapInputServer(fundingTx: Transaction, index: Int, parentTxOut: TxOut, serverKey: PrivateKeyDescriptor): ByteVector64 {
-        return Transactions.sign(fundingTx, index, Script.write(redeemScript), parentTxOut.amount, serverKey)
+        return serverKey.sign(fundingTx, index, Script.write(redeemScript), parentTxOut.amount)
     }
 
     companion object {

--- a/src/commonMain/kotlin/fr/acinq/lightning/transactions/SwapInProtocol.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/transactions/SwapInProtocol.kt
@@ -42,7 +42,7 @@ data class SwapInProtocol(val userPublicKey: PublicKey, val serverPublicKey: Pub
         require(userPrivateKey.publicKey() == userPublicKey) { "user private key does not match expected public key: are you using the refund key instead of the user key?" }
         val publicKeys = listOf(userPublicKey, serverPublicKey)
         val publicNonces = listOf(userNonce, serverNonce)
-        return Musig2.signTaprootInput(userPrivateKey.instantiate(), fundingTx, index, parentTxOuts, publicKeys, privateNonce, publicNonces, scriptTree)
+        return userPrivateKey.signMusig2TaprootInput(fundingTx, index, parentTxOuts, publicKeys, privateNonce, publicNonces, scriptTree)
     }
 
     fun signSwapInputRefund(fundingTx: Transaction, index: Int, parentTxOuts: List<TxOut>, userPrivateKey: PrivateKeyDescriptor): ByteVector64 {
@@ -53,7 +53,7 @@ data class SwapInProtocol(val userPublicKey: PublicKey, val serverPublicKey: Pub
     fun signSwapInputServer(fundingTx: Transaction, index: Int, parentTxOuts: List<TxOut>, serverPrivateKey: PrivateKeyDescriptor, privateNonce: SecretNonce, userNonce: IndividualNonce, serverNonce: IndividualNonce): Either<Throwable, ByteVector32> {
         val publicKeys = listOf(userPublicKey, serverPublicKey)
         val publicNonces = listOf(userNonce, serverNonce)
-        return Musig2.signTaprootInput(serverPrivateKey.instantiate(), fundingTx, index, parentTxOuts, publicKeys, privateNonce, publicNonces, scriptTree)
+        return serverPrivateKey.signMusig2TaprootInput(fundingTx, index, parentTxOuts, publicKeys, privateNonce, publicNonces, scriptTree)
     }
 
     companion object {

--- a/src/commonMain/kotlin/fr/acinq/lightning/transactions/SwapInProtocol.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/transactions/SwapInProtocol.kt
@@ -112,11 +112,11 @@ data class SwapInProtocolLegacy(val userPublicKey: PublicKey, val serverPublicKe
 
     fun signSwapInputUser(fundingTx: Transaction, index: Int, parentTxOut: TxOut, userKey: PrivateKeyDescriptor): ByteVector64 {
         require(userKey.publicKey() == userPublicKey) { "user private key does not match expected public key: are you using the refund key instead of the user key?" }
-        return Transactions.sign2(fundingTx, index, Script.write(redeemScript), parentTxOut.amount, userKey)
+        return Transactions.sign(fundingTx, index, Script.write(redeemScript), parentTxOut.amount, userKey)
     }
 
     fun signSwapInputServer(fundingTx: Transaction, index: Int, parentTxOut: TxOut, serverKey: PrivateKeyDescriptor): ByteVector64 {
-        return Transactions.sign2(fundingTx, index, Script.write(redeemScript), parentTxOut.amount, serverKey)
+        return Transactions.sign(fundingTx, index, Script.write(redeemScript), parentTxOut.amount, serverKey)
     }
 
     companion object {

--- a/src/commonMain/kotlin/fr/acinq/lightning/transactions/Transactions.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/transactions/Transactions.kt
@@ -801,27 +801,16 @@ object Transactions {
     val PlaceHolderSig = ByteVector64(ByteArray(64) { 0xaa.toByte() })
         .also { check(Scripts.der(it, SigHash.SIGHASH_ALL).size() == 72) { "Should be 72 bytes but is ${Scripts.der(it, SigHash.SIGHASH_ALL).size()} bytes" } }
 
-    fun sign(tx: Transaction, inputIndex: Int, redeemScript: ByteArray, amount: Satoshi, key: PrivateKey, sigHash: Int = SigHash.SIGHASH_ALL): ByteVector64 {
-        val sigDER = Transaction.signInput(tx, inputIndex, redeemScript, sigHash, amount, SigVersion.SIGVERSION_WITNESS_V0, key)
-        return Crypto.der2compact(sigDER)
-    }
-
-    fun sign(txInfo: TransactionWithInputInfo, key: PrivateKey, sigHash: Int = SigHash.SIGHASH_ALL): ByteVector64 {
-        val inputIndex = txInfo.tx.txIn.indexOfFirst { it.outPoint == txInfo.input.outPoint }
-        require(inputIndex >= 0) { "transaction doesn't spend the input to sign" }
-        return sign(txInfo.tx, inputIndex, txInfo.input.redeemScript.toByteArray(), txInfo.input.txOut.amount, key, sigHash)
-    }
-
-    fun sign2(tx: Transaction, inputIndex: Int, redeemScript: ByteArray, amount: Satoshi, keyDescriptor: PrivateKeyDescriptor, sigHash: Int = SigHash.SIGHASH_ALL): ByteVector64 {
+    fun sign(tx: Transaction, inputIndex: Int, redeemScript: ByteArray, amount: Satoshi, keyDescriptor: PrivateKeyDescriptor, sigHash: Int = SigHash.SIGHASH_ALL): ByteVector64 {
         val key = keyDescriptor.instantiate()
         val sigDER = Transaction.signInput(tx, inputIndex, redeemScript, sigHash, amount, SigVersion.SIGVERSION_WITNESS_V0, key)
         return Crypto.der2compact(sigDER)
     }
 
-    fun sign2(txInfo: TransactionWithInputInfo, keyDescriptor: PrivateKeyDescriptor, sigHash: Int = SigHash.SIGHASH_ALL): ByteVector64 {
+    fun sign(txInfo: TransactionWithInputInfo, keyDescriptor: PrivateKeyDescriptor, sigHash: Int = SigHash.SIGHASH_ALL): ByteVector64 {
         val inputIndex = txInfo.tx.txIn.indexOfFirst { it.outPoint == txInfo.input.outPoint }
         require(inputIndex >= 0) { "transaction doesn't spend the input to sign" }
-        return sign2(txInfo.tx, inputIndex, txInfo.input.redeemScript.toByteArray(), txInfo.input.txOut.amount, keyDescriptor, sigHash)
+        return sign(txInfo.tx, inputIndex, txInfo.input.redeemScript.toByteArray(), txInfo.input.txOut.amount, keyDescriptor, sigHash)
     }
 
     fun addSigs(

--- a/src/commonMain/kotlin/fr/acinq/lightning/transactions/Transactions.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/transactions/Transactions.kt
@@ -24,6 +24,7 @@ import fr.acinq.lightning.CltvExpiryDelta
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.channel.Commitments
+import fr.acinq.lightning.crypto.PrivateKeyDescriptor
 import fr.acinq.lightning.io.*
 import fr.acinq.lightning.transactions.CommitmentOutput.InHtlc
 import fr.acinq.lightning.transactions.CommitmentOutput.OutHtlc
@@ -809,6 +810,18 @@ object Transactions {
         val inputIndex = txInfo.tx.txIn.indexOfFirst { it.outPoint == txInfo.input.outPoint }
         require(inputIndex >= 0) { "transaction doesn't spend the input to sign" }
         return sign(txInfo.tx, inputIndex, txInfo.input.redeemScript.toByteArray(), txInfo.input.txOut.amount, key, sigHash)
+    }
+
+    fun sign2(tx: Transaction, inputIndex: Int, redeemScript: ByteArray, amount: Satoshi, keyDescriptor: PrivateKeyDescriptor, sigHash: Int = SigHash.SIGHASH_ALL): ByteVector64 {
+        val key = keyDescriptor.instantiate()
+        val sigDER = Transaction.signInput(tx, inputIndex, redeemScript, sigHash, amount, SigVersion.SIGVERSION_WITNESS_V0, key)
+        return Crypto.der2compact(sigDER)
+    }
+
+    fun sign2(txInfo: TransactionWithInputInfo, keyDescriptor: PrivateKeyDescriptor, sigHash: Int = SigHash.SIGHASH_ALL): ByteVector64 {
+        val inputIndex = txInfo.tx.txIn.indexOfFirst { it.outPoint == txInfo.input.outPoint }
+        require(inputIndex >= 0) { "transaction doesn't spend the input to sign" }
+        return sign2(txInfo.tx, inputIndex, txInfo.input.redeemScript.toByteArray(), txInfo.input.txOut.amount, keyDescriptor, sigHash)
     }
 
     fun addSigs(

--- a/src/commonMain/kotlin/fr/acinq/lightning/transactions/Transactions.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/transactions/Transactions.kt
@@ -801,18 +801,6 @@ object Transactions {
     val PlaceHolderSig = ByteVector64(ByteArray(64) { 0xaa.toByte() })
         .also { check(Scripts.der(it, SigHash.SIGHASH_ALL).size() == 72) { "Should be 72 bytes but is ${Scripts.der(it, SigHash.SIGHASH_ALL).size()} bytes" } }
 
-    fun sign(tx: Transaction, inputIndex: Int, redeemScript: ByteArray, amount: Satoshi, keyDescriptor: PrivateKeyDescriptor, sigHash: Int = SigHash.SIGHASH_ALL): ByteVector64 {
-        val key = keyDescriptor.instantiate()
-        val sigDER = Transaction.signInput(tx, inputIndex, redeemScript, sigHash, amount, SigVersion.SIGVERSION_WITNESS_V0, key)
-        return Crypto.der2compact(sigDER)
-    }
-
-    fun sign(txInfo: TransactionWithInputInfo, keyDescriptor: PrivateKeyDescriptor, sigHash: Int = SigHash.SIGHASH_ALL): ByteVector64 {
-        val inputIndex = txInfo.tx.txIn.indexOfFirst { it.outPoint == txInfo.input.outPoint }
-        require(inputIndex >= 0) { "transaction doesn't spend the input to sign" }
-        return sign(txInfo.tx, inputIndex, txInfo.input.redeemScript.toByteArray(), txInfo.input.txOut.amount, keyDescriptor, sigHash)
-    }
-
     fun addSigs(
         commitTx: TransactionWithInputInfo.CommitTx,
         localFundingPubkey: PublicKey,

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/RecoveryTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/RecoveryTestsCommon.kt
@@ -51,7 +51,7 @@ class RecoveryTestsCommon {
             )
             return when (mainTx) {
                 is Transactions.TxResult.Success -> {
-                    val sig = Transactions.sign(mainTx.result, channelKeys.paymentKey)
+                    val sig = Transactions.sign2(mainTx.result, channelKeys.paymentKey)
                     val signedTx = Transactions.addSigs(mainTx.result, sig).tx
                     Transaction.correctlySpends(signedTx, commitTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
                     signedTx

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/RecoveryTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/RecoveryTestsCommon.kt
@@ -51,7 +51,7 @@ class RecoveryTestsCommon {
             )
             return when (mainTx) {
                 is Transactions.TxResult.Success -> {
-                    val sig = Transactions.sign(mainTx.result, channelKeys.paymentKey)
+                    val sig = channelKeys.paymentKey.sign(mainTx.result)
                     val signedTx = Transactions.addSigs(mainTx.result, sig).tx
                     Transaction.correctlySpends(signedTx, commitTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
                     signedTx

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/RecoveryTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/RecoveryTestsCommon.kt
@@ -51,7 +51,7 @@ class RecoveryTestsCommon {
             )
             return when (mainTx) {
                 is Transactions.TxResult.Success -> {
-                    val sig = Transactions.sign2(mainTx.result, channelKeys.paymentKey)
+                    val sig = Transactions.sign(mainTx.result, channelKeys.paymentKey)
                     val signedTx = Transactions.addSigs(mainTx.result, sig).tx
                     Transaction.correctlySpends(signedTx, commitTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
                     signedTx

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -9,6 +9,7 @@ import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.blockchain.fee.OnChainFeerates
 import fr.acinq.lightning.channel.states.*
 import fr.acinq.lightning.crypto.KeyManager
+import fr.acinq.lightning.crypto.PrivateKeyDescriptor
 import fr.acinq.lightning.db.ChannelClosingType
 import fr.acinq.lightning.json.JsonSerializers
 import fr.acinq.lightning.logging.*
@@ -409,9 +410,9 @@ object TestsHelper {
         return Pair(paymentPreimage, cmd)
     }
 
-    fun createWallet(keyManager: KeyManager, amount: Satoshi): Pair<PrivateKey, List<WalletState.Utxo>> {
+    fun createWallet(keyManager: KeyManager, amount: Satoshi): Pair<PrivateKeyDescriptor, List<WalletState.Utxo>> {
         val swapInAddressIndex = 0
-        val (privateKey, script) = keyManager.swapInOnChainWallet.run { Pair(userPrivateKey.instantiate(), getSwapInProtocol(swapInAddressIndex).pubkeyScript) }
+        val (privateKey, script) = keyManager.swapInOnChainWallet.run { Pair(userPrivateKey, getSwapInProtocol(swapInAddressIndex).pubkeyScript) }
         val parentTx = Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 3), 0)), listOf(TxOut(amount, script)), 0)
         return privateKey to listOf(WalletState.Utxo(parentTx.txid, 0, 42, parentTx, WalletState.AddressMeta.Derived(swapInAddressIndex)))
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -380,7 +380,7 @@ object TestsHelper {
             localPerCommitmentPoint,
             alternativeSpec
         )
-        val localSig = Transactions.sign(localCommitTx, channelKeys.fundingKey(fundingTxIndex))
+        val localSig = channelKeys.fundingKey(fundingTxIndex).sign(localCommitTx)
         val signedCommitTx = Transactions.addSigs(localCommitTx, channelKeys.fundingPubKey(fundingTxIndex), remoteFundingPubKey, localSig, alternative.sig)
         assertTrue(Transactions.checkSpendable(signedCommitTx).isSuccess)
         return signedCommitTx.tx

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -380,7 +380,7 @@ object TestsHelper {
             localPerCommitmentPoint,
             alternativeSpec
         )
-        val localSig = Transactions.sign2(localCommitTx, channelKeys.fundingKey(fundingTxIndex))
+        val localSig = Transactions.sign(localCommitTx, channelKeys.fundingKey(fundingTxIndex))
         val signedCommitTx = Transactions.addSigs(localCommitTx, channelKeys.fundingPubKey(fundingTxIndex), remoteFundingPubKey, localSig, alternative.sig)
         assertTrue(Transactions.checkSpendable(signedCommitTx).isSuccess)
         return signedCommitTx.tx

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -380,7 +380,7 @@ object TestsHelper {
             localPerCommitmentPoint,
             alternativeSpec
         )
-        val localSig = Transactions.sign(localCommitTx, channelKeys.fundingKey(fundingTxIndex))
+        val localSig = Transactions.sign2(localCommitTx, channelKeys.fundingKey(fundingTxIndex))
         val signedCommitTx = Transactions.addSigs(localCommitTx, channelKeys.fundingPubKey(fundingTxIndex), remoteFundingPubKey, localSig, alternative.sig)
         assertTrue(Transactions.checkSpendable(signedCommitTx).isSuccess)
         return signedCommitTx.tx

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -411,7 +411,7 @@ object TestsHelper {
 
     fun createWallet(keyManager: KeyManager, amount: Satoshi): Pair<PrivateKey, List<WalletState.Utxo>> {
         val swapInAddressIndex = 0
-        val (privateKey, script) = keyManager.swapInOnChainWallet.run { Pair(userPrivateKey, getSwapInProtocol(swapInAddressIndex).pubkeyScript) }
+        val (privateKey, script) = keyManager.swapInOnChainWallet.run { Pair(userPrivateKey.instantiate(), getSwapInProtocol(swapInAddressIndex).pubkeyScript) }
         val parentTx = Transaction(2, listOf(TxIn(OutPoint(TxId(randomBytes32()), 3), 0)), listOf(TxOut(amount, script)), 0)
         return privateKey to listOf(WalletState.Utxo(parentTx.txid, 0, 42, parentTx, WalletState.AddressMeta.Derived(swapInAddressIndex)))
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/HardCodedPrivateKey.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/HardCodedPrivateKey.kt
@@ -1,11 +1,15 @@
 package fr.acinq.lightning.crypto
 
+import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.PrivateKey
 import fr.acinq.bitcoin.PublicKey
 
-class HardCodedPrivateKey(val keyAsHexString: String) : PrivateKeyDescriptor {
+
+class HardCodedPrivateKey(private val key: PrivateKey) : PrivateKeyDescriptor {
+    constructor(key: String): this(PrivateKey.fromHex(key))
+    constructor(key: ByteArray): this(PrivateKey(key))
     override fun instantiate(): PrivateKey {
-        return PrivateKey.fromHex(keyAsHexString)
+        return key
     }
 
     override fun publicKey(): PublicKey {

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/HardCodedPrivateKey.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/HardCodedPrivateKey.kt
@@ -8,6 +8,7 @@ import fr.acinq.bitcoin.PublicKey
 class HardCodedPrivateKey(private val key: PrivateKey) : PrivateKeyDescriptor {
     constructor(key: String): this(PrivateKey.fromHex(key))
     constructor(key: ByteArray): this(PrivateKey(key))
+    constructor(key: ByteVector32): this(PrivateKey(key))
     override fun instantiate(): PrivateKey {
         return key
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/HardCodedPrivateKey.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/HardCodedPrivateKey.kt
@@ -1,0 +1,14 @@
+package fr.acinq.lightning.crypto
+
+import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.bitcoin.PublicKey
+
+class HardCodedPrivateKey(val keyAsHexString: String) : PrivateKeyDescriptor {
+    override fun instantiate(): PrivateKey {
+        return PrivateKey.fromHex(keyAsHexString)
+    }
+
+    override fun publicKey(): PublicKey {
+        return instantiate().publicKey()
+    }
+}

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
@@ -46,8 +46,8 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         // some kind of migration process
         val errorMsg = "channel key generation is broken !!!"
         assertEquals(fundingKeyPath, channelKeys.fundingKeyPath, errorMsg)
-        assertEquals(PrivateKey.fromHex("cd85f39fad742e5c742eeab16f5f1acaa9d9c48977767c7daa4708a47b7222ec"), channelKeys.fundingKey(0), errorMsg)
-        assertEquals(PrivateKey.fromHex("ad635d9d4919e5657a9f306963a5976b533e9d70c8defa454f1bd958fae316c8"), channelKeys.paymentKey, errorMsg)
+        assertEquals(PrivateKey.fromHex("cd85f39fad742e5c742eeab16f5f1acaa9d9c48977767c7daa4708a47b7222ec"), channelKeys.fundingKey(0).instantiate(), errorMsg)
+        assertEquals(PrivateKey.fromHex("ad635d9d4919e5657a9f306963a5976b533e9d70c8defa454f1bd958fae316c8"), channelKeys.paymentKey.instantiate(), errorMsg)
         assertEquals(PrivateKey.fromHex("0f3c23df3feec614117de23d0b3f014174271826a16e59a17d9ebb655cc55e3f"), channelKeys.delayedPaymentKey, errorMsg)
         assertEquals(PrivateKey.fromHex("ee211f583f3b1b1fb10dca7c82708d985fde641e83e28080f669eb496de85113"), channelKeys.revocationKey, errorMsg)
         assertEquals(ByteVector32.fromValidHex("6255a59ea8155d41e62cddef2c8c63a077f75e23fd3eec1fd4881f6851412518"), channelKeys.shaSeed, errorMsg)

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
@@ -48,8 +48,8 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         assertEquals(fundingKeyPath, channelKeys.fundingKeyPath, errorMsg)
         assertEquals(PrivateKey.fromHex("cd85f39fad742e5c742eeab16f5f1acaa9d9c48977767c7daa4708a47b7222ec"), channelKeys.fundingKey(0).instantiate(), errorMsg)
         assertEquals(PrivateKey.fromHex("ad635d9d4919e5657a9f306963a5976b533e9d70c8defa454f1bd958fae316c8"), channelKeys.paymentKey.instantiate(), errorMsg)
-        assertEquals(PrivateKey.fromHex("0f3c23df3feec614117de23d0b3f014174271826a16e59a17d9ebb655cc55e3f"), channelKeys.delayedPaymentKey, errorMsg)
-        assertEquals(PrivateKey.fromHex("ee211f583f3b1b1fb10dca7c82708d985fde641e83e28080f669eb496de85113"), channelKeys.revocationKey, errorMsg)
+        assertEquals(PrivateKey.fromHex("0f3c23df3feec614117de23d0b3f014174271826a16e59a17d9ebb655cc55e3f"), channelKeys.delayedPaymentKey.instantiate(), errorMsg)
+        assertEquals(PrivateKey.fromHex("ee211f583f3b1b1fb10dca7c82708d985fde641e83e28080f669eb496de85113"), channelKeys.revocationKey.instantiate(), errorMsg)
         assertEquals(ByteVector32.fromValidHex("6255a59ea8155d41e62cddef2c8c63a077f75e23fd3eec1fd4881f6851412518"), channelKeys.shaSeed, errorMsg)
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
@@ -157,8 +157,8 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         val keyManager = LocalKeyManager(seed, Chain.Mainnet, DeterministicWallet.encode(dummyExtendedPubkey, testnet = false))
         assertEquals(keyManager.finalOnChainWallet.address(addressIndex = 0L), "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu")
         assertEquals(keyManager.finalOnChainWallet.address(addressIndex = 1L), "bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g")
-        assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 1L).toBase58(Base58.Prefix.SecretKey), "Kxpf5b8p3qX56DKEe5NqWbNUP9MnqoRFzZwHRtsFqhzuvUJsYZCy")
-        assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 0L).toBase58(Base58.Prefix.SecretKey), "KyZpNDKnfs94vbrwhJneDi77V6jF64PWPF8x5cdJb8ifgg2DUc9d")
+        assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 1L).instantiate().toBase58(Base58.Prefix.SecretKey), "Kxpf5b8p3qX56DKEe5NqWbNUP9MnqoRFzZwHRtsFqhzuvUJsYZCy")
+        assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 0L).instantiate().toBase58(Base58.Prefix.SecretKey), "KyZpNDKnfs94vbrwhJneDi77V6jF64PWPF8x5cdJb8ifgg2DUc9d")
         assertEquals(keyManager.finalOnChainWallet.xpub, "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs")
     }
 
@@ -168,8 +168,8 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         val mnemonics = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" ")
         val seed = MnemonicCode.toSeed(mnemonics, "").toByteVector()
         val keyManager = LocalKeyManager(seed, Chain.Testnet, TestConstants.aliceSwapInServerXpub)
-        assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 0L).toBase58(Base58.Prefix.SecretKeyTestnet), "cTGhosGriPpuGA586jemcuH9pE9spwUmneMBmYYzrQEbY92DJrbo")
-        assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 1L).toBase58(Base58.Prefix.SecretKeyTestnet), "cQFUndrpAyMaE3HAsjMCXiT94MzfsABCREat1x7Qe3Mtq9KihD4V")
+        assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 0L).instantiate().toBase58(Base58.Prefix.SecretKeyTestnet), "cTGhosGriPpuGA586jemcuH9pE9spwUmneMBmYYzrQEbY92DJrbo")
+        assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 1L).instantiate().toBase58(Base58.Prefix.SecretKeyTestnet), "cQFUndrpAyMaE3HAsjMCXiT94MzfsABCREat1x7Qe3Mtq9KihD4V")
         assertEquals(keyManager.finalOnChainWallet.xpub, "vpub5Y6cjg78GGuNLsaPhmYsiw4gYX3HoQiRBiSwDaBXKUafCt9bNwWQiitDk5VZ5BVxYnQdwoTyXSs2JHRPAgjAvtbBrf8ZhDYe2jWAqvZVnsc")
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/LocalKeyManagerTestsCommon.kt
@@ -5,6 +5,7 @@ import fr.acinq.bitcoin.crypto.Pack
 import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.blockchain.fee.FeeratePerByte
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
+import fr.acinq.lightning.crypto.local.LocalPrivateKeyDescriptor
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.transactions.SwapInProtocol
@@ -46,10 +47,10 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         // some kind of migration process
         val errorMsg = "channel key generation is broken !!!"
         assertEquals(fundingKeyPath, channelKeys.fundingKeyPath, errorMsg)
-        assertEquals(PrivateKey.fromHex("cd85f39fad742e5c742eeab16f5f1acaa9d9c48977767c7daa4708a47b7222ec"), channelKeys.fundingKey(0).instantiate(), errorMsg)
-        assertEquals(PrivateKey.fromHex("ad635d9d4919e5657a9f306963a5976b533e9d70c8defa454f1bd958fae316c8"), channelKeys.paymentKey.instantiate(), errorMsg)
-        assertEquals(PrivateKey.fromHex("0f3c23df3feec614117de23d0b3f014174271826a16e59a17d9ebb655cc55e3f"), channelKeys.delayedPaymentKey.instantiate(), errorMsg)
-        assertEquals(PrivateKey.fromHex("ee211f583f3b1b1fb10dca7c82708d985fde641e83e28080f669eb496de85113"), channelKeys.revocationKey.instantiate(), errorMsg)
+        assertEquals(PrivateKey.fromHex("cd85f39fad742e5c742eeab16f5f1acaa9d9c48977767c7daa4708a47b7222ec"), (channelKeys.fundingKey(0) as LocalPrivateKeyDescriptor).instantiate(), errorMsg)
+        assertEquals(PrivateKey.fromHex("ad635d9d4919e5657a9f306963a5976b533e9d70c8defa454f1bd958fae316c8"), (channelKeys.paymentKey as LocalPrivateKeyDescriptor).instantiate(), errorMsg)
+        assertEquals(PrivateKey.fromHex("0f3c23df3feec614117de23d0b3f014174271826a16e59a17d9ebb655cc55e3f"), (channelKeys.delayedPaymentKey as LocalPrivateKeyDescriptor).instantiate(), errorMsg)
+        assertEquals(PrivateKey.fromHex("ee211f583f3b1b1fb10dca7c82708d985fde641e83e28080f669eb496de85113"), (channelKeys.revocationKey as LocalPrivateKeyDescriptor).instantiate(), errorMsg)
         assertEquals(ByteVector32.fromValidHex("6255a59ea8155d41e62cddef2c8c63a077f75e23fd3eec1fd4881f6851412518"), channelKeys.shaSeed, errorMsg)
     }
 
@@ -157,8 +158,8 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         val keyManager = LocalKeyManager(seed, Chain.Mainnet, DeterministicWallet.encode(dummyExtendedPubkey, testnet = false))
         assertEquals(keyManager.finalOnChainWallet.address(addressIndex = 0L), "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu")
         assertEquals(keyManager.finalOnChainWallet.address(addressIndex = 1L), "bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g")
-        assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 1L).instantiate().toBase58(Base58.Prefix.SecretKey), "Kxpf5b8p3qX56DKEe5NqWbNUP9MnqoRFzZwHRtsFqhzuvUJsYZCy")
-        assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 0L).instantiate().toBase58(Base58.Prefix.SecretKey), "KyZpNDKnfs94vbrwhJneDi77V6jF64PWPF8x5cdJb8ifgg2DUc9d")
+        assertEquals((keyManager.finalOnChainWallet.privateKey(addressIndex = 1L) as LocalPrivateKeyDescriptor).instantiate().toBase58(Base58.Prefix.SecretKey), "Kxpf5b8p3qX56DKEe5NqWbNUP9MnqoRFzZwHRtsFqhzuvUJsYZCy")
+        assertEquals((keyManager.finalOnChainWallet.privateKey(addressIndex = 0L) as LocalPrivateKeyDescriptor).instantiate().toBase58(Base58.Prefix.SecretKey), "KyZpNDKnfs94vbrwhJneDi77V6jF64PWPF8x5cdJb8ifgg2DUc9d")
         assertEquals(keyManager.finalOnChainWallet.xpub, "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs")
     }
 
@@ -168,8 +169,8 @@ class LocalKeyManagerTestsCommon : LightningTestSuite() {
         val mnemonics = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" ")
         val seed = MnemonicCode.toSeed(mnemonics, "").toByteVector()
         val keyManager = LocalKeyManager(seed, Chain.Testnet, TestConstants.aliceSwapInServerXpub)
-        assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 0L).instantiate().toBase58(Base58.Prefix.SecretKeyTestnet), "cTGhosGriPpuGA586jemcuH9pE9spwUmneMBmYYzrQEbY92DJrbo")
-        assertEquals(keyManager.finalOnChainWallet.privateKey(addressIndex = 1L).instantiate().toBase58(Base58.Prefix.SecretKeyTestnet), "cQFUndrpAyMaE3HAsjMCXiT94MzfsABCREat1x7Qe3Mtq9KihD4V")
+        assertEquals((keyManager.finalOnChainWallet.privateKey(addressIndex = 0L) as LocalPrivateKeyDescriptor).instantiate().toBase58(Base58.Prefix.SecretKeyTestnet), "cTGhosGriPpuGA586jemcuH9pE9spwUmneMBmYYzrQEbY92DJrbo")
+        assertEquals((keyManager.finalOnChainWallet.privateKey(addressIndex = 1L) as LocalPrivateKeyDescriptor).instantiate().toBase58(Base58.Prefix.SecretKeyTestnet), "cQFUndrpAyMaE3HAsjMCXiT94MzfsABCREat1x7Qe3Mtq9KihD4V")
         assertEquals(keyManager.finalOnChainWallet.xpub, "vpub5Y6cjg78GGuNLsaPhmYsiw4gYX3HoQiRBiSwDaBXKUafCt9bNwWQiitDk5VZ5BVxYnQdwoTyXSs2JHRPAgjAvtbBrf8ZhDYe2jWAqvZVnsc")
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/crypto/local/HardCodedPrivateKey.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/crypto/local/HardCodedPrivateKey.kt
@@ -1,19 +1,16 @@
-package fr.acinq.lightning.crypto
+package fr.acinq.lightning.crypto.local
 
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.PrivateKey
 import fr.acinq.bitcoin.PublicKey
+import fr.acinq.lightning.crypto.PrivateKeyDescriptor
 
 
-class HardCodedPrivateKey(private val key: PrivateKey) : PrivateKeyDescriptor {
+class HardCodedPrivateKey(private val key: PrivateKey) : LocalPrivateKeyDescriptor {
     constructor(key: String): this(PrivateKey.fromHex(key))
     constructor(key: ByteArray): this(PrivateKey(key))
     constructor(key: ByteVector32): this(PrivateKey(key))
     override fun instantiate(): PrivateKey {
         return key
-    }
-
-    override fun publicKey(): PublicKey {
-        return instantiate().publicKey()
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/transactions/AnchorOutputsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/transactions/AnchorOutputsTestsCommon.kt
@@ -12,7 +12,7 @@ import fr.acinq.lightning.channel.Commitments
 import fr.acinq.lightning.channel.LocalParams
 import fr.acinq.lightning.channel.RemoteParams
 import fr.acinq.lightning.crypto.Bolt3Derivation.deriveForCommitment
-import fr.acinq.lightning.crypto.HardCodedPrivateKey
+import fr.acinq.lightning.crypto.local.HardCodedPrivateKey
 import fr.acinq.lightning.crypto.KeyManager.ChannelKeys
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx

--- a/src/commonTest/kotlin/fr/acinq/lightning/transactions/AnchorOutputsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/transactions/AnchorOutputsTestsCommon.kt
@@ -146,15 +146,15 @@ class AnchorOutputsTestsCommon {
             spec
         )
 
-        val localSig = Transactions.sign(commitTx, local_funding_privkey)
-        val remoteSig = Transactions.sign(commitTx, remote_funding_privkey)
+        val localSig = local_funding_privkey.sign(commitTx)
+        val remoteSig = remote_funding_privkey.sign(commitTx)
         val signedTx = Transactions.addSigs(commitTx, local_funding_pubkey, remote_funding_pubkey, localSig, remoteSig)
         assertEquals(Transaction.read(testCase.ExpectedCommitmentTxHex), signedTx.tx)
         val txs = testCase.HtlcDescs.map { Transaction.read(it.ResolutionTxHex).txid to Transaction.read(it.ResolutionTxHex) }.toMap()
         val remoteHtlcSigs = testCase.HtlcDescs.map { Transaction.read(it.ResolutionTxHex).txid to ByteVector(it.RemoteSigHex) }.toMap()
         assertTrue { remoteHtlcSigs.keys.containsAll(htlcTxs.map { it.tx.txid }) }
         htlcTxs.forEach { htlcTx ->
-            val localHtlcSig = Transactions.sign(htlcTx, local_htlc_privkey, SigHash.SIGHASH_ALL)
+            val localHtlcSig = local_htlc_privkey.sign(htlcTx, SigHash.SIGHASH_ALL)
             val remoteHtlcSig = Crypto.der2compact(remoteHtlcSigs[htlcTx.tx.txid]!!.toByteArray())
             val expectedTx = txs[htlcTx.tx.txid]
             val signed = when (htlcTx) {
@@ -194,8 +194,8 @@ class AnchorOutputsTestsCommon {
             true,
             outputs
         )
-        val localSig = Transactions.sign(commitTx, local_funding_privkey)
-        val remoteSig = Transactions.sign(commitTx, remote_funding_privkey)
+        val localSig = local_funding_privkey.sign(commitTx)
+        val remoteSig = remote_funding_privkey.sign(commitTx)
         val signedTx = Transactions.addSigs(commitTx, local_funding_pubkey, remote_funding_pubkey, localSig, remoteSig)
         assertEquals(testCase.ExpectedCommitmentTx, signedTx.tx)
 
@@ -204,7 +204,7 @@ class AnchorOutputsTestsCommon {
         val htlcTxs = Transactions.makeHtlcTxs(commitTx.tx, 546.sat, local_revocation_pubkey, CltvExpiryDelta(144), local_delayedpubkey, spec.feerate, outputs)
         assertTrue { remoteHtlcSigs.keys.containsAll(htlcTxs.map { it.tx.txid }) }
         htlcTxs.forEach { htlcTx ->
-            val localHtlcSig = Transactions.sign(htlcTx, local_htlc_privkey, SigHash.SIGHASH_ALL)
+            val localHtlcSig = local_htlc_privkey.sign(htlcTx, SigHash.SIGHASH_ALL)
             val remoteHtlcSig = Crypto.der2compact(remoteHtlcSigs[htlcTx.tx.txid]!!.toByteArray())
             val expectedTx = txs[htlcTx.tx.txid]
             val signed = when (htlcTx) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/transactions/AnchorOutputsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/transactions/AnchorOutputsTestsCommon.kt
@@ -39,7 +39,7 @@ class AnchorOutputsTestsCommon {
     val remotepubkey = PublicKey.fromHex("0394854aa6eab5b2a8122cc726e9dded053a2184d88256816826d6231c068d4a5b")
     val local_delayedpubkey = PublicKey.fromHex("03fd5960528dc152014952efdb702a88f71e3c1653b2314431701ec77e57fde83c")
     val local_revocation_pubkey = PublicKey.fromHex("0212a140cd0c6539d07cd08dfe09984dec3251ea808b892efeac3ede9402bf2b19")
-    val remote_funding_privkey = PrivateKey.fromHex("1552dfba4f6cf29a62a0af13c8d6981d36d0ef8d61ba10fb0fe90da7634d7e1301")
+    val remote_funding_privkey = HardCodedPrivateKey("1552dfba4f6cf29a62a0af13c8d6981d36d0ef8d61ba10fb0fe90da7634d7e1301")
     val local_payment_basepoint_secret = HardCodedPrivateKey("111111111111111111111111111111111111111111111111111111111111111101")
     val remote_revocation_basepoint_secret = PrivateKey.fromHex("222222222222222222222222222222222222222222222222222222222222222201")
     val local_delayed_payment_basepoint_secret = HardCodedPrivateKey("333333333333333333333333333333333333333333333333333333333333333301")
@@ -146,7 +146,7 @@ class AnchorOutputsTestsCommon {
             spec
         )
 
-        val localSig = Transactions.sign2(commitTx, local_funding_privkey)
+        val localSig = Transactions.sign(commitTx, local_funding_privkey)
         val remoteSig = Transactions.sign(commitTx, remote_funding_privkey)
         val signedTx = Transactions.addSigs(commitTx, local_funding_pubkey, remote_funding_pubkey, localSig, remoteSig)
         assertEquals(Transaction.read(testCase.ExpectedCommitmentTxHex), signedTx.tx)
@@ -154,7 +154,7 @@ class AnchorOutputsTestsCommon {
         val remoteHtlcSigs = testCase.HtlcDescs.map { Transaction.read(it.ResolutionTxHex).txid to ByteVector(it.RemoteSigHex) }.toMap()
         assertTrue { remoteHtlcSigs.keys.containsAll(htlcTxs.map { it.tx.txid }) }
         htlcTxs.forEach { htlcTx ->
-            val localHtlcSig = Transactions.sign2(htlcTx, local_htlc_privkey, SigHash.SIGHASH_ALL)
+            val localHtlcSig = Transactions.sign(htlcTx, local_htlc_privkey, SigHash.SIGHASH_ALL)
             val remoteHtlcSig = Crypto.der2compact(remoteHtlcSigs[htlcTx.tx.txid]!!.toByteArray())
             val expectedTx = txs[htlcTx.tx.txid]
             val signed = when (htlcTx) {
@@ -194,7 +194,7 @@ class AnchorOutputsTestsCommon {
             true,
             outputs
         )
-        val localSig = Transactions.sign2(commitTx, local_funding_privkey)
+        val localSig = Transactions.sign(commitTx, local_funding_privkey)
         val remoteSig = Transactions.sign(commitTx, remote_funding_privkey)
         val signedTx = Transactions.addSigs(commitTx, local_funding_pubkey, remote_funding_pubkey, localSig, remoteSig)
         assertEquals(testCase.ExpectedCommitmentTx, signedTx.tx)
@@ -204,7 +204,7 @@ class AnchorOutputsTestsCommon {
         val htlcTxs = Transactions.makeHtlcTxs(commitTx.tx, 546.sat, local_revocation_pubkey, CltvExpiryDelta(144), local_delayedpubkey, spec.feerate, outputs)
         assertTrue { remoteHtlcSigs.keys.containsAll(htlcTxs.map { it.tx.txid }) }
         htlcTxs.forEach { htlcTx ->
-            val localHtlcSig = Transactions.sign2(htlcTx, local_htlc_privkey, SigHash.SIGHASH_ALL)
+            val localHtlcSig = Transactions.sign(htlcTx, local_htlc_privkey, SigHash.SIGHASH_ALL)
             val remoteHtlcSig = Crypto.der2compact(remoteHtlcSigs[htlcTx.tx.txid]!!.toByteArray())
             val expectedTx = txs[htlcTx.tx.txid]
             val signed = when (htlcTx) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/transactions/AnchorOutputsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/transactions/AnchorOutputsTestsCommon.kt
@@ -42,8 +42,8 @@ class AnchorOutputsTestsCommon {
     val remote_funding_privkey = PrivateKey.fromHex("1552dfba4f6cf29a62a0af13c8d6981d36d0ef8d61ba10fb0fe90da7634d7e1301")
     val local_payment_basepoint_secret = HardCodedPrivateKey("111111111111111111111111111111111111111111111111111111111111111101")
     val remote_revocation_basepoint_secret = PrivateKey.fromHex("222222222222222222222222222222222222222222222222222222222222222201")
-    val local_delayed_payment_basepoint_secret = PrivateKey.fromHex("333333333333333333333333333333333333333333333333333333333333333301")
-    val remote_payment_basepoint_secret = PrivateKey.fromHex("444444444444444444444444444444444444444444444444444444444444444401")
+    val local_delayed_payment_basepoint_secret = HardCodedPrivateKey("333333333333333333333333333333333333333333333333333333333333333301")
+    val remote_payment_basepoint_secret = HardCodedPrivateKey("444444444444444444444444444444444444444444444444444444444444444401")
     val local_per_commitment_secret = PrivateKey.fromHex("1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a0908070605040302010001")
 
     // From remote_revocation_basepoint_secret
@@ -57,7 +57,7 @@ class AnchorOutputsTestsCommon {
     // From local_delayed_payment_basepoint_secret, local_per_commitment_point and local_delayed_payment_basepoint
     val local_delayed_privkey = PrivateKey.fromHex("adf3464ce9c2f230fd2582fda4c6965e4993ca5524e8c9580e3df0cf226981ad01")
 
-    val local_htlc_privkey = local_payment_basepoint_secret.instantiate().deriveForCommitment(local_per_commitment_point)
+    val local_htlc_privkey = local_payment_basepoint_secret.deriveForCommitment(local_per_commitment_point)
     val local_payment_privkey = local_payment_basepoint_secret
     val local_delayed_payment_privkey = local_delayed_payment_basepoint_secret.deriveForCommitment(local_per_commitment_point)
 
@@ -88,7 +88,7 @@ class AnchorOutputsTestsCommon {
 
     // high level tests which calls Commitments methods to generate transactions
     private fun runHighLevelTest(testCase: TestCase) {
-        val channelKeys = ChannelKeys(KeyPath.empty, { local_funding_privkey }, local_payment_basepoint_secret, local_delayed_payment_basepoint_secret, local_payment_basepoint_secret.instantiate(), local_payment_basepoint_secret.instantiate(), randomBytes32())
+        val channelKeys = ChannelKeys(KeyPath.empty, { local_funding_privkey }, local_payment_basepoint_secret, local_delayed_payment_basepoint_secret, local_payment_basepoint_secret, local_payment_basepoint_secret, randomBytes32())
         val localParams = LocalParams(
             TestConstants.Alice.nodeParams.nodeId,
             KeyPath.empty,
@@ -154,7 +154,7 @@ class AnchorOutputsTestsCommon {
         val remoteHtlcSigs = testCase.HtlcDescs.map { Transaction.read(it.ResolutionTxHex).txid to ByteVector(it.RemoteSigHex) }.toMap()
         assertTrue { remoteHtlcSigs.keys.containsAll(htlcTxs.map { it.tx.txid }) }
         htlcTxs.forEach { htlcTx ->
-            val localHtlcSig = Transactions.sign(htlcTx, local_htlc_privkey, SigHash.SIGHASH_ALL)
+            val localHtlcSig = Transactions.sign2(htlcTx, local_htlc_privkey, SigHash.SIGHASH_ALL)
             val remoteHtlcSig = Crypto.der2compact(remoteHtlcSigs[htlcTx.tx.txid]!!.toByteArray())
             val expectedTx = txs[htlcTx.tx.txid]
             val signed = when (htlcTx) {
@@ -204,7 +204,7 @@ class AnchorOutputsTestsCommon {
         val htlcTxs = Transactions.makeHtlcTxs(commitTx.tx, 546.sat, local_revocation_pubkey, CltvExpiryDelta(144), local_delayedpubkey, spec.feerate, outputs)
         assertTrue { remoteHtlcSigs.keys.containsAll(htlcTxs.map { it.tx.txid }) }
         htlcTxs.forEach { htlcTx ->
-            val localHtlcSig = Transactions.sign(htlcTx, local_htlc_privkey, SigHash.SIGHASH_ALL)
+            val localHtlcSig = Transactions.sign2(htlcTx, local_htlc_privkey, SigHash.SIGHASH_ALL)
             val remoteHtlcSig = Crypto.der2compact(remoteHtlcSigs[htlcTx.tx.txid]!!.toByteArray())
             val expectedTx = txs[htlcTx.tx.txid]
             val signed = when (htlcTx) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
@@ -51,7 +51,6 @@ import fr.acinq.lightning.transactions.Transactions.makeCommitTxOutputs
 import fr.acinq.lightning.transactions.Transactions.makeHtlcPenaltyTx
 import fr.acinq.lightning.transactions.Transactions.makeHtlcTxs
 import fr.acinq.lightning.transactions.Transactions.makeMainPenaltyTx
-import fr.acinq.lightning.transactions.Transactions.sign
 import fr.acinq.lightning.transactions.Transactions.swapInputWeight
 import fr.acinq.lightning.transactions.Transactions.swapInputWeightLegacy
 import fr.acinq.lightning.transactions.Transactions.weight2fee
@@ -276,8 +275,8 @@ class TransactionsTestsCommon : LightningTestSuite() {
         val commitTxNumber = 0x404142434445L
         val commitTx = run {
             val txInfo = makeCommitTx(commitInput, commitTxNumber, localPaymentPriv.publicKey(), remotePaymentPriv.publicKey(), true, outputs)
-            val localSig = sign(txInfo, localPaymentPriv)
-            val remoteSig = sign(txInfo, remotePaymentPriv)
+            val localSig = localPaymentPriv.sign(txInfo)
+            val remoteSig = remotePaymentPriv.sign(txInfo)
             addSigs(txInfo, localFundingPriv.publicKey(), remoteFundingPriv.publicKey(), localSig, remoteSig)
         }
 
@@ -300,8 +299,8 @@ class TransactionsTestsCommon : LightningTestSuite() {
         run {
             // either party spends local->remote htlc output with htlc timeout tx
             for (htlcTimeoutTx in htlcTimeoutTxs) {
-                val localSig = sign(htlcTimeoutTx, localHtlcPriv)
-                val remoteSig = sign(htlcTimeoutTx, remoteHtlcPriv, SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY)
+                val localSig = localHtlcPriv.sign(htlcTimeoutTx)
+                val remoteSig = remoteHtlcPriv.sign(htlcTimeoutTx, SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY)
                 val signed = addSigs(htlcTimeoutTx, localSig, remoteSig)
                 val csResult = checkSpendable(signed)
                 assertTrue(csResult.isSuccess, "is $csResult")
@@ -311,7 +310,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             // local spends delayed output of htlc1 timeout tx
             val claimHtlcDelayed = makeClaimLocalDelayedOutputTx(htlcTimeoutTxs[1].tx, localDustLimit, localRevocationPriv.publicKey(), toLocalDelay, localDelayedPaymentPriv.publicKey(), finalPubKeyScript, feerate)
             assertTrue(claimHtlcDelayed is Success, "is $claimHtlcDelayed")
-            val localSig = sign(claimHtlcDelayed.result, localDelayedPaymentPriv)
+            val localSig = localDelayedPaymentPriv.sign(claimHtlcDelayed.result)
             val signedTx = addSigs(claimHtlcDelayed.result, localSig)
             assertTrue(checkSpendable(signedTx).isSuccess)
             // local can't claim delayed output of htlc3 timeout tx because it is below the dust limit
@@ -324,7 +323,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
                 val claimHtlcSuccessTx =
                     makeClaimHtlcSuccessTx(commitTx.tx, outputs, localDustLimit, remoteHtlcPriv.publicKey(), localHtlcPriv.publicKey(), localRevocationPriv.publicKey(), finalPubKeyScript, htlc, feerate)
                 assertTrue(claimHtlcSuccessTx is Success, "is $claimHtlcSuccessTx")
-                val localSig = sign(claimHtlcSuccessTx.result, remoteHtlcPriv)
+                val localSig = remoteHtlcPriv.sign(claimHtlcSuccessTx.result)
                 val signed = addSigs(claimHtlcSuccessTx.result, localSig, paymentPreimage)
                 val csResult = checkSpendable(signed)
                 assertTrue(csResult.isSuccess, "is $csResult")
@@ -333,8 +332,8 @@ class TransactionsTestsCommon : LightningTestSuite() {
         run {
             // local spends remote->local htlc2/htlc4 output with htlc success tx using payment preimage
             for ((htlcSuccessTx, paymentPreimage) in listOf(htlcSuccessTxs[1] to paymentPreimage2, htlcSuccessTxs[0] to paymentPreimage4)) {
-                val localSig = sign(htlcSuccessTx, localHtlcPriv)
-                val remoteSig = sign(htlcSuccessTx, remoteHtlcPriv, SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY)
+                val localSig = localHtlcPriv.sign(htlcSuccessTx)
+                val remoteSig = remoteHtlcPriv.sign(htlcSuccessTx, SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY)
                 val signedTx = addSigs(htlcSuccessTx, localSig, remoteSig, paymentPreimage)
                 val csResult = checkSpendable(signedTx)
                 assertTrue(csResult.isSuccess, "is $csResult")
@@ -346,7 +345,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             // local spends delayed output of htlc2 success tx
             val claimHtlcDelayed = makeClaimLocalDelayedOutputTx(htlcSuccessTxs[1].tx, localDustLimit, localRevocationPriv.publicKey(), toLocalDelay, localDelayedPaymentPriv.publicKey(), finalPubKeyScript, feerate)
             assertTrue(claimHtlcDelayed is Success, "is $claimHtlcDelayed")
-            val localSig = sign(claimHtlcDelayed.result, localDelayedPaymentPriv)
+            val localSig = localDelayedPaymentPriv.sign(claimHtlcDelayed.result)
             val signedTx = addSigs(claimHtlcDelayed.result, localSig)
             val csResult = checkSpendable(signedTx)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -358,7 +357,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             // remote spends main output
             val claimP2WPKHOutputTx = makeClaimRemoteDelayedOutputTx(commitTx.tx, localDustLimit, remotePaymentPriv.publicKey(), finalPubKeyScript.toByteVector(), feerate)
             assertTrue(claimP2WPKHOutputTx is Success, "is $claimP2WPKHOutputTx")
-            val localSig = sign(claimP2WPKHOutputTx.result, remotePaymentPriv)
+            val localSig = remotePaymentPriv.sign(claimP2WPKHOutputTx.result)
             val signedTx = addSigs(claimP2WPKHOutputTx.result, localSig)
             val csResult = checkSpendable(signedTx)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -369,7 +368,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             assertEquals(1, claimHtlcDelayedPenaltyTxs.size)
             val claimHtlcDelayedPenaltyTx = claimHtlcDelayedPenaltyTxs.first()
             assertTrue(claimHtlcDelayedPenaltyTx is Success, "is $claimHtlcDelayedPenaltyTx")
-            val sig = sign(claimHtlcDelayedPenaltyTx.result, localRevocationPriv)
+            val sig = localRevocationPriv.sign(claimHtlcDelayedPenaltyTx.result)
             val signed = addSigs(claimHtlcDelayedPenaltyTx.result, sig)
             val csResult = checkSpendable(signed)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -382,7 +381,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             val claimHtlcTimeoutTx =
                 makeClaimHtlcTimeoutTx(commitTx.tx, outputs, localDustLimit, remoteHtlcPriv.publicKey(), localHtlcPriv.publicKey(), localRevocationPriv.publicKey(), finalPubKeyScript, htlc2, feerate)
             assertTrue(claimHtlcTimeoutTx is Success, "is $claimHtlcTimeoutTx")
-            val remoteSig = sign(claimHtlcTimeoutTx.result, remoteHtlcPriv)
+            val remoteSig = remoteHtlcPriv.sign(claimHtlcTimeoutTx.result)
             val signed = addSigs(claimHtlcTimeoutTx.result, remoteSig)
             val csResult = checkSpendable(signed)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -393,7 +392,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             assertEquals(1, claimHtlcDelayedPenaltyTxs.size)
             val claimHtlcDelayedPenaltyTx = claimHtlcDelayedPenaltyTxs.first()
             assertTrue(claimHtlcDelayedPenaltyTx is Success, "is $claimHtlcDelayedPenaltyTx")
-            val sig = sign(claimHtlcDelayedPenaltyTx.result, localRevocationPriv)
+            val sig = localRevocationPriv.sign(claimHtlcDelayedPenaltyTx.result)
             val signed = addSigs(claimHtlcDelayedPenaltyTx.result, sig)
             val csResult = checkSpendable(signed)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -423,7 +422,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             }
             val htlcPenaltyTx = makeHtlcPenaltyTx(commitTx.tx, htlcOutputIndex, script, localDustLimit, finalPubKeyScript, feerate)
             assertTrue(htlcPenaltyTx is Success, "is $htlcPenaltyTx")
-            val sig = sign(htlcPenaltyTx.result, localRevocationPriv)
+            val sig = localRevocationPriv.sign(htlcPenaltyTx.result)
             val signed = addSigs(htlcPenaltyTx.result, sig, localRevocationPriv.publicKey())
             val csResult = checkSpendable(signed)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -437,7 +436,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             }
             val htlcPenaltyTx = makeHtlcPenaltyTx(commitTx.tx, htlcOutputIndex, script, localDustLimit, finalPubKeyScript, feerate)
             assertTrue(htlcPenaltyTx is Success, "is $htlcPenaltyTx")
-            val sig = sign(htlcPenaltyTx.result, localRevocationPriv)
+            val sig = localRevocationPriv.sign(htlcPenaltyTx.result)
             val signed = addSigs(htlcPenaltyTx.result, sig, localRevocationPriv.publicKey())
             val csResult = checkSpendable(signed)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -622,8 +621,8 @@ class TransactionsTestsCommon : LightningTestSuite() {
                     spec
                 )
             val txInfo = makeCommitTx(commitInput, commitTxNumber, localPaymentPriv.publicKey(), remotePaymentPriv.publicKey(), true, outputs)
-            val localSig = sign(txInfo, this.localPaymentPriv)
-            val remoteSig = sign(txInfo, this.remotePaymentPriv)
+            val localSig = this.localPaymentPriv.sign(txInfo)
+            val remoteSig = this.remotePaymentPriv.sign(txInfo)
             val commitTx = addSigs(txInfo, localFundingPriv.publicKey(), remoteFundingPriv.publicKey(), localSig, remoteSig)
             val htlcTxs = makeHtlcTxs(commitTx.tx, localDustLimit, localRevocationPriv.publicKey(), toLocalDelay, localDelayedPaymentPriv.publicKey(), feerate, outputs)
             Triple(commitTx, outputs, htlcTxs)

--- a/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
@@ -15,8 +15,8 @@ import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.channel.Commitments
 import fr.acinq.lightning.channel.Helpers.Funding
-import fr.acinq.lightning.crypto.HardCodedPrivateKey
-import fr.acinq.lightning.crypto.LocalKeyManager
+import fr.acinq.lightning.crypto.local.HardCodedPrivateKey
+import fr.acinq.lightning.crypto.local.RootExtendedPrivateKeyDescriptor
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.transactions.CommitmentOutput.OutHtlc
@@ -492,7 +492,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
         val mnemonics = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" ")
         val seed = MnemonicCode.toSeed(mnemonics, "")
         val masterPrivateKey = DeterministicWallet.derivePrivateKey(DeterministicWallet.generate(seed), "/51'/0'/0'").copy(path = KeyPath.empty)
-        val masterPrivateKeyDescriptor = LocalKeyManager.RootExtendedPrivateKeyDescriptor(masterPrivateKey)
+        val masterPrivateKeyDescriptor = RootExtendedPrivateKeyDescriptor(masterPrivateKey)
         val userRefundPrivateKey = DeterministicWallet.derivePrivateKey(masterPrivateKey, "0").privateKey
         val userRefundPrivateKeyDescriptor = masterPrivateKeyDescriptor.derivePrivateKey(0)
         val swapInProtocol = SwapInProtocol(userPrivateKey.publicKey(), serverPrivateKey.publicKey(), userRefundPrivateKey.publicKey(), refundDelay)

--- a/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
@@ -51,7 +51,7 @@ import fr.acinq.lightning.transactions.Transactions.makeCommitTxOutputs
 import fr.acinq.lightning.transactions.Transactions.makeHtlcPenaltyTx
 import fr.acinq.lightning.transactions.Transactions.makeHtlcTxs
 import fr.acinq.lightning.transactions.Transactions.makeMainPenaltyTx
-import fr.acinq.lightning.transactions.Transactions.sign2
+import fr.acinq.lightning.transactions.Transactions.sign
 import fr.acinq.lightning.transactions.Transactions.swapInputWeight
 import fr.acinq.lightning.transactions.Transactions.swapInputWeightLegacy
 import fr.acinq.lightning.transactions.Transactions.weight2fee
@@ -276,8 +276,8 @@ class TransactionsTestsCommon : LightningTestSuite() {
         val commitTxNumber = 0x404142434445L
         val commitTx = run {
             val txInfo = makeCommitTx(commitInput, commitTxNumber, localPaymentPriv.publicKey(), remotePaymentPriv.publicKey(), true, outputs)
-            val localSig = sign2(txInfo, localPaymentPriv)
-            val remoteSig = sign2(txInfo, remotePaymentPriv)
+            val localSig = sign(txInfo, localPaymentPriv)
+            val remoteSig = sign(txInfo, remotePaymentPriv)
             addSigs(txInfo, localFundingPriv.publicKey(), remoteFundingPriv.publicKey(), localSig, remoteSig)
         }
 
@@ -300,8 +300,8 @@ class TransactionsTestsCommon : LightningTestSuite() {
         run {
             // either party spends local->remote htlc output with htlc timeout tx
             for (htlcTimeoutTx in htlcTimeoutTxs) {
-                val localSig = sign2(htlcTimeoutTx, localHtlcPriv)
-                val remoteSig = sign2(htlcTimeoutTx, remoteHtlcPriv, SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY)
+                val localSig = sign(htlcTimeoutTx, localHtlcPriv)
+                val remoteSig = sign(htlcTimeoutTx, remoteHtlcPriv, SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY)
                 val signed = addSigs(htlcTimeoutTx, localSig, remoteSig)
                 val csResult = checkSpendable(signed)
                 assertTrue(csResult.isSuccess, "is $csResult")
@@ -311,7 +311,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             // local spends delayed output of htlc1 timeout tx
             val claimHtlcDelayed = makeClaimLocalDelayedOutputTx(htlcTimeoutTxs[1].tx, localDustLimit, localRevocationPriv.publicKey(), toLocalDelay, localDelayedPaymentPriv.publicKey(), finalPubKeyScript, feerate)
             assertTrue(claimHtlcDelayed is Success, "is $claimHtlcDelayed")
-            val localSig = sign2(claimHtlcDelayed.result, localDelayedPaymentPriv)
+            val localSig = sign(claimHtlcDelayed.result, localDelayedPaymentPriv)
             val signedTx = addSigs(claimHtlcDelayed.result, localSig)
             assertTrue(checkSpendable(signedTx).isSuccess)
             // local can't claim delayed output of htlc3 timeout tx because it is below the dust limit
@@ -324,7 +324,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
                 val claimHtlcSuccessTx =
                     makeClaimHtlcSuccessTx(commitTx.tx, outputs, localDustLimit, remoteHtlcPriv.publicKey(), localHtlcPriv.publicKey(), localRevocationPriv.publicKey(), finalPubKeyScript, htlc, feerate)
                 assertTrue(claimHtlcSuccessTx is Success, "is $claimHtlcSuccessTx")
-                val localSig = sign2(claimHtlcSuccessTx.result, remoteHtlcPriv)
+                val localSig = sign(claimHtlcSuccessTx.result, remoteHtlcPriv)
                 val signed = addSigs(claimHtlcSuccessTx.result, localSig, paymentPreimage)
                 val csResult = checkSpendable(signed)
                 assertTrue(csResult.isSuccess, "is $csResult")
@@ -333,8 +333,8 @@ class TransactionsTestsCommon : LightningTestSuite() {
         run {
             // local spends remote->local htlc2/htlc4 output with htlc success tx using payment preimage
             for ((htlcSuccessTx, paymentPreimage) in listOf(htlcSuccessTxs[1] to paymentPreimage2, htlcSuccessTxs[0] to paymentPreimage4)) {
-                val localSig = sign2(htlcSuccessTx, localHtlcPriv)
-                val remoteSig = sign2(htlcSuccessTx, remoteHtlcPriv, SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY)
+                val localSig = sign(htlcSuccessTx, localHtlcPriv)
+                val remoteSig = sign(htlcSuccessTx, remoteHtlcPriv, SigHash.SIGHASH_SINGLE or SigHash.SIGHASH_ANYONECANPAY)
                 val signedTx = addSigs(htlcSuccessTx, localSig, remoteSig, paymentPreimage)
                 val csResult = checkSpendable(signedTx)
                 assertTrue(csResult.isSuccess, "is $csResult")
@@ -346,7 +346,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             // local spends delayed output of htlc2 success tx
             val claimHtlcDelayed = makeClaimLocalDelayedOutputTx(htlcSuccessTxs[1].tx, localDustLimit, localRevocationPriv.publicKey(), toLocalDelay, localDelayedPaymentPriv.publicKey(), finalPubKeyScript, feerate)
             assertTrue(claimHtlcDelayed is Success, "is $claimHtlcDelayed")
-            val localSig = sign2(claimHtlcDelayed.result, localDelayedPaymentPriv)
+            val localSig = sign(claimHtlcDelayed.result, localDelayedPaymentPriv)
             val signedTx = addSigs(claimHtlcDelayed.result, localSig)
             val csResult = checkSpendable(signedTx)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -358,7 +358,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             // remote spends main output
             val claimP2WPKHOutputTx = makeClaimRemoteDelayedOutputTx(commitTx.tx, localDustLimit, remotePaymentPriv.publicKey(), finalPubKeyScript.toByteVector(), feerate)
             assertTrue(claimP2WPKHOutputTx is Success, "is $claimP2WPKHOutputTx")
-            val localSig = sign2(claimP2WPKHOutputTx.result, remotePaymentPriv)
+            val localSig = sign(claimP2WPKHOutputTx.result, remotePaymentPriv)
             val signedTx = addSigs(claimP2WPKHOutputTx.result, localSig)
             val csResult = checkSpendable(signedTx)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -369,7 +369,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             assertEquals(1, claimHtlcDelayedPenaltyTxs.size)
             val claimHtlcDelayedPenaltyTx = claimHtlcDelayedPenaltyTxs.first()
             assertTrue(claimHtlcDelayedPenaltyTx is Success, "is $claimHtlcDelayedPenaltyTx")
-            val sig = sign2(claimHtlcDelayedPenaltyTx.result, localRevocationPriv)
+            val sig = sign(claimHtlcDelayedPenaltyTx.result, localRevocationPriv)
             val signed = addSigs(claimHtlcDelayedPenaltyTx.result, sig)
             val csResult = checkSpendable(signed)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -382,7 +382,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             val claimHtlcTimeoutTx =
                 makeClaimHtlcTimeoutTx(commitTx.tx, outputs, localDustLimit, remoteHtlcPriv.publicKey(), localHtlcPriv.publicKey(), localRevocationPriv.publicKey(), finalPubKeyScript, htlc2, feerate)
             assertTrue(claimHtlcTimeoutTx is Success, "is $claimHtlcTimeoutTx")
-            val remoteSig = sign2(claimHtlcTimeoutTx.result, remoteHtlcPriv)
+            val remoteSig = sign(claimHtlcTimeoutTx.result, remoteHtlcPriv)
             val signed = addSigs(claimHtlcTimeoutTx.result, remoteSig)
             val csResult = checkSpendable(signed)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -393,7 +393,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             assertEquals(1, claimHtlcDelayedPenaltyTxs.size)
             val claimHtlcDelayedPenaltyTx = claimHtlcDelayedPenaltyTxs.first()
             assertTrue(claimHtlcDelayedPenaltyTx is Success, "is $claimHtlcDelayedPenaltyTx")
-            val sig = sign2(claimHtlcDelayedPenaltyTx.result, localRevocationPriv)
+            val sig = sign(claimHtlcDelayedPenaltyTx.result, localRevocationPriv)
             val signed = addSigs(claimHtlcDelayedPenaltyTx.result, sig)
             val csResult = checkSpendable(signed)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -423,7 +423,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             }
             val htlcPenaltyTx = makeHtlcPenaltyTx(commitTx.tx, htlcOutputIndex, script, localDustLimit, finalPubKeyScript, feerate)
             assertTrue(htlcPenaltyTx is Success, "is $htlcPenaltyTx")
-            val sig = sign2(htlcPenaltyTx.result, localRevocationPriv)
+            val sig = sign(htlcPenaltyTx.result, localRevocationPriv)
             val signed = addSigs(htlcPenaltyTx.result, sig, localRevocationPriv.publicKey())
             val csResult = checkSpendable(signed)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -437,7 +437,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             }
             val htlcPenaltyTx = makeHtlcPenaltyTx(commitTx.tx, htlcOutputIndex, script, localDustLimit, finalPubKeyScript, feerate)
             assertTrue(htlcPenaltyTx is Success, "is $htlcPenaltyTx")
-            val sig = sign2(htlcPenaltyTx.result, localRevocationPriv)
+            val sig = sign(htlcPenaltyTx.result, localRevocationPriv)
             val signed = addSigs(htlcPenaltyTx.result, sig, localRevocationPriv.publicKey())
             val csResult = checkSpendable(signed)
             assertTrue(csResult.isSuccess, "is $csResult")
@@ -622,8 +622,8 @@ class TransactionsTestsCommon : LightningTestSuite() {
                     spec
                 )
             val txInfo = makeCommitTx(commitInput, commitTxNumber, localPaymentPriv.publicKey(), remotePaymentPriv.publicKey(), true, outputs)
-            val localSig = sign2(txInfo, this.localPaymentPriv)
-            val remoteSig = sign2(txInfo, this.remotePaymentPriv)
+            val localSig = sign(txInfo, this.localPaymentPriv)
+            val remoteSig = sign(txInfo, this.remotePaymentPriv)
             val commitTx = addSigs(txInfo, localFundingPriv.publicKey(), remoteFundingPriv.publicKey(), localSig, remoteSig)
             val htlcTxs = makeHtlcTxs(commitTx.tx, localDustLimit, localRevocationPriv.publicKey(), toLocalDelay, localDelayedPaymentPriv.publicKey(), feerate, outputs)
             Triple(commitTx, outputs, htlcTxs)

--- a/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
@@ -7,7 +7,6 @@ import fr.acinq.bitcoin.Script.pay2wpkh
 import fr.acinq.bitcoin.Script.pay2wsh
 import fr.acinq.bitcoin.Script.write
 import fr.acinq.bitcoin.crypto.Pack
-import fr.acinq.bitcoin.crypto.musig2.Musig2
 import fr.acinq.lightning.CltvExpiry
 import fr.acinq.lightning.CltvExpiryDelta
 import fr.acinq.lightning.Lightning.randomBytes32
@@ -513,8 +512,8 @@ class TransactionsTestsCommon : LightningTestSuite() {
             )
             // The first step of a musig2 signing session is to exchange nonces.
             // If participants are disconnected before the end of the signing session, they must start again with fresh nonces.
-            val userNonce = Musig2.generateNonce(randomBytes32(), userPrivateKey.instantiate(), listOf(userPrivateKey.publicKey(), serverPrivateKey.publicKey()))
-            val serverNonce = Musig2.generateNonce(randomBytes32(), serverPrivateKey.instantiate(), listOf(serverPrivateKey.publicKey(), userPrivateKey.publicKey()))
+            val userNonce = userPrivateKey.generateMusig2Nonce(randomBytes32(), listOf(userPrivateKey.publicKey(), serverPrivateKey.publicKey()))
+            val serverNonce = serverPrivateKey.generateMusig2Nonce(randomBytes32(), listOf(serverPrivateKey.publicKey(), userPrivateKey.publicKey()))
 
             // Once they have each other's public nonce, they can produce partial signatures.
             val userSig = swapInProtocol.signSwapInputUser(tx, 0, swapInTx.txOut, userPrivateKey, userNonce.first, userNonce.second, serverNonce.second).right!!


### PR DESCRIPTION
⚠️ Disclaimer:
* Being my first time with Kotlin, code might not be very idiomatic;
* It might be the case that this topic is already somewhere in your roadmap and you might have given it some though about some target architecture that could be very different from what I propose here;
* I've done my best to carefully craft each commit but, please, feel free to share any suggestion that could make this PR easier to review;
* any other feedback you can think of are welcome.

# Why

I'm planning to explore alternative implementations of a `KeyManager` and especially what can be done with [hardware](https://delvingbitcoin.org/t/lightning-hardware-wallet/555). As a pre-requisite, I believe some refactoring is needed to ensure that:
1. the `KeyManager` interface is fully agnostic to the key material implementation (currently there are some dependencies to `DeterministicWallet`);
2. private key material does not _leak_ outside `LocalKeyManager` (currently `DeterministicWallet.PrivateKey` appears in `Transactions`, `KeyManager`, `Channel`, `Bolt3Derivation`, `RouteBlinding` for instance.

I've noticed key material is way more concealed in [eclair-core](https://github.com/ACINQ/eclair/blob/android-phoenix/eclair-core/src/main/scala/fr/acinq/eclair/crypto/LocalKeyManager.scala#L54) (the `android-phoenix` branch).

# What

In the target architecture, the user application would be in charge of instantiating the `LocalKeyManager` as it's the application (or any lightning-kmp client for that matter) that's in charge of initiating, backing up or restoring the key material (in the form of a seed for instance). Then the application trusts lightning-kmp for the lightning logic, lightning-kmp using some abstract `KeyManager` implemented by `LocalKeyManager`:

```mermaid
block-beta
columns 3
Start(("User")) space:2
u2a<[" "]>(down) space:2

Application                                            a2l<["uses"]>(right)       LNKMP["Lighning Logic"]
downAgain<["Instantiates"]>(down) space                                l2k<["uses"]>(down)
LocalKeyManager                                 k2l<["delegates"]>(left) KeyManager 

style Start fill:#969;
```

That way, we may replace `LocalKeyManager` by alternative implementations like, for instance, a `HardwareKeyManager` or a `WhateverKeyManager`:

```mermaid
block-beta
columns 3
LNKMP["Lighning Logic"]:3
KeyManager:3
LocalKeyManager HardwareKeyManager WhateverKeyManager
```

# How

To limit the exposure of the key material, I've decided to create `PrivateKeyDescriptor` and `ExtendedPrivateKeyDescriptor` which are two interfaces, describing a private key that can be implemented to suit different crypto engines.

I've only implemented them interfaces for the `LocalKeyManager`.  `LocalKeyManager` and the local package is the only places where such keys can be instantiated and private key material  used for cryptography.

There are some cases where exporting private key material seems ok:
* NodeKeys, which are used for network authentication and communication;
* shaSeed, used for commitment points and eventually shared with channel peers;

It's also the case that Phoenix exports private key material to cypher cloud stored data for instance. In which case it seems very handy to rely on the `KeyManager` of lightning-kmp so that there is no need for another seed, or secret to backup/restore. But to open the way to alternative implementation, I've introduced the `deterministicKeyMaterial()` function.

Also note that, regarding the way Phoenix uses lightning-kmp, this PR introduces a breaking change. See commit `Refactor key management - BREAKING API`.

After this PR, to implement a `KeyManager`, one will have to also implement both interfaces as needed:
* PrivateKeyDescriptor
   *  publicKey
   * deriveForRevocation
   * deriveForCommitment
   * sign
   * signInputTaprootScriptPath
   * signMusig2TaprootInput
   * generateMusig2Nonce
* ExtendedPrivateKeyDescriptor
   *  privateKey
   * publicKey
   * derive
   * derivePrivateKey

# Notes

I've tried to carefully craft each commit to ease the review process. I suggest to review each commit separately instead of just the whole PR outcome as they come with detailed explanation of what's done and why it's done that way:
* _Refactor key management - fundingKey/paymentKey_ is the first commit, it introduces `PrivateKeyDescriptor` and handles the easiest part with the _funding_ and _payment_ keys which are used without basic derivation strategies;
* _Refactor key management - Bolt3_ focuses on everything that's Bolt3 related and, in particular it introduces two new implementations of `PrivateKeyDescriptor` to handle revocation and commitment derivations;
* _Refactor key management - swap in protocol_ focuses on the swap in protocol and introduces `ExtendedPrivateKeyDescriptor`;
* _Refactor key management - Bip84_ focuses on Bip84
* _Refactor key management - encapsulate Transactions.sign_ moves `Transactions.sign()` into the `PrivateKeyDescriptor` interface and is the first commit to migrate key operation into this interface
* _Refactor key management - segregate instantiate() to LocalKeyManager_ make it so that only the `LocalKeyManager` or code in the `local` package can instantiate actual private key material
* _Refactor key management - segregate instantiate() again_ does the same thing but for extended private keys
* _Refactor key management - BREAKING API_ introduces a breaking change. The commit message describes what kind of changes (which look minimal) are to be done to adapt the code of Phoenix to this breaking change.