### PR TITLE
Fix serialization of onion messages

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -1579,7 +1579,7 @@ data class OnionMessage(
 
     override fun write(out: Output) {
         LightningCodecs.writeBytes(blindingKey.value, out)
-        LightningCodecs.writeU16(onionRoutingPacket.payload.size(), out)
+        LightningCodecs.writeU16(onionRoutingPacket.payload.size() + 66, out)
         OnionRoutingPacketSerializer(onionRoutingPacket.payload.size()).write(onionRoutingPacket, out)
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -13,6 +13,7 @@ import fr.acinq.lightning.blockchain.fee.FeeratePerByte
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.crypto.assertArrayEquals
+import fr.acinq.lightning.message.OnionMessages
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.utils.msat
 import fr.acinq.lightning.utils.sat
@@ -863,5 +864,11 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
             assertEquals(encoded, out.toByteArray().toByteVector())
             assertEquals(decoded, LightningCodecs.encodedNodeId(ByteArrayInput(encoded.toByteArray())))
         }
+    }
+
+    @Test
+    fun `encode and decode onion message`() {
+        val onionMessage = OnionMessages.buildMessage(randomKey(), randomKey(), listOf(), OnionMessages.Destination.Recipient(randomKey().publicKey(), null), TlvStream.empty()).right!!
+        assertEquals(onionMessage, OnionMessage.read(onionMessage.write()))
     }
 }


### PR DESCRIPTION
The onion routing packet's size is 66 bytes more than its payload's size. We were taking this into account in the `read` function but not in the `write` one.