### PR TITLE
Include local mining fees for pure liquidity purchases

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelAction.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelAction.kt
@@ -88,7 +88,7 @@ sealed class ChannelAction {
             abstract val txId: TxId
             data class ViaSpliceOut(val amount: Satoshi, override val miningFees: Satoshi, val address: String, override val txId: TxId) : StoreOutgoingPayment()
             data class ViaSpliceCpfp(override val miningFees: Satoshi, override val txId: TxId) : StoreOutgoingPayment()
-            data class ViaInboundLiquidityRequest(override val txId: TxId, val purchase: LiquidityAds.Purchase) : StoreOutgoingPayment() { override val miningFees: Satoshi = purchase.fees.miningFee }
+            data class ViaInboundLiquidityRequest(override val txId: TxId, val localMiningFees: Satoshi, val purchase: LiquidityAds.Purchase) : StoreOutgoingPayment() { override val miningFees: Satoshi = localMiningFees + purchase.fees.miningFee }
             data class ViaClose(val amount: Satoshi, override val miningFees: Satoshi, val address: String, override val txId: TxId, val isSentToDefaultAddress: Boolean, val closingType: ChannelClosingType) : StoreOutgoingPayment()
         }
         data class SetLocked(val txId: TxId) : Storage()

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -884,16 +884,8 @@ data class Normal(
                 val isPurchaseOnly = action.fundingTx.sharedTx.tx.let {
                     action.fundingTx.fundingParams.isInitiator && it.localInputs.isEmpty() && it.localOutputs.isEmpty() && it.remoteInputs.isNotEmpty()
                 }
-                if (isPurchaseOnly) {
-                    val localMiningFees = action.fundingTx.sharedTx.tx.localFees.truncateToSatoshi()
-                    val purchase1 = when (purchase) {
-                        is LiquidityAds.Purchase.Standard -> purchase.copy(fees = purchase.fees.copy(miningFee = purchase.fees.miningFee + localMiningFees))
-                        is LiquidityAds.Purchase.WithFeeCredit -> purchase.copy(fees = purchase.fees.copy(miningFee = purchase.fees.miningFee + localMiningFees))
-                    }
-                    add(ChannelAction.Storage.StoreOutgoingPayment.ViaInboundLiquidityRequest(txId = action.fundingTx.txId, purchase = purchase1))
-                } else {
-                    add(ChannelAction.Storage.StoreOutgoingPayment.ViaInboundLiquidityRequest(txId = action.fundingTx.txId, purchase = purchase))
-                }
+                val localMiningFees = if (isPurchaseOnly) action.fundingTx.sharedTx.tx.localFees.truncateToSatoshi() else 0.sat
+                add(ChannelAction.Storage.StoreOutgoingPayment.ViaInboundLiquidityRequest(txId = action.fundingTx.txId, localMiningFees = localMiningFees, purchase = purchase))
                 add(ChannelAction.EmitEvent(LiquidityEvents.Purchased(purchase)))
             }
             // NB: the following assumes that there can't be a splice-in and a splice-out simultaneously,

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
@@ -10,7 +10,7 @@ import fr.acinq.lightning.blockchain.WatchConfirmed
 import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.crypto.ShaChain
 import fr.acinq.lightning.utils.msat
-import fr.acinq.lightning.utils.toMilliSatoshi
+import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.wire.*
 import kotlin.math.absoluteValue
 
@@ -125,7 +125,7 @@ data class WaitForFundingSigned(
                     // We only count the mining fees that we must refund to our peer as part of the liquidity purchase.
                     // If we're also contributing to the funding transaction, the mining fees we pay for our inputs and
                     // outputs will be recorded in the ViaNewChannel incoming payment entry below.
-                    add(ChannelAction.Storage.StoreOutgoingPayment.ViaInboundLiquidityRequest(txId = action.fundingTx.txId, purchase = purchase))
+                    add(ChannelAction.Storage.StoreOutgoingPayment.ViaInboundLiquidityRequest(txId = action.fundingTx.txId, localMiningFees = 0.sat, purchase = purchase))
                     add(ChannelAction.EmitEvent(LiquidityEvents.Purchased(purchase)))
                 }
             }

