### PR TITLE
Unlock swap-in utxos if initial channel creation fails

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
@@ -1201,7 +1201,7 @@ sealed class SpliceStatus {
     data class Requested(val command: ChannelCommand.Commitment.Splice.Request, val spliceInit: SpliceInit) : QuiescentSpliceStatus()
     /** We both agreed to splice and are building the splice transaction. */
     data class InProgress(
-        val replyTo: CompletableDeferred<ChannelCommand.Commitment.Splice.Response>?,
+        val replyTo: CompletableDeferred<ChannelFundingResponse>?,
         val spliceSession: InteractiveTxSession,
         val localPushAmount: MilliSatoshi,
         val remotePushAmount: MilliSatoshi,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
@@ -18,6 +18,7 @@ data object WaitForInit : ChannelState() {
         return when (cmd) {
             is ChannelCommand.Init.NonInitiator -> {
                 val nextState = WaitForOpenChannel(
+                    cmd.replyTo,
                     cmd.temporaryChannelId,
                     cmd.fundingAmount,
                     cmd.pushAmount,

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/QuiescenceTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/QuiescenceTestsCommon.kt
@@ -406,7 +406,7 @@ class QuiescenceTestsCommon : LightningTestSuite() {
         val (_, actionsAlice3) = alice2.process(ChannelCommand.MessageReceived(spliceAck))
         actionsAlice3.hasOutgoingMessage<TxAddInput>()
         withTimeout(100) {
-            assertIs<ChannelCommand.Commitment.Splice.Response.Failure.ConcurrentRemoteSplice>(cmdBob.replyTo.await())
+            assertIs<ChannelFundingResponse.Failure.ConcurrentRemoteSplice>(cmdBob.replyTo.await())
         }
     }
 
@@ -434,7 +434,7 @@ class QuiescenceTestsCommon : LightningTestSuite() {
         val (_, actionsBob5) = bob4.process(ChannelCommand.MessageReceived(spliceAck))
         actionsBob5.hasOutgoingMessage<TxAddInput>()
         withTimeout(100) {
-            assertIs<ChannelCommand.Commitment.Splice.Response.Failure.ConcurrentRemoteSplice>(cmdAlice.replyTo.await())
+            assertIs<ChannelFundingResponse.Failure.ConcurrentRemoteSplice>(cmdAlice.replyTo.await())
         }
     }
 

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SpliceTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/SpliceTestsCommon.kt
@@ -164,7 +164,7 @@ class SpliceTestsCommon : LightningTestSuite() {
         actionsAlice3.findOutgoingMessage<TxAbort>()
         runBlocking {
             val response = cmd.replyTo.await()
-            assertIs<ChannelCommand.Commitment.Splice.Response.Failure.InsufficientFunds>(response)
+            assertIs<ChannelFundingResponse.Failure.InsufficientFunds>(response)
         }
     }
 
@@ -260,7 +260,7 @@ class SpliceTestsCommon : LightningTestSuite() {
             actionsBob2.hasOutgoingMessage<TxAbort>()
             runBlocking {
                 val response = cmd.replyTo.await()
-                assertIs<ChannelCommand.Commitment.Splice.Response.Failure.InsufficientFunds>(response)
+                assertIs<ChannelFundingResponse.Failure.InsufficientFunds>(response)
                 assertEquals(10_000_000.msat, response.liquidityFees)
             }
             val (bob3, actionsBob3) = bob2.process(ChannelCommand.MessageReceived(TxAbort(bob.channelId, SpliceAborted(bob.channelId).message)))
@@ -332,7 +332,7 @@ class SpliceTestsCommon : LightningTestSuite() {
             actionsBob2.hasOutgoingMessage<TxAbort>()
             runBlocking {
                 val response = cmd.replyTo.await()
-                assertIs<ChannelCommand.Commitment.Splice.Response.Failure.InsufficientFunds>(response)
+                assertIs<ChannelFundingResponse.Failure.InsufficientFunds>(response)
                 assertEquals(500_000.msat, response.liquidityFees)
                 assertEquals(currentFeeCredit, response.currentFeeCredit)
             }
@@ -1570,9 +1570,9 @@ class SpliceTestsCommon : LightningTestSuite() {
             return exchangeSpliceSigs(alice1, commitSigAlice, bob1, commitSigBob)
         }
 
-        private fun checkCommandResponse(replyTo: CompletableDeferred<ChannelCommand.Commitment.Splice.Response>, parentCommitment: Commitment, spliceInit: SpliceInit): TxId = runBlocking {
+        private fun checkCommandResponse(replyTo: CompletableDeferred<ChannelFundingResponse>, parentCommitment: Commitment, spliceInit: SpliceInit): TxId = runBlocking {
             val response = replyTo.await()
-            assertIs<ChannelCommand.Commitment.Splice.Response.Created>(response)
+            assertIs<ChannelFundingResponse.Success>(response)
             assertEquals(response.capacity, parentCommitment.fundingAmount + spliceInit.fundingContribution)
             assertEquals(response.balance, parentCommitment.localCommit.spec.toLocal + spliceInit.fundingContribution.toMilliSatoshi() - spliceInit.pushAmount)
             assertEquals(response.fundingTxIndex, parentCommitment.fundingTxIndex + 1)


### PR DESCRIPTION
Add a `replyTo` field when opening or accepting a channel. This is used for swaps, to free utxos in case a failure happens during funding. Without this mechanism, the user needs to restart the app to be able to reuse those utxos.

Fixes #680