### PR TITLE
Use testnet4 for mempool space unit tests

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/mempool/MempoolSpaceClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/mempool/MempoolSpaceClient.kt
@@ -116,6 +116,7 @@ class MempoolSpaceClient(val mempoolUrl: Url, loggerFactory: LoggerFactory) : IC
     companion object {
         val OfficialMempoolMainnet = Url("https://mempool.space")
         val OfficialMempoolTestnet = Url("https://mempool.space/testnet/")
+        val OfficialMempoolTestnet4 = Url("https://mempool.space/testnet4/")
     }
 }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/blockchain/mempool/MempoolSpaceClient.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/blockchain/mempool/MempoolSpaceClient.kt
@@ -115,7 +115,7 @@ class MempoolSpaceClient(val mempoolUrl: Url, loggerFactory: LoggerFactory) : IC
 
     companion object {
         val OfficialMempoolMainnet = Url("https://mempool.space")
-        val OfficialMempoolTestnet = Url("https://mempool.space/testnet/")
+        val OfficialMempoolTestnet3 = Url("https://mempool.space/testnet/")
         val OfficialMempoolTestnet4 = Url("https://mempool.space/testnet4/")
     }
 }

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/mempool/MempoolSpaceClientTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/mempool/MempoolSpaceClientTest.kt
@@ -2,18 +2,17 @@ package fr.acinq.lightning.blockchain.mempool
 
 import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.blockchain.mempool.MempoolSpaceClient.Companion.OfficialMempoolMainnet
-import fr.acinq.lightning.blockchain.mempool.MempoolSpaceClient.Companion.OfficialMempoolTestnet
+import fr.acinq.lightning.blockchain.mempool.MempoolSpaceClient.Companion.OfficialMempoolTestnet4
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.tests.utils.runSuspendTest
 import fr.acinq.lightning.tests.utils.testLoggerFactory
 import kotlin.test.*
 
