### PR TITLE
Minor refactoring to #714

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -122,6 +122,8 @@ data class FinalCltvExpiryParams(val fulfillSafetyBeforeTimeout: CltvExpiryDelta
  * @param paymentRecipientExpiryParams configure the expiry delta used for the final node when sending payments.
  * @param finalCltvExpiryParams configure the expiry delta that we require when receiving payments.
  * @param checkHtlcTimeoutAfterStartupDelay delay before we check for timed out HTLCs in our channels after a wallet restart.
+ * @param bolt11InvoiceExpiry duration for which bolt11 invoices that we create are valid.
+ * @param bolt12InvoiceExpiry duration for which bolt12 invoices that we create are valid.
  * @param htlcMinimum minimum accepted HTLC value.
  * @param toRemoteDelayBlocks number of blocks our peer will have to wait before they get their main output back in case they force-close a channel.
  * @param maxToLocalDelayBlocks maximum number of blocks we will have to wait before we get our main output back in case we force-close a channel.
@@ -135,7 +137,6 @@ data class FinalCltvExpiryParams(val fulfillSafetyBeforeTimeout: CltvExpiryDelta
  * @param maxPaymentAttempts maximum number of retries when attempting an outgoing payment.
  * @param zeroConfPeers list of peers with whom we use zero-conf (note that this is a strong trust assumption).
  * @param liquidityPolicy fee policy for liquidity events, can be modified at any time.
- * @param bolt12InvoiceExpiry duration for which bolt12 invoices that we create are valid.
  */
 data class NodeParams(
     val loggerFactory: LoggerFactory,
@@ -152,6 +153,8 @@ data class NodeParams(
     val finalCltvExpiryParams: FinalCltvExpiryParams,
     val checkHtlcTimeoutAfterStartupDelay: Duration,
     val checkHtlcTimeoutInterval: Duration,
+    val bolt11InvoiceExpiry: Duration,
+    val bolt12InvoiceExpiry: Duration,
     val htlcMinimum: MilliSatoshi,
     val toRemoteDelayBlocks: CltvExpiryDelta,
     val maxToLocalDelayBlocks: CltvExpiryDelta,
@@ -165,7 +168,6 @@ data class NodeParams(
     val maxPaymentAttempts: Int,
     val zeroConfPeers: Set<PublicKey>,
     val liquidityPolicy: MutableStateFlow<LiquidityPolicy>,
-    val bolt12InvoiceExpiry: Duration,
 ) {
     val nodePrivateKey get() = keyManager.nodeKeys.nodeKey.privateKey
     val nodeId get() = keyManager.nodeKeys.nodeKey.publicKey
@@ -239,6 +241,8 @@ data class NodeParams(
         ),
         checkHtlcTimeoutAfterStartupDelay = 30.seconds,
         checkHtlcTimeoutInterval = 10.seconds,
+        bolt11InvoiceExpiry = 24.hours,
+        bolt12InvoiceExpiry = 24.hours,
         htlcMinimum = 1000.msat,
         minDepthBlocks = 3,
         toRemoteDelayBlocks = CltvExpiryDelta(2016),
@@ -261,7 +265,6 @@ data class NodeParams(
                 maxAllowedFeeCredit = 0.msat
             )
         ),
-        bolt12InvoiceExpiry = 24.hours,
     )
 
     /**

--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -609,7 +609,7 @@ sealed class ChannelStateWithCommitments : PersistedChannelState() {
     internal suspend fun ChannelContext.checkHtlcTimeout(): Pair<ChannelStateWithCommitments, List<ChannelAction>> {
         logger.info { "checking htlcs timeout at blockHeight=${currentBlockHeight}" }
         val timedOutOutgoing = commitments.timedOutOutgoingHtlcs(currentBlockHeight.toLong())
-        val almostTimedOutIncoming = commitments.almostTimedOutIncomingHtlcs(currentBlockHeight.toLong(), staticParams.nodeParams.fulfillSafetyBeforeTimeoutBlocks)
+        val almostTimedOutIncoming = commitments.almostTimedOutIncomingHtlcs(currentBlockHeight.toLong(), staticParams.nodeParams.finalCltvExpiryParams.fulfillSafetyBeforeTimeout)
         val channelEx: ChannelException? = when {
             timedOutOutgoing.isNotEmpty() -> HtlcsTimedOutDownstream(channelId, timedOutOutgoing)
             almostTimedOutIncoming.isNotEmpty() -> FulfilledHtlcsWillTimeout(channelId, almostTimedOutIncoming)

--- a/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -719,7 +719,7 @@ class Peer(
         return res.await()
     }
 
-    suspend fun createInvoice(paymentPreimage: ByteVector32, amount: MilliSatoshi?, description: Either<String, ByteVector32>, expirySeconds: Long? = null): Bolt11Invoice {
+    suspend fun createInvoice(paymentPreimage: ByteVector32, amount: MilliSatoshi?, description: Either<String, ByteVector32>, expiry: Duration? = null): Bolt11Invoice {
         // we add one extra hop which uses a virtual channel with a "peer id", using the highest remote fees and expiry across all
         // channels to maximize the likelihood of success on the first payment attempt
         val remoteChannelUpdates = _channels.values.mapNotNull { channelState ->
@@ -741,7 +741,7 @@ class Peer(
                 )
             )
         )
-        return incomingPaymentHandler.createInvoice(paymentPreimage, amount, description, extraHops, expirySeconds)
+        return incomingPaymentHandler.createInvoice(paymentPreimage, amount, description, extraHops, expiry ?: nodeParams.bolt11InvoiceExpiry)
     }
 
     // The (node_id, fcm_token) tuple only needs to be registered once.

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt11Invoice.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt11Invoice.kt
@@ -105,7 +105,7 @@ data class Bolt11Invoice(
     }
 
     companion object {
-        const val DEFAULT_EXPIRY_SECONDS = 24 * 3600 // 1 day
+        const val DEFAULT_EXPIRY_SECONDS = 3600 // default value from Bolt 11
         val DEFAULT_MIN_FINAL_EXPIRY_DELTA = CltvExpiryDelta(18) // default value from Bolt 11
 
         private val prefixes = mapOf(

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -17,6 +17,7 @@ import fr.acinq.lightning.logging.MDCLogger
 import fr.acinq.lightning.logging.mdc
 import fr.acinq.lightning.utils.*
 import fr.acinq.lightning.wire.*
+import kotlin.time.Duration
 
 sealed class PaymentPart {
     abstract val amount: MilliSatoshi
@@ -79,7 +80,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val db: PaymentsDb) {
         amount: MilliSatoshi?,
         description: Either<String, ByteVector32>,
         extraHops: List<List<Bolt11Invoice.TaggedField.ExtraHop>>,
-        expirySeconds: Long? = null,
+        expiry: Duration? = null,
         timestampSeconds: Long = currentTimestampSeconds()
     ): Bolt11Invoice {
         val paymentHash = Crypto.sha256(paymentPreimage).toByteVector32()
@@ -95,7 +96,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val db: PaymentsDb) {
             randomBytes32(),
             // We always include a payment metadata in our invoices, which lets us test whether senders support it
             ByteVector("2a"),
-            expirySeconds,
+            expiry?.inWholeSeconds,
             extraHops,
             timestampSeconds
         )

--- a/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlin.test.*
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
 
 class PeerTest : LightningTestSuite() {
@@ -396,7 +397,7 @@ class PeerTest : LightningTestSuite() {
         val bob = newPeer(nodeParams, walletParams)
 
         run {
-            val invoice = bob.createInvoice(randomBytes32(), 1.msat, Either.Left("A description: \uD83D\uDE2C"), 3600L * 3)
+            val invoice = bob.createInvoice(randomBytes32(), 1.msat, Either.Left("A description: \uD83D\uDE2C"), 3.hours)
             assertEquals(1.msat, invoice.amount)
             assertEquals(3600L * 3, invoice.expirySeconds)
             assertEquals("A description: \uD83D\uDE2C", invoice.description)

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -1569,7 +1569,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val paymentHandler = IncomingPaymentHandler(TestConstants.Bob.nodeParams, InMemoryPaymentsDb())
         val preimage = randomBytes32()
         val paymentHash = Crypto.sha256(preimage).toByteVector32()
-        val cltvExpiry = TestConstants.Bob.nodeParams.minFinalCltvExpiryDelta.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
+        val cltvExpiry = TestConstants.Bob.nodeParams.finalCltvExpiryParams.min.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
         val (finalPayload, route) = makeBlindedPayload(TestConstants.Bob.nodeParams.nodeId, defaultAmount, defaultAmount, cltvExpiry, preimage = preimage)
         val add = makeUpdateAddHtlc(8, randomBytes32(), paymentHandler, paymentHash, finalPayload, route.blindingKey)
         val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
@@ -1593,7 +1593,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val totalAmount = amount1 + amount2
         val preimage = randomBytes32()
         val paymentHash = Crypto.sha256(preimage).toByteVector32()
-        val cltvExpiry = TestConstants.Bob.nodeParams.minFinalCltvExpiryDelta.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
+        val cltvExpiry = TestConstants.Bob.nodeParams.finalCltvExpiryParams.min.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
 
         // Step 1 of 2:
         // - Alice sends first multipart htlc to Bob
@@ -1633,7 +1633,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val (paymentHandler, _, _) = createFixture(defaultAmount)
         val preimage = randomBytes32()
         val paymentHash = Crypto.sha256(preimage).toByteVector32()
-        val cltvExpiry = TestConstants.Bob.nodeParams.minFinalCltvExpiryDelta.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
+        val cltvExpiry = TestConstants.Bob.nodeParams.finalCltvExpiryParams.min.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
         val (finalPayload, route) = makeBlindedPayload(TestConstants.Bob.nodeParams.nodeId, defaultAmount, defaultAmount, cltvExpiry, preimage = preimage)
         val willAddHtlc = makeWillAddHtlc(paymentHandler, paymentHash, finalPayload, route.blindingKey)
         val result = paymentHandler.process(willAddHtlc, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, TestConstants.fundingRates)
@@ -1668,15 +1668,15 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         // We may thus be closer to the min_final_expiry_delta, but we've committed to accepting this HTLC already.
         // As long as the expiry is greater than twice our fulfill_safety_before_timeout, we will accept it.
         run {
-            val cltvExpiry = TestConstants.Bob.nodeParams.fulfillSafetyBeforeTimeoutBlocks.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
+            val cltvExpiry = TestConstants.Bob.nodeParams.finalCltvExpiryParams.fulfillSafetyBeforeTimeout.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
             val (finalPayload, route) = makeBlindedPayload(TestConstants.Bob.nodeParams.nodeId, defaultAmount, defaultAmount, cltvExpiry, preimage = preimage)
             val add = makeUpdateAddHtlc(0, randomBytes32(), paymentHandler, paymentHash, finalPayload, route.blindingKey, payment.fundingFee)
             val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, TestConstants.fundingRates)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Rejected>(result)
         }
         run {
-            assertTrue((TestConstants.Bob.nodeParams.fulfillSafetyBeforeTimeoutBlocks * 2) < TestConstants.Bob.nodeParams.minFinalCltvExpiryDelta)
-            val cltvExpiry = (TestConstants.Bob.nodeParams.fulfillSafetyBeforeTimeoutBlocks * 2).toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
+            assertTrue((TestConstants.Bob.nodeParams.finalCltvExpiryParams.fulfillSafetyBeforeTimeout * 2) < TestConstants.Bob.nodeParams.finalCltvExpiryParams.min)
+            val cltvExpiry = (TestConstants.Bob.nodeParams.finalCltvExpiryParams.fulfillSafetyBeforeTimeout * 2).toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
             val (finalPayload, route) = makeBlindedPayload(TestConstants.Bob.nodeParams.nodeId, defaultAmount, defaultAmount, cltvExpiry, preimage = preimage)
             val add = makeUpdateAddHtlc(0, randomBytes32(), paymentHandler, paymentHash, finalPayload, route.blindingKey, payment.fundingFee)
             val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, TestConstants.fundingRates)
@@ -1694,7 +1694,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
     @Test
     fun `reject blinded payment for Bolt11 invoice`() = runSuspendTest {
         val (paymentHandler, incomingPayment, _) = createFixture(defaultAmount)
-        val cltvExpiry = TestConstants.Bob.nodeParams.minFinalCltvExpiryDelta.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
+        val cltvExpiry = TestConstants.Bob.nodeParams.finalCltvExpiryParams.min.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
         val (blindedPayload, route) = makeBlindedPayload(TestConstants.Bob.nodeParams.nodeId, defaultAmount, defaultAmount, cltvExpiry, preimage = incomingPayment.preimage)
         val add = makeUpdateAddHtlc(8, randomBytes32(), paymentHandler, incomingPayment.paymentHash, blindedPayload, route.blindingKey)
         val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
@@ -1713,7 +1713,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val totalAmount = amount1 + amount2
         val preimage = randomBytes32()
         val paymentHash = Crypto.sha256(preimage).toByteVector32()
-        val cltvExpiry = TestConstants.Bob.nodeParams.minFinalCltvExpiryDelta.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
+        val cltvExpiry = TestConstants.Bob.nodeParams.finalCltvExpiryParams.min.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
 
         // Step 1 of 2:
         // - Alice sends first blinded multipart htlc to Bob
@@ -1742,7 +1742,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
     @Test
     fun `reject blinded payment with amount too low`() = runSuspendTest {
         val paymentHandler = IncomingPaymentHandler(TestConstants.Bob.nodeParams, InMemoryPaymentsDb())
-        val cltvExpiry = TestConstants.Bob.nodeParams.minFinalCltvExpiryDelta.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
+        val cltvExpiry = TestConstants.Bob.nodeParams.finalCltvExpiryParams.min.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
         val metadata = OfferPaymentMetadata.V1(randomBytes32(), 100_000_000.msat, randomBytes32(), randomKey().publicKey(), null, 1, currentTimestampMillis())
         val pathId = metadata.toPathId(TestConstants.Bob.nodeParams.nodePrivateKey)
         val amountTooLow = metadata.amount - 10_000_000.msat
@@ -1759,7 +1759,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
     @Test
     fun `reject blinded payment with payment_hash mismatch`() = runSuspendTest {
         val paymentHandler = IncomingPaymentHandler(TestConstants.Bob.nodeParams, InMemoryPaymentsDb())
-        val cltvExpiry = TestConstants.Bob.nodeParams.minFinalCltvExpiryDelta.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
+        val cltvExpiry = TestConstants.Bob.nodeParams.finalCltvExpiryParams.min.toCltvExpiry(TestConstants.defaultBlockHeight.toLong())
         val metadata = OfferPaymentMetadata.V1(randomBytes32(), 100_000_000.msat, randomBytes32(), randomKey().publicKey(), null, 1, currentTimestampMillis())
         val pathId = metadata.toPathId(TestConstants.Bob.nodeParams.nodePrivateKey)
         val (finalPayload, route) = makeBlindedPayload(TestConstants.Bob.nodeParams.nodeId, metadata.amount, metadata.amount, cltvExpiry, pathId)

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
@@ -88,7 +88,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
         assertEquals(1, payInvoice.invoice.blindedPaths.size)
         val path = payInvoice.invoice.blindedPaths.first()
         assertEquals(EncodedNodeId(aliceTrampolineKey.publicKey()), path.route.route.introductionNodeId)
-        assertEquals(aliceOfferManager.nodeParams.expiryDeltaBlocks + aliceOfferManager.nodeParams.minFinalCltvExpiryDelta, path.paymentInfo.cltvExpiryDelta)
+        assertEquals(aliceOfferManager.nodeParams.expiryDeltaBlocks + aliceOfferManager.nodeParams.finalCltvExpiryParams.min, path.paymentInfo.cltvExpiryDelta)
         assertEquals(TestConstants.Alice.nodeParams.htlcMinimum, path.paymentInfo.minHtlc)
         assertEquals(payOffer.amount * 2, path.paymentInfo.maxHtlc)
     }
@@ -122,7 +122,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
         assertEquals(1, payInvoice.invoice.blindedPaths.size)
         val path = payInvoice.invoice.blindedPaths.first()
         assertEquals(EncodedNodeId(aliceTrampolineKey.publicKey()), path.route.route.introductionNodeId)
-        assertEquals(aliceOfferManager.nodeParams.expiryDeltaBlocks + aliceOfferManager.nodeParams.minFinalCltvExpiryDelta, path.paymentInfo.cltvExpiryDelta)
+        assertEquals(aliceOfferManager.nodeParams.expiryDeltaBlocks + aliceOfferManager.nodeParams.finalCltvExpiryParams.min, path.paymentInfo.cltvExpiryDelta)
         assertEquals(TestConstants.Alice.nodeParams.htlcMinimum, path.paymentInfo.minHtlc)
         assertEquals(payOffer.amount * 2, path.paymentInfo.maxHtlc)
     }

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
@@ -470,7 +470,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertIs<PaymentOnion.FinalPayload.Standard>(payloadB)
             assertEquals(add.amount, payloadB.amount)
             assertEquals(300_000.msat, payloadB.totalAmount)
-            assertEquals(CltvExpiry(TestConstants.defaultBlockHeight.toLong()) + TestConstants.Alice.nodeParams.minFinalCltvExpiryDelta, payloadB.expiry)
+            assertEquals(CltvExpiry(TestConstants.defaultBlockHeight.toLong()) + TestConstants.Alice.nodeParams.finalCltvExpiryParams.min, payloadB.expiry)
             assertEquals(invoice.paymentSecret, payloadB.paymentSecret)
         }
 


### PR DESCRIPTION
The first commit groups final expiry parameters and creates a symmetry between `FinalCltvExpiryParams` and `RecipientCltvExpiryParams`. It reduces the number of expiries in `NodeParams` which are currently a bit overwhelming.

The second commit reverts `Bolt11Invoice.DEFAULT_EXPIRY_SECONDS` to its spec value and defines a new typed parameter `NodeParams.bolt11InvoiceExpiry`.