### PR TITLE
(Minor) Add an optional description to the default offer

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -240,7 +240,7 @@ data class NodeParams(
      * This offer will stay valid after restoring the seed on a different device.
      * @return the default offer and the private key that will sign invoices for this offer.
      */
-    fun defaultOffer(trampolineNodeId: PublicKey): Pair<OfferTypes.Offer, PrivateKey> {
+    fun defaultOffer(trampolineNodeId: PublicKey, description: String? = null): Pair<OfferTypes.Offer, PrivateKey> {
         // We generate a deterministic blindingSecret based on:
         //  - a custom tag indicating that this is used in the Bolt 12 context
         //  - our trampoline node, which is used as an introduction node for the offer's blinded path
@@ -248,6 +248,6 @@ data class NodeParams(
         val blindingSecret = PrivateKey(Crypto.sha256("bolt 12 default offer".toByteArray(Charsets.UTF_8).byteVector() + trampolineNodeId.value + nodePrivateKey.value).byteVector32())
         // We don't use our currently activated features, otherwise the offer would change when we add support for new features.
         // If we add a new feature that we would like to use by default, we will need to explicitly create a new offer.
-        return OfferTypes.Offer.createBlindedOffer(amount = null, description = null, this, trampolineNodeId, Features.empty, blindingSecret)
+        return OfferTypes.Offer.createBlindedOffer(amount = null, description = description, this, trampolineNodeId, Features.empty, blindingSecret)
     }
 }


### PR DESCRIPTION
Some services (e.g. https://ocean.xyz/docs/lightning) require a specific description for the offer.

Default offers all use the same blinding secret, are are really the same offer, just with a different description.