### PR TITLE
Clarify when the `WithFeeCredit` liquidity purchase is used

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/LiquidityAds.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/LiquidityAds.kt
@@ -324,6 +324,7 @@ object LiquidityAds {
         abstract val paymentDetails: PaymentDetails
 
         data class Standard(override val amount: Satoshi, override val fees: Fees, override val paymentDetails: PaymentDetails) : Purchase()
+        /** The liquidity purchase was paid (partially or entirely) using [fr.acinq.lightning.Feature.FundingFeeCredit]. */
         data class WithFeeCredit(override val amount: Satoshi, override val fees: Fees, val feeCreditUsed: MilliSatoshi, override val paymentDetails: PaymentDetails) : Purchase()
     }
 


### PR DESCRIPTION
Whenever we consume some of our fee credit for a liquidity purchase, we will use a `WithFeeCredit` purchase, even if we cannot pay the entire fee with our fee credit.