### PR TITLE
Basic implementation of fee credit + auto liquidity

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -29,15 +29,22 @@ sealed interface LiquidityEvents : NodeEvents {
     val source: Source
 
     enum class Source { OnChainWallet, OffChainPayment }
-    data class Rejected(override val amount: MilliSatoshi, override val fee: MilliSatoshi, override val source: Source, val reason: Reason) : LiquidityEvents {
-        sealed class Reason {
-            data object PolicySetToDisabled : Reason()
-            sealed class TooExpensive : Reason() {
-                data class OverAbsoluteFee(val maxAbsoluteFee: Satoshi) : TooExpensive()
-                data class OverRelativeFee(val maxRelativeFeeBasisPoints: Int) : TooExpensive()
+
+    sealed interface Decision : LiquidityEvents {
+        data class Rejected(override val amount: MilliSatoshi, override val fee: MilliSatoshi, override val source: Source, val reason: Reason) : Decision {
+            sealed class Reason {
+                data object PolicySetToDisabled : Reason()
+                sealed class TooExpensive : Reason() {
+                    data class OverAbsoluteFee(val maxAbsoluteFee: Satoshi) : TooExpensive()
+                    data class OverRelativeFee(val maxRelativeFeeBasisPoints: Int) : TooExpensive()
+                }
+                data class OverMaxCredit(val maxAllowedCredit: Satoshi) : TooExpensive()
+
+                data object ChannelInitializing : Reason()
             }
-            data object ChannelInitializing : Reason()
         }
+        data class AddedToFeeCredit(override val amount: MilliSatoshi, override val fee: MilliSatoshi, override val source: Source) : Decision
+        data class Accepted(override val amount: MilliSatoshi, override val fee: MilliSatoshi, override val source: Source) : Decision
     }
 
     data class ApprovalRequested(override val amount: MilliSatoshi, override val fee: MilliSatoshi, override val source: Source, val replyTo: CompletableDeferred<Boolean>) : LiquidityEvents

--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -13,10 +13,7 @@ import fr.acinq.lightning.payment.LiquidityPolicy
 import fr.acinq.lightning.utils.msat
 import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.utils.toMilliSatoshi
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.*
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -155,6 +152,9 @@ data class NodeParams(
     internal val _nodeEvents = MutableSharedFlow<NodeEvents>()
     val nodeEvents: SharedFlow<NodeEvents> get() = _nodeEvents.asSharedFlow()
 
+    internal val _feeCredit = MutableStateFlow<Satoshi>(0.sat)
+    val feeCredit: StateFlow<Satoshi> get() = _feeCredit.asStateFlow()
+
     init {
         require(features.hasFeature(Feature.VariableLengthOnion, FeatureSupport.Mandatory)) { "${Feature.VariableLengthOnion.rfcName} should be mandatory" }
         require(features.hasFeature(Feature.PaymentSecret, FeatureSupport.Mandatory)) { "${Feature.PaymentSecret.rfcName} should be mandatory" }
@@ -219,6 +219,13 @@ data class NodeParams(
         maxPaymentAttempts = 5,
         zeroConfPeers = emptySet(),
         paymentRecipientExpiryParams = RecipientCltvExpiryParams(CltvExpiryDelta(75), CltvExpiryDelta(200)),
-        liquidityPolicy = MutableStateFlow<LiquidityPolicy>(LiquidityPolicy.Auto(maxAbsoluteFee = 2_000.sat, maxRelativeFeeBasisPoints = 3_000 /* 3000 = 30 % */, skipAbsoluteFeeCheck = false))
+        liquidityPolicy = MutableStateFlow<LiquidityPolicy>(
+            LiquidityPolicy.Auto(
+                maxAbsoluteFee = 2_000.sat,
+                maxRelativeFeeBasisPoints = 3_000 /* 3000 = 30 % */,
+                skipAbsoluteFeeCheck = false,
+                maxAllowedCredit = 0.sat
+            )
+        )
     )
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -180,6 +180,10 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
             override val fees: MilliSatoshi = 0.msat // with Lightning, the fee is paid by the sender
         }
 
+        data class FeeCreditPayment(override val amount: MilliSatoshi) : ReceivedWith() {
+            override val fees: MilliSatoshi get() = 0.msat // there are no fees when payment is added to the fee credit
+        }
+
         sealed class OnChainIncomingPayment : ReceivedWith() {
             abstract val serviceFee: MilliSatoshi
             abstract val miningFee: Satoshi

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -12,7 +12,9 @@ import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.channel.states.*
 import fr.acinq.lightning.crypto.noise.*
 import fr.acinq.lightning.db.*
-import fr.acinq.lightning.logging.*
+import fr.acinq.lightning.logging.MDCLogger
+import fr.acinq.lightning.logging.mdc
+import fr.acinq.lightning.logging.withMDC
 import fr.acinq.lightning.payment.*
 import fr.acinq.lightning.serialization.Encryption.from
 import fr.acinq.lightning.serialization.Serialization.DeserializationResult
@@ -635,6 +637,11 @@ class Peer(
         peerConnection?.send(message)
     }
 
+    fun setAutoLiquidityParams(amount: Satoshi) {
+        logger.info { "setting auto-liquidity=$amount" }
+        peerConnection?.send(AutoLiquidityParams(amount))
+    }
+
     private suspend fun processActions(channelId: ByteVector32, peerConnection: PeerConnection?, actions: List<ChannelAction>) {
         // we peek into the actions to see if the id of the channel is going to change, but we're not processing it yet
         val actualChannelId = actions.filterIsInstance<ChannelAction.ChannelId.IdAssigned>().firstOrNull()?.channelId ?: channelId
@@ -914,12 +921,16 @@ class Peer(
                                 is Origin.PleaseOpenChannelOrigin -> when (val request = channelRequests[origin.requestId]) {
                                     is RequestChannelOpen -> {
                                         val totalFee = origin.serviceFee + origin.miningFee.toMilliSatoshi() - msg.pushAmount
-                                        nodeParams.liquidityPolicy.value.maybeReject(request.walletInputs.balance.toMilliSatoshi(), totalFee, LiquidityEvents.Source.OnChainWallet, logger)?.let { rejected ->
-                                            logger.info { "rejecting open_channel2: reason=${rejected.reason}" }
-                                            nodeParams._nodeEvents.emit(rejected)
-                                            swapInCommands.send(SwapInCommand.UnlockWalletInputs(request.walletInputs.map { it.outPoint }.toSet()))
-                                            peerConnection?.send(Error(msg.temporaryChannelId, "cancelling open due to local liquidity policy"))
-                                            return
+                                        val decision = nodeParams.liquidityPolicy.value.maybeReject(request.walletInputs.balance.toMilliSatoshi(), totalFee, LiquidityEvents.Source.OnChainWallet, logger, nodeParams.feeCredit.value)
+                                        when (decision) {
+                                            is LiquidityEvents.Decision.Rejected -> {
+                                                logger.info { "rejecting open_channel2: reason=${decision.reason}" }
+                                                nodeParams._nodeEvents.emit(decision)
+                                                swapInCommands.send(SwapInCommand.UnlockWalletInputs(request.walletInputs.map { it.outPoint }.toSet()))
+                                                peerConnection?.send(Error(msg.temporaryChannelId, "cancelling open due to local liquidity policy"))
+                                                return
+                                            }
+                                            else -> {}
                                         }
                                         val fundingFee = Transactions.weight2fee(msg.fundingFeerate, FundingContributions.weight(request.walletInputs))
                                         // We have to pay the fees for our inputs, so we deduce them from our funding amount.
@@ -1056,7 +1067,7 @@ class Peer(
                                 && !_channels.values.any { it is Normal } // we don't have a channel that can be spliced
                                 && _channels.values.any { it is WaitForFundingSigned || it is WaitForFundingConfirmed || it is WaitForChannelReady } // but we will have one soon
                         if (channelInitializing) {
-                            val rejected = LiquidityEvents.Rejected(msg.amountMsat, msg.payToOpenFeeSatoshis.toMilliSatoshi(), LiquidityEvents.Source.OffChainPayment, LiquidityEvents.Rejected.Reason.ChannelInitializing)
+                            val rejected = LiquidityEvents.Decision.Rejected(msg.amountMsat, msg.payToOpenFeeSatoshis.toMilliSatoshi(), LiquidityEvents.Source.OffChainPayment, LiquidityEvents.Decision.Rejected.Reason.ChannelInitializing)
                             logger.info { "rejecting pay-to-open: reason=${rejected.reason}" }
                             nodeParams._nodeEvents.emit(rejected)
                             val action = IncomingPaymentHandler.actionForPayToOpenFailure(nodeParams.nodePrivateKey, TemporaryNodeFailure, msg)
@@ -1072,6 +1083,10 @@ class Peer(
                     is OnionMessage -> {
                         logger.info { "received ${msg::class.simpleName}" }
                         // TODO: process onion message
+                    }
+                    is CurrentFeeCredit -> {
+                        logger.info { "current fee credit: ${msg.amount}" }
+                        nodeParams._feeCredit.emit(msg.amount)
                     }
                 }
             }
@@ -1095,11 +1110,15 @@ class Peer(
                         val (feerate, fee) = watcher.client.computeSpliceCpfpFeerate(channel.commitments, targetFeerate, spliceWeight = weight, logger)
 
                         logger.info { "requesting splice-in using balance=${cmd.walletInputs.balance} feerate=$feerate fee=$fee" }
-                        nodeParams.liquidityPolicy.value.maybeReject(cmd.walletInputs.balance.toMilliSatoshi(), fee.toMilliSatoshi(), LiquidityEvents.Source.OnChainWallet, logger)?.let { rejected ->
-                            logger.info { "rejecting splice: reason=${rejected.reason}" }
-                            nodeParams._nodeEvents.emit(rejected)
-                            swapInCommands.send(SwapInCommand.UnlockWalletInputs(cmd.walletInputs.map { it.outPoint }.toSet()))
-                            return
+                        val decision = nodeParams.liquidityPolicy.value.maybeReject(cmd.walletInputs.balance.toMilliSatoshi(), fee.toMilliSatoshi(), LiquidityEvents.Source.OnChainWallet, logger, nodeParams.feeCredit.value)
+                        nodeParams._nodeEvents.emit(decision)
+                        when (decision) {
+                            is LiquidityEvents.Decision.Rejected -> {
+                                logger.info { "rejecting splice: reason=${decision.reason}" }
+                                swapInCommands.send(SwapInCommand.UnlockWalletInputs(cmd.walletInputs.map { it.outPoint }.toSet()))
+                                return
+                            }
+                            else -> {}
                         }
 
                         val spliceCommand = ChannelCommand.Commitment.Splice.Request(

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/LiquidityPolicy.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/LiquidityPolicy.kt
@@ -3,8 +3,9 @@ package fr.acinq.lightning.payment
 import fr.acinq.bitcoin.Satoshi
 import fr.acinq.lightning.LiquidityEvents
 import fr.acinq.lightning.MilliSatoshi
-import fr.acinq.lightning.logging.*
+import fr.acinq.lightning.logging.MDCLogger
 import fr.acinq.lightning.utils.msat
+import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.utils.toMilliSatoshi
 
 
@@ -17,24 +18,38 @@ sealed class LiquidityPolicy {
      * @param maxAbsoluteFee max absolute fee
      * @param maxRelativeFeeBasisPoints max relative fee (all included: service fee and mining fee) (1_000 bips = 10 %)
      * @param skipAbsoluteFeeCheck only applies for off-chain payments, being more lax may make sense when the sender doesn't retry payments
+     * @param maxAllowedCredit if other checks fail, accept the payment and add the corresponding amount to fee credit up to this max value (only applies to offline payments, 0 sat to disable)
      */
-    data class Auto(val maxAbsoluteFee: Satoshi, val maxRelativeFeeBasisPoints: Int, val skipAbsoluteFeeCheck: Boolean) : LiquidityPolicy()
+    data class Auto(val maxAbsoluteFee: Satoshi, val maxRelativeFeeBasisPoints: Int, val skipAbsoluteFeeCheck: Boolean, val maxAllowedCredit: Satoshi) : LiquidityPolicy()
 
     /** Make decision for a particular liquidity event */
-    fun maybeReject(amount: MilliSatoshi, fee: MilliSatoshi, source: LiquidityEvents.Source, logger: MDCLogger): LiquidityEvents.Rejected? {
+    fun maybeReject(amount: MilliSatoshi, fee: MilliSatoshi, source: LiquidityEvents.Source, logger: MDCLogger, currentFeeCredit: Satoshi): LiquidityEvents.Decision {
         return when (this) {
-            is Disable -> LiquidityEvents.Rejected.Reason.PolicySetToDisabled
+            is Disable -> LiquidityEvents.Decision.Rejected(amount, fee, source, LiquidityEvents.Decision.Rejected.Reason.PolicySetToDisabled)
             is Auto -> {
                 val maxAbsoluteFee = if (skipAbsoluteFeeCheck && source == LiquidityEvents.Source.OffChainPayment) Long.MAX_VALUE.msat else this.maxAbsoluteFee.toMilliSatoshi()
-                val maxRelativeFee = amount * maxRelativeFeeBasisPoints / 10_000
-                logger.info { "liquidity policy check: fee=$fee maxAbsoluteFee=$maxAbsoluteFee maxRelativeFee=$maxRelativeFee policy=$this" }
-                if (fee > maxRelativeFee) {
-                    LiquidityEvents.Rejected.Reason.TooExpensive.OverRelativeFee(maxRelativeFeeBasisPoints)
-                } else if (fee > maxAbsoluteFee) {
-                    LiquidityEvents.Rejected.Reason.TooExpensive.OverAbsoluteFee(this.maxAbsoluteFee)
-                } else null
+                if (maxAllowedCredit == 0.sat || source == LiquidityEvents.Source.OnChainWallet) {
+                    val maxRelativeFee = amount * maxRelativeFeeBasisPoints / 10_000
+                    logger.info { "auto liquidity policy check: amount=$amount fee=$fee maxAbsoluteFee=$maxAbsoluteFee maxRelativeFee=$maxRelativeFee policy=$this" }
+                    if (fee > maxRelativeFee) {
+                        LiquidityEvents.Decision.Rejected(amount, fee, source, LiquidityEvents.Decision.Rejected.Reason.TooExpensive.OverRelativeFee(maxRelativeFeeBasisPoints))
+                    } else if (fee > maxAbsoluteFee) {
+                        LiquidityEvents.Decision.Rejected(amount, fee, source, LiquidityEvents.Decision.Rejected.Reason.TooExpensive.OverAbsoluteFee(this.maxAbsoluteFee))
+                    } else LiquidityEvents.Decision.Accepted(amount, fee, source)
+                } else {
+                    logger.info { "fee-credit liquidity policy check: amount=$amount fee=$fee maxAbsoluteFee=$maxAbsoluteFee currentFeeCredit=$currentFeeCredit maxAllowedCredit=$maxAllowedCredit policy=$this" }
+                    // NB: we do check the max absolute fee, but will never raise an explicit error for it, because the payment will either be added to fee credit or rejected due to exceeding the
+                    // max allowed credit
+                    if (fee <= maxAbsoluteFee && fee < (amount + currentFeeCredit.toMilliSatoshi())) {
+                        LiquidityEvents.Decision.Accepted(amount, fee, source)
+                    } else if ((amount + currentFeeCredit.toMilliSatoshi()) > maxAllowedCredit.toMilliSatoshi()) {
+                        LiquidityEvents.Decision.Rejected(amount, fee, source, LiquidityEvents.Decision.Rejected.Reason.OverMaxCredit(maxAllowedCredit))
+                    } else {
+                        LiquidityEvents.Decision.AddedToFeeCredit(amount, fee, source)
+                    }
+                }
             }
-        }?.let { reason -> LiquidityEvents.Rejected(amount, fee, source, reason) }
+        }
     }
 
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -240,9 +240,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val (paymentHandler, _, _) = createFixture(defaultAmount)
         val payToOpenRequest = PayToOpenRequest(
             chainHash = BlockHash(ByteVector32.Zeroes),
-            fundingSatoshis = 100_000.sat,
             amountMsat = defaultAmount,
-            payToOpenMinAmountMsat = 1_000_000.msat,
             payToOpenFeeSatoshis = 100.sat,
             paymentHash = ByteVector32.One, // <-- not associated to a pending invoice
             expireAt = Long.MAX_VALUE,
@@ -332,9 +330,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         )
         val payToOpenRequest = PayToOpenRequest(
             chainHash = BlockHash(ByteVector32.Zeroes),
-            fundingSatoshis = 100_000.sat,
             amountMsat = defaultAmount,
-            payToOpenMinAmountMsat = 1_000_000.msat,
             payToOpenFeeSatoshis = 100.sat,
             paymentHash = incomingPayment.paymentHash,
             expireAt = Long.MAX_VALUE,
@@ -1208,9 +1204,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         private fun makePayToOpenRequest(incomingPayment: IncomingPayment, finalPayload: PaymentOnion.FinalPayload): PayToOpenRequest {
             return PayToOpenRequest(
                 chainHash = Block.RegtestGenesisBlock.hash,
-                fundingSatoshis = 100_000.sat,
                 amountMsat = finalPayload.amount,
-                payToOpenMinAmountMsat = 10_000.msat,
                 payToOpenFeeSatoshis = finalPayload.amount.truncateToSatoshi() * payToOpenFeerate, // 10%
                 paymentHash = incomingPayment.paymentHash,
                 expireAt = Long.MAX_VALUE,

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/LiquidityPolicyTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/LiquidityPolicyTestsCommon.kt
@@ -1,7 +1,7 @@
 package fr.acinq.lightning.payment
 
 import fr.acinq.lightning.LiquidityEvents
-import fr.acinq.lightning.logging.*
+import fr.acinq.lightning.logging.MDCLogger
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.utils.msat
 import fr.acinq.lightning.utils.sat
@@ -16,42 +16,46 @@ class LiquidityPolicyTestsCommon : LightningTestSuite() {
     @Test
     fun `policy rejection`() {
 
-        val policy = LiquidityPolicy.Auto(maxAbsoluteFee = 2_000.sat, maxRelativeFeeBasisPoints = 3_000 /* 3000 = 30 % */, skipAbsoluteFeeCheck = false)
+        val policy = LiquidityPolicy.Auto(maxAbsoluteFee = 2_000.sat, maxRelativeFeeBasisPoints = 3_000 /* 3000 = 30 % */, skipAbsoluteFeeCheck = false, maxAllowedCredit = 0.sat)
 
         // fee over both absolute and relative
         assertEquals(
-            expected = LiquidityEvents.Rejected.Reason.TooExpensive.OverRelativeFee(policy.maxRelativeFeeBasisPoints),
-            actual = policy.maybeReject(amount = 4_000_000.msat, fee = 3_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger)?.reason
+            expected = LiquidityEvents.Decision.Rejected.Reason.TooExpensive.OverRelativeFee(policy.maxRelativeFeeBasisPoints),
+            actual = (policy.maybeReject(amount = 4_000_000.msat, fee = 3_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger, currentFeeCredit = 0.sat) as? LiquidityEvents.Decision.Rejected)?.reason
         )
 
         // fee over absolute
         assertEquals(
-            expected = LiquidityEvents.Rejected.Reason.TooExpensive.OverAbsoluteFee(policy.maxAbsoluteFee),
-            actual = policy.maybeReject(amount = 15_000_000.msat, fee = 3_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger)?.reason
+            expected = LiquidityEvents.Decision.Rejected.Reason.TooExpensive.OverAbsoluteFee(policy.maxAbsoluteFee),
+            actual = (policy.maybeReject(amount = 15_000_000.msat, fee = 3_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger, currentFeeCredit = 0.sat) as? LiquidityEvents.Decision.Rejected)?.reason
         )
 
         // fee over relative
         assertEquals(
-            expected = LiquidityEvents.Rejected.Reason.TooExpensive.OverRelativeFee(policy.maxRelativeFeeBasisPoints),
-            actual = policy.maybeReject(amount = 4_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger)?.reason
+            expected = LiquidityEvents.Decision.Rejected.Reason.TooExpensive.OverRelativeFee(policy.maxRelativeFeeBasisPoints),
+            actual = (policy.maybeReject(amount = 4_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger, currentFeeCredit = 0.sat) as? LiquidityEvents.Decision.Rejected)?.reason
         )
 
-        assertNull(policy.maybeReject(amount = 10_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger))
+        assertEquals(
+            expected = LiquidityEvents.Decision.Accepted(amount = 10_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment),
+            actual = policy.maybeReject(amount = 10_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger, currentFeeCredit = 0.sat))
 
     }
 
     @Test
     fun `policy rejection skip absolute check`() {
 
-        val policy = LiquidityPolicy.Auto(maxAbsoluteFee = 1_000.sat, maxRelativeFeeBasisPoints = 5_000 /* 3000 = 30 % */, skipAbsoluteFeeCheck = true)
+        val policy = LiquidityPolicy.Auto(maxAbsoluteFee = 1_000.sat, maxRelativeFeeBasisPoints = 5_000 /* 3000 = 30 % */, skipAbsoluteFeeCheck = true, maxAllowedCredit = 0.sat)
 
         // fee is over absolute, and it's an offchain payment so the check passes
-        assertNull(policy.maybeReject(amount = 4_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger))
+        assertEquals(
+            expected = LiquidityEvents.Decision.Accepted(amount = 4_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment),
+            actual = policy.maybeReject(amount = 4_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OffChainPayment, logger, currentFeeCredit = 0.sat))
 
         // fee is over absolute, but it's an on-chain payment so the check fails
         assertEquals(
-            expected = LiquidityEvents.Rejected.Reason.TooExpensive.OverAbsoluteFee(policy.maxAbsoluteFee),
-            actual = policy.maybeReject(amount = 4_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OnChainWallet, logger)?.reason
+            expected = LiquidityEvents.Decision.Rejected.Reason.TooExpensive.OverAbsoluteFee(policy.maxAbsoluteFee),
+            actual = (policy.maybeReject(amount = 4_000_000.msat, fee = 2_000_000.msat, source = LiquidityEvents.Source.OnChainWallet, logger, currentFeeCredit = 0.sat) as? LiquidityEvents.Decision.Rejected)?.reason
         )
 
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -753,7 +753,7 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
     @Test
     fun `encode - decode pay-to-open messages`() {
         val testCases = listOf(
-            PayToOpenRequest(BlockHash(randomBytes32()), 10_000.sat, 5_000.msat, 100.msat, 10.sat, randomBytes32(), 100, OnionRoutingPacket(0, randomKey().publicKey().value, ByteVector("0102030405"), randomBytes32())),
+            PayToOpenRequest(BlockHash(randomBytes32()), 5_000.msat, 10.sat, randomBytes32(), 100, OnionRoutingPacket(0, randomKey().publicKey().value, ByteVector("0102030405"), randomBytes32())),
             PayToOpenResponse(BlockHash(randomBytes32()), randomBytes32(), PayToOpenResponse.Result.Success(randomBytes32())),
             PayToOpenResponse(BlockHash(randomBytes32()), randomBytes32(), PayToOpenResponse.Result.Failure(null)),
             PayToOpenResponse(BlockHash(randomBytes32()), randomBytes32(), PayToOpenResponse.Result.Failure(ByteVector("deadbeef"))),


### PR DESCRIPTION
This is a basic prototype for:
- fee-credit: instead of rejecting a pay-to-open request that is too expensive (in absolute or relative terms), add the option to put the amount aside to pay for future mining/service fees.
- auto-liquidity: inform the peer that we would like additional liquidity during the next splice operation.

We also take the opportunity to do some clean-up in the `PayToOpenRequest` class by ignoring unused fields.