### PR TITLE
Add more blinded payment onion tests

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/message/OnionMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/message/OnionMessages.kt
@@ -70,7 +70,7 @@ object OnionMessages {
                     blindingSecret,
                     intermediateNodes.map { it.nodeId } + destination.nodeId,
                     intermediatePayloads + lastPayload
-                )
+                ).route
             }
             is Destination.BlindedPath -> when {
                 intermediateNodes.isEmpty() -> destination.route
@@ -85,7 +85,7 @@ object OnionMessages {
                         blindingSecret,
                         intermediateNodes.map { it.nodeId },
                         intermediatePayloads
-                    )
+                    ).route
                     RouteBlinding.BlindedRoute(
                         routePrefix.introductionNodeId,
                         routePrefix.blindingKey,

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
@@ -343,15 +343,14 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
                 NodeHop(walletParams.trampolineNode.id, request.recipient, fees.cltvExpiryDelta, fees.calculateFees(request.amount))
             )
         }
-
         when (request.paymentRequest) {
             is Bolt11Invoice -> {
                 val minFinalExpiryDelta = request.paymentRequest.minFinalExpiryDelta ?: Channel.MIN_CLTV_EXPIRY_DELTA
                 val finalExpiry = nodeParams.paymentRecipientExpiryParams.computeFinalExpiry(currentBlockHeight, minFinalExpiryDelta)
                 val finalPayload = PaymentOnion.FinalPayload.Standard.createSinglePartPayload(request.amount, finalExpiry, request.paymentRequest.paymentSecret, request.paymentRequest.paymentMetadata)
-
                 val invoiceFeatures = request.paymentRequest.features
                 val (trampolineAmount, trampolineExpiry, trampolineOnion) = if (invoiceFeatures.hasFeature(Feature.TrampolinePayment) || invoiceFeatures.hasFeature(Feature.ExperimentalTrampolinePayment)) {
+                    // We may be paying an older version of lightning-kmp that only supports trampoline packets of size 400.
                     OutgoingPaymentPacket.buildPacket(request.paymentHash, trampolineRoute, finalPayload, 400)
                 } else {
                     OutgoingPaymentPacket.buildTrampolineToNonTrampolinePacket(request.paymentRequest, trampolineRoute, finalPayload)
@@ -360,8 +359,7 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
             }
             is Bolt12Invoice -> {
                 val finalExpiry = nodeParams.paymentRecipientExpiryParams.computeFinalExpiry(currentBlockHeight, CltvExpiryDelta(0))
-                val dummyFinalPayload = PaymentOnion.FinalPayload.Standard.createSinglePartPayload(request.amount, finalExpiry, ByteVector32.Zeroes, null)
-                val (trampolineAmount, trampolineExpiry, trampolineOnion) = OutgoingPaymentPacket.buildTrampolineToNonTrampolinePacket(request.paymentRequest, trampolineRoute, dummyFinalPayload)
+                val (trampolineAmount, trampolineExpiry, trampolineOnion) = OutgoingPaymentPacket.buildTrampolineToNonTrampolinePacket(request.paymentRequest, trampolineRoute.last(), request.amount, finalExpiry)
                 return Triple(trampolineAmount, trampolineExpiry, trampolineOnion.packet)
             }
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/message/OnionMessagesTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/message/OnionMessagesTestsCommon.kt
@@ -92,10 +92,10 @@ class OnionMessagesTestsCommon {
         assertEquals("060401234567", encodedForDave.toHex())
 
         // Building blinded path Carol -> Dave
-        val routeFromCarol = RouteBlinding.create(blindingOverride, listOf(carol.publicKey(), dave.publicKey()), listOf(encodedForCarol, encodedForDave))
+        val routeFromCarol = RouteBlinding.create(blindingOverride, listOf(carol.publicKey(), dave.publicKey()), listOf(encodedForCarol, encodedForDave)).route
 
         // Building blinded path Alice -> Bob
-        val routeToCarol = RouteBlinding.create(blindingSecret, listOf(alice.publicKey(), bob.publicKey()), listOf(encodedForAlice, encodedForBob))
+        val routeToCarol = RouteBlinding.create(blindingSecret, listOf(alice.publicKey(), bob.publicKey()), listOf(encodedForAlice, encodedForBob)).route
 
         val publicKeys = routeToCarol.blindedNodes.map { it.blindedPublicKey } + routeFromCarol.blindedNodes.map { it.blindedPublicKey }
         val encryptedPayloads = routeToCarol.encryptedPayloads + routeFromCarol.encryptedPayloads
@@ -149,7 +149,7 @@ class OnionMessagesTestsCommon {
         val blindedPayload = RouteBlindingEncryptedData(TlvStream(RouteBlindingEncryptedDataTlv.OutgoingNodeId(EncodedNodeId(bob.publicKey()))))
         val encodedBlindedPayload = blindedPayload.write().toByteVector()
         assertEquals("04210324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c", encodedBlindedPayload.toHex())
-        val blindedRoute = RouteBlinding.create(blindingSecret, listOf(alice.publicKey()), listOf(encodedBlindedPayload))
+        val blindedRoute = RouteBlinding.create(blindingSecret, listOf(alice.publicKey()), listOf(encodedBlindedPayload)).route
         assertEquals(blindedAlice, blindedRoute.blindedNodes.first().blindedPublicKey)
         assertEquals("bae3d9ea2b06efd1b7b9b49b6cdcaad0e789474a6939ffa54ff5ec9224d5b76c", Crypto.sha256(blindingKey.value + sharedSecret).toHex())
         assertEquals("6970e870b473ddbc27e3098bfa45bb1aa54f1f637f803d957e6271d8ffeba89da2665d62123763d9b634e30714144a1c165ac9", blindedRoute.blindedNodes.first().encryptedPayload.toHex())
@@ -173,7 +173,7 @@ class OnionMessagesTestsCommon {
         val blindedPayload = RouteBlindingEncryptedData(TlvStream(RouteBlindingEncryptedDataTlv.OutgoingNodeId(EncodedNodeId(carol.publicKey())), RouteBlindingEncryptedDataTlv.NextBlinding(blindingOverride)))
         val encodedBlindedPayload = blindedPayload.write().toByteVector()
         assertEquals("0421027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007082102989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f", encodedBlindedPayload.toHex())
-        val blindedRoute = RouteBlinding.create(blindingSecret, listOf(bob.publicKey()), listOf(encodedBlindedPayload))
+        val blindedRoute = RouteBlinding.create(blindingSecret, listOf(bob.publicKey()), listOf(encodedBlindedPayload)).route
         assertEquals(blindedBob, blindedRoute.blindedNodes.first().blindedPublicKey)
         assertEquals("9afb8b2ebc174dcf9e270be24771da7796542398d29d4ff6a4e7b6b4b9205cfe", Crypto.sha256(blindingKey.value + sharedSecret).toHex())
         assertEquals("1630da85e8759b8f3b94d74a539c6f0d870a87cf03d4986175865a2985553c997b560c32613bd9184c1a6d41a37027aabdab5433009d8409a1b638eb90373778a05716af2c2140b3196dca23997cdad4cfa7a7adc8d4", blindedRoute.blindedNodes.first().encryptedPayload.toHex())
@@ -197,7 +197,7 @@ class OnionMessagesTestsCommon {
         val blindedPayload = RouteBlindingEncryptedData(TlvStream(RouteBlindingEncryptedDataTlv.Padding(ByteVector.fromHex("0000000000000000000000000000000000000000000000000000000000000000000000")), RouteBlindingEncryptedDataTlv.OutgoingNodeId(EncodedNodeId(dave.publicKey()))))
         val encodedBlindedPayload = blindedPayload.write().toByteVector()
         assertEquals("012300000000000000000000000000000000000000000000000000000000000000000000000421032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991", encodedBlindedPayload.toHex())
-        val blindedRoute = RouteBlinding.create(blindingSecret, listOf(carol.publicKey()), listOf(encodedBlindedPayload))
+        val blindedRoute = RouteBlinding.create(blindingSecret, listOf(carol.publicKey()), listOf(encodedBlindedPayload)).route
         assertEquals(blindedCarol, blindedRoute.blindedNodes.first().blindedPublicKey)
         assertEquals("cc3b918cda6b1b049bdbe469c4dd952935e7c1518dd9c7ed0cd2cd5bc2742b82", Crypto.sha256(blindingKey.value + sharedSecret).toHex())
         assertEquals("8285acbceb37dfb38b877a888900539be656233cd74a55c55344fb068f9d8da365340d21db96fb41b76123207daeafdfb1f571e3fea07a22e10da35f03109a0380b3c69fcbed9c698086671809658761cf65ecbc3c07a2e5", blindedRoute.blindedNodes.first().encryptedPayload.toHex())

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/Bolt12InvoiceTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/Bolt12InvoiceTestsCommon.kt
@@ -67,20 +67,16 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
         sessionKey: PrivateKey = randomKey(),
         pathId: ByteVector = randomBytes32()
     ): PaymentBlindedContactInfo {
-        val selfPayload = RouteBlindingEncryptedData(TlvStream(
-            RouteBlindingEncryptedDataTlv.PathId(pathId),
-            RouteBlindingEncryptedDataTlv.PaymentConstraints(CltvExpiry(1234567), 0.msat),
-            RouteBlindingEncryptedDataTlv.AllowedFeatures(Features.empty)
-        )).write().toByteVector()
-        return PaymentBlindedContactInfo(
-            ContactInfo.BlindedPath(
-                RouteBlinding.create(
-                    sessionKey,
-                    listOf(nodeId),
-                    listOf(selfPayload)
-                )
-            ), PaymentInfo(1.msat, 2, CltvExpiryDelta(3), 4.msat, 5.msat, Features.empty)
-        )
+        val selfPayload = RouteBlindingEncryptedData(
+            TlvStream(
+                RouteBlindingEncryptedDataTlv.PathId(pathId),
+                RouteBlindingEncryptedDataTlv.PaymentConstraints(CltvExpiry(1234567), 0.msat),
+                RouteBlindingEncryptedDataTlv.AllowedFeatures(Features.empty)
+            )
+        ).write().toByteVector()
+        val blindedRoute = RouteBlinding.create(sessionKey, listOf(nodeId), listOf(selfPayload)).route
+        val paymentInfo = PaymentInfo(1.msat, 2, CltvExpiryDelta(3), 4.msat, 5.msat, Features.empty)
+        return PaymentBlindedContactInfo(ContactInfo.BlindedPath(blindedRoute), paymentInfo)
     }
 
     @Test


### PR DESCRIPTION
Add more blinded payment onion tests:

- failure test cases (imported from `eclair`)
- payment to blinded path through trampoline node (similar to phoenix-to-phoenix payments)

We also fix how trampoline-to-blinded-path payments are created: since they always use a single trampoline node and don't include a dummy final payload, they're quite different from trampoline-to-legacy payments and deserve a separate function.