### PR TITLE
Upgrade to kotlin 1.9.23

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,8 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
 
 plugins {
-    kotlin("multiplatform") version "1.9.22"
-    kotlin("plugin.serialization") version "1.9.22"
+    kotlin("multiplatform") version "1.9.23"
+    kotlin("plugin.serialization") version "1.9.23"
     id("org.jetbrains.dokka") version "1.9.10"
     `maven-publish`
 }


### PR DESCRIPTION
This PR upgrades kotlin to version 1.9.23. This fixes an issue in cinterop in PhoenixCrypto with the latest XCode (version 15.3):

```
> Task :cinteropPhoenixCryptoIosArm64 FAILED
Exception in thread "main" java.lang.Error: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.4.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObjCRuntime.h:615:74: error: unknown type name 'NSUInteger'
        at org.jetbrains.kotlin.native.interop.indexer.UtilsKt.ensureNoCompileErrors(Utils.kt:275)
        at org.jetbrains.kotlin.native.interop.indexer.IndexerKt.indexDeclarations(Indexer.kt:1246)
        at org.jetbrains.kotlin.native.interop.indexer.IndexerKt.buildNativeIndexImpl(Indexer.kt:1229)
        ...
```

Details can be found [in KT-65542](https://youtrack.jetbrains.com/issue/KT-65542/Cinterop-tasks-fails-if-Xcode-15.3-is-used).