### PR TITLE
Enable route blinding

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/Features.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/Features.kt
@@ -109,7 +109,7 @@ sealed class Feature {
     object RouteBlinding : Feature() {
         override val rfcName get() = "option_route_blinding"
         override val mandatory get() = 24
-        override val scopes: Set<FeatureScope> get() = setOf(FeatureScope.Init, FeatureScope.Node, FeatureScope.Invoice)
+        override val scopes: Set<FeatureScope> get() = setOf(FeatureScope.Init, FeatureScope.Node)
     }
 
     @Serializable
@@ -319,6 +319,7 @@ data class Features(val activated: Map<Feature, FeatureSupport>, val unknown: Se
             Feature.BasicMultiPartPayment,
             Feature.Wumbo,
             Feature.AnchorOutputs,
+            Feature.RouteBlinding,
             Feature.ShutdownAnySegwit,
             Feature.DualFunding,
             Feature.ChannelType,

--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -168,6 +168,7 @@ data class NodeParams(
         require(features.hasFeature(Feature.PaymentSecret, FeatureSupport.Mandatory)) { "${Feature.PaymentSecret.rfcName} should be mandatory" }
         require(features.hasFeature(Feature.ChannelType, FeatureSupport.Mandatory)) { "${Feature.ChannelType.rfcName} should be mandatory" }
         require(features.hasFeature(Feature.DualFunding, FeatureSupport.Mandatory)) { "${Feature.DualFunding.rfcName} should be mandatory" }
+        require(features.hasFeature(Feature.RouteBlinding)) { "${Feature.RouteBlinding.rfcName} should be supported" }
         require(!features.hasFeature(Feature.ZeroConfChannels)) { "${Feature.ZeroConfChannels.rfcName} has been deprecated: use the zeroConfPeers whitelist instead" }
         require(!features.hasFeature(Feature.TrustedSwapInClient)) { "${Feature.TrustedSwapInClient.rfcName} has been deprecated" }
         require(!features.hasFeature(Feature.TrustedSwapInProvider)) { "${Feature.TrustedSwapInProvider.rfcName} has been deprecated" }

--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -189,6 +189,7 @@ data class NodeParams(
             Feature.Wumbo to FeatureSupport.Optional,
             Feature.StaticRemoteKey to FeatureSupport.Mandatory,
             Feature.AnchorOutputs to FeatureSupport.Optional, // can't set Mandatory because peers prefers AnchorOutputsZeroFeeHtlcTx
+            Feature.RouteBlinding to FeatureSupport.Optional,
             Feature.DualFunding to FeatureSupport.Mandatory,
             Feature.ShutdownAnySegwit to FeatureSupport.Mandatory,
             Feature.ChannelType to FeatureSupport.Mandatory,

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt12Invoice.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt12Invoice.kt
@@ -41,11 +41,7 @@ data class Bolt12Invoice(val records: TlvStream<InvoiceTlv>) : PaymentRequest() 
     val createdAtSeconds: Long = records.get<InvoiceCreatedAt>()!!.timestampSeconds
     val relativeExpirySeconds: Long = records.get<InvoiceRelativeExpiry>()?.seconds ?: DEFAULT_EXPIRY_SECONDS
 
-    // We add invoice features that are implicitly required for Bolt 12 (the spec doesn't allow explicitly setting them).
-    override val features: Features =
-        (records.get<InvoiceFeatures>()?.features?.invoiceFeatures() ?: Features.empty).let {
-            it.copy(activated = it.activated + (Feature.VariableLengthOnion to FeatureSupport.Mandatory) + (Feature.RouteBlinding to FeatureSupport.Mandatory))
-        }
+    override val features: Features = records.get<InvoiceFeatures>()?.features?.invoiceFeatures() ?: Features.empty
 
     val blindedPaths: List<PaymentBlindedContactInfo> = records.get<InvoicePaths>()!!.paths.zip(records.get<InvoiceBlindedPay>()!!.paymentInfos).map { PaymentBlindedContactInfo(it.first, it.second) }
     val fallbacks: List<FallbackAddress>? = records.get<InvoiceFallbacks>()?.addresses

--- a/src/commonTest/kotlin/fr/acinq/lightning/FeaturesTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/FeaturesTestsCommon.kt
@@ -5,6 +5,7 @@ import fr.acinq.lightning.Features.Companion.validateFeatureGraph
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.utils.BitField
 import fr.acinq.secp256k1.Hex
+import org.kodein.memory.text.toHex
 import kotlin.test.*
 
 class FeaturesTestsCommon : LightningTestSuite() {
@@ -237,17 +238,17 @@ class FeaturesTestsCommon : LightningTestSuite() {
                 PaymentSecret to FeatureSupport.Optional,
                 BasicMultiPartPayment to FeatureSupport.Optional
             ),
-            Hex.decode("09004200") to Features(
+            Hex.decode("08404200") to Features(
                 mapOf(
                     VariableLengthOnion to FeatureSupport.Optional,
                     PaymentSecret to FeatureSupport.Mandatory,
                     ShutdownAnySegwit to FeatureSupport.Optional
                 ),
-                setOf(UnknownFeature(24))
+                setOf(UnknownFeature(22))
             ),
-            Hex.decode("52000000") to Features(
+            Hex.decode("50800000") to Features(
                 mapOf(DualFunding to FeatureSupport.Mandatory),
-                setOf(UnknownFeature(25), UnknownFeature(30))
+                setOf(UnknownFeature(23), UnknownFeature(30))
             )
         )
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/FeaturesTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/FeaturesTestsCommon.kt
@@ -5,7 +5,6 @@ import fr.acinq.lightning.Features.Companion.validateFeatureGraph
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.utils.BitField
 import fr.acinq.secp256k1.Hex
-import org.kodein.memory.text.toHex
 import kotlin.test.*
 
 class FeaturesTestsCommon : LightningTestSuite() {

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/Bolt12InvoiceTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/Bolt12InvoiceTestsCommon.kt
@@ -133,7 +133,6 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
             listOf(createPaymentBlindedRoute(nodeKey.publicKey()))
         )
         assertEquals(invoice.records.unknown, setOf(GenericTlv(87, ByteVector.fromHex("0404"))))
-        println(invoice.validateFor(requestWithUnknownTlv))
         assertTrue(invoice.validateFor(requestWithUnknownTlv).isRight)
         assertEquals(Bolt12Invoice.fromString(invoice.toString()).get().toString(), invoice.toString())
     }
@@ -337,7 +336,7 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
         val chain = Block.TestnetGenesisBlock.hash
         val amount = 123456.msat
         val description = "invoice with many fields"
-        val features = Features(Feature.VariableLengthOnion to FeatureSupport.Mandatory, Feature.RouteBlinding to FeatureSupport.Mandatory)
+        val features = Features.empty
         val issuer = "alice"
         val nodeKey = PrivateKey.fromHex("998cf8ecab46f949bb960813b79d3317cabf4193452a211795cd8af1b9a25d90")
         val path = createPaymentBlindedRoute(

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
@@ -51,7 +51,8 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
             Feature.VariableLengthOnion to FeatureSupport.Mandatory,
             Feature.PaymentSecret to FeatureSupport.Mandatory,
             Feature.BasicMultiPartPayment to FeatureSupport.Optional,
-            Feature.DualFunding to FeatureSupport.Mandatory
+            Feature.DualFunding to FeatureSupport.Mandatory,
+            Feature.RouteBlinding to FeatureSupport.Optional,
         )
         // The following invoice requires payment_metadata.
         val invoice1 =

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
@@ -60,6 +60,7 @@ object TestConstants {
                 Feature.Wumbo to FeatureSupport.Optional,
                 Feature.StaticRemoteKey to FeatureSupport.Mandatory,
                 Feature.AnchorOutputs to FeatureSupport.Mandatory,
+                Feature.RouteBlinding to FeatureSupport.Optional,
                 Feature.DualFunding to FeatureSupport.Mandatory,
                 Feature.ChannelType to FeatureSupport.Mandatory,
                 Feature.PaymentMetadata to FeatureSupport.Optional,


### PR DESCRIPTION
Cleans the mess around `RouteBlinding` being an implicit feature in Bolt12 invoices.