### PR TITLE
Update TLV ranges for Offers

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/wire/OfferTypes.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/wire/OfferTypes.kt
@@ -654,7 +654,7 @@ object OfferTypes {
     }
 
     private fun isInvoiceRequestTlv(tlv: GenericTlv): Boolean {
-        // Offer TLVs are in the range [0, 159] or [1000000000, 2999999999].
+        // Invoice request TLVs are in the range [0, 159] or [1000000000, 2999999999].
         return tlv.tag in 0..159 || tlv.tag in 1000000000..2999999999
     }
 


### PR DESCRIPTION
The spec now allows the ranges [1000000000, 1999999999] and [2000000000, 2999999999] for offer and invoice request TLVs in addition to the previous [1, 79] and [80, 159].