### PR TITLE
Make feerates resolution asynchronous

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Closing.kt
@@ -208,7 +208,7 @@ data class Closing(
 
                         val revokedCommitPublishActions = mutableListOf<ChannelAction>()
                         val revokedCommitPublished1 = revokedCommitPublished.map { rev ->
-                            val (newRevokedCommitPublished, penaltyTxs) = claimRevokedHtlcTxOutputs(channelKeys(), commitments.params, rev, watch.tx, currentOnChainFeerates)
+                            val (newRevokedCommitPublished, penaltyTxs) = claimRevokedHtlcTxOutputs(channelKeys(), commitments.params, rev, watch.tx, currentOnChainFeerates())
                             penaltyTxs.forEach {
                                 revokedCommitPublishActions += ChannelAction.Blockchain.PublishTx(it)
                                 revokedCommitPublishActions += ChannelAction.Blockchain.SendWatch(WatchSpent(channelId, watch.tx, it.input.outPoint.index.toInt(), BITCOIN_OUTPUT_SPENT))
@@ -300,7 +300,7 @@ data class Closing(
             is ChannelCommand.Closing.GetHtlcInfosResponse -> {
                 val index = revokedCommitPublished.indexOfFirst { it.commitTx.txid == cmd.revokedCommitTxId }
                 if (index >= 0) {
-                    val revokedCommitPublished1 = claimRevokedRemoteCommitTxHtlcOutputs(channelKeys(), commitments.params, revokedCommitPublished[index], currentOnChainFeerates, cmd.htlcInfos)
+                    val revokedCommitPublished1 = claimRevokedRemoteCommitTxHtlcOutputs(channelKeys(), commitments.params, revokedCommitPublished[index], currentOnChainFeerates(), cmd.htlcInfos)
                     val nextState = copy(revokedCommitPublished = revokedCommitPublished.updated(index, revokedCommitPublished1))
                     val actions = buildList {
                         add(ChannelAction.Storage.StoreState(nextState))
@@ -339,14 +339,14 @@ data class Closing(
                     logger.info { "got valid payment preimage, recalculating transactions to redeem the corresponding htlc on-chain" }
                     val commitments1 = result.value.first
                     val localCommitPublished1 = localCommitPublished?.let {
-                        claimCurrentLocalCommitTxOutputs(channelKeys(), commitments1.latest, it.commitTx, currentOnChainFeerates)
+                        claimCurrentLocalCommitTxOutputs(channelKeys(), commitments1.latest, it.commitTx, currentOnChainFeerates())
                     }
                     val remoteCommitPublished1 = remoteCommitPublished?.let {
-                        claimRemoteCommitTxOutputs(channelKeys(), commitments1.latest, commitments1.latest.remoteCommit, it.commitTx, currentOnChainFeerates)
+                        claimRemoteCommitTxOutputs(channelKeys(), commitments1.latest, commitments1.latest.remoteCommit, it.commitTx, currentOnChainFeerates())
                     }
                     val nextRemoteCommitPublished1 = nextRemoteCommitPublished?.let {
                         val remoteCommit = commitments1.latest.nextRemoteCommit?.commit ?: error("next remote commit must be defined")
-                        claimRemoteCommitTxOutputs(channelKeys(), commitments1.latest, remoteCommit, it.commitTx, currentOnChainFeerates)
+                        claimRemoteCommitTxOutputs(channelKeys(), commitments1.latest, remoteCommit, it.commitTx, currentOnChainFeerates())
                     }
                     val republishList = buildList {
                         val minDepth = staticParams.nodeParams.minDepthBlocks.toLong()

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
@@ -60,7 +60,7 @@ data class Negotiating(
                                 }
                                 else -> {
                                     val theirFeeRange = cmd.message.tlvStream.get<ClosingSignedTlv.FeeRange>()
-                                    val ourFeeRange = closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate)
+                                    val ourFeeRange = closingFeerates ?: ClosingFeerates(currentOnChainFeerates().mutualCloseFeerate)
                                     when {
                                         theirFeeRange != null && !commitments.params.localParams.isInitiator -> {
                                             // if we are not the initiator and they proposed a fee range, we pick a value in that range and they should accept it without further negotiation

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -248,7 +248,7 @@ data class Normal(
                                             commitments1.latest,
                                             localShutdown.scriptPubKey.toByteArray(),
                                             remoteShutdown.scriptPubKey.toByteArray(),
-                                            closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate),
+                                            closingFeerates ?: ClosingFeerates(currentOnChainFeerates().mutualCloseFeerate),
                                         )
                                         listOf(listOf(ClosingTxProposed(closingTx, closingSigned)))
                                     } else {
@@ -319,7 +319,7 @@ data class Normal(
                                             commitments1.latest,
                                             localShutdown.scriptPubKey.toByteArray(),
                                             cmd.message.scriptPubKey.toByteArray(),
-                                            closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate),
+                                            closingFeerates ?: ClosingFeerates(currentOnChainFeerates().mutualCloseFeerate),
                                         )
                                         val nextState = Negotiating(
                                             commitments1,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/ShuttingDown.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/ShuttingDown.kt
@@ -51,7 +51,7 @@ data class ShuttingDown(
                                             commitments1.latest,
                                             localShutdown.scriptPubKey.toByteArray(),
                                             remoteShutdown.scriptPubKey.toByteArray(),
-                                            closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate)
+                                            closingFeerates ?: ClosingFeerates(currentOnChainFeerates().mutualCloseFeerate)
                                         )
                                         val nextState = Negotiating(
                                             commitments1,
@@ -99,7 +99,7 @@ data class ShuttingDown(
                                         commitments1.latest,
                                         localShutdown.scriptPubKey.toByteArray(),
                                         remoteShutdown.scriptPubKey.toByteArray(),
-                                        closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate)
+                                        closingFeerates ?: ClosingFeerates(currentOnChainFeerates().mutualCloseFeerate)
                                     )
                                     val nextState = Negotiating(
                                         commitments1,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -235,7 +235,7 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
                                     state.commitments.latest,
                                     state.localShutdown.scriptPubKey.toByteArray(),
                                     state.remoteShutdown.scriptPubKey.toByteArray(),
-                                    state.closingFeerates ?: ClosingFeerates(currentOnChainFeerates.mutualCloseFeerate)
+                                    state.closingFeerates ?: ClosingFeerates(currentOnChainFeerates().mutualCloseFeerate)
                                 )
                                 val closingTxProposed1 = state.closingTxProposed + listOf(listOf(ClosingTxProposed(closingTx, closingSigned)))
                                 val nextState = state.copy(closingTxProposed = closingTxProposed1)

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -201,7 +201,7 @@ class Peer(
         val ctx = ChannelContext(
             StaticParams(nodeParams, remoteNodeId),
             currentTipFlow.filterNotNull().first().first,
-            onChainFeeratesFlow.filterNotNull().first(),
+            onChainFeeratesFlow,
             logger = MDCLogger(
                 logger = _channelLogger,
                 staticMdc = mapOf("remoteNodeId" to remoteNodeId) + state.mdc()

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -21,6 +21,7 @@ import fr.acinq.lightning.tests.utils.testLoggerFactory
 import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.*
 import fr.acinq.lightning.wire.*
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import kotlin.test.*
@@ -63,7 +64,7 @@ internal inline fun <reified T : ChannelAction> List<ChannelAction>.find() = fin
 internal inline fun <reified T : ChannelAction> List<ChannelAction>.has() = assertTrue { any { it is T } }
 internal inline fun <reified T : ChannelAction> List<ChannelAction>.doesNotHave() = assertTrue { none { it is T } }
 
-fun <S : ChannelState> LNChannel<S>.updateFeerate(feerate: FeeratePerKw): LNChannel<S> = this.copy(ctx = this.ctx.copy(currentOnChainFeerates = OnChainFeerates(feerate, feerate, feerate, feerate)))
+fun <S : ChannelState> LNChannel<S>.updateFeerate(feerate: FeeratePerKw): LNChannel<S> = this.copy(ctx = this.ctx.copy(onChainFeerates = MutableStateFlow(OnChainFeerates(feerate, feerate, feerate, feerate))))
 
 fun Features.add(vararg pairs: Pair<Feature, FeatureSupport>): Features = this.copy(activated = this.activated + mapOf(*pairs))
 fun Features.remove(vararg features: Feature): Features = this.copy(activated = activated.filterKeys { f -> !features.contains(f) })
@@ -165,7 +166,7 @@ object TestsHelper {
             ChannelContext(
                 StaticParams(aliceNodeParams, TestConstants.Bob.nodeParams.nodeId),
                 currentBlockHeight = currentHeight,
-                currentOnChainFeerates = OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
+                onChainFeerates = MutableStateFlow(OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)),
                 logger = MDCLogger(testLoggerFactory.newLogger("ChannelState"))
             ),
             WaitForInit
@@ -174,7 +175,7 @@ object TestsHelper {
             ChannelContext(
                 StaticParams(bobNodeParams, TestConstants.Alice.nodeParams.nodeId),
                 currentBlockHeight = currentHeight,
-                currentOnChainFeerates = OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
+                onChainFeerates = MutableStateFlow(OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)),
                 logger = MDCLogger(testLoggerFactory.newLogger("ChannelState"))
             ),
             WaitForInit

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingConfirmedTestsCommon.kt
@@ -16,6 +16,8 @@ import fr.acinq.lightning.wire.ChannelReady
 import fr.acinq.lightning.wire.ChannelReestablish
 import fr.acinq.lightning.wire.EncryptedChannelData
 import fr.acinq.lightning.wire.Init
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -35,7 +37,7 @@ class LegacyWaitForFundingConfirmedTestsCommon {
         val ctx = ChannelContext(
             StaticParams(TestConstants.Bob.nodeParams, TestConstants.Alice.nodeParams.nodeId),
             TestConstants.defaultBlockHeight ,
-            OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
+            MutableStateFlow(OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)),
             MDCLogger(testLoggerFactory.newLogger("ChannelState"))
         )
         val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Init.Restore(state))

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/LegacyWaitForFundingLockedTestsCommon.kt
@@ -15,6 +15,7 @@ import fr.acinq.lightning.wire.ChannelReady
 import fr.acinq.lightning.wire.ChannelReestablish
 import fr.acinq.lightning.wire.EncryptedChannelData
 import fr.acinq.lightning.wire.Init
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -34,7 +35,7 @@ class LegacyWaitForFundingLockedTestsCommon {
         val ctx = ChannelContext(
             StaticParams(TestConstants.Bob.nodeParams, TestConstants.Alice.nodeParams.nodeId),
             TestConstants.defaultBlockHeight,
-            OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw),
+            MutableStateFlow(OnChainFeerates(TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw, TestConstants.feeratePerKw)),
             MDCLogger(testLoggerFactory.newLogger("ChannelState"))
         )
         val (state1, actions1) = LNChannel(ctx, WaitForInit).process(ChannelCommand.Init.Restore(state))


### PR DESCRIPTION
Instead of waiting for feerates to be available before processing any channel command, we just pass the `StateFlow` to the `ChannelContext` and will attempt to get feerates only when needed.

If feerates are not available, the `ChannelState.process` function will hang. Previously, the hanging would have happened in the `Peer`.