### PR TITLE
Make `ChannelContext.process` a suspend function

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Aborted.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Aborted.kt
@@ -7,7 +7,7 @@ import fr.acinq.lightning.channel.ChannelCommand
  * Channel has been aborted before it was funded (because we did not receive a FundingCreated or FundingSigned message for example)
  */
 data object Aborted : ChannelState() {
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return Pair(this@Aborted, listOf())
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -49,9 +49,9 @@ sealed class ChannelState {
      * @param cmd input event (for example, a message was received, a command was sent by the GUI/API, etc)
      * @return a (new state, list of actions) pair
      */
-    abstract fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>>
+    abstract suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>>
 
-    fun ChannelContext.process(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    suspend fun ChannelContext.process(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return try {
             processInternal(cmd)
                 .let { (newState, actions) -> Pair(newState, newState.run { maybeAddBackupToMessages(actions) }) }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closed.kt
@@ -14,7 +14,7 @@ data class Closed(val state: Closing) : ChannelStateWithCommitments() {
         return this.copy(state = state.updateCommitments(input) as Closing)
     }
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return Pair(this@Closed, listOf())
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closing.kt
@@ -71,7 +71,7 @@ data class Closing(
 
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.WatchReceived -> {
                 val watch = cmd.watch

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmed.kt
@@ -28,7 +28,7 @@ data class LegacyWaitForFundingConfirmed(
 ) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is ChannelReady -> Pair(this@LegacyWaitForFundingConfirmed.copy(deferred = cmd.message), listOf())

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLocked.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLocked.kt
@@ -22,7 +22,7 @@ data class LegacyWaitForFundingLocked(
 ) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is ChannelReady -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
@@ -28,7 +28,7 @@ data class Negotiating(
 
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is ClosingSigned -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -31,7 +31,7 @@ data class Normal(
 
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         val forbiddenPreSplice = cmd is ChannelCommand.ForbiddenDuringQuiescence && spliceStatus is QuiescenceNegotiation
         val forbiddenDuringSplice = cmd is ChannelCommand.ForbiddenDuringSplice && spliceStatus is QuiescentSpliceStatus
         if (forbiddenPreSplice || forbiddenDuringSplice) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
@@ -14,7 +14,7 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
 
     val channelId = state.channelId
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.Connected -> {
                 when (state) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/ShuttingDown.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/ShuttingDown.kt
@@ -15,7 +15,7 @@ data class ShuttingDown(
 ) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> {
                 when (cmd.message) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -18,7 +18,7 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
         is ChannelStateWithCommitments -> state.commitments.params.localParams.channelKeys(keyManager)
     }
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is ChannelReestablish -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannel.kt
@@ -25,7 +25,7 @@ data class WaitForAcceptChannel(
 ) : ChannelState() {
     val temporaryChannelId: ByteVector32 get() = lastSent.temporaryChannelId
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is AcceptDualFundedChannel -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReady.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForChannelReady.kt
@@ -18,7 +18,7 @@ data class WaitForChannelReady(
 ) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is TxSignatures -> when (commitments.latest.localFundingStatus) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
@@ -29,7 +29,7 @@ data class WaitForFundingConfirmed(
 
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is TxSignatures -> when (latestFundingTx.sharedTx) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreated.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingCreated.kt
@@ -45,7 +45,7 @@ data class WaitForFundingCreated(
 ) : ChannelState() {
     val channelId: ByteVector32 = interactiveTxSession.fundingParams.channelId
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is InteractiveTxConstructionMessage -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
@@ -47,7 +47,7 @@ data class WaitForFundingSigned(
 ) : PersistedChannelState() {
     override val channelId: ByteVector32 = channelParams.channelId
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is CommitSig -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
@@ -11,7 +11,7 @@ import fr.acinq.lightning.wire.OpenDualFundedChannel
 import fr.acinq.lightning.wire.TlvStream
 
 data object WaitForInit : ChannelState() {
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.Init.NonInitiator -> {
                 val nextState = WaitForOpenChannel(

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannel.kt
@@ -29,7 +29,7 @@ data class WaitForOpenChannel(
     val channelConfig: ChannelConfig,
     val remoteInit: Init
 ) : ChannelState() {
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when (cmd) {
             is ChannelCommand.MessageReceived -> when (cmd.message) {
                 is OpenDualFundedChannel -> {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForRemotePublishFutureCommitment.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForRemotePublishFutureCommitment.kt
@@ -14,7 +14,7 @@ data class WaitForRemotePublishFutureCommitment(
 ) : ChannelStateWithCommitments() {
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
 
-    override fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
+    override suspend fun ChannelContext.processInternal(cmd: ChannelCommand): Pair<ChannelState, List<ChannelAction>> {
         return when {
             cmd is ChannelCommand.WatchReceived && cmd.watch is WatchEventSpent && cmd.watch.event is BITCOIN_FUNDING_SPENT -> handlePotentialForceClose(cmd.watch)
             cmd is ChannelCommand.Disconnected -> Pair(Offline(this@WaitForRemotePublishFutureCommitment), listOf())

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/utils/runTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/utils/runTest.kt
@@ -7,6 +7,9 @@ import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+/**
+ * This defers to kotlin's [kotlinx.coroutines.runBlocking] on all platforms except iOS which needs custom code.
+ */
 expect fun runSuspendBlocking(block: suspend CoroutineScope.() -> Unit)
 
 fun runSuspendTest(timeout: Duration = 30.seconds, test: suspend CoroutineScope.() -> Unit) {


### PR DESCRIPTION
This touches many files but there are no functional changes. Making `process()` a `suspend` function opens the way for the channel FSM to itself call `suspend` functions, but for now we don't call any.