### PR TITLE
Rework channel reestablish

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelException.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelException.kt
@@ -84,7 +84,6 @@ data class CannotSignWithoutChanges                (override val channelId: Byte
 data class CannotSignBeforeRevocation              (override val channelId: ByteVector32) : ChannelException(channelId, "cannot sign until next revocation hash is received")
 data class UnexpectedRevocation                    (override val channelId: ByteVector32) : ChannelException(channelId, "received unexpected RevokeAndAck message")
 data class InvalidRevocation                       (override val channelId: ByteVector32) : ChannelException(channelId, "invalid revocation")
-data class RevocationSyncError                     (override val channelId: ByteVector32) : ChannelException(channelId, "revocation sync error")
 data class InvalidFailureCode                      (override val channelId: ByteVector32) : ChannelException(channelId, "UpdateFailMalformedHtlc message doesn't have BADONION bit set")
 data class PleasePublishYourCommitment             (override val channelId: ByteVector32) : ChannelException(channelId, "please publish your local commitment")
 data class CommandUnavailableInThisState           (override val channelId: ByteVector32, val state: String) : ChannelException(channelId, "cannot execute command in state=$state")

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -200,8 +200,8 @@ object Helpers {
      *         - false if we are behind
      */
     fun checkRemoteCommit(commitments: Commitments, nextLocalCommitmentNumber: Long): Boolean {
-        return when {
-            commitments.remoteNextCommitInfo.isLeft ->
+        return when (commitments.remoteNextCommitInfo) {
+            is Either.Left ->
                 when {
                     // we just sent a new commit_sig but they didn't receive it
                     nextLocalCommitmentNumber == commitments.nextRemoteCommitIndex -> true
@@ -211,7 +211,7 @@ object Helpers {
                     nextLocalCommitmentNumber < commitments.nextRemoteCommitIndex -> true
                     else -> false
                 }
-            commitments.remoteNextCommitInfo.isRight ->
+            is Either.Right ->
                 when {
                     // they have acknowledged the last commit_sig we sent
                     nextLocalCommitmentNumber == (commitments.remoteCommitIndex + 1) -> true
@@ -219,7 +219,6 @@ object Helpers {
                     nextLocalCommitmentNumber < (commitments.remoteCommitIndex + 1) -> true
                     else -> false
                 }
-            else -> false
         }
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -172,56 +172,6 @@ object Helpers {
         toRemote > it.localChannelReserve(commitments.params)
     }
 
-    /**
-     * Tells whether or not their expected next remote commitment number matches with our data
-     *
-     * @return
-     *         - true if parties are in sync or remote is behind
-     *         - false if we are behind
-     */
-    fun checkLocalCommit(commitments: Commitments, nextRemoteRevocationNumber: Long): Boolean {
-        return when {
-            // they just sent a new commit_sig, we have received it but they didn't receive our revocation
-            commitments.localCommitIndex == nextRemoteRevocationNumber -> true
-            // we are in sync
-            commitments.localCommitIndex == nextRemoteRevocationNumber + 1 -> true
-            // remote is behind: we return true because things are fine on our side
-            commitments.localCommitIndex > nextRemoteRevocationNumber + 1 -> true
-            // we are behind
-            else -> false
-        }
-    }
-
-    /**
-     * Tells whether or not their expected next local commitment number matches with our data
-     *
-     * @return
-     *         - true if parties are in sync or remote is behind
-     *         - false if we are behind
-     */
-    fun checkRemoteCommit(commitments: Commitments, nextLocalCommitmentNumber: Long): Boolean {
-        return when (commitments.remoteNextCommitInfo) {
-            is Either.Left ->
-                when {
-                    // we just sent a new commit_sig but they didn't receive it
-                    nextLocalCommitmentNumber == commitments.nextRemoteCommitIndex -> true
-                    // we just sent a new commit_sig, they have received it but we haven't received their revocation
-                    nextLocalCommitmentNumber == (commitments.nextRemoteCommitIndex + 1) -> true
-                    // they are behind
-                    nextLocalCommitmentNumber < commitments.nextRemoteCommitIndex -> true
-                    else -> false
-                }
-            is Either.Right ->
-                when {
-                    // they have acknowledged the last commit_sig we sent
-                    nextLocalCommitmentNumber == (commitments.remoteCommitIndex + 1) -> true
-                    // they are behind
-                    nextLocalCommitmentNumber < (commitments.remoteCommitIndex + 1) -> true
-                    else -> false
-                }
-        }
-    }
-
     /** This helper method will publish txs only if they haven't yet reached minDepth. */
     fun LoggingContext.publishIfNeeded(txs: List<ChannelAction.Blockchain.PublishTx>, irrevocablySpent: Map<OutPoint, Transaction>): List<ChannelAction.Blockchain.PublishTx> {
         val (skip, process) = txs.partition { it.tx.inputsAlreadySpent(irrevocablySpent) }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -115,109 +115,114 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
                             Pair(state, actions)
                         }
                         is Normal -> {
-                            try {
-                                when (val syncResult = checkSync(state, cmd.message)) {
-                                    is SyncResult.Failure -> handleSyncFailure(cmd.message, syncResult, state.commitments)
-                                    is SyncResult.Success -> {
-                                        // normal case, our data is up-to-date
-                                        val actions = ArrayList<ChannelAction>()
+                            when (val syncResult = handleSync(state.commitments, cmd.message)) {
+                                is SyncResult.Failure -> handleSyncFailure(state.commitments, cmd.message, syncResult)
+                                is SyncResult.Success -> {
+                                    // normal case, our data is up-to-date
+                                    val actions = ArrayList<ChannelAction>()
 
-                                        // re-send channel_ready if necessary
-                                        if (state.commitments.latest.fundingTxIndex == 0L && cmd.message.nextLocalCommitmentNumber == 1L && state.commitments.localCommitIndex == 0L) {
-                                            // If next_local_commitment_number is 1 in both the channel_reestablish it sent and received, then the node MUST retransmit channel_ready, otherwise it MUST NOT
-                                            logger.debug { "re-sending channel_ready" }
-                                            val nextPerCommitmentPoint = channelKeys().commitmentPoint(1)
-                                            val channelReady = ChannelReady(state.commitments.channelId, nextPerCommitmentPoint)
-                                            actions.add(ChannelAction.Message.Send(channelReady))
-                                        }
-
-                                        // resume splice signing session if any
-                                        val spliceStatus1 = if (state.spliceStatus is SpliceStatus.WaitingForSigs && state.spliceStatus.session.fundingTx.txId == cmd.message.nextFundingTxId) {
-                                            // We retransmit our commit_sig, and will send our tx_signatures once we've received their commit_sig.
-                                            logger.info { "re-sending commit_sig for splice attempt with fundingTxIndex=${state.spliceStatus.session.fundingTxIndex} fundingTxId=${state.spliceStatus.session.fundingTx.txId}" }
-                                            val commitSig = state.spliceStatus.session.remoteCommit.sign(channelKeys(), state.commitments.params, state.spliceStatus.session)
-                                            actions.add(ChannelAction.Message.Send(commitSig))
-                                            state.spliceStatus
-                                        } else if (state.commitments.latest.fundingTxId == cmd.message.nextFundingTxId) {
-                                            when (val localFundingStatus = state.commitments.latest.localFundingStatus) {
-                                                is LocalFundingStatus.UnconfirmedFundingTx -> {
-                                                    if (localFundingStatus.sharedTx is PartiallySignedSharedTransaction) {
-                                                        // If we have not received their tx_signatures, we can't tell whether they had received our commit_sig, so we need to retransmit it
-                                                        logger.info { "re-sending commit_sig for fundingTxIndex=${state.commitments.latest.fundingTxIndex} fundingTxId=${state.commitments.latest.fundingTxId}" }
-                                                        val commitSig = state.commitments.latest.remoteCommit.sign(
-                                                            channelKeys(),
-                                                            state.commitments.params,
-                                                            fundingTxIndex = state.commitments.latest.fundingTxIndex,
-                                                            state.commitments.latest.remoteFundingPubkey,
-                                                            state.commitments.latest.commitInput
-                                                        )
-                                                        actions.add(ChannelAction.Message.Send(commitSig))
-                                                    }
-                                                    logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
-                                                    actions.add(ChannelAction.Message.Send(localFundingStatus.sharedTx.localSigs))
-                                                }
-                                                is LocalFundingStatus.ConfirmedFundingTx -> {
-                                                    // The funding tx is confirmed, and they have not received our tx_signatures, but they must have received our commit_sig, otherwise they
-                                                    // would not have sent their tx_signatures and we would not have been able to publish the funding tx in the first place.
-                                                    logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
-                                                    actions.add(ChannelAction.Message.Send(localFundingStatus.localSigs))
-                                                }
-                                            }
-                                            state.spliceStatus
-                                        } else if (cmd.message.nextFundingTxId != null) {
-                                            // The fundingTxId must be for a splice attempt that we didn't store (we got disconnected before receiving their tx_complete)
-                                            logger.info { "aborting obsolete splice attempt for fundingTxId=${cmd.message.nextFundingTxId}" }
-                                            actions.add(ChannelAction.Message.Send(TxAbort(state.channelId, SpliceAborted(state.channelId).message)))
-                                            SpliceStatus.Aborted
-                                        } else {
-                                            state.spliceStatus
-                                        }
-
-                                        // Re-send splice_locked (must come *after* potentially retransmitting tx_signatures).
-                                        // NB: there is a key difference between channel_ready and splice_locked:
-                                        // - channel_ready: a non-zero commitment index implies that both sides have seen the channel_ready
-                                        // - splice_locked: the commitment index can be updated as long as it is compatible with all splices, so
-                                        //   we must keep sending our most recent splice_locked at each reconnection
-                                        state.commitments.active
-                                            .filter { it.fundingTxIndex > 0L } // only consider splice txs
-                                            .firstOrNull { staticParams.useZeroConf || it.localFundingStatus is LocalFundingStatus.ConfirmedFundingTx }
-                                            ?.let {
-                                                logger.debug { "re-sending splice_locked for fundingTxId=${it.fundingTxId}" }
-                                                val spliceLocked = SpliceLocked(channelId, it.fundingTxId)
-                                                actions.add(ChannelAction.Message.Send(spliceLocked))
-                                            }
-
-                                        val commitments1 = syncResult.commitments
-                                        actions.addAll(syncResult.actions)
-                                        // BOLT 2: A node if it has sent a previous shutdown MUST retransmit shutdown.
-                                        state.localShutdown?.let {
-                                            logger.debug { "re-sending local shutdown" }
-                                            actions.add(ChannelAction.Message.Send(it))
-                                        }
-                                        Pair(state.copy(commitments = commitments1, spliceStatus = spliceStatus1), actions)
+                                    // re-send channel_ready if necessary
+                                    if (state.commitments.latest.fundingTxIndex == 0L && cmd.message.nextLocalCommitmentNumber == 1L && state.commitments.localCommitIndex == 0L) {
+                                        // If next_local_commitment_number is 1 in both the channel_reestablish it sent and received, then the node MUST retransmit channel_ready, otherwise it MUST NOT
+                                        logger.debug { "re-sending channel_ready" }
+                                        val nextPerCommitmentPoint = channelKeys().commitmentPoint(1)
+                                        val channelReady = ChannelReady(state.commitments.channelId, nextPerCommitmentPoint)
+                                        actions.add(ChannelAction.Message.Send(channelReady))
                                     }
+
+                                    // resume splice signing session if any
+                                    val spliceStatus1 = if (state.spliceStatus is SpliceStatus.WaitingForSigs && state.spliceStatus.session.fundingTx.txId == cmd.message.nextFundingTxId) {
+                                        // We retransmit our commit_sig, and will send our tx_signatures once we've received their commit_sig.
+                                        logger.info { "re-sending commit_sig for splice attempt with fundingTxIndex=${state.spliceStatus.session.fundingTxIndex} fundingTxId=${state.spliceStatus.session.fundingTx.txId}" }
+                                        val commitSig = state.spliceStatus.session.remoteCommit.sign(channelKeys(), state.commitments.params, state.spliceStatus.session)
+                                        actions.add(ChannelAction.Message.Send(commitSig))
+                                        state.spliceStatus
+                                    } else if (state.commitments.latest.fundingTxId == cmd.message.nextFundingTxId) {
+                                        when (val localFundingStatus = state.commitments.latest.localFundingStatus) {
+                                            is LocalFundingStatus.UnconfirmedFundingTx -> {
+                                                if (localFundingStatus.sharedTx is PartiallySignedSharedTransaction) {
+                                                    // If we have not received their tx_signatures, we can't tell whether they had received our commit_sig, so we need to retransmit it
+                                                    logger.info { "re-sending commit_sig for fundingTxIndex=${state.commitments.latest.fundingTxIndex} fundingTxId=${state.commitments.latest.fundingTxId}" }
+                                                    val commitSig = state.commitments.latest.remoteCommit.sign(
+                                                        channelKeys(),
+                                                        state.commitments.params,
+                                                        fundingTxIndex = state.commitments.latest.fundingTxIndex,
+                                                        state.commitments.latest.remoteFundingPubkey,
+                                                        state.commitments.latest.commitInput
+                                                    )
+                                                    actions.add(ChannelAction.Message.Send(commitSig))
+                                                }
+                                                logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
+                                                actions.add(ChannelAction.Message.Send(localFundingStatus.sharedTx.localSigs))
+                                            }
+                                            is LocalFundingStatus.ConfirmedFundingTx -> {
+                                                // The funding tx is confirmed, and they have not received our tx_signatures, but they must have received our commit_sig, otherwise they
+                                                // would not have sent their tx_signatures and we would not have been able to publish the funding tx in the first place.
+                                                logger.info { "re-sending tx_signatures for fundingTxId=${cmd.message.nextFundingTxId}" }
+                                                actions.add(ChannelAction.Message.Send(localFundingStatus.localSigs))
+                                            }
+                                        }
+                                        state.spliceStatus
+                                    } else if (cmd.message.nextFundingTxId != null) {
+                                        // The fundingTxId must be for a splice attempt that we didn't store (we got disconnected before receiving their tx_complete)
+                                        logger.info { "aborting obsolete splice attempt for fundingTxId=${cmd.message.nextFundingTxId}" }
+                                        actions.add(ChannelAction.Message.Send(TxAbort(state.channelId, SpliceAborted(state.channelId).message)))
+                                        SpliceStatus.Aborted
+                                    } else {
+                                        state.spliceStatus
+                                    }
+
+                                    // Re-send splice_locked (must come *after* potentially retransmitting tx_signatures).
+                                    // NB: there is a key difference between channel_ready and splice_locked:
+                                    // - channel_ready: a non-zero commitment index implies that both sides have seen the channel_ready
+                                    // - splice_locked: the commitment index can be updated as long as it is compatible with all splices, so
+                                    //   we must keep sending our most recent splice_locked at each reconnection
+                                    state.commitments.active
+                                        .filter { it.fundingTxIndex > 0L } // only consider splice txs
+                                        .firstOrNull { staticParams.useZeroConf || it.localFundingStatus is LocalFundingStatus.ConfirmedFundingTx }
+                                        ?.let {
+                                            logger.debug { "re-sending splice_locked for fundingTxId=${it.fundingTxId}" }
+                                            val spliceLocked = SpliceLocked(channelId, it.fundingTxId)
+                                            actions.add(ChannelAction.Message.Send(spliceLocked))
+                                        }
+
+                                    // we may need to retransmit updates and/or commit_sig and/or revocation
+                                    actions.addAll(syncResult.retransmit.map { ChannelAction.Message.Send(it) })
+
+                                    // then we clean up unsigned updates
+                                    val commitments1 = discardUnsignedUpdates(state.commitments)
+
+                                    if (commitments1.changes.localHasChanges()) {
+                                        actions.add(ChannelAction.Message.SendToSelf(ChannelCommand.Commitment.Sign))
+                                    }
+
+                                    // When a channel is reestablished after a wallet restarts, we need to reprocess incoming HTLCs that may have been only partially processed
+                                    // (either because they didn't reach the payment handler, or because the payment handler response didn't reach the channel).
+                                    // Otherwise these HTLCs will stay in our commitment until they timeout and our peer closes the channel.
+                                    val htlcsToReprocess = commitments1.reprocessIncomingHtlcs()
+                                    logger.info { "re-processing signed IN: ${htlcsToReprocess.map { it.add.id }.joinToString()}" }
+                                    actions.addAll(htlcsToReprocess)
+
+                                    // BOLT 2: A node if it has sent a previous shutdown MUST retransmit shutdown.
+                                    state.localShutdown?.let {
+                                        logger.debug { "re-sending local shutdown" }
+                                        actions.add(ChannelAction.Message.Send(it))
+                                    }
+                                    Pair(state.copy(commitments = commitments1, spliceStatus = spliceStatus1), actions)
                                 }
-                            } catch (e: RevocationSyncError) {
-                                val error = Error(channelId, e.message)
-                                state.run { spendLocalCurrent() }.run { copy(second = second + ChannelAction.Message.Send(error)) }
                             }
                         }
                         is ShuttingDown -> {
-                            try {
-                                when (val syncResult = checkSync(state, cmd.message)) {
-                                    is SyncResult.Failure -> handleSyncFailure(cmd.message, syncResult, state.commitments)
-                                    is SyncResult.Success -> {
-                                        val commitments1 = syncResult.commitments
-                                        val actions = buildList {
-                                            addAll(syncResult.actions)
-                                            add(ChannelAction.Message.Send(state.localShutdown))
-                                        }
-                                        Pair(state.copy(commitments = commitments1), actions)
-                                    }
+                            when (val syncResult = handleSync(state.commitments, cmd.message)) {
+                                is SyncResult.Failure -> handleSyncFailure(state.commitments, cmd.message, syncResult)
+                                is SyncResult.Success -> {
+                                    val commitments1 = discardUnsignedUpdates(state.commitments)
+                                    val actions = buildList {
+                                        addAll(syncResult.retransmit)
+                                        add(state.localShutdown)
+                                    }.map { ChannelAction.Message.Send(it) }
+                                    Pair(state.copy(commitments = commitments1), actions)
                                 }
-                            } catch (e: RevocationSyncError) {
-                                val error = Error(channelId, e.message)
-                                state.run { spendLocalCurrent() }.run { copy(second = second + ChannelAction.Message.Send(error)) }
                             }
                         }
                         // negotiation restarts from the beginning, and is initialized by the initiator
@@ -340,123 +345,176 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
         }
     }
 
+    private fun ChannelContext.handleSyncFailure(commitments: Commitments, remoteChannelReestablish: ChannelReestablish, syncFailure: SyncResult.Failure): Pair<ChannelState, List<ChannelAction>> {
+        return when (syncFailure) {
+            is SyncResult.Failure.LocalLateProven -> {
+                // their data checks out, we indeed seem to be using an old revoked commitment, and must absolutely *NOT* publish it, because that would be a cheating attempt and they
+                // would punish us by taking all the funds in the channel
+                logger.warning { "counterparty proved that we have an outdated (revoked) local commitment!!! ourCommitmentNumber=${commitments.localCommitIndex} theirCommitmentNumber=${remoteChannelReestablish.nextRemoteRevocationNumber}" }
+                handleOutdatedCommitment(remoteChannelReestablish, commitments)
+            }
+            is SyncResult.Failure.LocalLateUnproven -> {
+                // there is no way to make sure that they are saying the truth, the best thing to do is ask them to publish their commitment right now
+                // maybe they will publish their commitment, in that case we need to remember their commitment point in order to be able to claim our outputs
+                // not that if they don't comply, we could publish our own commitment (it is not stale, otherwise we would be in the case above)
+                logger.warning { "counterparty says that they have a more recent commitment than the one we know of!!! ourCommitmentNumber=${commitments.latest.nextRemoteCommit?.commit?.index ?: commitments.latest.remoteCommit.index} theirCommitmentNumber=${remoteChannelReestablish.nextLocalCommitmentNumber}" }
+                handleOutdatedCommitment(remoteChannelReestablish, commitments)
+            }
+            is SyncResult.Failure.RemoteLying -> {
+                // they are deliberately trying to fool us into thinking we have a late commitment, but we cannot risk publishing it ourselves, because it may really be revoked!
+                logger.warning { "counterparty claims that we have an outdated commitment, but they sent an invalid proof, so our commitment may or may not be revoked: ourLocalCommitmentNumber=${commitments.localCommitIndex} theirRemoteCommitmentNumber=${remoteChannelReestablish.nextRemoteRevocationNumber}" }
+                handleOutdatedCommitment(remoteChannelReestablish, commitments)
+            }
+            is SyncResult.Failure.RemoteLate -> {
+                logger.error { "counterparty appears to be using an outdated commitment, they may request a force-close, standing by..." }
+                Pair(this@Syncing, listOf())
+            }
+        }
+    }
+
     companion object {
 
         // @formatter:off
         sealed class SyncResult {
-            data class Success(val commitments: Commitments, val actions: List<ChannelAction>) : SyncResult()
+            data class Success(val retransmit: List<LightningMessage>) : SyncResult()
             sealed class Failure : SyncResult() {
                 data class LocalLateProven(val ourLocalCommitmentNumber: Long, val theirRemoteCommitmentNumber: Long) : Failure()
                 data class LocalLateUnproven(val ourRemoteCommitmentNumber: Long, val theirLocalCommitmentNumber: Long) : Failure()
                 data class RemoteLying(val ourLocalCommitmentNumber: Long, val theirRemoteCommitmentNumber: Long, val invalidPerCommitmentSecret: PrivateKey) : Failure()
-                //data object RemoteLate : Failure()
+                data object RemoteLate : Failure()
             }
         }
         // @formatter:on
 
-        private fun ChannelContext.handleSync(channelReestablish: ChannelReestablish, d: ChannelStateWithCommitments): SyncResult.Success {
-            val sendQueue = ArrayList<ChannelAction>()
-            // first we clean up unacknowledged updates
-            logger.debug { "discarding proposed OUT: ${d.commitments.changes.localChanges.proposed}" }
-            logger.debug { "discarding proposed IN: ${d.commitments.changes.remoteChanges.proposed}" }
-            val commitments1 = d.commitments.copy(
-                changes = d.commitments.changes.copy(
-                    localChanges = d.commitments.changes.localChanges.copy(proposed = emptyList()),
-                    remoteChanges = d.commitments.changes.remoteChanges.copy(proposed = emptyList()),
-                    localNextHtlcId = d.commitments.changes.localNextHtlcId - d.commitments.changes.localChanges.proposed.filterIsInstance<UpdateAddHtlc>().size,
-                    remoteNextHtlcId = d.commitments.changes.remoteNextHtlcId - d.commitments.changes.remoteChanges.proposed.filterIsInstance<UpdateAddHtlc>().size
-                )
-            )
-            logger.debug { "localNextHtlcId=${d.commitments.changes.localNextHtlcId}->${commitments1.changes.localNextHtlcId}" }
-            logger.debug { "remoteNextHtlcId=${d.commitments.changes.remoteNextHtlcId}->${commitments1.changes.remoteNextHtlcId}" }
-
-            fun resendRevocation() {
-                // let's see the state of remote sigs
-                when (commitments1.localCommitIndex) {
-                    channelReestablish.nextRemoteRevocationNumber -> {
-                        // nothing to do
-                    }
-                    channelReestablish.nextRemoteRevocationNumber + 1 -> {
-                        // our last revocation got lost, let's resend it
-                        logger.debug { "re-sending last revocation" }
-                        val channelKeys = keyManager.channelKeys(d.commitments.params.localParams.fundingKeyPath)
-                        val localPerCommitmentSecret = channelKeys.commitmentSecret(d.commitments.localCommitIndex - 1)
-                        val localNextPerCommitmentPoint = channelKeys.commitmentPoint(d.commitments.localCommitIndex + 1)
-                        val revocation = RevokeAndAck(commitments1.channelId, localPerCommitmentSecret, localNextPerCommitmentPoint)
-                        sendQueue.add(ChannelAction.Message.Send(revocation))
-                    }
-                    else -> throw RevocationSyncError(d.channelId)
-                }
-            }
-
-            when {
-                commitments1.remoteNextCommitInfo.isLeft && commitments1.nextRemoteCommitIndex + 1 == channelReestablish.nextLocalCommitmentNumber -> {
-                    // we had sent a new sig and were waiting for their revocation
-                    // they had received the new sig but their revocation was lost during the disconnection
-                    // they will send us the revocation, nothing to do here
-                    logger.debug { "waiting for them to re-send their last revocation" }
-                    resendRevocation()
-                }
-                commitments1.remoteNextCommitInfo.isLeft && commitments1.nextRemoteCommitIndex == channelReestablish.nextLocalCommitmentNumber -> {
-                    // we had sent a new sig and were waiting for their revocation
-                    // they didn't receive the new sig because of the disconnection
-                    // we just resend the same updates and the same sig
-                    val revWasSentLast = commitments1.localCommitIndex > commitments1.remoteNextCommitInfo.left!!.sentAfterLocalCommitIndex
-                    if (!revWasSentLast) resendRevocation()
-
-                    logger.debug { "re-sending previously local signed changes: ${commitments1.changes.localChanges.signed}" }
-                    commitments1.changes.localChanges.signed.forEach { sendQueue.add(ChannelAction.Message.Send(it)) }
-                    logger.debug { "re-sending the exact same previous sig" }
-                    commitments1.active.forEach { sendQueue.add(ChannelAction.Message.Send(it.nextRemoteCommit!!.sig)) }
-                    if (revWasSentLast) resendRevocation()
-                }
-                commitments1.remoteNextCommitInfo.isRight && commitments1.remoteCommitIndex + 1 == channelReestablish.nextLocalCommitmentNumber -> {
-                    // there wasn't any sig in-flight when the disconnection occurred
-                    resendRevocation()
-                }
-                else -> throw RevocationSyncError(d.channelId)
-            }
-
-            if (commitments1.changes.localHasChanges()) {
-                sendQueue.add(ChannelAction.Message.SendToSelf(ChannelCommand.Commitment.Sign))
-            }
-
-            // When a channel is reestablished after a wallet restarts, we need to reprocess incoming HTLCs that may have been only partially processed
-            // (either because they didn't reach the payment handler, or because the payment handler response didn't reach the channel).
-            // Otherwise these HTLCs will stay in our commitment until they timeout and our peer closes the channel.
-            val htlcsToReprocess = commitments1.reprocessIncomingHtlcs()
-            logger.info { "re-processing signed IN: ${htlcsToReprocess.map { it.add.id }.joinToString()}" }
-            sendQueue.addAll(htlcsToReprocess)
-
-            return SyncResult.Success(commitments1, sendQueue)
-        }
-
-        private fun ChannelContext.checkSync(d: ChannelStateWithCommitments, remoteChannelReestablish: ChannelReestablish): SyncResult {
-            val commitments = d.commitments
+        /**
+         * Check whether we are in sync with our peer.
+         */
+        fun ChannelContext.handleSync(commitments: Commitments, remoteChannelReestablish: ChannelReestablish): SyncResult {
             val channelKeys = keyManager.channelKeys(commitments.params.localParams.fundingKeyPath)
-            return when {
-                !Helpers.checkLocalCommit(commitments, remoteChannelReestablish.nextRemoteRevocationNumber) -> {
-                    // if next_remote_revocation_number is greater than our local commitment index, it means that either we are using an outdated commitment, or they are lying
-                    // but first we need to make sure that the last per_commitment_secret that they claim to have received from us is correct for that next_remote_revocation_number minus 1
-                    if (channelKeys.commitmentSecret(remoteChannelReestablish.nextRemoteRevocationNumber - 1) == remoteChannelReestablish.yourLastCommitmentSecret) {
-                        SyncResult.Failure.LocalLateProven(ourLocalCommitmentNumber = commitments.localCommitIndex, theirRemoteCommitmentNumber = remoteChannelReestablish.nextRemoteRevocationNumber)
-                    } else {
-                        SyncResult.Failure.RemoteLying(
-                            ourLocalCommitmentNumber = commitments.localCommitIndex,
-                            theirRemoteCommitmentNumber = remoteChannelReestablish.nextRemoteRevocationNumber,
-                            invalidPerCommitmentSecret = remoteChannelReestablish.yourLastCommitmentSecret
-                        )
+            // This is done in two steps:
+            // - step 1: we check our local commitment
+            // - step 2: we check the remote commitment
+            // step 2 depends on step 1 because we need to preserve ordering between commit_sig and revocation
+
+            // step 2: we check the remote commitment
+            fun checkRemoteCommit(remoteChannelReestablish: ChannelReestablish, retransmitRevocation: RevokeAndAck?): SyncResult {
+                return when (val rnci = commitments.remoteNextCommitInfo) {
+                    is Either.Left -> {
+                        when {
+                            remoteChannelReestablish.nextLocalCommitmentNumber == commitments.nextRemoteCommitIndex -> {
+                                // we just sent a new commit_sig but they didn't receive it
+                                // we resend the same updates and the same sig, and preserve the same ordering
+                                val signedUpdates = commitments.changes.localChanges.signed
+                                val commitSigs = commitments.active.map { it.nextRemoteCommit }.filterIsInstance<NextRemoteCommit>().map { it.sig }
+                                SyncResult.Success(retransmit = when (retransmitRevocation) {
+                                    null -> buildList {
+                                        addAll(signedUpdates)
+                                        addAll(commitSigs)
+                                    }
+                                    else -> if (commitments.localCommitIndex > rnci.value.sentAfterLocalCommitIndex) {
+                                        buildList {
+                                            addAll(signedUpdates)
+                                            addAll(commitSigs)
+                                            add(retransmitRevocation)
+                                        }
+                                    } else {
+                                        buildList {
+                                            add(retransmitRevocation)
+                                            addAll(signedUpdates)
+                                            addAll(commitSigs)
+                                        }
+                                    }
+                                })
+                            }
+                            remoteChannelReestablish.nextLocalCommitmentNumber == (commitments.nextRemoteCommitIndex + 1) -> {
+                                // we just sent a new commit_sig, they have received it but we haven't received their revocation
+                                SyncResult.Success(retransmit = listOfNotNull(retransmitRevocation))
+                            }
+                            remoteChannelReestablish.nextLocalCommitmentNumber < commitments.nextRemoteCommitIndex -> {
+                                // they are behind
+                                SyncResult.Failure.RemoteLate
+                            }
+                            else -> {
+                                // we are behind
+                                SyncResult.Failure.LocalLateUnproven(
+                                    ourRemoteCommitmentNumber = commitments.nextRemoteCommitIndex,
+                                    theirLocalCommitmentNumber = remoteChannelReestablish.nextLocalCommitmentNumber - 1
+                                )
+                            }
+                        }
+                    }
+                    is Either.Right -> {
+                        when {
+                            remoteChannelReestablish.nextLocalCommitmentNumber == (commitments.remoteCommitIndex + 1) -> {
+                                // they have acknowledged the last commit_sig we sent
+                                SyncResult.Success(retransmit = listOfNotNull(retransmitRevocation))
+                            }
+                            remoteChannelReestablish.nextLocalCommitmentNumber < (commitments.remoteCommitIndex + 1) -> {
+                                // they are behind
+                                SyncResult.Failure.RemoteLate
+                            }
+                            else -> {
+                                // we are behind
+                                SyncResult.Failure.LocalLateUnproven(
+                                    ourRemoteCommitmentNumber = commitments.remoteCommitIndex,
+                                    theirLocalCommitmentNumber = remoteChannelReestablish.nextLocalCommitmentNumber - 1
+                                )
+                            }
+                        }
                     }
                 }
-                !Helpers.checkRemoteCommit(commitments, remoteChannelReestablish.nextLocalCommitmentNumber) -> {
-                    // if next_local_commit_number is more than one more our remote commitment index, it means that either we are using an outdated commitment, or they are lying
-                    SyncResult.Failure.LocalLateUnproven(
-                        ourRemoteCommitmentNumber = commitments.latest.nextRemoteCommit?.commit?.index ?: commitments.latest.remoteCommit.index,
-                        theirLocalCommitmentNumber = remoteChannelReestablish.nextLocalCommitmentNumber
+            }
+
+            // step 1: we check our local commitment
+            return if (commitments.localCommitIndex == remoteChannelReestablish.nextRemoteRevocationNumber) {
+                // our local commitment is in sync, let's check the remote commitment
+                checkRemoteCommit(remoteChannelReestablish, retransmitRevocation = null)
+            } else if (commitments.localCommitIndex == remoteChannelReestablish.nextRemoteRevocationNumber + 1) {
+                // they just sent a new commit_sig, we have received it but they didn't receive our revocation
+                val localPerCommitmentSecret = channelKeys.commitmentSecret(commitments.localCommitIndex - 1)
+                val localNextPerCommitmentPoint = channelKeys.commitmentPoint(commitments.localCommitIndex + 1)
+                val revocation = RevokeAndAck(
+                    channelId = commitments.channelId,
+                    perCommitmentSecret = localPerCommitmentSecret,
+                    nextPerCommitmentPoint = localNextPerCommitmentPoint
+                )
+                checkRemoteCommit(remoteChannelReestablish, retransmitRevocation = revocation)
+            } else if (commitments.localCommitIndex > remoteChannelReestablish.nextRemoteRevocationNumber + 1) {
+                SyncResult.Failure.RemoteLate
+            } else {
+                // if next_remote_revocation_number is greater than our local commitment index, it means that either we are using an outdated commitment, or they are lying
+                // but first we need to make sure that the last per_commitment_secret that they claim to have received from us is correct for that next_remote_revocation_number minus 1
+                if (channelKeys.commitmentSecret(remoteChannelReestablish.nextRemoteRevocationNumber - 1) == remoteChannelReestablish.yourLastCommitmentSecret) {
+                    SyncResult.Failure.LocalLateProven(
+                        ourLocalCommitmentNumber = commitments.localCommitIndex,
+                        theirRemoteCommitmentNumber = remoteChannelReestablish.nextRemoteRevocationNumber
+                    )
+                } else {
+                    // they lied! the last per_commitment_secret they claimed to have received from us is invalid
+                    SyncResult.Failure.RemoteLying(
+                        ourLocalCommitmentNumber = commitments.localCommitIndex,
+                        theirRemoteCommitmentNumber = remoteChannelReestablish.nextRemoteRevocationNumber,
+                        invalidPerCommitmentSecret = remoteChannelReestablish.yourLastCommitmentSecret
                     )
                 }
-                else -> handleSync(remoteChannelReestablish, d)
             }
+        }
+
+        /** When reconnecting, we drop all unsigned changes. */
+        fun ChannelContext.discardUnsignedUpdates(commitments: Commitments): Commitments {
+            logger.debug { "discarding proposed OUT: ${commitments.changes.localChanges.proposed}" }
+            logger.debug { "discarding proposed IN: ${commitments.changes.remoteChanges.proposed}" }
+            val commitments1 = commitments.copy(
+                changes = commitments.changes.copy(
+                    localChanges = commitments.changes.localChanges.copy(proposed = emptyList()),
+                    remoteChanges = commitments.changes.remoteChanges.copy(proposed = emptyList()),
+                    localNextHtlcId = commitments.changes.localNextHtlcId - commitments.changes.localChanges.proposed.filterIsInstance<UpdateAddHtlc>().size,
+                    remoteNextHtlcId = commitments.changes.remoteNextHtlcId - commitments.changes.remoteChanges.proposed.filterIsInstance<UpdateAddHtlc>().size
+                )
+            )
+            logger.debug { "localNextHtlcId=${commitments.changes.localNextHtlcId}->${commitments1.changes.localNextHtlcId}" }
+            logger.debug { "remoteNextHtlcId=${commitments.changes.remoteNextHtlcId}->${commitments1.changes.remoteNextHtlcId}" }
+            return commitments1
         }
 
         private fun handleOutdatedCommitment(remoteChannelReestablish: ChannelReestablish, commitments: Commitments): Pair<ChannelStateWithCommitments, List<ChannelAction>> {
@@ -468,33 +526,6 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
                 ChannelAction.Message.Send(error)
             )
             return Pair(nextState, actions)
-        }
-
-        private fun ChannelContext.handleSyncFailure(remoteChannelReestablish: ChannelReestablish, syncFailure: SyncResult.Failure, commitments: Commitments): Pair<ChannelStateWithCommitments, List<ChannelAction>> {
-            return when (syncFailure) {
-                is SyncResult.Failure.LocalLateProven -> {
-                    // their data checks out, we indeed seem to be using an old revoked commitment, and must absolutely *NOT* publish it, because that would be a cheating attempt and they
-                    // would punish us by taking all the funds in the channel
-                    logger.warning { "counterparty proved that we have an outdated (revoked) local commitment!!! ourCommitmentNumber=${commitments.localCommitIndex} theirCommitmentNumber=${remoteChannelReestablish.nextRemoteRevocationNumber}" }
-                    handleOutdatedCommitment(remoteChannelReestablish, commitments)
-                }
-                is SyncResult.Failure.LocalLateUnproven -> {
-                    // there is no way to make sure that they are saying the truth, the best thing to do is ask them to publish their commitment right now
-                    // maybe they will publish their commitment, in that case we need to remember their commitment point in order to be able to claim our outputs
-                    // not that if they don't comply, we could publish our own commitment (it is not stale, otherwise we would be in the case above)
-                    logger.warning { "counterparty says that they have a more recent commitment than the one we know of!!! ourCommitmentNumber=${commitments.latest.nextRemoteCommit?.commit?.index ?: commitments.latest.remoteCommit.index} theirCommitmentNumber=${remoteChannelReestablish.nextLocalCommitmentNumber}" }
-                    handleOutdatedCommitment(remoteChannelReestablish, commitments)
-                }
-                is SyncResult.Failure.RemoteLying -> {
-                    // they are deliberately trying to fool us into thinking we have a late commitment, but we cannot risk publishing it ourselves, because it may really be revoked!
-                    logger.warning { "counterparty claims that we have an outdated commitment, but they sent an invalid proof, so our commitment may or may not be revoked: ourLocalCommitmentNumber=${commitments.localCommitIndex} theirRemoteCommitmentNumber=${remoteChannelReestablish.nextRemoteRevocationNumber}" }
-                    handleOutdatedCommitment(remoteChannelReestablish, commitments)
-                }
-//                is SyncResult.Failure.RemoteLate -> {
-//                    logger.error { "counterparty appears to be using an outdated commitment, they may request a force-close, standing by..." }
-//                    stay()
-//                }
-            }
         }
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ShutdownTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ShutdownTestsCommon.kt
@@ -533,10 +533,10 @@ class ShutdownTestsCommon : LightningTestSuite() {
         val (alice0, bob0) = init(bobFeatures = TestConstants.Bob.nodeParams.features.remove(Feature.ChannelBackupClient))
         val (alice1, bob1, reestablishes) = SyncingTestsCommon.disconnect(alice0, bob0)
         val (aliceReestablish, bobReestablish) = reestablishes
-        val (alice2, actionsAlice2) = alice1.process(ChannelCommand.MessageReceived(aliceReestablish))
+        val (alice2, actionsAlice2) = alice1.process(ChannelCommand.MessageReceived(bobReestablish))
         assertIs<ShuttingDown>(alice2.state)
         actionsAlice2.hasOutgoingMessage<Shutdown>()
-        val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(bobReestablish))
+        val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(aliceReestablish))
         assertIs<ShuttingDown>(bob2.state)
         actionsBob2.hasOutgoingMessage<Shutdown>()
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ShutdownTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ShutdownTestsCommon.kt
@@ -528,6 +528,19 @@ class ShutdownTestsCommon : LightningTestSuite() {
         testLocalForceClose(alice1, actions1)
     }
 
+    @Test
+    fun `basic disconnection and reconnection`() {
+        val (alice0, bob0) = init(bobFeatures = TestConstants.Bob.nodeParams.features.remove(Feature.ChannelBackupClient))
+        val (alice1, bob1, reestablishes) = SyncingTestsCommon.disconnect(alice0, bob0)
+        val (aliceReestablish, bobReestablish) = reestablishes
+        val (alice2, actionsAlice2) = alice1.process(ChannelCommand.MessageReceived(aliceReestablish))
+        assertIs<ShuttingDown>(alice2.state)
+        actionsAlice2.hasOutgoingMessage<Shutdown>()
+        val (bob2, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(bobReestablish))
+        assertIs<ShuttingDown>(bob2.state)
+        actionsBob2.hasOutgoingMessage<Shutdown>()
+    }
+
     companion object {
         val r1 = randomBytes32()
         val r2 = randomBytes32()
@@ -566,6 +579,8 @@ class ShutdownTestsCommon : LightningTestSuite() {
             val (alice2, _) = alice1.process(ChannelCommand.MessageReceived(shutdown1))
             assertIs<LNChannel<ShuttingDown>>(alice2)
             assertIs<LNChannel<ShuttingDown>>(bob1)
+            assertIs<ShuttingDown>(alice2.state)
+            assertIs<ShuttingDown>(bob1.state)
             if (alice2.state.commitments.params.channelFeatures.hasFeature(Feature.ChannelBackupClient)) assertFalse(shutdown.channelData.isEmpty())
             if (bob1.state.commitments.params.channelFeatures.hasFeature(Feature.ChannelBackupClient)) assertFalse(shutdown1.channelData.isEmpty())
             return Pair(alice2, bob1)


### PR DESCRIPTION
This PR does two things:
- properly handle `channel_reestablish` in state `Syncing(Shutdown)`
- implement the equivalent of https://github.com/ACINQ/eclair/pull/2036, a major rework/cleanup of the reestablish logic, with separation of concerns, strong typing, etc.

The two middle commits are intermediate steps and may not be necessarily useful to review. I recommend checking the first commit, then the last 3 commits.

The full reestablish rework is sensitive stuff (a bug here could cause mass force close of phoenix channels). However, the code is a litteral copy paste of eclair, ported to Kotlin. Tests have not been modified, except two of them, which is due to a change in behavior: we are not pro-actively force closing channels when we detect that our peer is behind. Instead, we stay in stand-by and force-close when we receive their error.