### PR TITLE
Add `liquidity` field to `PayToOpenRequest`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -197,7 +197,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val db: IncomingPayment
         val logger = MDCLogger(logger.logger, staticMdc = paymentPart.mdc())
         when (paymentPart) {
             is HtlcPart -> logger.info { "processing htlc part expiry=${paymentPart.htlc.cltvExpiry}" }
-            is PayToOpenPart -> logger.info { "processing pay-to-open part amount=${paymentPart.payToOpenRequest.amountMsat} funding=${paymentPart.payToOpenRequest.fundingSatoshis} fees=${paymentPart.payToOpenRequest.payToOpenFeeSatoshis}" }
+            is PayToOpenPart -> logger.info { "processing pay-to-open part amount=${paymentPart.payToOpenRequest.amountMsat} fees=${paymentPart.payToOpenRequest.payToOpenFeeSatoshis}" }
         }
         return when (val validationResult = validatePaymentPart(paymentPart, currentBlockHeight)) {
             is Either.Left -> validationResult.value

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -239,9 +239,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val (paymentHandler, _, _) = createFixture(defaultAmount)
         val payToOpenRequest = PayToOpenRequest(
             chainHash = BlockHash(ByteVector32.Zeroes),
-            fundingSatoshis = 100_000.sat,
             amountMsat = defaultAmount,
-            payToOpenMinAmountMsat = 1_000_000.msat,
             payToOpenFeeSatoshis = 100.sat,
             paymentHash = ByteVector32.One, // <-- not associated to a pending invoice
             expireAt = Long.MAX_VALUE,
@@ -331,9 +329,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         )
         val payToOpenRequest = PayToOpenRequest(
             chainHash = BlockHash(ByteVector32.Zeroes),
-            fundingSatoshis = 100_000.sat,
             amountMsat = defaultAmount,
-            payToOpenMinAmountMsat = 1_000_000.msat,
             payToOpenFeeSatoshis = 100.sat,
             paymentHash = incomingPayment.paymentHash,
             expireAt = Long.MAX_VALUE,
@@ -1400,9 +1396,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         private fun makePayToOpenRequest(incomingPayment: IncomingPayment, finalPayload: PaymentOnion.FinalPayload): PayToOpenRequest {
             return PayToOpenRequest(
                 chainHash = Block.RegtestGenesisBlock.hash,
-                fundingSatoshis = 100_000.sat,
                 amountMsat = finalPayload.amount,
-                payToOpenMinAmountMsat = 10_000.msat,
                 payToOpenFeeSatoshis = finalPayload.amount.truncateToSatoshi() * payToOpenFeerate, // 10%
                 paymentHash = incomingPayment.paymentHash,
                 expireAt = Long.MAX_VALUE,

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -758,8 +758,8 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
         val preimage = ByteVector32("339770785632e71fe1f4b48b8b90d14af94a2a3a2c70af66f2156ed8a150f795")
         val testCases = listOf(
             // @formatter:off
-            PayToOpenRequest(Block.LivenetGenesisBlock.hash, 10_000.sat, 5_000.msat, 100.msat, 10.sat, preimage.sha256(), 100, onionPacket) to Hex.decode("88cd 6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000 0000000000002710 0000000000001388 0000000000000064 000000000000000a e7e2ae1540f63627007acc816c8b978b8344265b581840d5feec7ff0a85bbf0b 00000064 0005 000209be9bd1016d73fc1f611c6f8fdccd99ffb0885594e96156a268ee9afd35559c0102030405e0a0d5be2ca6faafa03880258e4af33a0d15aa950ab738c88566a471bf3bb14f"),
-            PayToOpenRequest(Block.LivenetGenesisBlock.hash, 10_000.sat, 5_000.msat, 100.msat, 10.sat, preimage.sha256(), 100, onionPacket, TlvStream(PayToOpenRequestTlv.Blinding(blinding))) to Hex.decode("88cd 6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000 0000000000002710 0000000000001388 0000000000000064 000000000000000a e7e2ae1540f63627007acc816c8b978b8344265b581840d5feec7ff0a85bbf0b 00000064 0005 000209be9bd1016d73fc1f611c6f8fdccd99ffb0885594e96156a268ee9afd35559c0102030405e0a0d5be2ca6faafa03880258e4af33a0d15aa950ab738c88566a471bf3bb14f 0021033da8b63fd839472b49935127072039e65d8f99d4603f14d79cdf74b59f895721"),
+            PayToOpenRequest(Block.LivenetGenesisBlock.hash, 5_000.msat, 10.sat, preimage.sha256(), 100, onionPacket, 1_000_000.sat) to Hex.decode("88cd 6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000 0000000000000000 0000000000001388 0000000000000000 000000000000000a e7e2ae1540f63627007acc816c8b978b8344265b581840d5feec7ff0a85bbf0b 00000064 0005 000209be9bd1016d73fc1f611c6f8fdccd99ffb0885594e96156a268ee9afd35559c0102030405e0a0d5be2ca6faafa03880258e4af33a0d15aa950ab738c88566a471bf3bb14f 00000000000f4240"),
+            PayToOpenRequest(Block.LivenetGenesisBlock.hash, 5_000.msat, 10.sat, preimage.sha256(), 100, onionPacket, 0.sat, TlvStream(PayToOpenRequestTlv.Blinding(blinding))) to Hex.decode("88cd 6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000 0000000000000000 0000000000001388 0000000000000000 000000000000000a e7e2ae1540f63627007acc816c8b978b8344265b581840d5feec7ff0a85bbf0b 00000064 0005 000209be9bd1016d73fc1f611c6f8fdccd99ffb0885594e96156a268ee9afd35559c0102030405e0a0d5be2ca6faafa03880258e4af33a0d15aa950ab738c88566a471bf3bb14f 0000000000000000 0021033da8b63fd839472b49935127072039e65d8f99d4603f14d79cdf74b59f895721"),
             PayToOpenResponse(Block.LivenetGenesisBlock.hash, preimage.sha256(), PayToOpenResponse.Result.Success(preimage)) to Hex.decode("88bb 6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000 e7e2ae1540f63627007acc816c8b978b8344265b581840d5feec7ff0a85bbf0b 339770785632e71fe1f4b48b8b90d14af94a2a3a2c70af66f2156ed8a150f795"),
             PayToOpenResponse(Block.LivenetGenesisBlock.hash, preimage.sha256(), PayToOpenResponse.Result.Failure(null)) to Hex.decode("88bb 6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000 e7e2ae1540f63627007acc816c8b978b8344265b581840d5feec7ff0a85bbf0b 0000000000000000000000000000000000000000000000000000000000000000"),
             PayToOpenResponse(Block.LivenetGenesisBlock.hash, preimage.sha256(), PayToOpenResponse.Result.Failure(ByteVector("deadbeef"))) to Hex.decode("88bb 6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000 e7e2ae1540f63627007acc816c8b978b8344265b581840d5feec7ff0a85bbf0b 0000000000000000000000000000000000000000000000000000000000000000 0004deadbeef"),
@@ -771,7 +771,7 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
             assertNotNull(decoded)
             assertEquals(it.first, decoded)
             val encoded = LightningMessage.encode(decoded)
-            assertArrayEquals(it.second, encoded)
+            assertContentEquals(it.second, encoded)
         }
     }
 


### PR DESCRIPTION
It is currently unused on `master` but we need it for compatibility with the fee-credit feature branch.

Also remove legacy unused fields.

cc @dpad85 