--- a/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -177,7 +177,7 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
         }
 
         /**
-         * Payment was added to our fee credit for future on-chain operations (see [Feature.FundingFeeCredit]).
+         * Payment was added to our fee credit for future on-chain operations (see [fr.acinq.lightning.Feature.FundingFeeCredit]).
          * We didn't really receive this amount yet, but we trust our peer to use it for future on-chain operations.
          */
         data class AddedToFeeCredit(override val amountReceived: MilliSatoshi) : ReceivedWith() {
@@ -427,14 +427,15 @@ data class InboundLiquidityOutgoingPayment(
     override val id: UUID,
     override val channelId: ByteVector32,
     override val txId: TxId,
+    val localMiningFees: Satoshi,
     val purchase: LiquidityAds.Purchase,
     override val createdAt: Long,
     override val confirmedAt: Long?,
     override val lockedAt: Long?,
 ) : OnChainOutgoingPayment() {
-    override val miningFees: Satoshi = purchase.fees.miningFee
+    override val miningFees: Satoshi = localMiningFees + purchase.fees.miningFee
     val serviceFees: Satoshi = purchase.fees.serviceFee
-    override val fees: MilliSatoshi = purchase.fees.total.toMilliSatoshi()
+    override val fees: MilliSatoshi = (localMiningFees + purchase.fees.total).toMilliSatoshi()
     override val amount: MilliSatoshi = fees
     override val completedAt: Long? = lockedAt
     val fundingFee: LiquidityAds.FundingFee = LiquidityAds.FundingFee(purchase.fees.total.toMilliSatoshi(), txId)

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -887,6 +887,7 @@ class Peer(
                                     id = UUID.randomUUID(),
                                     channelId = channelId,
                                     txId = action.txId,
+                                    localMiningFees = action.localMiningFees,
                                     purchase = action.purchase,
                                     createdAt = currentTimestampMillis(),
                                     confirmedAt = null,

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -863,7 +863,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
                 splice.fees(TestConstants.feeratePerKw, isChannelCreation = false),
                 LiquidityAds.PaymentDetails.FromFutureHtlc(listOf(incomingPayment.paymentHash)),
             )
-            val payment = InboundLiquidityOutgoingPayment(UUID.randomUUID(), channelId, TxId(randomBytes32()), purchase, 0, null, null)
+            val payment = InboundLiquidityOutgoingPayment(UUID.randomUUID(), channelId, TxId(randomBytes32()), 0.sat, purchase, 0, null, null)
             paymentHandler.db.addOutgoingPayment(payment)
             payment
         }
@@ -911,7 +911,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
                 splice.fees(TestConstants.feeratePerKw, isChannelCreation = false),
                 LiquidityAds.PaymentDetails.FromChannelBalanceForFutureHtlc(listOf(incomingPayment.paymentHash)),
             )
-            val payment = InboundLiquidityOutgoingPayment(UUID.randomUUID(), channelId, TxId(randomBytes32()), purchase, 0, null, null)
+            val payment = InboundLiquidityOutgoingPayment(UUID.randomUUID(), channelId, TxId(randomBytes32()), 500.sat, purchase, 0, null, null)
             paymentHandler.db.addOutgoingPayment(payment)
             payment
         }
@@ -963,7 +963,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             LiquidityAds.Fees(2000.sat, 3000.sat),
             LiquidityAds.PaymentDetails.FromFutureHtlc(listOf(incomingPayment.paymentHash)),
         )
-        val payment = InboundLiquidityOutgoingPayment(UUID.randomUUID(), channelId, TxId(randomBytes32()), purchase, 0, null, null)
+        val payment = InboundLiquidityOutgoingPayment(UUID.randomUUID(), channelId, TxId(randomBytes32()), 100.sat, purchase, 0, null, null)
         paymentHandler.db.addOutgoingPayment(payment)
 
         run {
@@ -999,7 +999,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             LiquidityAds.Fees(2000.sat, 3000.sat),
             LiquidityAds.PaymentDetails.FromChannelBalanceForFutureHtlc(listOf(incomingPayment.paymentHash)),
         )
-        val payment = InboundLiquidityOutgoingPayment(UUID.randomUUID(), channelId, TxId(randomBytes32()), purchase, 0, null, null)
+        val payment = InboundLiquidityOutgoingPayment(UUID.randomUUID(), channelId, TxId(randomBytes32()), 0.sat, purchase, 0, null, null)
         paymentHandler.db.addOutgoingPayment(payment)
 
         val add = makeUpdateAddHtlc(0, channelId, paymentHandler, incomingPayment.paymentHash, makeMppPayload(defaultAmount, defaultAmount, paymentSecret), fundingFee = payment.fundingFee)
@@ -1022,7 +1022,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             250_000.msat,
             LiquidityAds.PaymentDetails.FromFutureHtlc(listOf(randomBytes32())),
         )
-        val payment = InboundLiquidityOutgoingPayment(UUID.randomUUID(), channelId, TxId(randomBytes32()), purchase, 0, null, null)
+        val payment = InboundLiquidityOutgoingPayment(UUID.randomUUID(), channelId, TxId(randomBytes32()), 0.sat, purchase, 0, null, null)
         paymentHandler.db.addOutgoingPayment(payment)
 
         val add = makeUpdateAddHtlc(0, channelId, paymentHandler, incomingPayment.paymentHash, makeMppPayload(defaultAmount, defaultAmount, paymentSecret), fundingFee = payment.fundingFee)
@@ -1658,7 +1658,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             500.msat,
             LiquidityAds.PaymentDetails.FromFutureHtlcWithPreimage(listOf(preimage)),
         )
-        val payment = InboundLiquidityOutgoingPayment(UUID.randomUUID(), channelId, TxId(randomBytes32()), purchase, 0, null, null)
+        val payment = InboundLiquidityOutgoingPayment(UUID.randomUUID(), channelId, TxId(randomBytes32()), 500.sat, purchase, 0, null, null)
         paymentHandler.db.addOutgoingPayment(payment)
 
         val cltvExpiry = TestConstants.Bob.nodeParams.minFinalCltvExpiryDelta.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())


### PR DESCRIPTION
When we are purchasing liquidity without any other splice operation (splice-in, splice-out or splice-cpfp), we will have a single entry in our DB: the liquidity purchase itself. In that case, we are paying mining fees for the shared input and output: we must record those in the purchase. This happens during manual liquidity purchases and on-the-fly funding.

We cannot easily add tests because we don't implement the liquidity seller side, which makes it hard to trigger those conditions.