### PR TITLE
Follow-ups to #649 and #660

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -14,6 +14,7 @@ import fr.acinq.lightning.channel.states.WaitForFundingCreated
 import fr.acinq.lightning.db.IncomingPayment
 import fr.acinq.lightning.utils.sum
 import fr.acinq.lightning.wire.Init
+import fr.acinq.lightning.wire.LiquidityAds
 
 sealed interface NodeEvents
 
@@ -35,13 +36,8 @@ sealed interface ChannelEvents : NodeEvents {
 }
 
 sealed interface LiquidityEvents : NodeEvents {
-    /** Amount of liquidity purchased, before fees are paid. */
-    val amount: MilliSatoshi
-    val fee: MilliSatoshi
-    val source: Source
-
     enum class Source { OnChainWallet, OffChainPayment }
-    data class Rejected(override val amount: MilliSatoshi, override val fee: MilliSatoshi, override val source: Source, val reason: Reason) : LiquidityEvents {
+    data class Rejected(val amount: MilliSatoshi, val fee: MilliSatoshi, val source: Source, val reason: Reason) : LiquidityEvents {
         sealed class Reason {
             data object PolicySetToDisabled : Reason()
             sealed class TooExpensive : Reason() {
@@ -54,7 +50,7 @@ sealed interface LiquidityEvents : NodeEvents {
             data class TooManyParts(val parts: Int) : Reason()
         }
     }
-    data class Accepted(override val amount: MilliSatoshi, override val fee: MilliSatoshi, override val source: Source) : LiquidityEvents
+    data class Purchased(val purchase: LiquidityAds.Purchase) : PaymentEvents
 }
 
 /** This is useful on iOS to ask the OS for time to finish some sensitive tasks. */

--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -12,6 +12,7 @@ import fr.acinq.lightning.channel.states.ChannelStateWithCommitments
 import fr.acinq.lightning.channel.states.Normal
 import fr.acinq.lightning.channel.states.WaitForFundingCreated
 import fr.acinq.lightning.db.IncomingPayment
+import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.utils.sum
 import fr.acinq.lightning.wire.Init
 import fr.acinq.lightning.wire.LiquidityAds
@@ -50,7 +51,7 @@ sealed interface LiquidityEvents : NodeEvents {
             data class TooManyParts(val parts: Int) : Reason()
         }
     }
-    data class Purchased(val purchase: LiquidityAds.Purchase) : PaymentEvents
+    data class Purchased(val purchase: LiquidityAds.Purchase) : LiquidityEvents
 }
 
 /** This is useful on iOS to ask the OS for time to finish some sensitive tasks. */
@@ -73,4 +74,5 @@ sealed interface PaymentEvents : NodeEvents {
         val amount: MilliSatoshi = receivedWith.map { it.amountReceived }.sum()
         val fees: MilliSatoshi = receivedWith.map { it.fees }.sum()
     }
+    data class PaymentSent(val payment: OutgoingPayment) : PaymentEvents
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -205,6 +205,7 @@ data class NodeParams(
             Feature.ChannelBackupClient to FeatureSupport.Optional,
             Feature.ExperimentalSplice to FeatureSupport.Optional,
             Feature.OnTheFlyFunding to FeatureSupport.Optional,
+            Feature.FundingFeeCredit to FeatureSupport.Optional,
         ),
         dustLimit = 546.sat,
         maxRemoteDustLimit = 600.sat,

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -432,7 +432,8 @@ data class InboundLiquidityOutgoingPayment(
     override val confirmedAt: Long?,
     override val lockedAt: Long?,
 ) : OnChainOutgoingPayment() {
-    override val fees: MilliSatoshi = (miningFees + purchase.fees.serviceFee).toMilliSatoshi()
+    val serviceFees: Satoshi = purchase.fees.serviceFee
+    override val fees: MilliSatoshi = (miningFees + serviceFees).toMilliSatoshi()
     override val amount: MilliSatoshi = fees
     override val completedAt: Long? = lockedAt
     val fundingFee: LiquidityAds.FundingFee = LiquidityAds.FundingFee(purchase.fees.total.toMilliSatoshi(), txId)

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -910,6 +910,7 @@ class Peer(
                                 )
                             }
                         }
+                        nodeParams._nodeEvents.emit(PaymentEvents.PaymentSent(payment))
                         db.payments.addOutgoingPayment(payment)
                     }
                     is ChannelAction.Storage.SetLocked -> {

--- a/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
@@ -99,7 +99,7 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
         val (alice, _, _, commitSigBob) = init(aliceFundingAmount = 0.sat, alicePushAmount = 0.msat, bobPushAmount = 50_000_000.msat, channelOrigin = channelOrigin)
         val (alice1, actionsAlice1) = alice.process(ChannelCommand.MessageReceived(commitSigBob))
         assertIs<WaitForFundingConfirmed>(alice1.state)
-        assertEquals(actionsAlice1.size, 6)
+        assertEquals(5, actionsAlice1.size)
         actionsAlice1.hasOutgoingMessage<TxSignatures>()
         actionsAlice1.has<ChannelAction.Storage.StoreState>()
         actionsAlice1.find<ChannelAction.Storage.StoreIncomingPayment.ViaNewChannel>().also {
@@ -110,7 +110,6 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
         actionsAlice1.hasWatch<WatchConfirmed>()
         val events = actionsAlice1.filterIsInstance<ChannelAction.EmitEvent>().map { it.event }
         assertTrue(events.any { it is ChannelEvents.Created })
-        assertTrue(events.any { it is LiquidityEvents.Accepted })
     }
 
     @Test
@@ -194,7 +193,7 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
             assertTrue(actionsAlice1.isEmpty())
             val (alice2, actionsAlice2) = alice1.process(ChannelCommand.MessageReceived(txSigsBob))
             assertIs<WaitForFundingConfirmed>(alice2.state)
-            assertEquals(7, actionsAlice2.size)
+            assertEquals(8, actionsAlice2.size)
             assertTrue(actionsAlice2.hasOutgoingMessage<TxSignatures>().channelData.isEmpty())
             actionsAlice2.has<ChannelAction.Storage.StoreState>()
             val watchConfirmedAlice = actionsAlice2.findWatch<WatchConfirmed>()


### PR DESCRIPTION
Minor changes, best reviewed commit-by-commit.

In particular we enable the `FeeCredit` feature by default.