### PR TITLE
Make `ChannelContext.process` a suspend function

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Aborted.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Aborted.kt
@@ -7,7 +7,7 @@ import fr.acinq.lightning.channel.ChannelCommand
  * Channel has been aborted before it was funded (because we did not receive a FundingCreated or FundingSigned message for example)
  */
 data object Aborted : ChannelState() {
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return Pair(this@Aborted, listOf())
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -49,9 +49,9 @@ sealed class ChannelState {
      * @param cmd input event (for example, a message was received, a command was sent by the GUI/API, etc)
      * @return a (new state, list of actions) pair
      */
-    abstract fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>>
+    abstract suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>>
 
-    fun ChannelContext.process(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    suspend fun ChannelContext.process(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return try {
             processInternal(cmd)
                 .let { (newState, actions) -> Pair(newState, newState.run { maybeAddBackupToMessages(actions) }) }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closed.kt
@@ -14,7 +14,7 @@ data class Closed(val state: Closing) : ChannelStateWithCommitments() {
         return this.copy(state = state.updateCommitments(input) as Closing)
     }
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return Pair(this@Closed, listOf())
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closing.kt
@@ -71,7 +71,7 @@ data class Closing(
 
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.WatchReceived -> {
                 val watch = cmd.watch

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closing.kt
@@ -208,7 +208,7 @@ data class Closing(
 
                         val revokedCommitPublishActions = mutableListOf<ChannelAction>()
                         val revokedCommitPublished1 = revokedCommitPublished.map { rev ->
-                            val (newRevokedCommitPublished, penaltyTxs) = claimRevokedHtlcTxOutputs(channelKeys(), commitments.params, rev, watch.tx, currentOnChainFeerates)
+                            val (newRevokedCommitPublished, penaltyTxs) = claimRevokedHtlcTxOutputs(channelKeys(), commitments.params, rev, watch.tx, currentOnChainFeerates())
                             penaltyTxs.forEach {
                                 revokedCommitPublishActions += ChannelAction.Blockchain.PublishTx(it)
                                 revokedCommitPublishActions += ChannelAction.Blockchain.SendWatch(WatchSpent(channelId, watch.tx, it.input.outPoint.index.toInt(), BITCOIN_OUTPUT_SPENT))
@@ -300,7 +300,7 @@ data class Closing(
             is ChannelCommand.Closing.GetHtlcInfosResponse -> {
                 val index = revokedCommitPublished.indexOfFirst { it.commitTx.txid == cmd.revokedCommitTxId }
                 if (index >= 0) {
-                    val revokedCommitPublished1 = claimRevokedRemoteCommitTxHtlcOutputs(channelKeys(), commitments.params, revokedCommitPublished[index], currentOnChainFeerates, cmd.htlcInfos)
+                    val revokedCommitPublished1 = claimRevokedRemoteCommitTxHtlcOutputs(channelKeys(), commitments.params, revokedCommitPublished[index], currentOnChainFeerates(), cmd.htlcInfos)
                     val nextState = copy(revokedCommitPublished = revokedCommitPublished.updated(index, revokedCommitPublished1))
                     val actions = buildList {
                         add(ChannelAction.Storage.StoreState(nextState))
@@ -339,14 +339,14 @@ data class Closing(
                     logger.info { "got valid payment preimage, recalculating transactions to redeem the corresponding htlc on-chain" }
                     val commitments1 = result.value.first
                     val localCommitPublished1 = localCommitPublished?.let {
-                        claimCurrentLocalCommitTxOutputs(channelKeys(), commitments1.latest, it.commitTx, currentOnChainFeerates)
+                        claimCurrentLocalCommitTxOutputs(channelKeys(), commitments1.latest, it.commitTx, currentOnChainFeerates())
                     }
                     val remoteCommitPublished1 = remoteCommitPublished?.let {
-                        claimRemoteCommitTxOutputs(channelKeys(), commitments1.latest, commitments1.latest.remoteCommit, it.commitTx, currentOnChainFeerates)
+                        claimRemoteCommitTxOutputs(channelKeys(), commitments1.latest, commitments1.latest.remoteCommit, it.commitTx, currentOnChainFeerates())
                     }
                     val nextRemoteCommitPublished1 = nextRemoteCommitPublished?.let {
                         val remoteCommit = commitments1.latest.nextRemoteCommit?.commit ?: error("next remote commit must be defined")
-                        claimRemoteCommitTxOutputs(channelKeys(), commitments1.latest, remoteCommit, it.commitTx, currentOnChainFeerates)
+                        claimRemoteCommitTxOutputs(channelKeys(), commitments1.latest, remoteCommit, it.commitTx, currentOnChainFeerates())
                     }
                     val republishList = buildList {
                         val minDepth = staticParams.nodeParams.minDepthBlocks.toLong()

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmed.kt
@@ -28,7 +28,7 @@ data class LegacyWaitForFundingConfirmed(
 ) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is ChannelReady -> Pair(this@LegacyWaitForFundingConfirmed.copy(deferred = cmd.message), listOf())

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLocked.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLocked.kt
@@ -22,7 +22,7 @@ data class LegacyWaitForFundingLocked(
 ) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is ChannelReady -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
@@ -60,7 +60,7 @@ data class Negotiating(
                                 }
                                 else -> {
                                     val theirFeeRange = cmd.message.tlvStream.get<ClosingSignedTlv.FeeRange>()
-                                    val ourFeeRange = closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate)
+                                    val ourFeeRange = closingFeerates ?: ClosingFeerates(currentOnChainFeerates().mutualCloseFeerate)
                                     when {
                                         theirFeeRange != null && !commitments.params.localParams.isInitiator -> {
                                             // if we are not the initiator and they proposed a fee range, we pick a value in that range and they should accept it without further negotiation

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
@@ -154,7 +154,7 @@ data class Negotiating(
                         val closingTx = getMutualClosePublished(watch.tx)
                         val nextState = Closing(
                             commitments,
-                            waitingSinceBlock = currentBlockHeight.toLong(),
+                            waitingSinceBlock = currentBlockHeight(),
                             mutualCloseProposed = closingTxProposed.flatten().map { it.unsignedTx },
                             mutualClosePublished = listOf(closingTx)
                         )
@@ -189,10 +189,10 @@ data class Negotiating(
         return closingTxProposed.flatten().first { it.unsignedTx.tx.txid == tx.txid }.unsignedTx.copy(tx = tx)
     }
 
-    private fun ChannelContext.completeMutualClose(signedClosingTx: ClosingTx, closingSigned: ClosingSigned?): Pair<ChannelState, List<ChannelAction>> {
+    private suspend fun ChannelContext.completeMutualClose(signedClosingTx: ClosingTx, closingSigned: ClosingSigned?): Pair<ChannelState, List<ChannelAction>> {
         val nextState = Closing(
             commitments,
-            waitingSinceBlock = currentBlockHeight.toLong(),
+            waitingSinceBlock = currentBlockHeight(),
             mutualCloseProposed = closingTxProposed.flatten().map { it.unsignedTx },
             mutualClosePublished = listOf(signedClosingTx)
         )

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
@@ -28,7 +28,7 @@ data class Negotiating(
 
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is ClosingSigned -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -31,7 +31,7 @@ data class Normal(
 
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         val forbiddenPreSplice = cmd is ChannelCommand.ForbiddenDuringQuiescence && spliceStatus is QuiescenceNegotiation
         val forbiddenDuringSplice = cmd is ChannelCommand.ForbiddenDuringSplice && spliceStatus is QuiescentSpliceStatus
         if (forbiddenPreSplice || forbiddenDuringSplice) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -53,7 +53,7 @@ data class Normal(
                     val error = NoMoreHtlcsClosingInProgress(channelId)
                     return handleCommandError(cmd, error, channelUpdate)
                 }
-                handleCommandResult(cmd, commitments.sendAdd(cmd, cmd.paymentId, currentBlockHeight.toLong()), cmd.commit)
+                handleCommandResult(cmd, commitments.sendAdd(cmd, cmd.paymentId, currentBlockHeight()), cmd.commit)
             }
             is ChannelCommand.Htlc.Settlement.Fulfill -> handleCommandResult(cmd, commitments.sendFulfill(cmd), cmd.commit)
             is ChannelCommand.Htlc.Settlement.Fail -> handleCommandResult(cmd, commitments.sendFail(cmd, this.privateKey), cmd.commit)
@@ -170,7 +170,7 @@ data class Normal(
                             Pair(this@Normal, listOf())
                         }
                         spliceStatus is SpliceStatus.WaitingForSigs -> {
-                            val (signingSession1, action) = spliceStatus.session.receiveCommitSig(channelKeys(), commitments.params, cmd.message, currentBlockHeight.toLong(), logger)
+                            val (signingSession1, action) = spliceStatus.session.receiveCommitSig(channelKeys(), commitments.params, cmd.message, currentBlockHeight(), logger)
                             when (action) {
                                 is InteractiveTxSigningSessionAction.AbortFundingAttempt -> {
                                     logger.warning { "splice attempt failed: ${action.reason.message} (fundingTxId=${spliceStatus.session.fundingTx.txId})" }
@@ -417,7 +417,7 @@ data class Normal(
                                             val spliceInit = SpliceInit(
                                                 channelId,
                                                 fundingContribution = fundingContribution,
-                                                lockTime = currentBlockHeight.toLong(),
+                                                lockTime = currentBlockHeight(),
                                                 feerate = spliceStatus.command.feerate,
                                                 fundingPubkey = channelKeys().fundingPubKey(parentCommitment.fundingTxIndex + 1),
                                                 pushAmount = spliceStatus.command.pushAmount,
@@ -667,7 +667,7 @@ data class Normal(
                     }
                     is TxSignatures -> when (spliceStatus) {
                         is SpliceStatus.WaitingForSigs -> {
-                            when (val res = spliceStatus.session.receiveTxSigs(channelKeys(), cmd.message, currentBlockHeight.toLong())) {
+                            when (val res = spliceStatus.session.receiveTxSigs(channelKeys(), cmd.message, currentBlockHeight())) {
                                 is Either.Left -> {
                                     val action: InteractiveTxSigningSessionAction.AbortFundingAttempt = res.value
                                     logger.warning { "splice attempt failed: ${action.reason.message}" }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -248,7 +248,7 @@ data class Normal(
                                             commitments1.latest,
                                             localShutdown.scriptPubKey.toByteArray(),
                                             remoteShutdown.scriptPubKey.toByteArray(),
-                                            closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate),
+                                            closingFeerates ?: ClosingFeerates(currentOnChainFeerates().mutualCloseFeerate),
                                         )
                                         listOf(listOf(ClosingTxProposed(closingTx, closingSigned)))
                                     } else {
@@ -319,7 +319,7 @@ data class Normal(
                                             commitments1.latest,
                                             localShutdown.scriptPubKey.toByteArray(),
                                             cmd.message.scriptPubKey.toByteArray(),
-                                            closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate),
+                                            closingFeerates ?: ClosingFeerates(currentOnChainFeerates().mutualCloseFeerate),
                                         )
                                         val nextState = Negotiating(
                                             commitments1,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
@@ -85,7 +85,7 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
                             val closingTx = state.getMutualClosePublished(watch.tx)
                             val nextState = Closing(
                                 state.commitments,
-                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                waitingSinceBlock = currentBlockHeight(),
                                 mutualCloseProposed = state.closingTxProposed.flatten().map { it.unsignedTx },
                                 mutualClosePublished = listOf(closingTx)
                             )

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
@@ -14,7 +14,7 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
 
     val channelId = state.channelId
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.Connected -> {
                 when (state) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/ShuttingDown.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/ShuttingDown.kt
@@ -51,7 +51,7 @@ data class ShuttingDown(
                                             commitments1.latest,
                                             localShutdown.scriptPubKey.toByteArray(),
                                             remoteShutdown.scriptPubKey.toByteArray(),
-                                            closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate)
+                                            closingFeerates ?: ClosingFeerates(currentOnChainFeerates().mutualCloseFeerate)
                                         )
                                         val nextState = Negotiating(
                                             commitments1,
@@ -99,7 +99,7 @@ data class ShuttingDown(
                                         commitments1.latest,
                                         localShutdown.scriptPubKey.toByteArray(),
                                         remoteShutdown.scriptPubKey.toByteArray(),
-                                        closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate)
+                                        closingFeerates ?: ClosingFeerates(currentOnChainFeerates().mutualCloseFeerate)
                                     )
                                     val nextState = Negotiating(
                                         commitments1,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/ShuttingDown.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/ShuttingDown.kt
@@ -15,7 +15,7 @@ data class ShuttingDown(
 ) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> {
                 when (cmd.message) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -276,7 +276,7 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
                             val closingTx = state.getMutualClosePublished(watch.tx)
                             val nextState = Closing(
                                 state.commitments,
-                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                waitingSinceBlock = currentBlockHeight(),
                                 mutualCloseProposed = state.closingTxProposed.flatten().map { it.unsignedTx },
                                 mutualClosePublished = listOf(closingTx)
                             )

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -235,7 +235,7 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
                                     state.commitments.latest,
                                     state.localShutdown.scriptPubKey.toByteArray(),
                                     state.remoteShutdown.scriptPubKey.toByteArray(),
-                                    state.closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate)
+                                    state.closingFeerates ?: ClosingFeerates(currentOnChainFeerates().mutualCloseFeerate)
                                 )
                                 val closingTxProposed1 = state.closingTxProposed + listOf(listOf(ClosingTxProposed(closingTx, closingSigned)))
                                 val nextState = state.copy(closingTxProposed = closingTxProposed1)

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -18,7 +18,7 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
         is ChannelStateWithCommitments -> state.commitments.params.localParams.channelKeys(keyManager)
     }
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is ChannelReestablish -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannel.kt
@@ -25,7 +25,7 @@ data class WaitForAcceptChannel(
 ) : ChannelState() {
     val temporaryChannelId: ByteVector32 get() = lastSent.temporaryChannelId
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is AcceptDualFundedChannel -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReady.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReady.kt
@@ -18,7 +18,7 @@ data class WaitForChannelReady(
 ) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is TxSignatures -> when (commitments.latest.localFundingStatus) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
@@ -56,7 +56,7 @@ data class WaitForFundingConfirmed(
                     }
                     is FullySignedSharedTransaction -> when (rbfStatus) {
                         is RbfStatus.WaitingForSigs -> {
-                            when (val res = rbfStatus.session.receiveTxSigs(channelKeys(), cmd.message, currentBlockHeight.toLong())) {
+                            when (val res = rbfStatus.session.receiveTxSigs(channelKeys(), cmd.message, currentBlockHeight())) {
                                 is Either.Left -> {
                                     val action: InteractiveTxSigningSessionAction.AbortFundingAttempt = res.value
                                     logger.warning { "rbf attempt failed: ${action.reason.message}" }
@@ -214,7 +214,7 @@ data class WaitForFundingConfirmed(
                 }
                 is CommitSig -> when (rbfStatus) {
                     is RbfStatus.WaitingForSigs -> {
-                        val (signingSession1, action) = rbfStatus.session.receiveCommitSig(channelKeys(), commitments.params, cmd.message, currentBlockHeight.toLong(), logger)
+                        val (signingSession1, action) = rbfStatus.session.receiveCommitSig(channelKeys(), commitments.params, cmd.message, currentBlockHeight(), logger)
                         when (action) {
                             is InteractiveTxSigningSessionAction.AbortFundingAttempt -> {
                                 logger.warning { "rbf attempt failed: ${action.reason.message}" }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
@@ -29,7 +29,7 @@ data class WaitForFundingConfirmed(
 
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is TxSignatures -> when (latestFundingTx.sharedTx) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreated.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreated.kt
@@ -45,7 +45,7 @@ data class WaitForFundingCreated(
 ) : ChannelState() {
     val channelId: ByteVector32 = interactiveTxSession.fundingParams.channelId
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is InteractiveTxConstructionMessage -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
@@ -47,7 +47,7 @@ data class WaitForFundingSigned(
 ) : PersistedChannelState() {
     override val channelId: ByteVector32 = channelParams.channelId
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is CommitSig -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
@@ -38,7 +38,7 @@ data object WaitForInit : ChannelState() {
                     htlcMinimum = cmd.localParams.htlcMinimum,
                     toSelfDelay = cmd.localParams.toSelfDelay,
                     maxAcceptedHtlcs = cmd.localParams.maxAcceptedHtlcs,
-                    lockTime = currentBlockHeight.toLong(),
+                    lockTime = currentBlockHeight(),
                     fundingPubkey = channelKeys.fundingPubKey(0),
                     revocationBasepoint = channelKeys.revocationBasepoint,
                     paymentBasepoint = channelKeys.paymentBasepoint,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
@@ -11,7 +11,7 @@ import fr.acinq.lightning.wire.OpenDualFundedChannel
 import fr.acinq.lightning.wire.TlvStream
 
 data object WaitForInit : ChannelState() {
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.Init.NonInitiator -> {
                 val nextState = WaitForOpenChannel(

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannel.kt
@@ -29,7 +29,7 @@ data class WaitForOpenChannel(
     val channelConfig: ChannelConfig,
     val remoteInit: Init
 ) : ChannelState() {
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is OpenDualFundedChannel -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForRemotePublishFutureCommitment.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForRemotePublishFutureCommitment.kt
@@ -14,7 +14,7 @@ data class WaitForRemotePublishFutureCommitment(
 ) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when {
             cmd is ChannelCommand.WatchReceived && cmd.watch is WatchEventSpent && cmd.watch.event is BITCOIN_FUNDING_SPENT -> handlePotentialForceClose(cmd.watch)
             cmd is ChannelCommand.Disconnected -> Pair(Offline(this@WaitForRemotePublishFutureCommitment), listOf())

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -201,7 +201,7 @@ class Peer(
         val ctx = ChannelContext(
             StaticParams(nodeParams, remoteNodeId),
             currentTipFlow.filterNotNull().first().first,
-            onChainFeeratesFlow.filterNotNull().first(),
+            onChainFeeratesFlow,
             logger = MDCLogger(
                 logger = _channelLogger,
                 staticMdc = mapOf("remoteNodeId" to remoteNodeId) + state.mdc()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
@@ -45,8 +45,8 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
     fun `correct values for availableForSend - availableForReceive -- success case`() {
         val (alice, bob) = reachNormal()
 
-        val aliceKeys = alice.ctx.keyManager.channelKeys(alice.commitments.params.localParams.fundingKeyPath)
-        val bobKeys = bob.ctx.keyManager.channelKeys(bob.commitments.params.localParams.fundingKeyPath)
+        val aliceKeys = alice.keyManager.channelKeys(alice.commitments.params.localParams.fundingKeyPath)
+        val bobKeys = bob.keyManager.channelKeys(bob.commitments.params.localParams.fundingKeyPath)
 
         val a = 774_660_000.msat // initial balance alice
         val b = 190_000_000.msat // initial balance bob
@@ -134,8 +134,8 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
     fun `correct values for availableForSend - availableForReceive -- failure case`() {
         val (alice, bob) = reachNormal()
 
-        val aliceKeys = alice.ctx.keyManager.channelKeys(alice.commitments.params.localParams.fundingKeyPath)
-        val bobKeys = bob.ctx.keyManager.channelKeys(bob.commitments.params.localParams.fundingKeyPath)
+        val aliceKeys = alice.keyManager.channelKeys(alice.commitments.params.localParams.fundingKeyPath)
+        val bobKeys = bob.keyManager.channelKeys(bob.commitments.params.localParams.fundingKeyPath)
 
         val a = 774_660_000.msat // initial balance alice
         val b = 190_000_000.msat // initial balance bob
@@ -223,8 +223,8 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
     fun `correct values for availableForSend - availableForReceive -- multiple htlcs`() {
         val (alice, bob) = reachNormal()
 
-        val aliceKeys = alice.ctx.keyManager.channelKeys(alice.commitments.params.localParams.fundingKeyPath)
-        val bobKeys = bob.ctx.keyManager.channelKeys(bob.commitments.params.localParams.fundingKeyPath)
+        val aliceKeys = alice.keyManager.channelKeys(alice.commitments.params.localParams.fundingKeyPath)
+        val bobKeys = bob.keyManager.channelKeys(bob.commitments.params.localParams.fundingKeyPath)
 
         val a = 774_660_000.msat // initial balance alice
         val b = 190_000_000.msat // initial balance bob

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -21,6 +21,7 @@ import fr.acinq.lightning.tests.utils.testLoggerFactory
 import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.*
 import fr.acinq.lightning.wire.*
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import kotlin.test.*
@@ -63,7 +64,7 @@ internal inline fun <reified T : ChannelAction> List<ChannelAction>.find() = fin
 internal inline fun <reified T : ChannelAction> List<ChannelAction>.has() = assertTrue { any { it is T } }
 internal inline fun <reified T : ChannelAction> List<ChannelAction>.doesNotHave() = assertTrue { none { it is T } }
 
-fun <S : ChannelState> LNChannel<S>.updateFeerate(feerate: FeeratePerKw): LNChannel<S> = this.copy(ctx = this.ctx.copy(currentOnChainFeerates = OnChainFeerates(feerate, feerate, feerate, feerate)))
+fun <S : ChannelState> LNChannel<S>.updateFeerate(feerate: FeeratePerKw): LNChannel<S> = this.copy(ctx = this.ctx.copy(onChainFeerates = MutableStateFlow(OnChainFeerates(feerate, feerate, feerate, feerate))))
 
 fun Features.add(vararg pairs: Pair<Feature, FeatureSupport>): Features = this.copy(activated = this.activated + mapOf(*pairs))
 fun Features.remove(vararg features: Feature): Features = this.copy(activated = activated.filterKeys { f -> !features.contains(f) })
@@ -165,7 +166,7 @@ object TestsHelper {
             ChannelContext(
                 StaticParams(aliceNodeParams, TestConstants.Bob.nodeParams.nodeId),
                 currentBlockHeight = currentHeight,
-                currentOnChainFeerates = OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
+                onChainFeerates = MutableStateFlow(OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)),
                 logger = MDCLogger(testLoggerFactory.newLogger("ChannelState"))
             ),
             WaitForInit
@@ -174,7 +175,7 @@ object TestsHelper {
             ChannelContext(
                 StaticParams(bobNodeParams, TestConstants.Alice.nodeParams.nodeId),
                 currentBlockHeight = currentHeight,
-                currentOnChainFeerates = OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
+                onChainFeerates = MutableStateFlow(OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)),
                 logger = MDCLogger(testLoggerFactory.newLogger("ChannelState"))
             ),
             WaitForInit

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
@@ -510,7 +510,7 @@ class ClosingTestsCommon : LightningTestSuite() {
         assertEquals(1, localCommitPublished.claimHtlcDelayedTxs.size)
 
         // Simulate a wallet restart
-        val initState = LNChannel(aliceClosing.ctx, WaitForInit)
+        val initState = aliceClosing.setState(WaitForInit)
         val (alice1, actions1) = initState.process(ChannelCommand.Init.Restore(aliceClosing.state))
         assertIs<Closing>(alice1.state)
         assertEquals(aliceClosing, alice1)
@@ -838,7 +838,7 @@ class ClosingTestsCommon : LightningTestSuite() {
         assertEquals(1, remoteCommitPublished.claimHtlcTimeoutTxs().size)
 
         // Simulate a wallet restart
-        val initState = LNChannel(aliceClosing.ctx, WaitForInit)
+        val initState = aliceClosing.setState(WaitForInit)
         val (alice1, actions1) = initState.process(ChannelCommand.Init.Restore(aliceClosing.state))
         assertIs<Closing>(alice1.state)
         assertEquals(aliceClosing, alice1)
@@ -1117,7 +1117,7 @@ class ClosingTestsCommon : LightningTestSuite() {
         assertEquals(2, remoteCommitPublished.claimHtlcTimeoutTxs().size)
 
         // Simulate a wallet restart
-        val initState = LNChannel(aliceClosing.ctx, WaitForInit)
+        val initState = aliceClosing.setState(WaitForInit)
         val (alice1, actions1) = initState.process(ChannelCommand.Init.Restore(aliceClosing.state))
         assertTrue(alice1.state is Closing)
         assertEquals(aliceClosing, alice1)
@@ -1170,7 +1170,7 @@ class ClosingTestsCommon : LightningTestSuite() {
         val remoteInit = Init(bob0.commitments.params.localParams.features)
 
         // then we manually replace alice's state with an older one and reconnect them.
-        val (alice1, aliceActions1) = LNChannel(alice0.ctx, Offline(alice0.state)).process(ChannelCommand.Connected(localInit, remoteInit))
+        val (alice1, aliceActions1) = alice0.setState(Offline(alice0.state)).process(ChannelCommand.Connected(localInit, remoteInit))
         assertIs<Syncing>(alice1.state)
         val channelReestablishA = aliceActions1.findOutgoingMessage<ChannelReestablish>()
         val (bob1, bobActions1) = bobDisconnected.process(ChannelCommand.Connected(remoteInit, localInit))
@@ -1216,7 +1216,7 @@ class ClosingTestsCommon : LightningTestSuite() {
 
         // simulate a wallet restart
         run {
-            val initState = LNChannel(alice3.ctx, WaitForInit)
+            val initState = alice3.setState(WaitForInit)
             val (alice4, actions4) = initState.process(ChannelCommand.Init.Restore(alice3.state))
             assertIs<Closing>(alice4.state)
             assertEquals(alice3, alice4)
@@ -1312,7 +1312,7 @@ class ClosingTestsCommon : LightningTestSuite() {
 
         // simulate a wallet restart
         run {
-            val initState = LNChannel(alice2.ctx, WaitForInit)
+            val initState = alice2.setState(WaitForInit)
             val (alice3, actions3) = initState.process(ChannelCommand.Init.Restore(alice2.state))
             assertIs<Closing>(alice3.state)
             assertEquals(alice2, alice3)
@@ -1684,7 +1684,7 @@ class ClosingTestsCommon : LightningTestSuite() {
     @Test
     fun `recv ChannelReestablish`() {
         val (alice0, bob0, _) = initMutualClose()
-        val bobCurrentPerCommitmentPoint = bob0.commitments.params.localParams.channelKeys(bob0.ctx.keyManager).commitmentPoint(bob0.commitments.localCommitIndex)
+        val bobCurrentPerCommitmentPoint = bob0.commitments.params.localParams.channelKeys(bob0.keyManager).commitmentPoint(bob0.commitments.localCommitIndex)
         val channelReestablish = ChannelReestablish(bob0.channelId, 42, 42, PrivateKey(ByteVector32.Zeroes), bobCurrentPerCommitmentPoint)
         val (alice1, actions1) = alice0.process(ChannelCommand.MessageReceived(channelReestablish))
         assertIs<Closing>(alice1.state)
@@ -1717,7 +1717,7 @@ class ClosingTestsCommon : LightningTestSuite() {
         }
 
         run {
-            val alice1 = aliceClosing.copy(ctx = alice.ctx.copy(currentBlockHeight = htlc.cltvExpiry.toLong().toInt()))
+            val alice1 = aliceClosing.copy(currentBlockHeight = htlc.cltvExpiry.toLong().toInt())
             val (alice2, actions) = alice1.process(ChannelCommand.Commitment.CheckHtlcTimeout)
             assertEquals(alice1.state, alice2.state)
             assertTrue(actions.isEmpty())

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
@@ -34,13 +34,14 @@ class LegacyWaitForFundingConfirmedTestsCommon {
         assertIs<LegacyWaitForFundingConfirmed>(state)
         val fundingTx = Transaction.read("020000000100000000000000000000000000000000000000000000000000000000000000000000000000ffffffff0140420f0000000000220020f9aafa9be1212d0d373760c279f3817f9be707d674cae5f38bb31c1fd85c202900000000")
         assertEquals(state.commitments.latest.fundingTxId, fundingTx.txid)
-        val ctx = ChannelContext(
+        val state0 = LNChannel(
             StaticParams(TestConstants.Bob.nodeParams, TestConstants.Alice.nodeParams.nodeId),
             TestConstants.defaultBlockHeight ,
             MutableStateFlow(OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)),
-            MDCLogger(testLoggerFactory.newLogger("ChannelState"))
+            MDCLogger(testLoggerFactory.newLogger("ChannelState")),
+            WaitForInit
         )
-        val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Init.Restore(state))
+        val (state1, actions1) = state0.process(ChannelCommand.Init.Restore(state))
         assertIs<LNChannel<Offline>>(state1)
         assertEquals(actions1.size, 1)
         val watchConfirmed = actions1.findWatch<WatchConfirmed>()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
@@ -16,6 +16,8 @@ import fr.acinq.lightning.wire.ChannelReady
 import fr.acinq.lightning.wire.ChannelReestablish
 import fr.acinq.lightning.wire.EncryptedChannelData
 import fr.acinq.lightning.wire.Init
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -35,7 +37,7 @@ class LegacyWaitForFundingConfirmedTestsCommon {
         val ctx = ChannelContext(
             StaticParams(TestConstants.Bob.nodeParams, TestConstants.Alice.nodeParams.nodeId),
             TestConstants.defaultBlockHeight ,
-            OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
+            MutableStateFlow(OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)),
             MDCLogger(testLoggerFactory.newLogger("ChannelState"))
         )
         val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Init.Restore(state))

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
@@ -32,13 +32,14 @@ class LegacyWaitForFundingLockedTestsCommon {
         assertIs<LegacyWaitForFundingLocked>(state)
         val fundingTx = Transaction.read("020000000100000000000000000000000000000000000000000000000000000000000000000000000000ffffffff0140420f0000000000220020f9aafa9be1212d0d373760c279f3817f9be707d674cae5f38bb31c1fd85c202900000000")
         assertEquals(state.commitments.latest.fundingTxId, fundingTx.txid)
-        val ctx = ChannelContext(
+        val state0 = LNChannel(
             StaticParams(TestConstants.Bob.nodeParams, TestConstants.Alice.nodeParams.nodeId),
             TestConstants.defaultBlockHeight,
             MutableStateFlow(OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)),
-            MDCLogger(testLoggerFactory.newLogger("ChannelState"))
+            MDCLogger(testLoggerFactory.newLogger("ChannelState")),
+            WaitForInit
         )
-        val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Init.Restore(state))
+        val (state1, actions1) = state0.process(ChannelCommand.Init.Restore(state))
         assertIs<LNChannel<Offline>>(state1)
         assertEquals(actions1.size, 1)
         val watchConfirmed = actions1.findWatch<WatchConfirmed>()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
@@ -15,6 +15,7 @@ import fr.acinq.lightning.wire.ChannelReady
 import fr.acinq.lightning.wire.ChannelReestablish
 import fr.acinq.lightning.wire.EncryptedChannelData
 import fr.acinq.lightning.wire.Init
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -34,7 +35,7 @@ class LegacyWaitForFundingLockedTestsCommon {
         val ctx = ChannelContext(
             StaticParams(TestConstants.Bob.nodeParams, TestConstants.Alice.nodeParams.nodeId),
             TestConstants.defaultBlockHeight,
-            OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
+            MutableStateFlow(OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)),
             MDCLogger(testLoggerFactory.newLogger("ChannelState"))
         )
         val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Init.Restore(state))

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NegotiatingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NegotiatingTestsCommon.kt
@@ -455,8 +455,8 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         private fun makeLegacyClosingSigned(alice: LNChannel<Negotiating>, bob: LNChannel<Negotiating>, closingFee: Satoshi): Pair<ClosingSigned, ClosingSigned> {
             val aliceScript = alice.state.localShutdown.scriptPubKey.toByteArray()
             val bobScript = bob.state.localShutdown.scriptPubKey.toByteArray()
-            val aliceKeys = alice.ctx.keyManager.channelKeys(alice.commitments.params.localParams.fundingKeyPath)
-            val bobKeys = bob.ctx.keyManager.channelKeys(bob.commitments.params.localParams.fundingKeyPath)
+            val aliceKeys = alice.keyManager.channelKeys(alice.commitments.params.localParams.fundingKeyPath)
+            val bobKeys = bob.keyManager.channelKeys(bob.commitments.params.localParams.fundingKeyPath)
             val (_, aliceClosingSigned) = Helpers.Closing.makeClosingTx(aliceKeys, alice.commitments.latest, aliceScript, bobScript, ClosingFees(closingFee, closingFee, closingFee))
             val (_, bobClosingSigned) = Helpers.Closing.makeClosingTx(bobKeys, bob.commitments.latest, bobScript, aliceScript, ClosingFees(closingFee, closingFee, closingFee))
             return Pair(aliceClosingSigned.copy(tlvStream = TlvStream.empty()), bobClosingSigned.copy(tlvStream = TlvStream.empty()))
@@ -465,7 +465,7 @@ class NegotiatingTestsCommon : LightningTestSuite() {
         tailrec fun converge(a: LNChannel<ChannelState>, b: LNChannel<ChannelState>, aliceCloseSig: ClosingSigned?): Pair<LNChannel<Closing>, LNChannel<Closing>>? {
             return when {
                 a.state !is ChannelStateWithCommitments || b.state !is ChannelStateWithCommitments -> null
-                a.state is Closing && b.state is Closing -> Pair(LNChannel(a.ctx, a.state), LNChannel(b.ctx, b.state))
+                a.state is Closing && b.state is Closing -> Pair(a.setState(a.state), b.setState(b.state))
                 aliceCloseSig != null -> {
                     val (b1, actions) = b.process(ChannelCommand.MessageReceived(aliceCloseSig))
                     val bobCloseSig = actions.findOutgoingMessageOpt<ClosingSigned>()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/QuiescenceTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/QuiescenceTestsCommon.kt
@@ -447,7 +447,7 @@ class QuiescenceTestsCommon : LightningTestSuite() {
         val (alice3, _, _) = exchangeStfu(createSpliceCommand(alice2), alice2, bob2)
         // The outgoing HTLC from Alice has timed out: she should force-close to avoid an on-chain race.
         val (alice4, actionsAlice4) = run {
-            val tmp = alice3.copy(ctx = alice3.ctx.copy(currentBlockHeight = add.cltvExpiry.toLong().toInt()))
+            val tmp = alice3.copy(currentBlockHeight = add.cltvExpiry.toLong().toInt())
             tmp.process(ChannelCommand.Commitment.CheckHtlcTimeout)
         }
         assertIs<Closing>(alice4.state)
@@ -477,7 +477,7 @@ class QuiescenceTestsCommon : LightningTestSuite() {
             // The incoming HTLC to Alice has timed out: it is Bob's responsibility to force-close.
             // If Bob doesn't force-close, Alice will fulfill or fail the HTLC when they reconnect.
             val (alice5, actionsAlice5) = run {
-                val tmp = alice4.copy(ctx = alice4.ctx.copy(currentBlockHeight = add.cltvExpiry.toLong().toInt()))
+                val tmp = alice4.copy(currentBlockHeight = add.cltvExpiry.toLong().toInt())
                 tmp.process(ChannelCommand.Commitment.CheckHtlcTimeout)
             }
             assertTrue(actionsAlice5.isEmpty())

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ShutdownTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ShutdownTestsCommon.kt
@@ -384,7 +384,7 @@ class ShutdownTestsCommon : LightningTestSuite() {
         val commitTx = alice.commitments.latest.localCommit.publishableTxs.commitTx.tx
         val htlcExpiry = alice.commitments.latest.localCommit.spec.htlcs.map { it.add.cltvExpiry }.first()
         val (alice1, actions1) = run {
-            val tmp = alice.copy(ctx = alice.ctx.copy(currentBlockHeight = htlcExpiry.toLong().toInt()))
+            val tmp = alice.copy(currentBlockHeight = htlcExpiry.toLong().toInt())
             tmp.process(ChannelCommand.Commitment.CheckHtlcTimeout)
         }
         assertIs<LNChannel<Closing>>(alice1)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannelTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannelTestsCommon.kt
@@ -108,7 +108,7 @@ class WaitForAcceptChannelTestsCommon : LightningTestSuite() {
         // we don't want their dust limit to be below 354
         val lowDustLimitSatoshis = 353.sat
         // but we only enforce it on mainnet
-        val aliceMainnet = alice.copy(ctx = alice.ctx.copy(staticParams = alice.ctx.staticParams.copy(nodeParams = alice.staticParams.nodeParams.copy(chain = Chain.Mainnet))))
+        val aliceMainnet = alice.copy(staticParams = alice.staticParams.copy(nodeParams = alice.staticParams.nodeParams.copy(chain = Chain.Mainnet)))
         val (alice1, actions1) = aliceMainnet.process(ChannelCommand.MessageReceived(accept.copy(dustLimit = lowDustLimitSatoshis)))
         assertIs<LNChannel<Aborted>>(alice1)
         val error = actions1.hasOutgoingMessage<Error>()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReadyTestsCommon.kt
@@ -33,7 +33,7 @@ class WaitForChannelReadyTestsCommon : LightningTestSuite() {
         val txSigsAlice = getFundingSigs(alice)
         val (bob1, actionsBob1) = bob.process(ChannelCommand.MessageReceived(txSigsAlice))
         val fundingTx = actionsBob1.find<ChannelAction.Blockchain.PublishTx>().tx
-        val (bob2, actionsBob2) = LNChannel(bob1.ctx, WaitForInit).process(ChannelCommand.Init.Restore(bob1.state as PersistedChannelState))
+        val (bob2, actionsBob2) = bob1.setState(WaitForInit).process(ChannelCommand.Init.Restore(bob1.state as PersistedChannelState))
         assertIs<Offline>(bob2.state)
         assertEquals(actionsBob2.size, 2)
         assertEquals(actionsBob2.find<ChannelAction.Blockchain.PublishTx>().tx, fundingTx)

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmedTestsCommon.kt
@@ -106,7 +106,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
     fun `recv BITCOIN_FUNDING_DEPTHOK -- after restart`() {
         val (alice, bob, fundingTx) = init(ChannelType.SupportedChannelType.AnchorOutputs)
         run {
-            val (alice1, _) = LNChannel(alice.ctx, WaitForInit).process(ChannelCommand.Init.Restore(alice.state))
+            val (alice1, _) = alice.setState(WaitForInit).process(ChannelCommand.Init.Restore(alice.state))
                 .also { (state, actions) ->
                     assertIs<Offline>(state.state)
                     assertEquals(actions.size, 2)
@@ -122,7 +122,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
                 }
         }
         run {
-            val (bob1, _) = LNChannel(bob.ctx, WaitForInit).process(ChannelCommand.Init.Restore(bob.state))
+            val (bob1, _) = bob.setState(WaitForInit).process(ChannelCommand.Init.Restore(bob.state))
                 .also { (state, actions) ->
                     assertIs<Offline>(state.state)
                     assertEquals(actions.size, 2)
@@ -144,7 +144,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
         val (alice, bob, fundingTx1, walletAlice) = init(ChannelType.SupportedChannelType.AnchorOutputs)
         val (alice1, bob1, fundingTx2) = rbf(alice, bob, walletAlice)
         run {
-            val (alice2, _) = LNChannel(alice.ctx, WaitForInit).process(ChannelCommand.Init.Restore(alice1.state))
+            val (alice2, _) = alice.setState(WaitForInit).process(ChannelCommand.Init.Restore(alice1.state))
                 .also { (state, actions) ->
                     assertIs<Offline>(state.state)
                     assertEquals(actions.size, 4)
@@ -164,7 +164,7 @@ class WaitForFundingConfirmedTestsCommon : LightningTestSuite() {
                 }
         }
         run {
-            val (bob2, _) = LNChannel(bob.ctx, WaitForInit).process(ChannelCommand.Init.Restore(bob1.state))
+            val (bob2, _) = bob.setState(WaitForInit).process(ChannelCommand.Init.Restore(bob1.state))
                 .also { (state, actions) ->
                     assertIs<Offline>(state.state)
                     assertEquals(actions.size, 4)

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/io/peer/builders.kt
@@ -145,7 +145,7 @@ suspend fun CoroutineScope.newPeer(
 
     remotedNodeChannelState?.let { state ->
         // send Init from remote node
-        val theirInit = Init(features = state.ctx.staticParams.nodeParams.features.initFeatures())
+        val theirInit = Init(features = state.staticParams.nodeParams.features.initFeatures())
 
         peer.send(MessageReceived(connection.id, theirInit))
         peer.expectStatus(Connection.ESTABLISHED)
@@ -182,7 +182,7 @@ suspend fun buildPeer(
     nodeParams: NodeParams,
     walletParams: WalletParams,
     databases: InMemoryDatabases = InMemoryDatabases(),
-    currentTip: Pair<Int, BlockHeader> = 0 to Block.RegtestGenesisBlock.header
+    currentTip: Int = 0
 ): Peer {
     val electrum = ElectrumClient(scope, nodeParams.loggerFactory)
     val watcher = ElectrumWatcher(electrum, scope, nodeParams.loggerFactory)

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/utils/runTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/utils/runTest.kt
@@ -7,6 +7,9 @@ import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+/**
+ * This defers to kotlin's [kotlinx.coroutines.runBlocking] on all platforms except iOS which needs custom code.
+ */
 expect fun runSuspendBlocking(block: suspend CoroutineScope.() -> Unit)
 
 fun runSuspendTest(timeout: Duration = 30.seconds, test: suspend CoroutineScope.() -> Unit) {


### PR DESCRIPTION
The first commit touches many files but there are no functional changes. Making `process()` a `suspend` function opens the way for the channel FSM to itself call `suspend` functions, but for now we don't call any.

In the next two commits we leverage the `suspend` function by adding a touch of asynchronicity for blockchain-related data: feerates and block height. The goal is to make the Peer much less dependent on blockchain data:

- Getting feerates asynchronously is straightforward and doesn't seem to have many side effects. Feerates are used at closing (mutual or force close). Instead of waiting for feerates to be available before processing any channel command, we just pass the `StateFlow` to the `ChannelContext` and will attempt to get feerates only when needed. If feerates are not available, the `ChannelState.process` function will hang. Previously, the hanging would have happened in the `Peer`.

- We then do the same for the blockheight (and also simplify by removing the unused `BlockHeader`). There are more side effects because we call `currentTipFlow.filterNotNull().first()` from several places in `Peer`. Some are addressed as PR comments  below.