### PR TITLE
Expose private key for default offer

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -238,8 +238,9 @@ data class NodeParams(
     /**
      * We generate a default, deterministic Bolt 12 offer based on the node's seed and its trampoline node.
      * This offer will stay valid after restoring the seed on a different device.
+     * @return the default offer and the private key that will sign invoices for this offer.
      */
-    fun defaultOffer(trampolineNodeId: PublicKey): OfferTypes.Offer {
+    fun defaultOffer(trampolineNodeId: PublicKey): Pair<OfferTypes.Offer, PrivateKey> {
         // We generate a deterministic blindingSecret based on:
         //  - a custom tag indicating that this is used in the Bolt 12 context
         //  - our trampoline node, which is used as an introduction node for the offer's blinded path

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
@@ -48,7 +48,7 @@ class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, v
     private val localOffers: HashMap<ByteVector32, OfferTypes.Offer> = HashMap()
 
     init {
-        registerOffer(nodeParams.defaultOffer(walletParams.trampolineNode.id), null)
+        registerOffer(nodeParams.defaultOffer(walletParams.trampolineNode.id).first, null)
     }
 
     fun registerOffer(offer: OfferTypes.Offer, pathId: ByteVector32?) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
@@ -51,7 +51,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
 
     private fun createOffer(offerManager: OfferManager, amount: MilliSatoshi? = null): OfferTypes.Offer {
         val blindingSecret = randomKey()
-        val offer = OfferTypes.Offer.createBlindedOffer(
+        val (offer, _) = OfferTypes.Offer.createBlindedOffer(
             amount,
             "Blockaccino",
             offerManager.nodeParams,

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/OfferTypesTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/OfferTypesTestsCommon.kt
@@ -508,7 +508,7 @@ class OfferTypesTestsCommon : LightningTestSuite() {
     fun `generate deterministic blinded offer through trampoline node`() {
         val trampolineNode = PublicKey.fromHex("03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f")
         val nodeParams = TestConstants.Alice.nodeParams.copy(chain = Chain.Mainnet)
-        val offer = nodeParams.defaultOffer(trampolineNode)
+        val (offer, key) = nodeParams.defaultOffer(trampolineNode)
         assertNull(offer.amount)
         assertNull(offer.description)
         assertEquals(Features.empty, offer.features) // the offer shouldn't have any feature to guarantee stability
@@ -518,6 +518,7 @@ class OfferTypesTestsCommon : LightningTestSuite() {
         val path = offer.contactInfos.first()
         assertIs<BlindedPath>(path)
         assertEquals(EncodedNodeId(trampolineNode), path.route.introductionNodeId)
+        assertEquals(key.publicKey(), path.route.blindedNodeIds.last())
         val expectedOffer = Offer.decode("lno1zrxq8pjw7qjlm68mtp7e3yvxee4y5xrgjhhyf2fxhlphpckrvevh50u0qf70a6j2x2akrhazctejaaqr8y4qtzjtjzmfesay6mzr3s789uryuqsr8dpgfgxuk56vh7cl89769zdpdrkqwtypzhu2t8ehp73dqeeq65lsqvlx5pj8mw2kz54p4f6ct66stdfxz0df8nqq7svjjdjn2dv8sz28y7z07yg3vqyfyy8ywevqc8kzp36lhd5cqwlpkg8vdcqsfvz89axkmv5sgdysmwn95tpsct6mdercmz8jh2r82qqscrf6uc3tse5gw5sv5xjdfw8f6c").get()
         assertEquals(expectedOffer, offer)
     }


### PR DESCRIPTION
This key can be used as a payer key when paying offers to serve as our new identifier (the old node id is not exposed at all with BOLT 12).