### PR TITLE
Use Peer scope for invoice request timeout

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -1292,11 +1292,9 @@ class Peer(
             is PayOffer -> {
                 val (pathId, invoiceRequests) = offerManager.requestInvoice(cmd)
                 invoiceRequests.forEach { input.send(SendOnionMessage(it)) }
-                coroutineScope {
-                    launch {
-                        delay(cmd.fetchInvoiceTimeout)
-                        input.send(CheckInvoiceRequestTimeout(pathId, cmd))
-                    }
+                this.launch {
+                    delay(cmd.fetchInvoiceTimeout)
+                    input.send(CheckInvoiceRequestTimeout(pathId, cmd))
                 }
             }
             is CheckInvoiceRequestTimeout -> offerManager.checkInvoiceRequestTimeout(cmd.pathId, cmd.payOffer)


### PR DESCRIPTION
Instead of `coroutineScope { }` that waits for completion of the coroutine, we use the peer's scope.