### PR TITLE
Include `min_final_cltv_expiry_delta` in blinded paths

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/OfferTypes.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/OfferTypes.kt
@@ -860,6 +860,8 @@ object OfferTypes {
                     Features.areCompatible(offer.features, features) &&
                     checkSignature()
 
+        fun requestedAmount(): MilliSatoshi? = amount ?: offer.amount?.let { it * quantity }
+
         fun checkSignature(): Boolean =
             verifySchnorr(
                 signatureTag,

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
@@ -151,12 +151,10 @@ class NormalTestsCommon : LightningTestSuite() {
     @Test
     fun `recv ChannelCommand_Htlc_Add -- 0 msat`() {
         val (alice0, bob0) = reachNormal()
-        // Alice has a minimum set to 0 msat (which should be invalid, but may mislead Bob into relaying 0-value HTLCs which is forbidden by the spec).
-        assertEquals(0.msat, alice0.commitments.params.localParams.htlcMinimum)
         val add = defaultAdd.copy(amount = 0.msat)
         val (bob1, actions) = bob0.process(add)
         val actualError = actions.findCommandError<HtlcValueTooSmall>()
-        val expectedError = HtlcValueTooSmall(bob0.channelId, 1.msat, 0.msat)
+        val expectedError = HtlcValueTooSmall(bob0.channelId, alice0.commitments.params.localParams.htlcMinimum, 0.msat)
         assertEquals(expectedError, actualError)
         assertEquals(bob0, bob1)
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
@@ -206,7 +206,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
     }
 
     @Test
-    fun `receive invoice error`() = runSuspendTest {
+    fun `receive invoice error -- amount below offer amount`() = runSuspendTest {
         // Alice and Bob use the same trampoline node.
         val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
         val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
@@ -214,6 +214,27 @@ class OfferManagerTestsCommon : LightningTestSuite() {
 
         // Bob sends an invoice request to Alice that pays less than the offer amount.
         val payOffer = PayOffer(UUID.randomUUID(), randomKey(), null, 40_000.msat, offer, 20.seconds)
+        val (_, invoiceRequests) = bobOfferManager.requestInvoice(payOffer)
+        val (messageForAlice, _) = trampolineRelay(invoiceRequests.first(), aliceTrampolineKey)
+        // Alice sends an invoice error back to Bob.
+        val invoiceResponse = aliceOfferManager.receiveMessage(messageForAlice, listOf(), 0)
+        assertIs<OnionMessageAction.SendMessage>(invoiceResponse)
+        val (messageForBob, _) = trampolineRelay(invoiceResponse.message, aliceTrampolineKey)
+        assertNull(bobOfferManager.receiveMessage(messageForBob, listOf(), 0))
+        val event = bobOfferManager.eventsFlow.first()
+        assertIs<OfferNotPaid>(event)
+        assertIs<Bolt12InvoiceRequestFailure.ErrorFromRecipient>(event.reason)
+    }
+
+    @Test
+    fun `receive invoice error -- amount too low`() = runSuspendTest {
+        // Alice and Bob use the same trampoline node.
+        val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
+        val offer = createOffer(aliceOfferManager, null)
+
+        // Bob sends an invoice request to Alice that pays less than the minimum htlc amount.
+        val payOffer = PayOffer(UUID.randomUUID(), randomKey(), null, 10.msat, offer, 20.seconds)
         val (_, invoiceRequests) = bobOfferManager.requestInvoice(payOffer)
         val (messageForAlice, _) = trampolineRelay(invoiceRequests.first(), aliceTrampolineKey)
         // Alice sends an invoice error back to Bob.

--- a/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
@@ -78,7 +78,7 @@ object TestConstants {
             ),
             maxHtlcValueInFlightMsat = 1_500_000_000L,
             maxAcceptedHtlcs = 100,
-            htlcMinimum = 0.msat,
+            htlcMinimum = 100.msat,
             toRemoteDelayBlocks = CltvExpiryDelta(144),
             maxToLocalDelayBlocks = CltvExpiryDelta(2048),
             feeBase = 100.msat,


### PR DESCRIPTION
If a payer uses the current block height as the expiry for the payments they send to us, we will reject it because we need to have a few blocks to potentially force-close and get our funds back safely.

With blinded paths, we don't need to rely on payers to add a safety margin: we can directly encode it in the blinded path's total expiry delta.