### PR TITLE
Unblock channels stuck in `Syncing`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelCommand.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelCommand.kt
@@ -51,6 +51,9 @@ sealed class ChannelCommand {
         ) : Init()
 
         data class Restore(val state: PersistedChannelState) : Init()
+
+        /** Force sending our channel_reestablish if we timeout waiting for theirs. */
+        data object ForceReestablish : Init()
     }
 
     sealed class Funding : ChannelCommand() {

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
@@ -139,6 +139,7 @@ data object WaitForInit : ChannelState() {
                     }
                 }
             }
+            is ChannelCommand.Init.ForceReestablish -> unhandled(cmd)
             is ChannelCommand.Close -> Pair(Aborted, listOf())
             is ChannelCommand.MessageReceived -> unhandled(cmd)
             is ChannelCommand.WatchReceived -> unhandled(cmd)


### PR DESCRIPTION
When using channel backups, we wait for our peer to send their `channel_reestablish` first. This can be an issue for channels that are only present locally, and have been forgotten by our peer (for example because they force-close while we were offline).

In that case we would stay in `Syncing` indefinitely: to avoid that, we send our `channel_reestablish` if we haven't received theirs, which gives them an opportunity to send back an error and forget the channel.