### PR TITLE
Rename `OfferIssuerId`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
@@ -666,7 +666,7 @@ object JsonSerializers {
         val description: String?,
         val metadata: ByteVector?,
         val expirySeconds: Long?,
-        val nodeId: PublicKey?,
+        val issuerId: PublicKey?,
         val path: List<RouteBlinding.BlindedRoute>?,
         val features: Features?,
         val unknownTlvs: List<GenericTlv>?
@@ -690,7 +690,7 @@ object JsonSerializers {
                 description = o.description,
                 metadata = o.metadata,
                 expirySeconds = o.expirySeconds,
-                nodeId = o.nodeId,
+                issuerId = o.issuerId,
                 path = o.paths?.map { it.route }?.run { ifEmpty { null } },
                 features = o.features.let { if (it == Features.empty) null else it },
                 unknownTlvs = o.records.unknown.toList().run { ifEmpty { null } }

--- a/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt12Invoice.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt12Invoice.kt
@@ -52,7 +52,7 @@ data class Bolt12Invoice(val records: TlvStream<InvoiceTlv>) : PaymentRequest() 
 
     // It is assumed that the request is valid for this offer.
     fun validateFor(request: InvoiceRequest): Either<String, Unit> {
-        val offerNodeIds = invoiceRequest.offer.nodeId?.let { listOf(it) } ?: invoiceRequest.offer.paths!!.map { it.route.blindedNodeIds.last() }
+        val offerNodeIds = invoiceRequest.offer.issuerId?.let { listOf(it) } ?: invoiceRequest.offer.paths!!.map { it.route.blindedNodeIds.last() }
         return if (invoiceRequest.unsigned() != request.unsigned()) {
             Either.Left("Invoice does not match request")
         } else if (!offerNodeIds.contains(nodeId)) {

--- a/src/commonTest/kotlin/fr/acinq/lightning/payment/Bolt12InvoiceTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/payment/Bolt12InvoiceTestsCommon.kt
@@ -37,7 +37,7 @@ import fr.acinq.lightning.wire.OfferTypes.OfferChains
 import fr.acinq.lightning.wire.OfferTypes.OfferDescription
 import fr.acinq.lightning.wire.OfferTypes.OfferFeatures
 import fr.acinq.lightning.wire.OfferTypes.OfferIssuer
-import fr.acinq.lightning.wire.OfferTypes.OfferNodeId
+import fr.acinq.lightning.wire.OfferTypes.OfferIssuerId
 import fr.acinq.lightning.wire.OfferTypes.OfferQuantityMax
 import fr.acinq.lightning.wire.OfferTypes.PaymentInfo
 import fr.acinq.lightning.wire.OfferTypes.Signature
@@ -173,7 +173,7 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
         val otherNodeKey = randomKey()
         val withOtherNodeId = signInvoice(Bolt12Invoice(TlvStream(invoice.records.records.map {
             when (it) {
-                is OfferNodeId -> OfferNodeId(otherNodeKey.publicKey())
+                is OfferIssuerId -> OfferIssuerId(otherNodeKey.publicKey())
                 else -> it
             }
         }.toSet())), nodeKey)
@@ -236,7 +236,7 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
         val tlvs = setOf(
             InvoiceRequestMetadata(ByteVector.fromHex("010203040506")),
             OfferDescription("offer description"),
-            OfferNodeId(nodeKey.publicKey()),
+            OfferIssuerId(nodeKey.publicKey()),
             InvoiceRequestAmount(15000.msat),
             InvoiceRequestPayerId(payerKey.publicKey()),
             InvoiceRequestPayerNote("I am Batman"),
@@ -306,7 +306,7 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
         val nodeKey = randomKey()
         val tlvs = setOf(
             InvoiceRequestMetadata(ByteVector.fromHex("012345")),
-            OfferNodeId(nodeKey.publicKey()),
+            OfferIssuerId(nodeKey.publicKey()),
             InvoiceRequestPayerId(randomKey().publicKey()),
             InvoicePaths(listOf(createPaymentBlindedRoute(randomKey().publicKey()).route)),
             InvoiceBlindedPay(listOf(PaymentInfo(0.msat, 0, CltvExpiryDelta(0), 0.msat, 765432.msat, Features.empty))),
@@ -360,7 +360,7 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
                 OfferDescription(description),
                 OfferFeatures(Features.empty),
                 OfferIssuer(issuer),
-                OfferNodeId(nodeKey.publicKey()),
+                OfferIssuerId(nodeKey.publicKey()),
                 InvoiceRequestChain(chain),
                 InvoiceRequestAmount(amount),
                 InvoiceRequestQuantity(quantity),
@@ -489,7 +489,7 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
                 OfferDescription("offer with quantity"),
                 OfferIssuer("alice@bigshop.com"),
                 OfferQuantityMax(1000),
-                OfferNodeId(nodeKey.publicKey())
+                OfferIssuerId(nodeKey.publicKey())
             )
         )
         val encodedOffer = "lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgf6gw45q75vcfqqqqqqqgqvqcdgq2zdhkven9wgs8w6t5dqs8zatpde6xjarezggkzmrfvdj5qcnfvaeksmms9e3k7mg5qgp7s93pqvn6l4vemgezdarq3wt2kpp0u4vt74vzz8futen7ej97n93jypp57"


### PR DESCRIPTION
The `OfferIssuerId` was previously named `OfferNodeId`, but its usage changed when it was renamed: it doesn't necessarily match a lightning `node_id` and can instead be a completely unrelated public key. Note that we should probably also rename this in `eclair` if it hasn't already been done.

It can now be included in combination with blinded paths: when that happens, the blinded paths must be used in priority to reach the node as the `issuer_id` may not match a network `node_id` at all (or may even match an unrelated node).

I'm clarifying this and getting rid of `contact_node_ids` because for #719 I would like to use as `contact_node_id`:

- the `issuer_id` if included
- otherwise the last `blinded_node_id` of the first path
- (whereas we were previously doing the opposite)

This makes more sense for wallets that generate multiple offers with different blinded paths each time, but keep the same `issuer_id`.