### PR TITLE
Add a helper method to spend expired swap-in utxos

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientExtensions.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClientExtensions.kt
@@ -1,14 +1,12 @@
 package fr.acinq.lightning.blockchain.electrum
 
-import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.Satoshi
 import fr.acinq.bitcoin.Transaction
 import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.channel.Commitments
 import fr.acinq.lightning.channel.LocalFundingStatus
-import fr.acinq.lightning.crypto.KeyManager
-import fr.acinq.lightning.logging.MDCLogger
+import fr.acinq.lightning.logging.*
 import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.sat
 
@@ -57,17 +55,4 @@ suspend fun IElectrumClient.computeSpliceCpfpFeerate(commitments: Commitments, t
     logger.info { "projectedFeerate=$projectedFeerate projectedFee=$projectedFee" }
     logger.info { "actualFeerate=$actualFeerate actualFee=$actualFee" }
     return Pair(actualFeerate, actualFee)
-}
-
-suspend fun IElectrumClient.spendExpiredSwapIn(swapInKeys: KeyManager.SwapInOnChainKeys, wallet: WalletState.WalletWithConfirmations, scriptPubKey: ByteVector, feerate: FeeratePerKw): Transaction? {
-    val utxos = wallet.readyForRefund.map {
-        KeyManager.SwapInOnChainKeys.SwapInUtxo(
-            txOut = it.txOut,
-            outPoint = it.outPoint,
-            addressIndex = it.addressMeta.indexOrNull
-        )
-    }
-    val tx = swapInKeys.createRecoveryTransaction(utxos, scriptPubKey, feerate)
-    tx?.let { broadcastTransaction(tx) }
-    return tx
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -35,7 +35,8 @@ data class WalletState(val addresses: Map<String, AddressState>) {
 
     data class Utxo(val txId: TxId, val outputIndex: Int, val blockHeight: Long, val previousTx: Transaction, val addressMeta: AddressMeta) {
         val outPoint = OutPoint(previousTx, outputIndex.toLong())
-        val amount = previousTx.txOut[outputIndex].amount
+        val txOut = previousTx.txOut[outputIndex]
+        val amount = txOut.amount
     }
 
     data class AddressState(val meta: AddressMeta, val alreadyUsed: Boolean, val utxos: List<Utxo>)
@@ -43,13 +44,13 @@ data class WalletState(val addresses: Map<String, AddressState>) {
     sealed class AddressMeta {
         data object Single : AddressMeta()
         data class Derived(val index: Int) : AddressMeta()
-    }
 
-    val AddressMeta.indexOrNull: Int?
-        get() = when (this) {
-            is AddressMeta.Single -> null
-            is AddressMeta.Derived -> this.index
-        }
+        val indexOrNull: Int?
+            get() = when (this) {
+                is Single -> null
+                is Derived -> this.index
+            }
+    }
 
     /**
      * The utxos of a wallet may be discriminated against their number of confirmations. Typically, this is used in the

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWallet.kt
@@ -3,6 +3,8 @@ package fr.acinq.lightning.blockchain.electrum
 import co.touchlab.kermit.Logger
 import fr.acinq.bitcoin.*
 import fr.acinq.lightning.SwapInParams
+import fr.acinq.lightning.blockchain.fee.FeeratePerKw
+import fr.acinq.lightning.crypto.KeyManager
 import fr.acinq.lightning.logging.debug
 import fr.acinq.lightning.logging.info
 import fr.acinq.lightning.utils.sat
@@ -88,6 +90,22 @@ data class WalletState(val addresses: Map<String, AddressState>) {
             0 -> swapInParams.minConfirmations
             else -> swapInParams.minConfirmations - confirmations(utxo)
         }.coerceAtLeast(0)
+
+        /** Builds a transaction spending all expired utxos and computes the mining fee. The transaction is fully signed but not published. */
+        fun spendExpiredSwapIn(swapInKeys: KeyManager.SwapInOnChainKeys, scriptPubKey: ByteVector, feerate: FeeratePerKw): Pair<Transaction, Satoshi>? {
+            val utxos = readyForRefund.map {
+                KeyManager.SwapInOnChainKeys.SwapInUtxo(
+                    txOut = it.txOut,
+                    outPoint = it.outPoint,
+                    addressIndex = it.addressMeta.indexOrNull
+                )
+            }
+            val tx = swapInKeys.createRecoveryTransaction(utxos, scriptPubKey, feerate)
+            return tx?.let {
+                val fee = utxos.map { it.txOut.amount }.sum() - tx.txOut.map { it.amount }.sum()
+                tx to fee
+            }
+        }
     }
 
     companion object {


### PR DESCRIPTION
After the `refundDelay`, swap-in utxos can be spent unilaterally by the user. There was already a `SwapInOnChainKeys.createRecoveryTransaction()` example function, but it wasn't directly usable.

This PR exposes a `spendExpiredSwapIn()` function in `WalletWithConfirmations`, which makes it easy to add this feature in Phoenix. The function returns the fully signed transaction and associated mining fees, but does not publish the transaction. It must be done explicitly with `electrum.broadcastTx(tx)`.
