### PR TITLE
Ignore expired utxos migrated from the legacy app

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManager.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInManager.kt
@@ -39,7 +39,8 @@ class SwapInManager(private var reservedUtxos: Set<OutPoint>, private val logger
             logger.info { "swap-in wallet balance: deeplyConfirmed=${availableWallet.deeplyConfirmed.balance}, weaklyConfirmed=${availableWallet.weaklyConfirmed.balance}, unconfirmed=${availableWallet.unconfirmed.balance}" }
             val utxos = buildSet {
                 // some utxos may be used for swap-in even if they are not confirmed, for example when migrating from the legacy phoenix android app
-                addAll(availableWallet.all.filter { cmd.trustedTxs.contains(it.outPoint.txid) })
+                addAll(availableWallet.unconfirmed.filter { cmd.trustedTxs.contains(it.outPoint.txid) })
+                addAll(availableWallet.weaklyConfirmed.filter { cmd.trustedTxs.contains(it.outPoint.txid) })
                 addAll(availableWallet.deeplyConfirmed.filter { Transaction.write(it.previousTx.stripInputWitnesses()).size < 65_000 })
             }.toList()
             if (utxos.balance > 0.sat) {


### PR DESCRIPTION
When migrating from the legacy android app, we allowed unconfirmed utxos to be able to do an instantaneous migration. But we allowed *all* utxos coming from the legacy app instead of only allowing unconfirmed and weakly confirmed ones. That also included swap-in-potentiam utxos that expired (for example because they were too small to be economical), which are automatically rejected by the LSP because they can be double spent.

The result is that we are unable to complete swaps if we have an expired utxo coming from a migration from the legacy application. We fix this by only whitelisting unconfirmed and weakly confirmed utxos.

Note that we will remove the migration code entirely when we merge #649.

Fixes https://github.com/ACINQ/phoenix/issues/582