### PR TITLE
Minor API improvements for sending/receiving payments

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -7,6 +7,9 @@ import fr.acinq.lightning.channel.SharedFundingInput
 import fr.acinq.lightning.channel.states.ChannelStateWithCommitments
 import fr.acinq.lightning.channel.states.Normal
 import fr.acinq.lightning.channel.states.WaitForFundingCreated
+import fr.acinq.lightning.db.IncomingPayment
+import fr.acinq.lightning.utils.sum
+import fr.acinq.lightning.wire.Node
 import fr.acinq.lightning.wire.PleaseOpenChannel
 import kotlinx.coroutines.CompletableDeferred
 
@@ -58,3 +61,10 @@ sealed interface SensitiveTaskEvents : NodeEvents {
 
 /** This will be emitted in a corner case where the user restores a wallet on an older version of the app, which is unable to read the channel data. */
 data object UpgradeRequired : NodeEvents
+
+sealed interface PaymentEvents : NodeEvents {
+    data class PaymentReceived(val paymentHash: ByteVector32, val receivedWith: List<IncomingPayment.ReceivedWith>) : PaymentEvents {
+        val amount: MilliSatoshi = receivedWith.map { it.amount }.sum()
+        val fees: MilliSatoshi = receivedWith.map { it.fees }.sum()
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -77,6 +77,7 @@ data class SendPayment(val paymentId: UUID, val amount: MilliSatoshi, val recipi
 data class PurgeExpiredPayments(val fromCreatedAt: Long, val toCreatedAt: Long) : PaymentCommand()
 
 sealed class PeerEvent
+@Deprecated("Replaced by NodeEvents", replaceWith = ReplaceWith("PaymentEvents.PaymentReceived", "fr.acinq.lightning.PaymentEvents"))
 data class PaymentReceived(val incomingPayment: IncomingPayment, val received: IncomingPayment.Received) : PeerEvent()
 data class PaymentProgress(val request: SendPayment, val fees: MilliSatoshi) : PeerEvent()
 data class PaymentNotSent(val request: SendPayment, val reason: OutgoingPaymentFailure) : PeerEvent()
@@ -795,6 +796,7 @@ class Peer(
                     // this was a multi-part payment, we signal that the task is finished
                     nodeParams._nodeEvents.tryEmit(SensitiveTaskEvents.TaskEnded(SensitiveTaskEvents.TaskIdentifier.IncomingMultiPartPayment(result.incomingPayment.paymentHash)))
                 }
+                @Suppress("DEPRECATION")
                 _eventsFlow.emit(PaymentReceived(result.incomingPayment, result.received))
             }
             is IncomingPaymentHandler.ProcessAddResult.Pending -> if (result.pendingPayment.parts.size == 1) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -18,6 +18,7 @@ import fr.acinq.lightning.serialization.Encryption.from
 import fr.acinq.lightning.serialization.Serialization.DeserializationResult
 import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.*
+import fr.acinq.lightning.utils.UUID.Companion.randomUUID
 import fr.acinq.lightning.wire.*
 import fr.acinq.lightning.wire.Ping
 import kotlinx.coroutines.*
@@ -80,8 +81,11 @@ sealed class PeerEvent
 @Deprecated("Replaced by NodeEvents", replaceWith = ReplaceWith("PaymentEvents.PaymentReceived", "fr.acinq.lightning.PaymentEvents"))
 data class PaymentReceived(val incomingPayment: IncomingPayment, val received: IncomingPayment.Received) : PeerEvent()
 data class PaymentProgress(val request: SendPayment, val fees: MilliSatoshi) : PeerEvent()
-data class PaymentNotSent(val request: SendPayment, val reason: OutgoingPaymentFailure) : PeerEvent()
-data class PaymentSent(val request: SendPayment, val payment: LightningOutgoingPayment) : PeerEvent()
+sealed class SendPaymentResult : PeerEvent() {
+    abstract val request: SendPayment
+}
+data class PaymentNotSent(override val request: SendPayment, val reason: OutgoingPaymentFailure) : SendPaymentResult()
+data class PaymentSent(override val request: SendPayment, val payment: LightningOutgoingPayment) : SendPaymentResult()
 data class ChannelClosing(val channelId: ByteVector32) : PeerEvent()
 
 /**
@@ -602,6 +606,20 @@ class Peer(
                 send(WrappedChannelCommand(channel.channelId, spliceCommand))
                 spliceCommand.replyTo.await()
             }
+    }
+
+    suspend fun sendLightning(amount: MilliSatoshi, paymentRequest: Bolt11Invoice): SendPaymentResult {
+        val res = CompletableDeferred<SendPaymentResult>()
+        val paymentId = randomUUID()
+        this.launch {
+            res.complete(eventsFlow
+                .filterIsInstance<SendPaymentResult>()
+                .filter { it.request.paymentId == paymentId }
+                .first()
+            )
+        }
+        send(SendPayment(paymentId, amount, paymentRequest.nodeId, paymentRequest))
+        return res.await()
     }
 
     suspend fun createInvoice(paymentPreimage: ByteVector32, amount: MilliSatoshi?, description: Either<String, ByteVector32>, expirySeconds: Long? = null): Bolt11Invoice {


### PR DESCRIPTION
Commits are independent.

Define a `NodeEvent.PaymentReceived` that aims to replace the eponym class in the `Peer` (which is marked as deprecated, but otherwise left untouched). The previous impl wasn't emitted for pay-to-open parts.

Also define a "synchronous' `sendLightning` method similar to other peer methods.