### PR TITLE
Add peer storage backup

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/Features.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/Features.kt
@@ -134,6 +134,13 @@ sealed class Feature {
     }
 
     @Serializable
+    object ProvideStorage : Feature() {
+        override val rfcName get() = "option_provide_storage"
+        override val mandatory get() = 42
+        override val scopes: Set<FeatureScope> get() = setOf(FeatureScope.Init, FeatureScope.Node)
+    }
+
+    @Serializable
     object ChannelType : Feature() {
         override val rfcName get() = "option_channel_type"
         override val mandatory get() = 44
@@ -337,6 +344,7 @@ data class Features(val activated: Map<Feature, FeatureSupport>, val unknown: Se
             Feature.ShutdownAnySegwit,
             Feature.DualFunding,
             Feature.Quiescence,
+            Feature.ProvideStorage,
             Feature.ChannelType,
             Feature.PaymentMetadata,
             Feature.TrampolinePayment,


### PR DESCRIPTION
We use peer storage (https://github.com/lightning/bolts/pull/1110) for channel backups.
We also keep the legacy channel data backup for some transition period.
Requires https://github.com/ACINQ/eclair/pull/2888 on eclair's side.