-@Ignore
 class MempoolSpaceClientTest : LightningTestSuite() {
 
     @Test
-    fun `retrieve feerates -- testnet`() = runSuspendTest {
-        val client = MempoolSpaceClient(mempoolUrl = OfficialMempoolTestnet, testLoggerFactory)
+    fun `retrieve feerates -- testnet4`() = runSuspendTest {
+        val client = MempoolSpaceClient(mempoolUrl = OfficialMempoolTestnet4, testLoggerFactory)
         val feerates = client.getFeerates()
         assertNotNull(feerates)
     }
@@ -26,11 +25,11 @@ class MempoolSpaceClientTest : LightningTestSuite() {
     }
 
     @Test
-    fun `get tx -- testnet`() = runSuspendTest {
-        val client = MempoolSpaceClient(mempoolUrl = OfficialMempoolTestnet, testLoggerFactory)
-        val res = client.getTransaction(TxId("5693d68997abfacb65cc7e6019e8ed2edb3f9f2260ae8d221e8726b8fe870ae0"))
+    fun `get tx -- testnet4`() = runSuspendTest {
+        val client = MempoolSpaceClient(mempoolUrl = OfficialMempoolTestnet4, testLoggerFactory)
+        val res = client.getTransaction(TxId("002f3246fa012ded792050f4a834e2eccdd772e1c7dc3a6a88cd6acdcbb9a2b2"))
         assertNotNull(res)
-        assertEquals(TxId("5693d68997abfacb65cc7e6019e8ed2edb3f9f2260ae8d221e8726b8fe870ae0"), res.txid)
+        assertEquals(TxId("002f3246fa012ded792050f4a834e2eccdd772e1c7dc3a6a88cd6acdcbb9a2b2"), res.txid)
     }
 
     @Test
@@ -42,9 +41,9 @@ class MempoolSpaceClientTest : LightningTestSuite() {
     }
 
     @Test
-    fun `get tx confirmations -- testnet`() = runSuspendTest {
-        val client = MempoolSpaceClient(mempoolUrl = OfficialMempoolTestnet, testLoggerFactory)
-        val res = client.getConfirmations(TxId("5693d68997abfacb65cc7e6019e8ed2edb3f9f2260ae8d221e8726b8fe870ae0"))
+    fun `get tx confirmations -- testnet4`() = runSuspendTest {
+        val client = MempoolSpaceClient(mempoolUrl = OfficialMempoolTestnet4, testLoggerFactory)
+        val res = client.getConfirmations(TxId("002f3246fa012ded792050f4a834e2eccdd772e1c7dc3a6a88cd6acdcbb9a2b2"))
         assertNotNull(res)
         assertTrue(res > 0)
     }
@@ -58,15 +57,15 @@ class MempoolSpaceClientTest : LightningTestSuite() {
     }
 
     @Test
-    fun `get spending tx -- testnet`() = runSuspendTest {
-        val client = MempoolSpaceClient(mempoolUrl = OfficialMempoolTestnet, testLoggerFactory)
-        val res = client.getOutspend(TxId("b97167ea09da62daaa1d3198460fc4c204a553cb3e5c80ab48f5b75a870f15c5"), 0)
+    fun `get spending tx -- testnet4`() = runSuspendTest {
+        val client = MempoolSpaceClient(mempoolUrl = OfficialMempoolTestnet4, testLoggerFactory)
+        val res = client.getOutspend(TxId("002f3246fa012ded792050f4a834e2eccdd772e1c7dc3a6a88cd6acdcbb9a2b2"), 1)
         assertNotNull(res)
-        assertEquals(TxId("5693d68997abfacb65cc7e6019e8ed2edb3f9f2260ae8d221e8726b8fe870ae0"), res.txid)
+        assertEquals(TxId("8bce727fe08fbb79f02682f71d0b1f33a79039cd7a70623a51945bf2dc86d77c"), res.txid)
     }
 
     @Test
-    fun `get spending tx -- mainnet`() = runSuspendTest {
+    fun `get spending tx -- mainnet4`() = runSuspendTest {
         val client = MempoolSpaceClient(mempoolUrl = OfficialMempoolMainnet, testLoggerFactory)
         val res = client.getOutspend(TxId("308c09d986000be7f05ba776b38204317bf928b70db65bf175af7f2036951649"), 3)
         assertNotNull(res)

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/mempool/MempoolSpaceWatcherTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/mempool/MempoolSpaceWatcherTest.kt
@@ -5,7 +5,7 @@ import fr.acinq.bitcoin.Transaction
 import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.Lightning.randomBytes32
 import fr.acinq.lightning.blockchain.*
-import fr.acinq.lightning.blockchain.mempool.MempoolSpaceClient.Companion.OfficialMempoolTestnet
+import fr.acinq.lightning.blockchain.mempool.MempoolSpaceClient.Companion.OfficialMempoolTestnet4
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.tests.utils.runSuspendTest
 import fr.acinq.lightning.tests.utils.testLoggerFactory
@@ -17,12 +17,11 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.time.Duration.Companion.seconds
 
-@Ignore
 class MempoolSpaceWatcherTest : LightningTestSuite() {
 
     @Test
     fun `watch-spent on a transaction`() = runSuspendTest {
-        val client = MempoolSpaceClient(mempoolUrl = OfficialMempoolTestnet, testLoggerFactory)
+        val client = MempoolSpaceClient(mempoolUrl = OfficialMempoolTestnet4, testLoggerFactory)
         val watcher = MempoolSpaceWatcher(client, scope = this, testLoggerFactory)
 
         val notifications = watcher.openWatchNotificationsFlow()
@@ -45,7 +44,7 @@ class MempoolSpaceWatcherTest : LightningTestSuite() {
 
     @Test
     fun `watch-confirmed on a transaction`() = runSuspendTest {
-        val client = MempoolSpaceClient(mempoolUrl = OfficialMempoolTestnet, testLoggerFactory)
+        val client = MempoolSpaceClient(mempoolUrl = OfficialMempoolTestnet4, testLoggerFactory)
         val watcher = MempoolSpaceWatcher(client, scope = this, testLoggerFactory)
 
         val notifications = watcher.openWatchNotificationsFlow()

--- a/src/commonTest/kotlin/fr/acinq/lightning/blockchain/mempool/MempoolSpaceWatcherTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/blockchain/mempool/MempoolSpaceWatcherTest.kt
@@ -28,14 +28,14 @@ class MempoolSpaceWatcherTest : LightningTestSuite() {
 
         val watch = WatchSpent(
             channelId = randomBytes32(),
-            txId = TxId("b97167ea09da62daaa1d3198460fc4c204a553cb3e5c80ab48f5b75a870f15c5"),
-            outputIndex = 0,
+            txId = TxId("002f3246fa012ded792050f4a834e2eccdd772e1c7dc3a6a88cd6acdcbb9a2b2"),
+            outputIndex = 1,
             publicKeyScript = ByteVector.empty,
             event = BITCOIN_FUNDING_SPENT
         )
         watcher.watch(watch)
         val event = assertIs<WatchEventSpent>(notifications.first())
-        assertEquals(TxId("5693d68997abfacb65cc7e6019e8ed2edb3f9f2260ae8d221e8726b8fe870ae0"), event.tx.txid)
+        assertEquals(TxId("8bce727fe08fbb79f02682f71d0b1f33a79039cd7a70623a51945bf2dc86d77c"), event.tx.txid)
         // Right after checking whether the watched utxo is spent, a 2nd call is made by the watcher
         // to find out whether the spending tx is confirmed, and the watch can be cleaned up. We give
         // some time for that call to complete, in order to prevent a coroutine cancellation stack trace.
@@ -51,13 +51,13 @@ class MempoolSpaceWatcherTest : LightningTestSuite() {
 
         val watch = WatchConfirmed(
             channelId = randomBytes32(),
-            txId = TxId("5693d68997abfacb65cc7e6019e8ed2edb3f9f2260ae8d221e8726b8fe870ae0"),
+            txId = TxId("8bce727fe08fbb79f02682f71d0b1f33a79039cd7a70623a51945bf2dc86d77c"),
             publicKeyScript = ByteVector.empty,
             event = BITCOIN_FUNDING_DEPTHOK,
             minDepth = 5
         )
         watcher.watch(watch)
         val event = assertIs<WatchEventConfirmed>(notifications.first())
-        assertEquals(TxId("5693d68997abfacb65cc7e6019e8ed2edb3f9f2260ae8d221e8726b8fe870ae0"), event.tx.txid)
+        assertEquals(TxId("8bce727fe08fbb79f02682f71d0b1f33a79039cd7a70623a51945bf2dc86d77c"), event.tx.txid)
     }
 }


### PR DESCRIPTION
Tests for our mempool space client used testnet3 and were disabled in https://github.com/ACINQ/lightning-kmp/pull/711 because of the ongoing block spam that was making them fail. Here we re-enable these tests but against mempool space's testnet4 servers (testnet4 fixes of lot of the "block spam" issues that are plaguing testnet3).