### PR TITLE
Set `Connection.ESTABLISHED` after noise handshake

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -1,6 +1,7 @@
 package fr.acinq.lightning
 
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.PublicKey
 import fr.acinq.bitcoin.Satoshi
 import fr.acinq.lightning.channel.InteractiveTxParams
 import fr.acinq.lightning.channel.SharedFundingInput
@@ -9,11 +10,13 @@ import fr.acinq.lightning.channel.states.Normal
 import fr.acinq.lightning.channel.states.WaitForFundingCreated
 import fr.acinq.lightning.db.IncomingPayment
 import fr.acinq.lightning.utils.sum
-import fr.acinq.lightning.wire.Node
+import fr.acinq.lightning.wire.Init
 import fr.acinq.lightning.wire.PleaseOpenChannel
 import kotlinx.coroutines.CompletableDeferred
 
 sealed interface NodeEvents
+
+data class PeerConnected(val remoteNodeId: PublicKey, val theirInit: Init) : NodeEvents
 
 sealed interface SwapInEvents : NodeEvents {
     data class Requested(val req: PleaseOpenChannel) : SwapInEvents

--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -160,7 +160,7 @@ data class NodeParams(
     val nodeId get() = keyManager.nodeKeys.nodeKey.publicKey
     val chainHash get() = chain.chainHash
 
-    internal val _nodeEvents = MutableSharedFlow<NodeEvents>()
+    internal val _nodeEvents = MutableSharedFlow<NodeEvents>(replay = 10)
     val nodeEvents: SharedFlow<NodeEvents> get() = _nodeEvents.asSharedFlow()
 
     init {

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/ConnectionTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/ConnectionTest.kt
@@ -7,10 +7,8 @@ import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.io.peer.newPeer
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.tests.utils.runSuspendTest
-import fr.acinq.lightning.utils.Connection
 import kotlinx.coroutines.flow.first
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class ConnectionTest : LightningTestSuite() {
 
@@ -18,11 +16,9 @@ class ConnectionTest : LightningTestSuite() {
     fun `connection lost`() = runSuspendTest {
         val (alice0, bob0) = reachNormal()
         val peer = newPeer(alice0.staticParams.nodeParams, TestConstants.Alice.walletParams, bob0) { channels.addOrUpdateChannel(alice0.state) }
-
         peer.send(Disconnected)
         // Wait until alice is Offline
         peer.channelsFlow.first { it.values.size == 1 && it.values.all { channelState -> channelState is Offline } }
-        assertEquals(Connection.ESTABLISHED, peer.connectionState.value)
     }
 
 }


### PR DESCRIPTION
We were previously setting `Connection.ESTABLISHED` when receiving our peer's `init` message. This was primarily for tests, but was a mistake that could lead to a connection deadlock, because that could happen after a connection was actually closed.

An example flow where this happens is:

- the `connect()` function succeeds:
  - we are in state `Connection.ESTABLISHING`
  - we do `input.send(Connected(peerConnection))`
- we receive their `init` and queue it up in our `input` channel
- the TCP connection is closed:
  - we transition to state `Connection.CLOSED`
- then we dequeue their `init` from the `input` channel
  - we set the connection status to `Connection.ESTABLISHED`
- future reconnection attempts fail immediately because it starts by checking that we are in `Connection.CLOSED` before attempting a TCP connect