### PR TITLE
Improvements to the `OfferManager`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -120,6 +120,7 @@ data class RecipientCltvExpiryParams(val min: CltvExpiryDelta, val max: CltvExpi
  * @param zeroConfPeers list of peers with whom we use zero-conf (note that this is a strong trust assumption).
  * @param liquidityPolicy fee policy for liquidity events, can be modified at any time.
  * @param minFinalCltvExpiryDelta cltv-expiry-delta that we require when receiving a payment.
+ * @param maxFinalCltvExpiryDelta maximum cltv-expiry-delta that we accept when receiving a payment.
  * @param bolt12invoiceExpiry duration for which bolt12 invoices that we create are valid.
  */
 data class NodeParams(
@@ -151,6 +152,7 @@ data class NodeParams(
     val zeroConfPeers: Set<PublicKey>,
     val liquidityPolicy: MutableStateFlow<LiquidityPolicy>,
     val minFinalCltvExpiryDelta: CltvExpiryDelta,
+    val maxFinalCltvExpiryDelta: CltvExpiryDelta,
     val bolt12invoiceExpiry: Duration
 ) {
     val nodePrivateKey get() = keyManager.nodeKeys.nodeKey.privateKey
@@ -226,6 +228,7 @@ data class NodeParams(
         paymentRecipientExpiryParams = RecipientCltvExpiryParams(CltvExpiryDelta(75), CltvExpiryDelta(200)),
         liquidityPolicy = MutableStateFlow<LiquidityPolicy>(LiquidityPolicy.Auto(maxAbsoluteFee = 2_000.sat, maxRelativeFeeBasisPoints = 3_000 /* 3000 = 30 % */, skipAbsoluteFeeCheck = false)),
         minFinalCltvExpiryDelta = Bolt11Invoice.DEFAULT_MIN_FINAL_EXPIRY_DELTA,
+        maxFinalCltvExpiryDelta = CltvExpiryDelta(500),
         bolt12invoiceExpiry = 60.seconds
     )
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -228,7 +228,7 @@ data class NodeParams(
         paymentRecipientExpiryParams = RecipientCltvExpiryParams(CltvExpiryDelta(75), CltvExpiryDelta(200)),
         liquidityPolicy = MutableStateFlow<LiquidityPolicy>(LiquidityPolicy.Auto(maxAbsoluteFee = 2_000.sat, maxRelativeFeeBasisPoints = 3_000 /* 3000 = 30 % */, skipAbsoluteFeeCheck = false)),
         minFinalCltvExpiryDelta = Bolt11Invoice.DEFAULT_MIN_FINAL_EXPIRY_DELTA,
-        maxFinalCltvExpiryDelta = CltvExpiryDelta(500),
+        maxFinalCltvExpiryDelta = CltvExpiryDelta(360),
         bolt12invoiceExpiry = 60.seconds
     )
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -105,7 +105,7 @@ data class PaymentNotSent(override val request: PayInvoice, val reason: Outgoing
 /** We successfully paid the corresponding request. */
 data class PaymentSent(override val request: PayInvoice, val payment: LightningOutgoingPayment) : SendPaymentResult()
 
-data class OfferInvoiceReceived(val request: PayOffer, val invoice: Bolt12Invoice, val payerKey: PrivateKey) : PeerEvent()
+data class OfferInvoiceReceived(val request: PayOffer, val invoice: Bolt12Invoice) : PeerEvent()
 data class ChannelClosing(val channelId: ByteVector32) : PeerEvent()
 
 /**
@@ -1311,8 +1311,8 @@ class Peer(
     private suspend fun processOnionMessageAction(action: OnionMessageAction) {
         when (action) {
             is OnionMessageAction.PayInvoice -> {
-                _eventsFlow.emit(OfferInvoiceReceived(action.payOffer, action.invoice, action.payerKey))
-                input.send(PayInvoice(action.payOffer.paymentId, action.payOffer.amount, LightningOutgoingPayment.Details.Blinded(action.invoice, action.payerKey), action.payOffer.trampolineFeesOverride))
+                _eventsFlow.emit(OfferInvoiceReceived(action.payOffer, action.invoice))
+                input.send(PayInvoice(action.payOffer.paymentId, action.payOffer.amount, LightningOutgoingPayment.Details.Blinded(action.invoice, action.payOffer.payerKey), action.payOffer.trampolineFeesOverride))
             }
             is OnionMessageAction.ReportPaymentFailure -> _eventsFlow.emit(OfferNotPaid(action.payOffer, action.failure))
             is OnionMessageAction.SendMessage -> input.send(SendOnionMessage(action.message))

--- a/src/commonMain/kotlin/fr/acinq/lightning/logging/MDCLogger.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/logging/MDCLogger.kt
@@ -3,7 +3,7 @@ package fr.acinq.lightning.logging
 import co.touchlab.kermit.Logger
 import fr.acinq.lightning.channel.states.*
 import fr.acinq.lightning.db.LightningOutgoingPayment
-import fr.acinq.lightning.io.SendPayment
+import fr.acinq.lightning.io.PayInvoice
 import fr.acinq.lightning.payment.PaymentPart
 import fr.acinq.lightning.wire.HasChannelId
 import fr.acinq.lightning.wire.HasTemporaryChannelId
@@ -63,7 +63,7 @@ fun PaymentPart.mdc(): Map<String, Any> = mapOf(
     "totalAmount" to totalAmount
 )
 
-fun SendPayment.mdc(): Map<String, Any> = mapOf(
+fun PayInvoice.mdc(): Map<String, Any> = mapOf(
     "paymentId" to paymentId,
     "paymentHash" to paymentHash,
     "amount" to amount,

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt11Invoice.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt11Invoice.kt
@@ -17,7 +17,7 @@ data class Bolt11Invoice(
     val prefix: String,
     override val amount: MilliSatoshi?,
     val timestampSeconds: Long,
-    val nodeId: PublicKey,
+    override val nodeId: PublicKey,
     val tags: List<TaggedField>,
     val signature: ByteVector
 ) : PaymentRequest() {

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt12Invoice.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt12Invoice.kt
@@ -35,7 +35,7 @@ data class Bolt12Invoice(val records: TlvStream<InvoiceTlv>) : PaymentRequest() 
     val invoiceRequest: InvoiceRequest = InvoiceRequest.validate(filterInvoiceRequestFields(records)).right!!
 
     override val amount: MilliSatoshi? = records.get<InvoiceAmount>()?.amount
-    val nodeId: PublicKey = records.get<InvoiceNodeId>()!!.nodeId
+    override val nodeId: PublicKey = records.get<InvoiceNodeId>()!!.nodeId
     override val paymentHash: ByteVector32 = records.get<InvoicePaymentHash>()!!.hash
     val description: String = invoiceRequest.offer.description
     val createdAtSeconds: Long = records.get<InvoiceCreatedAt>()!!.timestampSeconds

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
@@ -1,0 +1,142 @@
+package fr.acinq.lightning.payment
+
+import fr.acinq.bitcoin.ByteVector
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.bitcoin.PublicKey
+import fr.acinq.bitcoin.utils.Either.Left
+import fr.acinq.bitcoin.utils.Either.Right
+import fr.acinq.lightning.*
+import fr.acinq.lightning.Lightning.randomBytes32
+import fr.acinq.lightning.Lightning.randomKey
+import fr.acinq.lightning.channel.states.ChannelState
+import fr.acinq.lightning.channel.states.Normal
+import fr.acinq.lightning.channel.states.Offline
+import fr.acinq.lightning.channel.states.Syncing
+import fr.acinq.lightning.crypto.RouteBlinding
+import fr.acinq.lightning.io.PayOffer
+import fr.acinq.lightning.logging.MDCLogger
+import fr.acinq.lightning.message.OnionMessages
+import fr.acinq.lightning.message.OnionMessages.Destination
+import fr.acinq.lightning.message.OnionMessages.IntermediateNode
+import fr.acinq.lightning.message.OnionMessages.buildMessage
+import fr.acinq.lightning.utils.currentTimestampMillis
+import fr.acinq.lightning.utils.currentTimestampSeconds
+import fr.acinq.lightning.utils.msat
+import fr.acinq.lightning.utils.toByteVector
+import fr.acinq.lightning.wire.*
+import kotlin.math.max
+
+sealed class OnionMessageAction {
+    data class SendMessage(val message: OnionMessage): OnionMessageAction()
+    data class PayInvoice(val payOffer: PayOffer, val invoice: Bolt12Invoice, val payerKey: PrivateKey): OnionMessageAction()
+    data class ReportPaymentFailure(val payOffer: PayOffer, val failure: OfferPaymentFailure): OnionMessageAction()
+}
+
+private data class PendingInvoiceRequest(val payOffer: PayOffer, val payerKey: PrivateKey, val request: OfferTypes.InvoiceRequest, val createAtSeconds: Long)
+
+class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, val logger: MDCLogger) {
+    val remoteNodeId: PublicKey = walletParams.trampolineNode.id
+    private val pendingInvoiceRequests: HashMap<ByteVector32, PendingInvoiceRequest> = HashMap()
+    private val localOffers: HashMap<ByteVector32, OfferTypes.Offer> = HashMap()
+
+    fun registerOffer(offer: OfferTypes.Offer, pathId: ByteVector32) {
+        localOffers[pathId] = offer
+    }
+
+    fun requestInvoice(payOffer: PayOffer): List<OnionMessage> {
+        val payerKey = randomKey()
+        val request = OfferTypes.InvoiceRequest(payOffer.offer, payOffer.amount, payOffer.quantity, nodeParams.features.bolt12Features(), payerKey, nodeParams.chainHash)
+        val replyPathId = randomBytes32()
+        pendingInvoiceRequests[replyPathId] = PendingInvoiceRequest(payOffer, payerKey, request, currentTimestampSeconds())
+        val numHopsToAdd = max(0, payOffer.minReplyPathHops - 1)
+        val replyPathHops = (listOf(remoteNodeId) + List(numHopsToAdd) { nodeParams.nodeId }).map { IntermediateNode(it) }
+        val lastHop = Destination.Recipient(nodeParams.nodeId, replyPathId)
+        val replyPath = OnionMessages.buildRoute(randomKey(), replyPathHops, lastHop)
+        val messageContent = TlvStream(OnionMessagePayloadTlv.ReplyPath(replyPath), OnionMessagePayloadTlv.InvoiceRequest(request.records))
+        return payOffer.offer.contactInfos.mapNotNull { contactInfo -> buildMessage(randomKey(), randomKey(), listOf(IntermediateNode(remoteNodeId)), Destination(contactInfo), messageContent).right }
+    }
+
+    fun receiveMessage(msg: OnionMessage, channels: Map<ByteVector32, ChannelState>, currentBlockHeight: Int): OnionMessageAction? {
+        val decrypted = OnionMessages.decryptMessage(nodeParams.nodePrivateKey, msg, logger)
+        if (decrypted == null) {
+            return null
+        } else {
+            if (pendingInvoiceRequests.containsKey(decrypted.pathId)) {
+                val (payOffer, payerKey, request, _) = pendingInvoiceRequests[decrypted.pathId]!!
+                pendingInvoiceRequests.remove(decrypted.pathId)
+                val invoice = decrypted.content.records.get<OnionMessagePayloadTlv.Invoice>()?.let { Bolt12Invoice.validate(it.tlvs).right }
+                if (invoice == null) {
+                    val error = decrypted.content.records.get<OnionMessagePayloadTlv.InvoiceError>()?.let { OfferTypes.InvoiceError.validate(it.tlvs).right }
+                    val failure = error?.let { OfferPaymentFailure.InvoiceError(request, it) } ?: OfferPaymentFailure.InvalidResponse(request)
+                    return OnionMessageAction.ReportPaymentFailure(payOffer, failure)
+                } else {
+                    if (invoice.validateFor(request).isRight) {
+                        return OnionMessageAction.PayInvoice(payOffer, invoice, payerKey)
+                    } else {
+                        return OnionMessageAction.ReportPaymentFailure(
+                            payOffer,
+                            OfferPaymentFailure.InvalidInvoice(request, invoice)
+                        )
+                    }
+                }
+            } else if (localOffers.containsKey(decrypted.pathId) && decrypted.content.replyPath != null) {
+                val offer = localOffers[decrypted.pathId]!!
+                val offerPathId = ByteVector32(decrypted.pathId)
+                val request = decrypted.content.records.get<OnionMessagePayloadTlv.InvoiceRequest>()?.let { OfferTypes.InvoiceRequest.validate(it.tlvs).right }
+                if (request != null && request.offer == offer && request.isValid()) {
+                    val amount = request.amount ?: (request.offer.amount!! * request.quantity)
+                    val preimage = randomBytes32()
+                    val pathId = OfferPaymentMetadata.V1(offerPathId, amount, preimage, request.payerId, request.quantity, currentTimestampMillis()).toPathId(nodeParams.nodePrivateKey)
+                    val recipientPayload = RouteBlindingEncryptedData(TlvStream(RouteBlindingEncryptedDataTlv.PathId(pathId))).write().toByteVector()
+                    val remoteChannelUpdates = channels.values.mapNotNull { channelState ->
+                        when (channelState) {
+                            is Normal -> channelState.remoteChannelUpdate
+                            is Offline -> (channelState.state as? Normal)?.remoteChannelUpdate
+                            is Syncing -> (channelState.state as? Normal)?.remoteChannelUpdate
+                            else -> null
+                        }
+                    }
+                    val paymentInfo = OfferTypes.PaymentInfo(
+                        feeBase = remoteChannelUpdates.maxOfOrNull { it.feeBaseMsat } ?: walletParams.invoiceDefaultRoutingFees.feeBase,
+                        feeProportionalMillionths = remoteChannelUpdates.maxOfOrNull { it.feeProportionalMillionths } ?: walletParams.invoiceDefaultRoutingFees.feeProportional,
+                        cltvExpiryDelta = remoteChannelUpdates.maxOfOrNull { it.cltvExpiryDelta } ?: walletParams.invoiceDefaultRoutingFees.cltvExpiryDelta,
+                        minHtlc = remoteChannelUpdates.minOfOrNull { it.htlcMinimumMsat } ?: 1.msat,
+                        maxHtlc = amount,
+                        allowedFeatures = Features.empty
+                    )
+                    val remoteNodePayload = RouteBlindingEncryptedData(TlvStream(
+                        RouteBlindingEncryptedDataTlv.OutgoingChannelId(ShortChannelId.peerId(nodeParams.nodeId)),
+                        RouteBlindingEncryptedDataTlv.PaymentRelay(paymentInfo.cltvExpiryDelta, paymentInfo.feeProportionalMillionths, paymentInfo.feeBase),
+                        RouteBlindingEncryptedDataTlv.PaymentConstraints((paymentInfo.cltvExpiryDelta + nodeParams.maxFinalCltvExpiryDelta).toCltvExpiry(currentBlockHeight.toLong()), paymentInfo.minHtlc)
+                    )).write().toByteVector()
+                    val blindedRoute = RouteBlinding.create(randomKey(), listOf(remoteNodeId, nodeParams.nodeId), listOf(remoteNodePayload, recipientPayload)).route
+                    val path = Bolt12Invoice.Companion.PaymentBlindedContactInfo(OfferTypes.ContactInfo.BlindedPath(blindedRoute), paymentInfo)
+                    val invoice = Bolt12Invoice(request, preimage, decrypted.blindedPrivateKey, nodeParams.bolt12invoiceExpiry.inWholeSeconds, nodeParams.features.bolt12Features(), listOf(path))
+                    return when (val invoiceMessage = buildMessage(randomKey(), randomKey(), listOf(IntermediateNode(remoteNodeId)), Destination.BlindedPath(decrypted.content.replyPath), TlvStream(OnionMessagePayloadTlv.Invoice(invoice.records)))) {
+                        is Left -> null
+                        is Right -> OnionMessageAction.SendMessage(invoiceMessage.value)
+                    }
+                } else {
+                    // TODO: send back invoice error
+                    return null
+                }
+            } else {
+                // Ignore unexpected messages.
+                return null
+            }
+        }
+    }
+
+    fun checkInvoiceRequestTimeout(timeoutSeconds: Long): List<OnionMessageAction.ReportPaymentFailure> {
+        val timedOut = ArrayList<OnionMessageAction.ReportPaymentFailure>()
+        val cutoff = currentTimestampSeconds() - timeoutSeconds
+        for ((pathId, pending) in pendingInvoiceRequests) {
+            if (pending.createAtSeconds < cutoff) {
+                timedOut.add(OnionMessageAction.ReportPaymentFailure(pending.payOffer, OfferPaymentFailure.NoResponse))
+                pendingInvoiceRequests.remove(pathId)
+            }
+        }
+        return timedOut
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferPaymentFailure.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferPaymentFailure.kt
@@ -1,0 +1,10 @@
+package fr.acinq.lightning.payment
+
+import fr.acinq.lightning.wire.OfferTypes
+
+sealed class OfferPaymentFailure {
+    data object NoResponse : OfferPaymentFailure()
+    data class InvalidResponse(val request: OfferTypes.InvoiceRequest) : OfferPaymentFailure()
+    data class InvoiceError(val request: OfferTypes.InvoiceRequest, val error: OfferTypes.InvoiceError) : OfferPaymentFailure()
+    data class InvalidInvoice(val request: OfferTypes.InvoiceRequest, val invoice: Bolt12Invoice) : OfferPaymentFailure()
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/PaymentRequest.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/PaymentRequest.kt
@@ -1,6 +1,7 @@
 package fr.acinq.lightning.payment
 
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.PublicKey
 import fr.acinq.bitcoin.utils.Try
 import fr.acinq.lightning.Features
 import fr.acinq.lightning.MilliSatoshi
@@ -9,6 +10,7 @@ import fr.acinq.lightning.utils.currentTimestampSeconds
 sealed class PaymentRequest {
     abstract val amount: MilliSatoshi?
     abstract val paymentHash: ByteVector32
+    abstract val nodeId: PublicKey
     abstract val features: Features
 
     abstract fun isExpired(currentTimestampSeconds: Long = currentTimestampSeconds()): Boolean

--- a/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
@@ -367,7 +367,7 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         val (db, _, pr) = createFixture()
         assertTrue(db.listLightningOutgoingPayments(pr.paymentHash).isEmpty())
 
-        val payment1 = LightningOutgoingPayment(UUID.randomUUID(), 50_000.msat, pr.nodeId, pr)
+        val payment1 = LightningOutgoingPayment(UUID.randomUUID(), 50_000.msat, pr.nodeId, LightningOutgoingPayment.Details.Normal(pr))
         db.addOutgoingPayment(payment1)
         assertEquals(listOf(payment1), db.listLightningOutgoingPayments(pr.paymentHash))
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -518,7 +518,7 @@ class PeerTest : LightningTestSuite() {
 
         val invoice = bob.createInvoice(randomBytes32(), 15_000_000.msat, Either.Left("test invoice"), null)
 
-        alice.send(PayInvoice(UUID.randomUUID(), invoice.amount!!, alice.remoteNodeId, LightningOutgoingPayment.Details.Normal(invoice)))
+        alice.send(PayInvoice(UUID.randomUUID(), invoice.amount!!, LightningOutgoingPayment.Details.Normal(invoice)))
 
         val updateHtlc = alice2bob.expect<UpdateAddHtlc>()
         val aliceCommitSig = alice2bob.expect<CommitSig>()
@@ -563,7 +563,7 @@ class PeerTest : LightningTestSuite() {
         // Bob sends a multipart payment to Alice.
         val (alice, bob, alice2bob1, bob2alice1) = newPeers(this, nodeParams, walletParams, listOf(aliceChan1 to bobChan1, aliceChan2 to bobChan2), automateMessaging = false)
         val invoice = alice.createInvoice(randomBytes32(), 150_000_000.msat, Either.Left("test invoice"), null)
-        bob.send(PayInvoice(UUID.randomUUID(), invoice.amount!!, alice.nodeParams.nodeId, LightningOutgoingPayment.Details.Normal(invoice)))
+        bob.send(PayInvoice(UUID.randomUUID(), invoice.amount!!, LightningOutgoingPayment.Details.Normal(invoice)))
 
         // Bob sends one HTLC on each channel.
         val htlcs = listOf(
@@ -663,7 +663,7 @@ class PeerTest : LightningTestSuite() {
 
         val invoice = bob.createInvoice(randomBytes32(), 15_000_000.msat, Either.Left("test invoice"), null)
 
-        alice.send(PayInvoice(UUID.randomUUID(), invoice.amount!!, alice.remoteNodeId, LightningOutgoingPayment.Details.Normal(invoice)))
+        alice.send(PayInvoice(UUID.randomUUID(), invoice.amount!!, LightningOutgoingPayment.Details.Normal(invoice)))
 
         alice.expectState<Normal> { commitments.availableBalanceForReceive() > alice0.commitments.availableBalanceForReceive() }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -20,6 +20,7 @@ import fr.acinq.lightning.channel.TestsHelper
 import fr.acinq.lightning.channel.TestsHelper.createWallet
 import fr.acinq.lightning.channel.states.*
 import fr.acinq.lightning.db.InMemoryDatabases
+import fr.acinq.lightning.db.LightningOutgoingPayment
 import fr.acinq.lightning.io.*
 import fr.acinq.lightning.router.Announcements
 import fr.acinq.lightning.tests.TestConstants
@@ -517,7 +518,7 @@ class PeerTest : LightningTestSuite() {
 
         val invoice = bob.createInvoice(randomBytes32(), 15_000_000.msat, Either.Left("test invoice"), null)
 
-        alice.send(SendPayment(UUID.randomUUID(), invoice.amount!!, alice.remoteNodeId, invoice))
+        alice.send(PayInvoice(UUID.randomUUID(), invoice.amount!!, alice.remoteNodeId, LightningOutgoingPayment.Details.Normal(invoice)))
 
         val updateHtlc = alice2bob.expect<UpdateAddHtlc>()
         val aliceCommitSig = alice2bob.expect<CommitSig>()
@@ -562,7 +563,7 @@ class PeerTest : LightningTestSuite() {
         // Bob sends a multipart payment to Alice.
         val (alice, bob, alice2bob1, bob2alice1) = newPeers(this, nodeParams, walletParams, listOf(aliceChan1 to bobChan1, aliceChan2 to bobChan2), automateMessaging = false)
         val invoice = alice.createInvoice(randomBytes32(), 150_000_000.msat, Either.Left("test invoice"), null)
-        bob.send(SendPayment(UUID.randomUUID(), invoice.amount!!, alice.nodeParams.nodeId, invoice))
+        bob.send(PayInvoice(UUID.randomUUID(), invoice.amount!!, alice.nodeParams.nodeId, LightningOutgoingPayment.Details.Normal(invoice)))
 
         // Bob sends one HTLC on each channel.
         val htlcs = listOf(
@@ -662,7 +663,7 @@ class PeerTest : LightningTestSuite() {
 
         val invoice = bob.createInvoice(randomBytes32(), 15_000_000.msat, Either.Left("test invoice"), null)
 
-        alice.send(SendPayment(UUID.randomUUID(), invoice.amount!!, alice.remoteNodeId, invoice))
+        alice.send(PayInvoice(UUID.randomUUID(), invoice.amount!!, alice.remoteNodeId, LightningOutgoingPayment.Details.Normal(invoice)))
 
         alice.expectState<Normal> { commitments.availableBalanceForReceive() > alice0.commitments.availableBalanceForReceive() }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
@@ -1,0 +1,85 @@
+package fr.acinq.lightning.payment
+
+import fr.acinq.bitcoin.ByteVector
+import fr.acinq.bitcoin.utils.Either
+import fr.acinq.lightning.EncodedNodeId
+import fr.acinq.lightning.Lightning.randomBytes32
+import fr.acinq.lightning.Lightning.randomKey
+import fr.acinq.lightning.NodeUri
+import fr.acinq.lightning.ShortChannelId
+import fr.acinq.lightning.crypto.RouteBlinding
+import fr.acinq.lightning.crypto.sphinx.DecryptedPacket
+import fr.acinq.lightning.crypto.sphinx.Sphinx
+import fr.acinq.lightning.io.PayOffer
+import fr.acinq.lightning.logging.MDCLogger
+import fr.acinq.lightning.tests.TestConstants
+import fr.acinq.lightning.tests.utils.LightningTestSuite
+import fr.acinq.lightning.tests.utils.runSuspendTest
+import fr.acinq.lightning.tests.utils.testLoggerFactory
+import fr.acinq.lightning.utils.UUID
+import fr.acinq.lightning.utils.msat
+import fr.acinq.lightning.wire.MessageOnion
+import fr.acinq.lightning.wire.OfferTypes
+import fr.acinq.lightning.wire.OnionMessage
+import fr.acinq.lightning.wire.RouteBlindingEncryptedData
+import kotlin.test.*
+
+class OfferManagerTestsCommon : LightningTestSuite() {
+    val trampolineKey = randomKey()
+    val walletParams = TestConstants.Alice.walletParams.copy(trampolineNode = NodeUri(trampolineKey.publicKey(), "trampoline.com", 9735))
+    val logger: MDCLogger = MDCLogger(testLoggerFactory.newLogger(this::class))
+
+    fun trampolineRelay(msg: OnionMessage): Pair<OnionMessage, Either<ShortChannelId, EncodedNodeId>> {
+        val blindedPrivateKey = RouteBlinding.derivePrivateKey(trampolineKey, msg.blindingKey)
+        val decrypted = Sphinx.peel(
+            blindedPrivateKey,
+            ByteVector.empty,
+            msg.onionRoutingPacket
+        )
+        assertIs<Either.Right<DecryptedPacket>>(decrypted)
+        assertFalse(decrypted.value.isLastPacket)
+        val message = MessageOnion.read(decrypted.value.payload.toByteArray())
+        val (decryptedPayload, nextBlinding) = RouteBlinding.decryptPayload(
+            trampolineKey,
+            msg.blindingKey,
+            message.encryptedData
+        ).right!!
+        val relayInfo = RouteBlindingEncryptedData.read(decryptedPayload.toByteArray()).right!!
+
+        return Pair(OnionMessage(relayInfo.nextBlindingOverride ?: nextBlinding, decrypted.value.nextPacket), relayInfo.nextNodeId?.let { Either.Right(it) } ?: Either.Left(relayInfo.outgoingChannelId!!))
+    }
+
+    @Test
+    fun `offer workflow`() = runSuspendTest {
+        val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, walletParams, logger)
+        val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, walletParams, logger)
+
+        val pathId = randomBytes32()
+        val offer = OfferTypes.Offer.createBlindedOffer(
+            1000.msat,
+            "Blockaccino",
+            TestConstants.Alice.nodeParams,
+            walletParams.trampolineNode,
+            pathId,
+            setOf(OfferTypes.OfferQuantityMax(0))
+        )
+        aliceOfferManager.registerOffer(offer, pathId)
+
+        val payOffer = PayOffer(UUID.randomUUID(), 5500.msat, 5, offer, 2)
+        val invoiceRequests = bobOfferManager.requestInvoice(payOffer)
+        assertTrue(invoiceRequests.size == 1)
+        val relay1 = trampolineRelay(invoiceRequests.first())
+        assertEquals(Either.Right(EncodedNodeId(trampolineKey.publicKey())), relay1.second)
+        val relay2 = trampolineRelay(relay1.first)
+        assertEquals(Either.Left(ShortChannelId.peerId(TestConstants.Alice.nodeParams.nodeId)), relay2.second)
+        val invoiceResponse = aliceOfferManager.receiveMessage(relay2.first, mapOf(), 0)
+        assertIs<OnionMessageAction.SendMessage>(invoiceResponse)
+        val relay3 = trampolineRelay(invoiceResponse.message)
+        assertEquals(Either.Right(EncodedNodeId(trampolineKey.publicKey())), relay3.second)
+        val relay4 = trampolineRelay(relay3.first)
+        assertEquals(Either.Right(EncodedNodeId(TestConstants.Bob.nodeParams.nodeId)), relay4.second)
+        val payInvoice = bobOfferManager.receiveMessage(relay4.first, mapOf(), 0)
+        assertIs<OnionMessageAction.PayInvoice>(payInvoice)
+        assertEquals(payOffer, payInvoice.payOffer)
+    }
+}

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
@@ -1,17 +1,17 @@
 package fr.acinq.lightning.payment
 
 import fr.acinq.bitcoin.ByteVector
+import fr.acinq.bitcoin.PrivateKey
 import fr.acinq.bitcoin.utils.Either
-import fr.acinq.lightning.EncodedNodeId
+import fr.acinq.lightning.*
 import fr.acinq.lightning.Lightning.randomBytes32
 import fr.acinq.lightning.Lightning.randomKey
-import fr.acinq.lightning.NodeUri
-import fr.acinq.lightning.ShortChannelId
 import fr.acinq.lightning.crypto.RouteBlinding
 import fr.acinq.lightning.crypto.sphinx.DecryptedPacket
 import fr.acinq.lightning.crypto.sphinx.Sphinx
+import fr.acinq.lightning.io.OfferInvoiceReceived
+import fr.acinq.lightning.io.OfferNotPaid
 import fr.acinq.lightning.io.PayOffer
-import fr.acinq.lightning.io.PeerEvent
 import fr.acinq.lightning.logging.MDCLogger
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
@@ -24,66 +24,193 @@ import fr.acinq.lightning.wire.OfferTypes
 import fr.acinq.lightning.wire.OnionMessage
 import fr.acinq.lightning.wire.RouteBlindingEncryptedData
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
 import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
 
 class OfferManagerTestsCommon : LightningTestSuite() {
-    val trampolineKey = randomKey()
-    val walletParams = TestConstants.Alice.walletParams.copy(trampolineNode = NodeUri(trampolineKey.publicKey(), "trampoline.com", 9735))
-    val logger: MDCLogger = MDCLogger(testLoggerFactory.newLogger(this::class))
+    private val aliceTrampolineKey = randomKey()
+    private val bobTrampolineKey = randomKey()
+    private val aliceWalletParams = TestConstants.Alice.walletParams.copy(trampolineNode = NodeUri(aliceTrampolineKey.publicKey(), "trampoline.com", 9735))
+    private val bobWalletParams = TestConstants.Bob.walletParams.copy(trampolineNode = NodeUri(bobTrampolineKey.publicKey(), "trampoline.com", 9735))
+    private val logger: MDCLogger = MDCLogger(testLoggerFactory.newLogger(this::class))
 
-    fun trampolineRelay(msg: OnionMessage): Pair<OnionMessage, Either<ShortChannelId, EncodedNodeId>> {
+    /** Simulate the decryption step performed by the trampoline node when relaying onion messages. */
+    private fun trampolineRelay(msg: OnionMessage, trampolineKey: PrivateKey): Pair<OnionMessage, Either<ShortChannelId, EncodedNodeId>> {
         val blindedPrivateKey = RouteBlinding.derivePrivateKey(trampolineKey, msg.blindingKey)
-        val decrypted = Sphinx.peel(
-            blindedPrivateKey,
-            ByteVector.empty,
-            msg.onionRoutingPacket
-        )
+        val decrypted = Sphinx.peel(blindedPrivateKey, ByteVector.empty, msg.onionRoutingPacket)
         assertIs<Either.Right<DecryptedPacket>>(decrypted)
         assertFalse(decrypted.value.isLastPacket)
         val message = MessageOnion.read(decrypted.value.payload.toByteArray())
-        val (decryptedPayload, nextBlinding) = RouteBlinding.decryptPayload(
-            trampolineKey,
-            msg.blindingKey,
-            message.encryptedData
-        ).right!!
+        val (decryptedPayload, nextBlinding) = RouteBlinding.decryptPayload(trampolineKey, msg.blindingKey, message.encryptedData).right!!
         val relayInfo = RouteBlindingEncryptedData.read(decryptedPayload.toByteArray()).right!!
+        assertNull(relayInfo.pathId)
+        assertEquals(Features.empty, relayInfo.allowedFeatures)
+        val nextNode = relayInfo.nextNodeId?.let { Either.Right(it) } ?: Either.Left(relayInfo.outgoingChannelId!!)
+        return Pair(OnionMessage(relayInfo.nextBlindingOverride ?: nextBlinding, decrypted.value.nextPacket), nextNode)
+    }
 
-        return Pair(OnionMessage(relayInfo.nextBlindingOverride ?: nextBlinding, decrypted.value.nextPacket), relayInfo.nextNodeId?.let { Either.Right(it) } ?: Either.Left(relayInfo.outgoingChannelId!!))
+    private fun createOffer(offerManager: OfferManager, amount: MilliSatoshi? = null): OfferTypes.Offer {
+        val pathId = randomBytes32()
+        val offer = OfferTypes.Offer.createBlindedOffer(
+            amount,
+            "Blockaccino",
+            offerManager.nodeParams,
+            offerManager.walletParams.trampolineNode,
+            pathId,
+        )
+        offerManager.registerOffer(offer, pathId)
+        return offer
     }
 
     @Test
-    fun `offer workflow`() = runSuspendTest {
-        val eventsFlow = MutableSharedFlow<PeerEvent>(extraBufferCapacity = 64)
-        val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, walletParams, eventsFlow, logger)
-        val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, walletParams, eventsFlow, logger)
+    fun `pay offer through the same trampoline node`() = runSuspendTest {
+        // Alice and Bob use the same trampoline node.
+        val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val offer = createOffer(aliceOfferManager, amount = 1000.msat)
 
-        val pathId = randomBytes32()
-        val offer = OfferTypes.Offer.createBlindedOffer(
-            1000.msat,
-            "Blockaccino",
-            TestConstants.Alice.nodeParams,
-            walletParams.trampolineNode,
-            pathId,
-            setOf(OfferTypes.OfferQuantityMax(0))
-        )
-        aliceOfferManager.registerOffer(offer, pathId)
-
+        // Bob sends an invoice request to Alice.
         val payOffer = PayOffer(UUID.randomUUID(), randomKey(), 5500.msat, offer, 20.seconds)
         val (_, invoiceRequests) = bobOfferManager.requestInvoice(payOffer)
         assertTrue(invoiceRequests.size == 1)
-        val relay1 = trampolineRelay(invoiceRequests.first())
-        assertEquals(Either.Right(EncodedNodeId(trampolineKey.publicKey())), relay1.second)
-        val relay2 = trampolineRelay(relay1.first)
-        assertEquals(Either.Left(ShortChannelId.peerId(TestConstants.Alice.nodeParams.nodeId)), relay2.second)
-        val invoiceResponse = aliceOfferManager.receiveMessage(relay2.first, listOf(), 0)
+        val (messageForAlice, nextNodeAlice) = trampolineRelay(invoiceRequests.first(), aliceTrampolineKey)
+        assertEquals(Either.Left(ShortChannelId.peerId(TestConstants.Alice.nodeParams.nodeId)), nextNodeAlice)
+        // Alice sends an invoice back to Bob.
+        val invoiceResponse = aliceOfferManager.receiveMessage(messageForAlice, listOf(), 0)
         assertIs<OnionMessageAction.SendMessage>(invoiceResponse)
-        val relay3 = trampolineRelay(invoiceResponse.message)
-        assertEquals(Either.Right(EncodedNodeId(trampolineKey.publicKey())), relay3.second)
-        val relay4 = trampolineRelay(relay3.first)
-        assertEquals(Either.Right(EncodedNodeId(TestConstants.Bob.nodeParams.nodeId)), relay4.second)
-        val payInvoice = bobOfferManager.receiveMessage(relay4.first, listOf(), 0)
+        val (messageForBob, nextNodeBob) = trampolineRelay(invoiceResponse.message, aliceTrampolineKey)
+        assertEquals(Either.Right(EncodedNodeId(TestConstants.Bob.nodeParams.nodeId)), nextNodeBob)
+        val payInvoice = bobOfferManager.receiveMessage(messageForBob, listOf(), 0)
         assertIs<OnionMessageAction.PayInvoice>(payInvoice)
+        assertEquals(OfferInvoiceReceived(payOffer, payInvoice.invoice), bobOfferManager.eventsFlow.first())
         assertEquals(payOffer, payInvoice.payOffer)
+    }
+
+    @Test
+    fun `pay offer through different trampoline nodes`() = runSuspendTest {
+        // Alice and Bob use different trampoline nodes.
+        val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, bobWalletParams, MutableSharedFlow(replay = 10), logger)
+        val offer = createOffer(aliceOfferManager)
+
+        // Bob sends an invoice request to Alice.
+        val payOffer = PayOffer(UUID.randomUUID(), randomKey(), 5500.msat, offer, 20.seconds)
+        val (_, invoiceRequests) = bobOfferManager.requestInvoice(payOffer)
+        assertTrue(invoiceRequests.size == 1)
+        val (messageForAliceTrampoline, nextNodeAliceTrampoline) = trampolineRelay(invoiceRequests.first(), bobTrampolineKey)
+        assertEquals(Either.Right(EncodedNodeId(aliceTrampolineKey.publicKey())), nextNodeAliceTrampoline)
+        val (messageForAlice, nextNodeAlice) = trampolineRelay(messageForAliceTrampoline, aliceTrampolineKey)
+        assertEquals(Either.Left(ShortChannelId.peerId(TestConstants.Alice.nodeParams.nodeId)), nextNodeAlice)
+        // Alice sends an invoice back to Bob.
+        val invoiceResponse = aliceOfferManager.receiveMessage(messageForAlice, listOf(), 0)
+        assertIs<OnionMessageAction.SendMessage>(invoiceResponse)
+        val (messageForBobTrampoline, nextNodeBobTrampoline) = trampolineRelay(invoiceResponse.message, aliceTrampolineKey)
+        assertEquals(Either.Right(EncodedNodeId(bobTrampolineKey.publicKey())), nextNodeBobTrampoline)
+        val (messageForBob, nextNodeBob) = trampolineRelay(messageForBobTrampoline, bobTrampolineKey)
+        assertEquals(Either.Right(EncodedNodeId(TestConstants.Bob.nodeParams.nodeId)), nextNodeBob)
+        val payInvoice = bobOfferManager.receiveMessage(messageForBob, listOf(), 0)
+        assertIs<OnionMessageAction.PayInvoice>(payInvoice)
+        assertEquals(OfferInvoiceReceived(payOffer, payInvoice.invoice), bobOfferManager.eventsFlow.first())
+        assertEquals(payOffer, payInvoice.payOffer)
+    }
+
+    @Test
+    fun `invoice request timed out`() = runSuspendTest {
+        val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val offer = createOffer(aliceOfferManager)
+
+        // Bob sends an invoice request to Alice.
+        val payOffer = PayOffer(UUID.randomUUID(), randomKey(), 5500.msat, offer, 20.seconds)
+        val (invoiceRequestPathId, invoiceRequests) = bobOfferManager.requestInvoice(payOffer)
+        val (messageForAlice, _) = trampolineRelay(invoiceRequests.first(), aliceTrampolineKey)
+        // The invoice request times out.
+        bobOfferManager.checkInvoiceRequestTimeout(invoiceRequestPathId, payOffer)
+        assertEquals(OfferNotPaid(payOffer, OfferPaymentFailure.NoResponse), bobOfferManager.eventsFlow.first())
+        // The timeout can be replayed without any side-effect.
+        bobOfferManager.checkInvoiceRequestTimeout(invoiceRequestPathId, payOffer)
+        // Alice sends an invoice back to Bob after the timeout.
+        val invoiceResponse = aliceOfferManager.receiveMessage(messageForAlice, listOf(), 0)
+        assertIs<OnionMessageAction.SendMessage>(invoiceResponse)
+        val (messageForBob, _) = trampolineRelay(invoiceResponse.message, aliceTrampolineKey)
+        assertNull(bobOfferManager.receiveMessage(messageForBob, listOf(), 0))
+    }
+
+    @Test
+    fun `duplicate invoice request`() = runSuspendTest {
+        val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val offer = createOffer(aliceOfferManager)
+
+        // Bob sends two invoice requests to Alice.
+        val payOffer = PayOffer(UUID.randomUUID(), randomKey(), 5500.msat, offer, 20.seconds)
+        val (_, invoiceRequests) = bobOfferManager.requestInvoice(payOffer)
+        val (messageForAlice, _) = trampolineRelay(invoiceRequests.first(), aliceTrampolineKey)
+        // Alice sends two invoices back to Bob.
+        val invoiceResponse1 = aliceOfferManager.receiveMessage(messageForAlice, listOf(), 0)
+        assertIs<OnionMessageAction.SendMessage>(invoiceResponse1)
+        val (messageForBob1, _) = trampolineRelay(invoiceResponse1.message, aliceTrampolineKey)
+        val invoiceResponse2 = aliceOfferManager.receiveMessage(messageForAlice, listOf(), 0)
+        assertIs<OnionMessageAction.SendMessage>(invoiceResponse2)
+        val (messageForBob2, _) = trampolineRelay(invoiceResponse2.message, aliceTrampolineKey)
+        // Bob pays the first invoice and ignores the second one.
+        val payInvoice = bobOfferManager.receiveMessage(messageForBob1, listOf(), 0)
+        assertIs<OnionMessageAction.PayInvoice>(payInvoice)
+        assertEquals(OfferInvoiceReceived(payOffer, payInvoice.invoice), bobOfferManager.eventsFlow.first())
+        assertEquals(payOffer, payInvoice.payOffer)
+        assertNull(bobOfferManager.receiveMessage(messageForBob2, listOf(), 0))
+    }
+
+    @Test
+    fun `receive invalid invoice request`() = runSuspendTest {
+        val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val offer = createOffer(aliceOfferManager)
+
+        // Bob sends an invalid invoice request to Alice.
+        val payOffer = PayOffer(UUID.randomUUID(), randomKey(), 5500.msat, offer, 20.seconds)
+        val (_, invoiceRequests) = bobOfferManager.requestInvoice(payOffer)
+        val (messageForAlice, _) = trampolineRelay(invoiceRequests.first(), aliceTrampolineKey)
+        assertNull(aliceOfferManager.receiveMessage(messageForAlice.copy(blindingKey = randomKey().publicKey()), listOf(), 0))
+    }
+
+    @Test
+    fun `receive invalid invoice response`() = runSuspendTest {
+        // Alice and Bob use the same trampoline node.
+        val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val offer = createOffer(aliceOfferManager)
+
+        // Bob sends an invoice request to Alice.
+        val payOffer = PayOffer(UUID.randomUUID(), randomKey(), 5500.msat, offer, 20.seconds)
+        val (_, invoiceRequests) = bobOfferManager.requestInvoice(payOffer)
+        val (messageForAlice, _) = trampolineRelay(invoiceRequests.first(), aliceTrampolineKey)
+        // Alice sends an invalid response back to Bob.
+        val invoiceResponse = aliceOfferManager.receiveMessage(messageForAlice, listOf(), 0)
+        assertIs<OnionMessageAction.SendMessage>(invoiceResponse)
+        val (messageForBob, _) = trampolineRelay(invoiceResponse.message, aliceTrampolineKey)
+        assertNull(bobOfferManager.receiveMessage(messageForBob.copy(blindingKey = randomKey().publicKey()), listOf(), 0))
+    }
+
+    @Test
+    fun `receive invoice error`() = runSuspendTest {
+        // Alice and Bob use the same trampoline node.
+        val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val offer = createOffer(aliceOfferManager, 50_000.msat)
+
+        // Bob sends an invoice request to Alice that pays less than the offer amount.
+        val payOffer = PayOffer(UUID.randomUUID(), randomKey(), 40_000.msat, offer, 20.seconds)
+        val (_, invoiceRequests) = bobOfferManager.requestInvoice(payOffer)
+        val (messageForAlice, _) = trampolineRelay(invoiceRequests.first(), aliceTrampolineKey)
+        // Alice sends an invoice error back to Bob.
+        val invoiceResponse = aliceOfferManager.receiveMessage(messageForAlice, listOf(), 0)
+        assertIs<OnionMessageAction.SendMessage>(invoiceResponse)
+        val (messageForBob, _) = trampolineRelay(invoiceResponse.message, aliceTrampolineKey)
+        assertNull(bobOfferManager.receiveMessage(messageForBob, listOf(), 0))
+        val event = bobOfferManager.eventsFlow.first()
+        assertIs<OfferNotPaid>(event)
+        assertIs<OfferPaymentFailure.InvoiceError>(event.reason)
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
@@ -19,7 +19,7 @@ import fr.acinq.lightning.crypto.sphinx.Sphinx
 import fr.acinq.lightning.db.InMemoryPaymentsDb
 import fr.acinq.lightning.db.LightningOutgoingPayment
 import fr.acinq.lightning.db.OutgoingPaymentsDb
-import fr.acinq.lightning.io.SendPayment
+import fr.acinq.lightning.io.PayInvoice
 import fr.acinq.lightning.io.WrappedChannelCommand
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
@@ -38,7 +38,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val (alice, _) = TestsHelper.reachNormal()
         val invoice = makeInvoice(amount = 100_000.msat, supportsTrampoline = true)
         val outgoingPaymentHandler = OutgoingPaymentHandler(alice.staticParams.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
-        val payment = SendPayment(UUID.randomUUID(), MilliSatoshi(-1), invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), MilliSatoshi(-1), invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
         val result = outgoingPaymentHandler.sendPayment(payment, mapOf(), alice.currentBlockHeight)
         assertFailureEquals(result as OutgoingPaymentHandler.Failure, OutgoingPaymentHandler.Failure(payment, FinalFailure.InvalidPaymentAmount.toPaymentFailure()))
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
@@ -62,7 +62,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val invoice2 = Bolt11InvoiceTestsCommon.createInvoiceUnsafe(features = Features(mapOf(Feature.VariableLengthOnion to FeatureSupport.Mandatory, Feature.PaymentSecret to FeatureSupport.Mandatory), setOf(UnknownFeature(188))))
         for (invoice in listOf(invoice1, invoice2)) {
             val outgoingPaymentHandler = OutgoingPaymentHandler(alice.staticParams.nodeParams.copy(features = features), defaultWalletParams, InMemoryPaymentsDb())
-            val payment = SendPayment(UUID.randomUUID(), 15_000.msat, invoice.nodeId, invoice)
+            val payment = PayInvoice(UUID.randomUUID(), 15_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
             val result = outgoingPaymentHandler.sendPayment(payment, mapOf(), alice.currentBlockHeight)
             assertFailureEquals(result as OutgoingPaymentHandler.Failure, OutgoingPaymentHandler.Failure(payment, FinalFailure.FeaturesNotSupported.toPaymentFailure()))
             assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
@@ -75,7 +75,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val (alice, _) = TestsHelper.reachNormal()
         val invoice = makeInvoice(amount = 100_000.msat, supportsTrampoline = true)
         val outgoingPaymentHandler = OutgoingPaymentHandler(alice.staticParams.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
-        val payment = SendPayment(UUID.randomUUID(), 100_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
         val result = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to Offline(alice.state)), alice.currentBlockHeight)
         assertFailureEquals(result as OutgoingPaymentHandler.Failure, OutgoingPaymentHandler.Failure(payment, FinalFailure.NoAvailableChannels.toPaymentFailure()))
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
@@ -95,7 +95,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val amount = alice.commitments.availableBalanceForSend() + 10.msat
         val invoice = makeInvoice(amount = amount, supportsTrampoline = true)
         val outgoingPaymentHandler = OutgoingPaymentHandler(alice.staticParams.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
-        val payment = SendPayment(UUID.randomUUID(), amount, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), amount, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
         val result = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to alice.state), alice.currentBlockHeight)
         assertFailureEquals(result as OutgoingPaymentHandler.Failure, OutgoingPaymentHandler.Failure(payment, FinalFailure.InsufficientBalance.toPaymentFailure()))
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
@@ -113,7 +113,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val channels = makeChannels()
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
         val invoice = makeInvoice(amount = 100_000.msat, supportsTrampoline = true)
-        val payment = SendPayment(UUID.randomUUID(), 100_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
         val result = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val (channelId, add) = filterAddHtlcCommands(result).first()
         outgoingPaymentHandler.processAddSettled(createRemoteFulfill(channelId, add, randomBytes32())) as OutgoingPaymentHandler.Success
@@ -132,7 +132,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         run {
             // Send payment 1 of 2: this should work because we're still under the maxAcceptedHtlcs.
             val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-            val payment = SendPayment(UUID.randomUUID(), 100_000.msat, invoice.nodeId, invoice)
+            val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
             val result = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to alice.state), alice.currentBlockHeight)
             assertTrue { result is OutgoingPaymentHandler.Progress }
 
@@ -152,7 +152,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         run {
             // Send payment 2 of 2: this should exceed the configured maxAcceptedHtlcs.
             val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-            val payment = SendPayment(UUID.randomUUID(), 50_000.msat, invoice.nodeId, invoice)
+            val payment = PayInvoice(UUID.randomUUID(), 50_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
             val result1 = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to alice.state), alice.currentBlockHeight)
             assertTrue { result1 is OutgoingPaymentHandler.Progress }
 
@@ -185,7 +185,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         run {
             // Send payment 1 of 2: this should work because we're still under the maxHtlcValueInFlightMsat.
             val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-            val payment = SendPayment(UUID.randomUUID(), 100_000.msat, invoice.nodeId, invoice)
+            val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
             val result = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to alice.state), alice.currentBlockHeight)
             assertTrue { result is OutgoingPaymentHandler.Progress }
 
@@ -205,7 +205,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         run {
             // Send payment 2 of 2: this should exceed the configured maxHtlcValueInFlightMsat.
             val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-            val payment = SendPayment(UUID.randomUUID(), 100_000.msat, invoice.nodeId, invoice)
+            val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
             val result1 = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to alice.state), alice.currentBlockHeight)
             assertTrue { result1 is OutgoingPaymentHandler.Progress }
 
@@ -231,7 +231,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
     fun `successful first attempt -- single part`() = runSuspendTest {
         val recipientKey = randomKey()
         val invoice = makeInvoice(amount = 195_000.msat, supportsTrampoline = true, privKey = recipientKey)
-        val payment = SendPayment(UUID.randomUUID(), 200_000.msat, invoice.nodeId, invoice) // we slightly overpay the invoice amount
+        val payment = PayInvoice(UUID.randomUUID(), 200_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice)) // we slightly overpay the invoice amount
         testSinglePartTrampolinePayment(payment, invoice, recipientKey)
     }
 
@@ -256,11 +256,11 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
                 features = Features(invoiceFeatures.toMap()),
             )
         }
