### PR TITLE
Update build docs to install libcurl4-openssh-dev on linux

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -16,6 +16,12 @@ brew install libtool
 brew install gmp
 ```
 
+For Linux, our tests use ktor-client which depends on [ktor-client-curl-linuxx64](https://mvnrepository.com/artifact/io.ktor/ktor-client-curl-linuxx64) so you should install:
+
+```sh
+apt install libcurl4-openssh-dev
+```
+
 ## Build
 
 You should start by cloning the repository locally:


### PR DESCRIPTION
This updates the docs to address issue #321 . 