### PR TITLE
Requesting BIP353 address from peer

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -715,6 +715,11 @@ class Peer(
         peerConnection?.send(message)
     }
 
+    /**
+     * Request a BIP-353's compliant DNS address from our peer.
+     *
+     * @param languageSubtag IETF BCP 47 language tag (en, fr, de, es, ...) to indicate preference for the words that make up the address
+     */
     suspend fun requestAddress(languageSubtag: String): String {
         val replyTo = CompletableDeferred<String>()
         this.launch {
@@ -723,7 +728,7 @@ class Peer(
                 .first()
                 .let { event -> replyTo.complete(event.address) }
         }
-        peerConnection?.send(DNSAddressRequest(nodeParams.defaultOffer(walletParams.trampolineNode.id).first, languageSubtag))
+        peerConnection?.send(DNSAddressRequest(nodeParams.chainHash, nodeParams.defaultOffer(walletParams.trampolineNode.id).first, languageSubtag))
         return replyTo.await()
     }
 
@@ -1204,7 +1209,7 @@ class Peer(
                         }
                     }
                     is DNSAddressResponse -> {
-                        logger.info { "dns address assigned: ${msg}" }
+                        logger.info { "bip353 dns address assigned: ${msg.address}" }
                         _eventsFlow.emit(AddressAssigned(msg.address))
                     }
                 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -718,6 +718,8 @@ class Peer(
     /**
      * Request a BIP-353's compliant DNS address from our peer.
      *
+     * This will only return if there are existing channels with the peer, otherwise it will hang. This should be handled by the caller.
+     *
      * @param languageSubtag IETF BCP 47 language tag (en, fr, de, es, ...) to indicate preference for the words that make up the address
      */
     suspend fun requestAddress(languageSubtag: String): String {

--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -1775,7 +1775,7 @@ data class DNSAddressRequest(override val chainHash: BlockHash, val offer: Offer
         override fun read(input: Input): DNSAddressRequest {
             return DNSAddressRequest(
                 chainHash = BlockHash(LightningCodecs.bytes(input, 32)),
-                offer = OfferTypes.Offer.decode(LightningCodecs.bytes(input, LightningCodecs.u16(input)).decodeToString()).get(),
+                offer = OfferTypes.Offer(OfferTypes.Offer.tlvSerializer.read(LightningCodecs.bytes(input, LightningCodecs.u16(input)))),
                 languageSubtag = LightningCodecs.bytes(input, LightningCodecs.u16(input)).decodeToString()
             )
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/wire/LightningCodecsTestsCommon.kt
@@ -17,6 +17,7 @@ import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.utils.msat
 import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.utils.toByteVector
+import fr.acinq.lightning.wire.OfferTypes.Offer
 import fr.acinq.secp256k1.Hex
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -873,5 +874,20 @@ class LightningCodecsTestsCommon : LightningTestSuite() {
     fun `encode and decode onion message`() {
         val onionMessage = OnionMessages.buildMessage(randomKey(), randomKey(), listOf(), OnionMessages.Destination.Recipient(EncodedNodeId(randomKey().publicKey()), null), TlvStream.empty()).right!!
         assertEquals(onionMessage, OnionMessage.read(onionMessage.write()))
+    }
+
+    @Test
+    fun `encode and decode dns address request`() {
+        val encoded = "lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgf6gw45q75vcfqqqqqqqgqyeq5ym0venx2u3qwa5hg6pqw96kzmn5d968jys3v9kxjcm9gp3xjemndphhqtnrdak3gqqkyypsmuhrtwfzm85mht4a3vcp0yrlgua3u3m5uqpc6kf7nqjz6v70qwg"
+        val offer = Offer.decode(encoded).get()
+
+        val msg = DNSAddressRequest(Chain.Testnet.chainHash, offer, "en")
+        assertEquals(msg, LightningMessage.decode(LightningMessage.encode(msg)))
+    }
+
+    @Test
+    fun `encode and decode dns address response`() {
+        val msg = DNSAddressResponse(Chain.Testnet.chainHash, "foo@bar.baz")
+        assertEquals(msg, LightningMessage.decode(LightningMessage.encode(msg)))
     }
 }


### PR DESCRIPTION
The peer will only answer if there is a channel.

Optionally pass an IETF BCP 47 language tag (en, fr, de, es, ...) to indicate preference for the words that make up the address.