-        val payment = SendPayment(UUID.randomUUID(), 200_000.msat, invoice.nodeId, invoice) // we slightly overpay the invoice amount
+        val payment = PayInvoice(UUID.randomUUID(), 200_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice)) // we slightly overpay the invoice amount
         testSinglePartTrampolinePayment(payment, invoice, recipientKey)
     }
 
-    private suspend fun testSinglePartTrampolinePayment(payment: SendPayment, invoice: Bolt11Invoice, recipientKey: PrivateKey) {
+    private suspend fun testSinglePartTrampolinePayment(payment: PayInvoice, invoice: Bolt11Invoice, recipientKey: PrivateKey) {
         val channels = makeChannels()
         val walletParams = defaultWalletParams.copy(trampolineFees = listOf(TrampolineFees(3.sat, 10_000, CltvExpiryDelta(144))))
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, walletParams, InMemoryPaymentsDb())
@@ -315,7 +315,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, walletParams, InMemoryPaymentsDb())
         val recipientKey = randomKey()
         val invoice = makeInvoice(amount = null, supportsTrampoline = true, privKey = recipientKey)
-        val payment = SendPayment(UUID.randomUUID(), 300_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
         val result = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds = filterAddHtlcCommands(result)
@@ -373,7 +373,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val recipientKey = randomKey()
         val extraHops = listOf(listOf(Bolt11Invoice.TaggedField.ExtraHop(randomKey().publicKey(), ShortChannelId(42), 10.msat, 100, CltvExpiryDelta(48))))
         val invoice = makeInvoice(amount = null, supportsTrampoline = false, privKey = recipientKey, extraHops = extraHops)
-        val payment = SendPayment(UUID.randomUUID(), 300_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
         val result = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds = filterAddHtlcCommands(result)
@@ -425,7 +425,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams.copy(paymentRecipientExpiryParams = recipientExpiryParams), walletParams, InMemoryPaymentsDb())
         val recipientKey = randomKey()
         val invoice = makeInvoice(amount = null, supportsTrampoline = true, privKey = recipientKey)
-        val payment = SendPayment(UUID.randomUUID(), 300_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
         val result = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds = filterAddHtlcCommands(result)
@@ -456,7 +456,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val preimage = randomBytes32()
         val incomingPaymentHandler = IncomingPaymentHandler(TestConstants.Bob.nodeParams, InMemoryPaymentsDb())
         val invoice = incomingPaymentHandler.createInvoice(preimage, amount = null, Either.Left("phoenix to phoenix"), listOf())
-        val payment = SendPayment(UUID.randomUUID(), 300_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
         val result = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds = filterAddHtlcCommands(result)
@@ -510,7 +510,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
         val recipientKey = randomKey()
         val invoice = makeInvoice(amount = null, supportsTrampoline = true, privKey = recipientKey)
-        val payment = SendPayment(UUID.randomUUID(), 300_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
         val progress1 = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds1 = filterAddHtlcCommands(progress1)
@@ -582,7 +582,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
         // The invoice comes from Bob, our direct peer (and trampoline node).
         val invoice = makeInvoice(amount = null, supportsTrampoline = true, privKey = TestConstants.Bob.nodeParams.nodePrivateKey)
-        val payment = SendPayment(UUID.randomUUID(), 300_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
         val result1 = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds1 = filterAddHtlcCommands(result1)
@@ -629,7 +629,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         )
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, walletParams, InMemoryPaymentsDb())
         val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-        val payment = SendPayment(UUID.randomUUID(), 550_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 550_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
         val progress1 = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds1 = filterAddHtlcCommands(progress1)
@@ -658,7 +658,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         )
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, walletParams, InMemoryPaymentsDb())
         val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-        val payment = SendPayment(UUID.randomUUID(), 220_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 220_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
         val progress1 = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds1 = filterAddHtlcCommands(progress1)
@@ -690,7 +690,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
             val channels = makeChannels()
             val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
             val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-            val payment = SendPayment(UUID.randomUUID(), 50_000.msat, invoice.nodeId, invoice)
+            val payment = PayInvoice(UUID.randomUUID(), 50_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
             val progress = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
             val adds = filterAddHtlcCommands(progress)
@@ -710,7 +710,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
     private suspend fun testLocalChannelFailures(invoice: Bolt11Invoice) {
         val channels = makeChannels()
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
-        val payment = SendPayment(UUID.randomUUID(), 5_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 5_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
         var progress = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         assertEquals(1, progress.actions.size)
@@ -754,7 +754,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val channels = makeChannels()
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
         val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-        val payment = SendPayment(UUID.randomUUID(), 5_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 5_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
         val progress1 = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         assertEquals(1, progress1.actions.size)
@@ -783,7 +783,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val channels = makeChannels()
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
         val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-        val payment = SendPayment(UUID.randomUUID(), 310_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 310_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
         val progress = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds = filterAddHtlcCommands(progress)
@@ -810,7 +810,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val channels = makeChannels()
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
         val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-        val payment = SendPayment(UUID.randomUUID(), 310_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 310_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
         val progress = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds = filterAddHtlcCommands(progress)
@@ -843,7 +843,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val (adds, attempt) = run {
             val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, db)
             val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-            val payment = SendPayment(UUID.randomUUID(), 550_000.msat, invoice.nodeId, invoice)
+            val payment = PayInvoice(UUID.randomUUID(), 550_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
 
             val progress = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
             val attempt = outgoingPaymentHandler.getPendingPayment(payment.paymentId)!!
@@ -873,7 +873,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val channels = makeChannels()
         val preimage = randomBytes32()
         val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-        val payment = SendPayment(UUID.randomUUID(), 550_000.msat, invoice.nodeId, invoice)
+        val payment = PayInvoice(UUID.randomUUID(), 550_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
         val db = InMemoryPaymentsDb()
 
         // Step 1: a payment attempt is made.
@@ -896,7 +896,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
             val result2 = outgoingPaymentHandler.processAddSettled(createRemoteFulfill(adds[2].first, adds[2].second, preimage)) as OutgoingPaymentHandler.Success
             assertEquals(preimage, result2.preimage)
             assertEquals(3, result2.payment.parts.size)
-            assertEquals(payment, SendPayment(result2.payment.id, result2.payment.recipientAmount, result2.payment.recipient, (result2.payment.details as LightningOutgoingPayment.Details.Normal).paymentRequest))
+            assertEquals(payment, PayInvoice(result2.payment.id, result2.payment.recipientAmount, result2.payment.recipient, (result2.payment.details as LightningOutgoingPayment.Details.Normal)))
             assertEquals(preimage, (result2.payment.status as LightningOutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         }
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
@@ -38,7 +38,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val (alice, _) = TestsHelper.reachNormal()
         val invoice = makeInvoice(amount = 100_000.msat, supportsTrampoline = true)
         val outgoingPaymentHandler = OutgoingPaymentHandler(alice.staticParams.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
-        val payment = PayInvoice(UUID.randomUUID(), MilliSatoshi(-1), invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), MilliSatoshi(-1), LightningOutgoingPayment.Details.Normal(invoice))
         val result = outgoingPaymentHandler.sendPayment(payment, mapOf(), alice.currentBlockHeight)
         assertFailureEquals(result as OutgoingPaymentHandler.Failure, OutgoingPaymentHandler.Failure(payment, FinalFailure.InvalidPaymentAmount.toPaymentFailure()))
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
@@ -62,7 +62,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val invoice2 = Bolt11InvoiceTestsCommon.createInvoiceUnsafe(features = Features(mapOf(Feature.VariableLengthOnion to FeatureSupport.Mandatory, Feature.PaymentSecret to FeatureSupport.Mandatory), setOf(UnknownFeature(188))))
         for (invoice in listOf(invoice1, invoice2)) {
             val outgoingPaymentHandler = OutgoingPaymentHandler(alice.staticParams.nodeParams.copy(features = features), defaultWalletParams, InMemoryPaymentsDb())
-            val payment = PayInvoice(UUID.randomUUID(), 15_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+            val payment = PayInvoice(UUID.randomUUID(), 15_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
             val result = outgoingPaymentHandler.sendPayment(payment, mapOf(), alice.currentBlockHeight)
             assertFailureEquals(result as OutgoingPaymentHandler.Failure, OutgoingPaymentHandler.Failure(payment, FinalFailure.FeaturesNotSupported.toPaymentFailure()))
             assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
@@ -75,7 +75,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val (alice, _) = TestsHelper.reachNormal()
         val invoice = makeInvoice(amount = 100_000.msat, supportsTrampoline = true)
         val outgoingPaymentHandler = OutgoingPaymentHandler(alice.staticParams.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
-        val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
         val result = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to Offline(alice.state)), alice.currentBlockHeight)
         assertFailureEquals(result as OutgoingPaymentHandler.Failure, OutgoingPaymentHandler.Failure(payment, FinalFailure.NoAvailableChannels.toPaymentFailure()))
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
@@ -95,7 +95,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val amount = alice.commitments.availableBalanceForSend() + 10.msat
         val invoice = makeInvoice(amount = amount, supportsTrampoline = true)
         val outgoingPaymentHandler = OutgoingPaymentHandler(alice.staticParams.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
-        val payment = PayInvoice(UUID.randomUUID(), amount, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), amount, LightningOutgoingPayment.Details.Normal(invoice))
         val result = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to alice.state), alice.currentBlockHeight)
         assertFailureEquals(result as OutgoingPaymentHandler.Failure, OutgoingPaymentHandler.Failure(payment, FinalFailure.InsufficientBalance.toPaymentFailure()))
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
@@ -113,7 +113,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val channels = makeChannels()
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
         val invoice = makeInvoice(amount = 100_000.msat, supportsTrampoline = true)
-        val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
         val result = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val (channelId, add) = filterAddHtlcCommands(result).first()
         outgoingPaymentHandler.processAddSettled(createRemoteFulfill(channelId, add, randomBytes32())) as OutgoingPaymentHandler.Success
@@ -132,7 +132,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         run {
             // Send payment 1 of 2: this should work because we're still under the maxAcceptedHtlcs.
             val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-            val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+            val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
             val result = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to alice.state), alice.currentBlockHeight)
             assertTrue { result is OutgoingPaymentHandler.Progress }
 
@@ -152,7 +152,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         run {
             // Send payment 2 of 2: this should exceed the configured maxAcceptedHtlcs.
             val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-            val payment = PayInvoice(UUID.randomUUID(), 50_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+            val payment = PayInvoice(UUID.randomUUID(), 50_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
             val result1 = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to alice.state), alice.currentBlockHeight)
             assertTrue { result1 is OutgoingPaymentHandler.Progress }
 
@@ -185,7 +185,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         run {
             // Send payment 1 of 2: this should work because we're still under the maxHtlcValueInFlightMsat.
             val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-            val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+            val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
             val result = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to alice.state), alice.currentBlockHeight)
             assertTrue { result is OutgoingPaymentHandler.Progress }
 
@@ -205,7 +205,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         run {
             // Send payment 2 of 2: this should exceed the configured maxHtlcValueInFlightMsat.
             val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-            val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+            val payment = PayInvoice(UUID.randomUUID(), 100_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
             val result1 = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to alice.state), alice.currentBlockHeight)
             assertTrue { result1 is OutgoingPaymentHandler.Progress }
 
@@ -231,7 +231,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
     fun `successful first attempt -- single part`() = runSuspendTest {
         val recipientKey = randomKey()
         val invoice = makeInvoice(amount = 195_000.msat, supportsTrampoline = true, privKey = recipientKey)
-        val payment = PayInvoice(UUID.randomUUID(), 200_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice)) // we slightly overpay the invoice amount
+        val payment = PayInvoice(UUID.randomUUID(), 200_000.msat, LightningOutgoingPayment.Details.Normal(invoice)) // we slightly overpay the invoice amount
         testSinglePartTrampolinePayment(payment, invoice, recipientKey)
     }
 
@@ -256,7 +256,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
                 features = Features(invoiceFeatures.toMap()),
             )
         }
-        val payment = PayInvoice(UUID.randomUUID(), 200_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice)) // we slightly overpay the invoice amount
+        val payment = PayInvoice(UUID.randomUUID(), 200_000.msat, LightningOutgoingPayment.Details.Normal(invoice)) // we slightly overpay the invoice amount
         testSinglePartTrampolinePayment(payment, invoice, recipientKey)
     }
 
@@ -315,7 +315,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, walletParams, InMemoryPaymentsDb())
         val recipientKey = randomKey()
         val invoice = makeInvoice(amount = null, supportsTrampoline = true, privKey = recipientKey)
-        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
         val result = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds = filterAddHtlcCommands(result)
@@ -373,7 +373,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val recipientKey = randomKey()
         val extraHops = listOf(listOf(Bolt11Invoice.TaggedField.ExtraHop(randomKey().publicKey(), ShortChannelId(42), 10.msat, 100, CltvExpiryDelta(48))))
         val invoice = makeInvoice(amount = null, supportsTrampoline = false, privKey = recipientKey, extraHops = extraHops)
-        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
         val result = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds = filterAddHtlcCommands(result)
@@ -425,7 +425,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams.copy(paymentRecipientExpiryParams = recipientExpiryParams), walletParams, InMemoryPaymentsDb())
         val recipientKey = randomKey()
         val invoice = makeInvoice(amount = null, supportsTrampoline = true, privKey = recipientKey)
-        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
         val result = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds = filterAddHtlcCommands(result)
@@ -456,7 +456,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val preimage = randomBytes32()
         val incomingPaymentHandler = IncomingPaymentHandler(TestConstants.Bob.nodeParams, InMemoryPaymentsDb())
         val invoice = incomingPaymentHandler.createInvoice(preimage, amount = null, Either.Left("phoenix to phoenix"), listOf())
-        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
         val result = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds = filterAddHtlcCommands(result)
@@ -510,7 +510,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
         val recipientKey = randomKey()
         val invoice = makeInvoice(amount = null, supportsTrampoline = true, privKey = recipientKey)
-        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
         val progress1 = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds1 = filterAddHtlcCommands(progress1)
@@ -582,7 +582,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
         // The invoice comes from Bob, our direct peer (and trampoline node).
         val invoice = makeInvoice(amount = null, supportsTrampoline = true, privKey = TestConstants.Bob.nodeParams.nodePrivateKey)
-        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 300_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
         val result1 = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds1 = filterAddHtlcCommands(result1)
@@ -629,7 +629,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         )
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, walletParams, InMemoryPaymentsDb())
         val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-        val payment = PayInvoice(UUID.randomUUID(), 550_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 550_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
         val progress1 = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds1 = filterAddHtlcCommands(progress1)
@@ -658,7 +658,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         )
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, walletParams, InMemoryPaymentsDb())
         val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-        val payment = PayInvoice(UUID.randomUUID(), 220_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 220_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
         val progress1 = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds1 = filterAddHtlcCommands(progress1)
@@ -690,7 +690,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
             val channels = makeChannels()
             val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
             val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-            val payment = PayInvoice(UUID.randomUUID(), 50_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+            val payment = PayInvoice(UUID.randomUUID(), 50_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
             val progress = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
             val adds = filterAddHtlcCommands(progress)
@@ -710,7 +710,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
     private suspend fun testLocalChannelFailures(invoice: Bolt11Invoice) {
         val channels = makeChannels()
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
-        val payment = PayInvoice(UUID.randomUUID(), 5_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 5_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
         var progress = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         assertEquals(1, progress.actions.size)
@@ -754,7 +754,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val channels = makeChannels()
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
         val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-        val payment = PayInvoice(UUID.randomUUID(), 5_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 5_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
         val progress1 = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         assertEquals(1, progress1.actions.size)
@@ -783,7 +783,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val channels = makeChannels()
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
         val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-        val payment = PayInvoice(UUID.randomUUID(), 310_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 310_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
         val progress = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds = filterAddHtlcCommands(progress)
@@ -810,7 +810,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val channels = makeChannels()
         val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, InMemoryPaymentsDb())
         val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-        val payment = PayInvoice(UUID.randomUUID(), 310_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 310_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
         val progress = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val adds = filterAddHtlcCommands(progress)
@@ -843,7 +843,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val (adds, attempt) = run {
             val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, db)
             val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-            val payment = PayInvoice(UUID.randomUUID(), 550_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+            val payment = PayInvoice(UUID.randomUUID(), 550_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
 
             val progress = outgoingPaymentHandler.sendPayment(payment, channels, TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
             val attempt = outgoingPaymentHandler.getPendingPayment(payment.paymentId)!!
@@ -873,7 +873,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
         val channels = makeChannels()
         val preimage = randomBytes32()
         val invoice = makeInvoice(amount = null, supportsTrampoline = true)
-        val payment = PayInvoice(UUID.randomUUID(), 550_000.msat, invoice.nodeId, LightningOutgoingPayment.Details.Normal(invoice))
+        val payment = PayInvoice(UUID.randomUUID(), 550_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
         val db = InMemoryPaymentsDb()
 
         // Step 1: a payment attempt is made.
@@ -896,7 +896,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
             val result2 = outgoingPaymentHandler.processAddSettled(createRemoteFulfill(adds[2].first, adds[2].second, preimage)) as OutgoingPaymentHandler.Success
             assertEquals(preimage, result2.preimage)
             assertEquals(3, result2.payment.parts.size)
-            assertEquals(payment, PayInvoice(result2.payment.id, result2.payment.recipientAmount, result2.payment.recipient, (result2.payment.details as LightningOutgoingPayment.Details.Normal)))
+            assertEquals(payment, PayInvoice(result2.payment.id, result2.payment.recipientAmount, result2.payment.details as LightningOutgoingPayment.Details.Normal))
             assertEquals(preimage, (result2.payment.status as LightningOutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         }
     }


### PR DESCRIPTION
This PR is targeting #624 and adds some improvements and refactoring. Each commit is independent and should be reviewed separately (the commit messages contain useful details about the commit itself). This PR fixes the comments from my latest review of #624.

The main changes are:

- more fine-grained invoice request timeout to minimize UX issues (see details in the commit message)
- add more logs around error cases, as I suspect we'll spend quite some time debugging compatibility issues with other implementations initially
- remove some duplication and add a few helper functions
- add more tests