### PR TITLE
Rework `IncomingPayment` model

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -12,6 +12,7 @@ import fr.acinq.lightning.channel.states.ChannelStateWithCommitments
 import fr.acinq.lightning.channel.states.Normal
 import fr.acinq.lightning.channel.states.WaitForFundingCreated
 import fr.acinq.lightning.db.IncomingPayment
+import fr.acinq.lightning.db.LightningIncomingPayment
 import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.utils.sum
 import fr.acinq.lightning.wire.Init
@@ -70,9 +71,6 @@ sealed interface SensitiveTaskEvents : NodeEvents {
 data object UpgradeRequired : NodeEvents
 
 sealed interface PaymentEvents : NodeEvents {
-    data class PaymentReceived(val paymentHash: ByteVector32, val receivedWith: List<IncomingPayment.ReceivedWith>) : PaymentEvents {
-        val amount: MilliSatoshi = receivedWith.map { it.amountReceived }.sum()
-        val fees: MilliSatoshi = receivedWith.map { it.fees }.sum()
-    }
+    data class PaymentReceived(val payment: IncomingPayment) : PaymentEvents
     data class PaymentSent(val payment: OutgoingPayment) : PaymentEvents
 }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelAction.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelAction.kt
@@ -9,7 +9,6 @@ import fr.acinq.lightning.channel.states.PersistedChannelState
 import fr.acinq.lightning.db.ChannelClosingType
 import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.UUID
-import fr.acinq.lightning.utils.toMilliSatoshi
 import fr.acinq.lightning.wire.*
 
 /** Channel Actions (outputs produced by the state machine). */
@@ -80,7 +79,7 @@ sealed class ChannelAction {
             abstract val txId: TxId
             abstract val localInputs: Set<OutPoint>
             data class ViaNewChannel(val amountReceived: MilliSatoshi, val serviceFee: MilliSatoshi, val miningFee: Satoshi, override val localInputs: Set<OutPoint>, override val txId: TxId, override val origin: Origin?) : StoreIncomingPayment()
-            data class ViaSpliceIn(val amountReceived: MilliSatoshi, val serviceFee: MilliSatoshi, val miningFee: Satoshi, override val localInputs: Set<OutPoint>, override val txId: TxId, override val origin: Origin?) : StoreIncomingPayment()
+            data class ViaSpliceIn(val amountReceived: MilliSatoshi, val miningFee: Satoshi, override val localInputs: Set<OutPoint>, override val txId: TxId, override val origin: Origin?) : StoreIncomingPayment()
         }
         /** Payment sent through on-chain operations (channel close or splice-out) */
         sealed class StoreOutgoingPayment : Storage() {

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -883,7 +883,6 @@ data class Normal(
             if (action.fundingTx.sharedTx.tx.localInputs.isNotEmpty()) add(
                 ChannelAction.Storage.StoreIncomingPayment.ViaSpliceIn(
                     amountReceived = action.fundingTx.sharedTx.tx.localInputs.map { i -> i.txOut.amount }.sum().toMilliSatoshi() - action.fundingTx.sharedTx.tx.localFees,
-                    serviceFee = 0.msat,
                     miningFee = action.fundingTx.sharedTx.tx.localFees.truncateToSatoshi(),
                     localInputs = action.fundingTx.sharedTx.tx.localInputs.map { it.outPoint }.toSet(),
                     txId = action.fundingTx.txId,

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -91,6 +91,8 @@ interface OutgoingPaymentsDb {
 
 /** A payment made to or from the wallet. */
 sealed class WalletPayment {
+    abstract val id: UUID
+
     /** Absolute time in milliseconds since UNIX epoch when the payment was created. */
     abstract val createdAt: Long
 
@@ -120,6 +122,8 @@ sealed class WalletPayment {
 data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val received: Received?, override val createdAt: Long = currentTimestampMillis()) : WalletPayment() {
 
     val paymentHash: ByteVector32 = Crypto.sha256(preimage).toByteVector32()
+
+    override val id: UUID = UUID.fromBytes(paymentHash.toByteArray().copyOf(16))
 
     /**
      * This timestamp will be defined when the payment is final and usable for spending:
@@ -228,9 +232,7 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
     fun isExpired(): Boolean = origin is Origin.Invoice && origin.paymentRequest.isExpired()
 }
 
-sealed class OutgoingPayment : WalletPayment() {
-    abstract val id: UUID
-}
+sealed class OutgoingPayment : WalletPayment()
 
 /**
  * An outgoing payment sent by this node.

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -257,24 +257,24 @@ data class LegacySwapInIncomingPayment(
 
 @Deprecated("Legacy pay-to-open/pay-to-splice, kept for backwards-compatibility with existing databases. Those payments can be a mix of lightning parts and on-chain parts, and either Bolt11 or Bolt12.")
 data class LegacyPayToOpenIncomingPayment(
-    override val id: UUID,
-    override val amountReceived: MilliSatoshi,
-    override val fees: MilliSatoshi,
-    val channelId: ByteVector32,
     val paymentPreimage: ByteVector32,
     val origin: Origin,
     val parts: List<Part>,
     override val createdAt: Long,
     override val completedAt: Long?
 ) : IncomingPayment() {
+    val paymentHash: ByteVector32 = Crypto.sha256(paymentPreimage).toByteVector32()
+    override val id: UUID = UUID.fromBytes(paymentHash.toByteArray().copyOf(16))
+    override val amountReceived: MilliSatoshi = parts.map { it.amountReceived }.sum()
+    override val fees: MilliSatoshi = parts.filterIsInstance<Part.OnChain>().map { it.serviceFee + it.miningFee.toMilliSatoshi() }.sum()
     sealed class Origin {
         data class Invoice(val paymentRequest: Bolt11Invoice) : Origin()
         data class Offer(val metadata: OfferPaymentMetadata) : Origin()
     }
-
     sealed class Part {
-        data class Lightning(val amount: MilliSatoshi, val channelId: ByteVector32, val htlcId: Long)
-        data class OnChain(val amount: MilliSatoshi, val serviceFee: MilliSatoshi, val miningFee: Satoshi, val channelId: ByteVector32, val txId: TxId, val confirmedAt: Long?, val lockedAt: Long?)
+        abstract val amountReceived: MilliSatoshi
+        data class Lightning(override val amountReceived: MilliSatoshi, val channelId: ByteVector32, val htlcId: Long) : Part()
+        data class OnChain(override val amountReceived: MilliSatoshi, val serviceFee: MilliSatoshi, val miningFee: Satoshi, val channelId: ByteVector32, val txId: TxId, val confirmedAt: Long?, val lockedAt: Long?) : Part()
     }
 }
 

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -169,13 +169,11 @@ sealed class LightningIncomingPayment(val paymentPreimage: ByteVector32) : Incom
     /** A payment expires if it is a [Bolt11IncomingPayment] and its invoice has expired. */
     fun isExpired(): Boolean = this is Bolt11IncomingPayment && this.paymentRequest.isExpired()
 
-    companion object {
-        /** Helper method to facilitate updating child classes */
-        fun LightningIncomingPayment.addReceivedParts(parts: List<Part>): LightningIncomingPayment {
-            return when (this) {
-                is Bolt11IncomingPayment -> copy(parts = this.parts + parts)
-                is Bolt12IncomingPayment -> copy(parts = this.parts + parts)
-            }
+    /** Helper method to facilitate updating child classes */
+    fun addReceivedParts(parts: List<Part>): LightningIncomingPayment {
+        return when (this) {
+            is Bolt11IncomingPayment -> copy(parts = this.parts + parts)
+            is Bolt12IncomingPayment -> copy(parts = this.parts + parts)
         }
     }
 }
@@ -216,21 +214,19 @@ sealed class OnChainIncomingPayment : IncomingPayment() {
      */
     override val completedAt: Long? get() = lockedAt
 
-    companion object {
-        /** Helper method to facilitate updating child classes */
-        fun OnChainIncomingPayment.setLocked(lockedAt: Long): OnChainIncomingPayment =
-            when (this) {
-                is NewChannelIncomingPayment -> copy(lockedAt = lockedAt)
-                is SpliceInIncomingPayment -> copy(lockedAt = lockedAt)
-            }
+    /** Helper method to facilitate updating child classes */
+    fun setLocked(lockedAt: Long): OnChainIncomingPayment =
+        when (this) {
+            is NewChannelIncomingPayment -> copy(lockedAt = lockedAt)
+            is SpliceInIncomingPayment -> copy(lockedAt = lockedAt)
+        }
 
-        /** Helper method to facilitate updating child classes */
-        fun OnChainIncomingPayment.setConfirmed(confirmedAt: Long): OnChainIncomingPayment =
-            when (this) {
-                is NewChannelIncomingPayment -> copy(confirmedAt = confirmedAt)
-                is SpliceInIncomingPayment -> copy(confirmedAt = confirmedAt)
-            }
-    }
+    /** Helper method to facilitate updating child classes */
+    fun setConfirmed(confirmedAt: Long): OnChainIncomingPayment =
+        when (this) {
+            is NewChannelIncomingPayment -> copy(confirmedAt = confirmedAt)
+            is SpliceInIncomingPayment -> copy(confirmedAt = confirmedAt)
+        }
 }
 
 /**

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -139,7 +139,7 @@ data class SendOnTheFlyFundingMessage(val message: OnTheFlyFundingMessage) : Pee
 sealed class PeerEvent
 
 @Deprecated("Replaced by NodeEvents", replaceWith = ReplaceWith("PaymentEvents.PaymentReceived", "fr.acinq.lightning.PaymentEvents"))
-data class PaymentReceived(val incomingPayment: IncomingPayment, val received: IncomingPayment.Received) : PeerEvent()
+data class PaymentReceived(val incomingPayment: LightningIncomingPayment, val received: LightningIncomingPayment.Received) : PeerEvent()
 data class PaymentProgress(val request: SendPayment, val fees: MilliSatoshi) : PeerEvent()
 sealed class SendPaymentResult : PeerEvent() {
     abstract val request: SendPayment
@@ -847,8 +847,37 @@ class Peer(
                         action.htlcs.forEach { db.channels.addHtlcInfo(actualChannelId, it.commitmentNumber, it.paymentHash, it.cltvExpiry) }
                     }
                     is ChannelAction.Storage.StoreIncomingPayment -> {
-                        logger.info { "storing incoming payment $action" }
-                        incomingPaymentHandler.process(actualChannelId, action)
+                        logger.info { "storing $action" }
+                        val payment = when (action) {
+                            is ChannelAction.Storage.StoreIncomingPayment.ViaNewChannel ->
+                                NewChannelIncomingPayment(
+                                    id = UUID.randomUUID(),
+                                    amountReceived = action.amountReceived,
+                                    serviceFee = action.serviceFee,
+                                    miningFee = action.miningFee,
+                                    channelId = channelId,
+                                    txId = action.txId,
+                                    localInputs = action.localInputs,
+                                    createdAt = currentTimestampMillis(),
+                                    confirmedAt = null,
+                                    lockedAt = null,
+                                )
+                            is ChannelAction.Storage.StoreIncomingPayment.ViaSpliceIn ->
+                                SpliceInIncomingPayment(
+                                    id = UUID.randomUUID(),
+                                    amountReceived = action.amountReceived,
+                                    serviceFee = action.serviceFee,
+                                    miningFee = action.miningFee,
+                                    channelId = channelId,
+                                    txId = action.txId,
+                                    localInputs = action.localInputs,
+                                    createdAt = currentTimestampMillis(),
+                                    confirmedAt = null,
+                                    lockedAt = null,
+                                )
+                        }
+                        nodeParams._nodeEvents.emit(PaymentEvents.PaymentReceived(payment))
+                        db.payments.addIncomingPayment(payment)
                     }
                     is ChannelAction.Storage.StoreOutgoingPayment -> {
                         logger.info { "storing $action" }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -964,7 +964,7 @@ class Peer(
         }
         when (result) {
             is IncomingPaymentHandler.ProcessAddResult.Accepted -> {
-                if ((result.incomingPayment.received?.parts?.size ?: 0) > 1) {
+                if (result.incomingPayment.parts.size > 1) {
                     // this was a multi-part payment, we signal that the task is finished
                     nodeParams._nodeEvents.tryEmit(SensitiveTaskEvents.TaskEnded(SensitiveTaskEvents.TaskIdentifier.IncomingMultiPartPayment(result.incomingPayment.paymentHash)))
                 }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -138,8 +138,6 @@ data class SendOnTheFlyFundingMessage(val message: OnTheFlyFundingMessage) : Pee
 
 sealed class PeerEvent
 
-@Deprecated("Replaced by NodeEvents", replaceWith = ReplaceWith("PaymentEvents.PaymentReceived", "fr.acinq.lightning.PaymentEvents"))
-data class PaymentReceived(val incomingPayment: LightningIncomingPayment, val received: LightningIncomingPayment.Received) : PeerEvent()
 data class PaymentProgress(val request: SendPayment, val fees: MilliSatoshi) : PeerEvent()
 sealed class SendPaymentResult : PeerEvent() {
     abstract val request: SendPayment
@@ -970,8 +968,6 @@ class Peer(
                     // this was a multi-part payment, we signal that the task is finished
                     nodeParams._nodeEvents.tryEmit(SensitiveTaskEvents.TaskEnded(SensitiveTaskEvents.TaskIdentifier.IncomingMultiPartPayment(result.incomingPayment.paymentHash)))
                 }
-                @Suppress("DEPRECATION")
-                _eventsFlow.emit(PaymentReceived(result.incomingPayment, result.received))
             }
             is IncomingPaymentHandler.ProcessAddResult.Pending -> if (result.pendingPayment.parts.size == 1) {
                 // this is the first part of a multi-part payment, we request to keep the app alive to receive subsequent parts

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -866,7 +866,6 @@ class Peer(
                                 SpliceInIncomingPayment(
                                     id = UUID.randomUUID(),
                                     amountReceived = action.amountReceived,
-                                    serviceFee = action.serviceFee,
                                     miningFee = action.miningFee,
                                     channelId = channelId,
                                     txId = action.txId,

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -967,7 +967,7 @@ class Peer(
         }
         when (result) {
             is IncomingPaymentHandler.ProcessAddResult.Accepted -> {
-                if ((result.incomingPayment.received?.receivedWith?.size ?: 0) > 1) {
+                if ((result.incomingPayment.received?.parts?.size ?: 0) > 1) {
                     // this was a multi-part payment, we signal that the task is finished
                     nodeParams._nodeEvents.tryEmit(SensitiveTaskEvents.TaskEnded(SensitiveTaskEvents.TaskIdentifier.IncomingMultiPartPayment(result.incomingPayment.paymentHash)))
                 }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -8,7 +8,6 @@ import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.crypto.sphinx.Sphinx
 import fr.acinq.lightning.db.*
-import fr.acinq.lightning.db.LightningIncomingPayment.Companion.addReceivedParts
 import fr.acinq.lightning.io.AddLiquidityForIncomingPayment
 import fr.acinq.lightning.io.PeerCommand
 import fr.acinq.lightning.io.SendOnTheFlyFundingMessage
@@ -48,7 +47,9 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val db: PaymentsDb) {
     sealed class ProcessAddResult {
         abstract val actions: List<PeerCommand>
 
-        data class Accepted(override val actions: List<PeerCommand>, val incomingPayment: LightningIncomingPayment, val parts: List<LightningIncomingPayment.Part>) : ProcessAddResult()
+        data class Accepted(override val actions: List<PeerCommand>, val incomingPayment: LightningIncomingPayment, val parts: List<LightningIncomingPayment.Part>) : ProcessAddResult() {
+            val amount = parts.map { it.amountReceived }.sum()
+        }
         data class Rejected(override val actions: List<PeerCommand>, val incomingPayment: LightningIncomingPayment?) : ProcessAddResult()
         data class Pending(val incomingPayment: LightningIncomingPayment, val pendingPayment: PendingPayment, override val actions: List<PeerCommand> = listOf()) : ProcessAddResult()
     }

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
@@ -2,7 +2,6 @@ package fr.acinq.lightning.db
 
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.TxId
-import fr.acinq.lightning.db.LightningIncomingPayment.Companion.addReceivedParts
 import fr.acinq.lightning.payment.FinalFailure
 import fr.acinq.lightning.utils.UUID
 

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/InMemoryPaymentsDb.kt
@@ -29,19 +29,19 @@ class InMemoryPaymentsDb : PaymentsDb {
 
     override suspend fun getLightningIncomingPayment(paymentHash: ByteVector32): LightningIncomingPayment? = incoming[paymentHash]
 
-    override suspend fun receiveLightningPayment(paymentHash: ByteVector32, receivedWith: List<LightningIncomingPayment.ReceivedWith>, receivedAt: Long) {
+    override suspend fun receiveLightningPayment(paymentHash: ByteVector32, parts: List<LightningIncomingPayment.Received.Part>, receivedAt: Long) {
         when (val payment = incoming[paymentHash]) {
             null -> Unit // no-op
             is Bolt11IncomingPayment ->
                 incoming[paymentHash] = payment.copy(
                     received = LightningIncomingPayment.Received(
-                        receivedWith = payment.received?.receivedWith.orEmpty() + receivedWith,
+                        parts = payment.received?.parts.orEmpty() + parts,
                         receivedAt = receivedAt
                     )
                 )
             is Bolt12IncomingPayment -> incoming[paymentHash] = payment.copy(
                 received = LightningIncomingPayment.Received(
-                    receivedWith = payment.received?.receivedWith.orEmpty() + receivedWith,
+                    parts = payment.received?.parts.orEmpty() + parts,
                     receivedAt = receivedAt
                 )
             )

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
@@ -5,7 +5,6 @@ import fr.acinq.bitcoin.utils.Either
 import fr.acinq.lightning.*
 import fr.acinq.lightning.Lightning.randomBytes32
 import fr.acinq.lightning.Lightning.randomKey
-import fr.acinq.lightning.db.LightningIncomingPayment.Companion.addReceivedParts
 import fr.acinq.lightning.payment.Bolt11Invoice
 import fr.acinq.lightning.payment.FinalFailure
 import fr.acinq.lightning.tests.utils.LightningTestSuite

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
@@ -18,49 +18,49 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
     @Test
     fun `receive incoming lightning payment with 1 htlc`() = runSuspendTest {
         val (db, preimage, pr) = createFixture()
-        assertNull(db.getIncomingPayment(pr.paymentHash))
+        assertNull(db.getLightningIncomingPayment(pr.paymentHash))
 
         val channelId = randomBytes32()
-        val incoming = IncomingPayment(preimage, IncomingPayment.Origin.Invoice(pr), null, 100)
-        db.addIncomingPayment(preimage, IncomingPayment.Origin.Invoice(pr), 100)
-        val pending = db.getIncomingPayment(pr.paymentHash)
-        assertNotNull(pending)
+        val incoming = Bolt11IncomingPayment(preimage, pr, null, 100)
+        db.addIncomingPayment(incoming)
+        val pending = db.getLightningIncomingPayment(pr.paymentHash)
+        assertIs<Bolt11IncomingPayment>(pending)
         assertEquals(incoming, pending)
 
-        val receivedWith = IncomingPayment.ReceivedWith.LightningPayment(200_000.msat, channelId, 1, fundingFee = null)
-        db.receivePayment(pr.paymentHash, listOf(receivedWith), 110)
-        val received = db.getIncomingPayment(pr.paymentHash)
+        val receivedWith = LightningIncomingPayment.ReceivedWith.LightningPayment(200_000.msat, channelId, 1, fundingFee = null)
+        db.receiveLightningPayment(pr.paymentHash, listOf(receivedWith), 110)
+        val received = db.getLightningIncomingPayment(pr.paymentHash)
         assertNotNull(received)
-        assertEquals(pending.copy(received = IncomingPayment.Received(listOf(receivedWith), 110)), received)
+        assertEquals(pending.copy(received = LightningIncomingPayment.Received(listOf(receivedWith), 110)), received)
     }
 
     @Test
     fun `receive incoming lightning payment with several parts`() = runSuspendTest {
         val (db, preimage, pr) = createFixture()
-        assertNull(db.getIncomingPayment(pr.paymentHash))
+        assertNull(db.getLightningIncomingPayment(pr.paymentHash))
 
         val (channelId1, channelId2) = listOf(randomBytes32(), randomBytes32())
-        val incoming = IncomingPayment(preimage, IncomingPayment.Origin.Invoice(pr), null, 200)
-        db.addIncomingPayment(preimage, IncomingPayment.Origin.Invoice(pr), 200)
-        val pending = db.getIncomingPayment(pr.paymentHash)
-        assertNotNull(pending)
+        val incoming = Bolt11IncomingPayment(preimage, pr, null, 200)
+        db.addIncomingPayment(incoming)
+        val pending = db.getLightningIncomingPayment(pr.paymentHash)
+        assertIs<Bolt11IncomingPayment>(pending)
         assertEquals(incoming, pending)
 
-        db.receivePayment(
+        db.receiveLightningPayment(
             pr.paymentHash, listOf(
-                IncomingPayment.ReceivedWith.LightningPayment(57_000.msat, channelId1, 1, fundingFee = null),
-                IncomingPayment.ReceivedWith.LightningPayment(43_000.msat, channelId2, 54, fundingFee = null),
+                LightningIncomingPayment.ReceivedWith.LightningPayment(57_000.msat, channelId1, 1, fundingFee = null),
+                LightningIncomingPayment.ReceivedWith.LightningPayment(43_000.msat, channelId2, 54, fundingFee = null),
             ), 110
         )
-        val received = db.getIncomingPayment(pr.paymentHash)
+        val received = db.getLightningIncomingPayment(pr.paymentHash)
         assertNotNull(received)
         assertEquals(100_000.msat, received.amount)
         assertEquals(0.msat, received.fees)
         assertEquals(2, received.received!!.receivedWith.size)
         assertEquals(57_000.msat, received.received!!.receivedWith.elementAt(0).amountReceived)
         assertEquals(0.msat, received.received!!.receivedWith.elementAt(0).fees)
-        assertEquals(channelId1, (received.received!!.receivedWith.elementAt(0) as IncomingPayment.ReceivedWith.LightningPayment).channelId)
-        assertEquals(54, (received.received!!.receivedWith.elementAt(1) as IncomingPayment.ReceivedWith.LightningPayment).htlcId)
+        assertEquals(channelId1, (received.received!!.receivedWith.elementAt(0) as LightningIncomingPayment.ReceivedWith.LightningPayment).channelId)
+        assertEquals(54, (received.received!!.receivedWith.elementAt(1) as LightningIncomingPayment.ReceivedWith.LightningPayment).htlcId)
     }
 
     @Test
@@ -68,19 +68,20 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
         val (db, preimage, pr) = createFixture()
         val channelId = randomBytes32()
 
-        db.addIncomingPayment(preimage, IncomingPayment.Origin.Invoice(pr), 200)
+        val incoming = Bolt11IncomingPayment(preimage, pr, null, 200)
+        db.addIncomingPayment(incoming)
         val receivedWith = listOf(
-            IncomingPayment.ReceivedWith.LightningPayment(200_000.msat, channelId, 1, fundingFee = null),
-            IncomingPayment.ReceivedWith.LightningPayment(100_000.msat, channelId, 2, fundingFee = null)
+            LightningIncomingPayment.ReceivedWith.LightningPayment(200_000.msat, channelId, 1, fundingFee = null),
+            LightningIncomingPayment.ReceivedWith.LightningPayment(100_000.msat, channelId, 2, fundingFee = null)
         )
-        db.receivePayment(pr.paymentHash, listOf(receivedWith.first()), 110)
-        val received1 = db.getIncomingPayment(pr.paymentHash)
+        db.receiveLightningPayment(pr.paymentHash, listOf(receivedWith.first()), 110)
+        val received1 = db.getLightningIncomingPayment(pr.paymentHash)
         assertNotNull(received1)
         assertNotNull(received1.received)
         assertEquals(200_000.msat, received1.amount)
 
-        db.receivePayment(pr.paymentHash, listOf(receivedWith.last()), 150)
-        val received2 = db.getIncomingPayment(pr.paymentHash)
+        db.receiveLightningPayment(pr.paymentHash, listOf(receivedWith.last()), 150)
+        val received2 = db.getLightningIncomingPayment(pr.paymentHash)
         assertNotNull(received2)
         assertNotNull(received2.received)
         assertEquals(300_000.msat, received2.amount)
@@ -91,57 +92,34 @@ class PaymentsDbTestsCommon : LightningTestSuite() {
     @Test
     fun `receive lightning payment with funding fee`() = runSuspendTest {
         val (db, preimage, pr) = createFixture()
-        db.addIncomingPayment(preimage, IncomingPayment.Origin.Invoice(pr), 200)
-        val receivedWith = IncomingPayment.ReceivedWith.LightningPayment(40_000_000.msat, randomBytes32(), 3, LiquidityAds.FundingFee(10_000_000.msat, TxId(randomBytes32())))
-        db.receivePayment(pr.paymentHash, listOf(receivedWith), 110)
-        val received = db.getIncomingPayment(pr.paymentHash)
+        val incoming = Bolt11IncomingPayment(preimage, pr, null, 200)
+        db.addIncomingPayment(incoming)
+        val receivedWith = LightningIncomingPayment.ReceivedWith.LightningPayment(40_000_000.msat, randomBytes32(), 3, LiquidityAds.FundingFee(10_000_000.msat, TxId(randomBytes32())))
+        db.receiveLightningPayment(pr.paymentHash, listOf(receivedWith), 110)
+        val received = db.getLightningIncomingPayment(pr.paymentHash)
         assertNotNull(received?.received)
         assertEquals(40_000_000.msat, received!!.amount)
         assertEquals(10_000_000.msat, received.fees)
     }
 
     @Test
-    fun `receive incoming on-chain payments`() = runSuspendTest {
-        val (db, _, _) = createFixture()
-        val origin = IncomingPayment.Origin.OnChain(TxId(randomBytes32()), setOf(OutPoint(TxId(randomBytes32()), 7)))
-        run {
-            val incomingPayment = db.addIncomingPayment(randomBytes32(), origin)
-            val receivedWith = IncomingPayment.ReceivedWith.NewChannel(100_000_000.msat, 5_000_000.msat, 2_500.sat, randomBytes32(), origin.txId, null, null)
-            db.receivePayment(incomingPayment.paymentHash, listOf(receivedWith))
-            val received = db.getIncomingPayment(incomingPayment.paymentHash)
-            assertNotNull(received?.received)
-            assertEquals(100_000_000.msat, received!!.amount)
-            assertEquals(7_500_000.msat, received.fees)
-        }
-        run {
-            val incomingPayment = db.addIncomingPayment(randomBytes32(), origin)
-            val receivedWith = IncomingPayment.ReceivedWith.SpliceIn(100_000_000.msat, 5_000_000.msat, 2_500.sat, randomBytes32(), origin.txId, null, null)
-            db.receivePayment(incomingPayment.paymentHash, listOf(receivedWith))
-            val received = db.getIncomingPayment(incomingPayment.paymentHash)
-            assertNotNull(received?.received)
-            assertEquals(100_000_000.msat, received!!.amount)
-            assertEquals(7_500_000.msat, received.fees)
-        }
-    }
-
-    @Test
     fun `reject duplicate payment hash`() = runSuspendTest {
         val (db, preimage, pr) = createFixture()
-        db.addIncomingPayment(preimage, IncomingPayment.Origin.Invoice(pr))
-        assertFails { db.addIncomingPayment(preimage, IncomingPayment.Origin.Invoice(pr)) }
+        db.addIncomingPayment(Bolt11IncomingPayment(preimage, pr, null))
+        assertFails { db.addIncomingPayment(Bolt11IncomingPayment(preimage, pr, null)) }
     }
 
     @Test
     fun `set expired invoices`() = runSuspendTest {
         val (db, preimage, _) = createFixture()
         val pr = createExpiredInvoice(preimage)
-        db.addIncomingPayment(preimage, IncomingPayment.Origin.Invoice(pr))
+        db.addIncomingPayment(Bolt11IncomingPayment(preimage, pr, null))
 
-        val expired = db.getIncomingPayment(pr.paymentHash)
-        assertNotNull(expired)
+        val expired = db.getLightningIncomingPayment(pr.paymentHash)
+        assertIs<Bolt11IncomingPayment>(expired)
         assertTrue(expired.isExpired())
-        assertEquals(IncomingPayment.Origin.Invoice(pr), expired.origin)
-        assertEquals(preimage, expired.preimage)
+        assertEquals(pr, expired.paymentRequest)
+        assertEquals(preimage, expired.paymentPreimage)
     }
 
     @Test

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -533,7 +533,7 @@ class PeerTest : LightningTestSuite() {
         alice.forward(bob2alice3.expect<CommitSig>(), connectionId = 2)
         bob.forward(alice2bob3.expect<RevokeAndAck>(), connectionId = 2)
 
-        assertEquals(invoice.amount, alice.db.payments.getLightningIncomingPayment(invoice.paymentHash)?.received?.amount)
+        assertEquals(invoice.amount, alice.db.payments.getLightningIncomingPayment(invoice.paymentHash)?.amount)
     }
 
     @Test

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/io/peer/PeerTest.kt
@@ -533,7 +533,7 @@ class PeerTest : LightningTestSuite() {
         alice.forward(bob2alice3.expect<CommitSig>(), connectionId = 2)
         bob.forward(alice2bob3.expect<RevokeAndAck>(), connectionId = 2)
 
-        assertEquals(invoice.amount, alice.db.payments.getIncomingPayment(invoice.paymentHash)?.received?.amount)
+        assertEquals(invoice.amount, alice.db.payments.getLightningIncomingPayment(invoice.paymentHash)?.received?.amount)
     }
 
     @Test

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -1774,8 +1774,6 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val defaultAmount = 150_000_000.msat
         val feeCreditFeatures = Features(Feature.ExperimentalSplice to FeatureSupport.Optional, Feature.OnTheFlyFunding to FeatureSupport.Optional, Feature.FundingFeeCredit to FeatureSupport.Optional)
 
-        val IncomingPaymentHandler.ProcessAddResult.Accepted.amount: MilliSatoshi get() = this.parts.map { it.amountReceived }.sum()
-
         fun LightningIncomingPayment.Part.resetTimestamp() = when (this) {
             is LightningIncomingPayment.Part.Htlc -> copy(receivedAt = 0)
             is LightningIncomingPayment.Part.FeeCredit -> copy(receivedAt = 0)

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -1883,8 +1883,6 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             )
             assertEquals(incomingPayment.amount, dbPayment.amount)
             assertEquals(incomingPayment.received?.parts, dbPayment.received?.parts)
-
-
         }
 
         private suspend fun createFixture(invoiceAmount: MilliSatoshi?): Triple<IncomingPaymentHandler, LightningIncomingPayment, ByteVector32> {

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -145,7 +145,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
 
         assertEquals(result.incomingPayment.received, result.received)
         assertEquals(defaultAmount, result.received.amount)
-        assertEquals(listOf(LightningIncomingPayment.ReceivedWith.LightningPayment(defaultAmount, channelId, 12, null)), result.received.receivedWith)
+        assertEquals(listOf(LightningIncomingPayment.Received.Part.Htlc(defaultAmount, channelId, 12, null)), result.received.parts)
         checkDbPayment(result.incomingPayment, paymentHandler.db)
     }
 
@@ -175,13 +175,13 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
             val (expectedActions, expectedReceivedWith) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, defaultPreimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount1, channelId, 0, fundingFee = null),
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(5, defaultPreimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount2, channelId, 5, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, defaultPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 0, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(5, defaultPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount2, channelId, 5, fundingFee = null),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
             assertEquals(totalAmount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.receivedWith)
+            assertEquals(expectedReceivedWith, result.received.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -221,13 +221,13 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
             val (expectedActions, expectedReceivedWith) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, defaultPreimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount1, channelId, 0, fundingFee = null),
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, defaultPreimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount2, channelId, 1, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, defaultPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 0, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, defaultPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount2, channelId, 1, fundingFee = null),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
             assertEquals(totalAmount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.receivedWith)
+            assertEquals(expectedReceivedWith, result.received.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -502,13 +502,13 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
             val (expectedActions, expectedReceivedWith) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount1, channelId, 0, fundingFee = null),
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount2, channelId, 1, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 0, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount2, channelId, 1, fundingFee = null),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
             assertEquals(totalAmount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.receivedWith)
+            assertEquals(expectedReceivedWith, result.received.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -566,13 +566,13 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
             val (expectedActions, expectedReceivedWith) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount1, channelId, 1, fundingFee = null),
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(2, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount2, channelId, 2, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 1, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(2, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount2, channelId, 2, fundingFee = null),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
             assertEquals(totalAmount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.receivedWith)
+            assertEquals(expectedReceivedWith, result.received.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -634,7 +634,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
                     assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
                     assertEquals(listOf(SendOnTheFlyFundingMessage(AddFeeCredit(paymentHandler.nodeParams.chainHash, incomingPayment.paymentPreimage))), result.actions)
                     assertEquals(totalAmount, result.received.amount)
-                    assertEquals(listOf(LightningIncomingPayment.ReceivedWith.AddedToFeeCredit(totalAmount)), result.received.receivedWith)
+                    assertEquals(listOf(LightningIncomingPayment.Received.Part.FeeCredit(totalAmount)), result.received.parts)
                     checkDbPayment(result.incomingPayment, paymentHandler.db)
                 }
                 else -> {
@@ -677,13 +677,13 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
             val (expectedActions, expectedReceivedWith) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount1, channelId, 0, fundingFee = null),
-                SendOnTheFlyFundingMessage(AddFeeCredit(paymentHandler.nodeParams.chainHash, incomingPayment.paymentPreimage)) to LightningIncomingPayment.ReceivedWith.AddedToFeeCredit(amount2),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 0, fundingFee = null),
+                SendOnTheFlyFundingMessage(AddFeeCredit(paymentHandler.nodeParams.chainHash, incomingPayment.paymentPreimage)) to LightningIncomingPayment.Received.Part.FeeCredit(amount2),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
             assertEquals(totalAmount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.receivedWith)
+            assertEquals(expectedReceivedWith, result.received.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -877,13 +877,13 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
             val (expectedActions, expectedReceivedWith) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount1, channelId, 0, fundingFee = null),
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount2 - purchase.fundingFee.amount, channelId, 1, purchase.fundingFee),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 0, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount2 - purchase.fundingFee.amount, channelId, 1, purchase.fundingFee),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
             assertEquals(totalAmount - purchase.fundingFee.amount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.receivedWith)
+            assertEquals(expectedReceivedWith, result.received.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -929,12 +929,12 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
             val (expectedActions, expectedReceivedWith) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(7, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount, channelId, 7, fundingFee),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(7, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount, channelId, 7, fundingFee),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
             assertEquals(amount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.receivedWith)
+            assertEquals(expectedReceivedWith, result.received.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -984,7 +984,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
             assertEquals(listOf(WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true))), result.actions)
             assertEquals(defaultAmount - payment.fundingFee.amount, result.received.amount)
-            assertEquals(listOf(LightningIncomingPayment.ReceivedWith.LightningPayment(defaultAmount - payment.fundingFee.amount, channelId, 1, payment.fundingFee)), result.received.receivedWith)
+            assertEquals(listOf(LightningIncomingPayment.Received.Part.Htlc(defaultAmount - payment.fundingFee.amount, channelId, 1, payment.fundingFee)), result.received.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -1532,8 +1532,8 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         )
         paymentHandler.db.receiveLightningPayment(
             paidInvoice.paymentHash,
-            receivedWith = listOf(
-                LightningIncomingPayment.ReceivedWith.LightningPayment(
+            parts = listOf(
+                LightningIncomingPayment.Received.Part.Htlc(
                     amountReceived = 15_000_000.msat,
                     channelId = randomBytes32(),
                     htlcId = 42,
@@ -1576,7 +1576,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
 
         assertEquals(result.incomingPayment.received, result.received)
         assertEquals(defaultAmount, result.received.amount)
-        assertEquals(listOf(LightningIncomingPayment.ReceivedWith.LightningPayment(defaultAmount, add.channelId, 8, null)), result.received.receivedWith)
+        assertEquals(listOf(LightningIncomingPayment.Received.Part.Htlc(defaultAmount, add.channelId, 8, null)), result.received.parts)
 
         checkDbPayment(result.incomingPayment, paymentHandler.db)
     }
@@ -1613,13 +1613,13 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
             val (expectedActions, expectedReceivedWith) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, preimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount1, channelId, 0, null),
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, preimage, commit = true)) to LightningIncomingPayment.ReceivedWith.LightningPayment(amount2, channelId, 1, null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, preimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 0, null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, preimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount2, channelId, 1, null),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
             assertEquals(totalAmount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.receivedWith)
+            assertEquals(expectedReceivedWith, result.received.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -1681,8 +1681,8 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertEquals(setOf(WrappedChannelCommand(add.channelId, fulfill)), result.actions.toSet())
             assertEquals(result.incomingPayment.received, result.received)
             assertEquals(defaultAmount - payment.fundingFee.amount, result.received.amount)
-            val receivedWith = LightningIncomingPayment.ReceivedWith.LightningPayment(defaultAmount - payment.fundingFee.amount, add.channelId, 0, payment.fundingFee)
-            assertEquals(listOf(receivedWith), result.received.receivedWith)
+            val parts = LightningIncomingPayment.Received.Part.Htlc(defaultAmount - payment.fundingFee.amount, add.channelId, 0, payment.fundingFee)
+            assertEquals(listOf(parts), result.received.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -1882,7 +1882,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
                 }
             )
             assertEquals(incomingPayment.amount, dbPayment.amount)
-            assertEquals(incomingPayment.received?.receivedWith, dbPayment.received?.receivedWith)
+            assertEquals(incomingPayment.received?.parts, dbPayment.received?.parts)
 
 
         }

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -143,9 +143,9 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val expected = ChannelCommand.Htlc.Settlement.Fulfill(add.id, incomingPayment.paymentPreimage, commit = true)
         assertEquals(setOf(WrappedChannelCommand(add.channelId, expected)), result.actions.toSet())
 
-        assertEquals(result.incomingPayment.received, result.received)
-        assertEquals(defaultAmount, result.received.amount)
-        assertEquals(listOf(LightningIncomingPayment.Received.Part.Htlc(defaultAmount, channelId, 12, null)), result.received.parts)
+        assertEqualsIgnoreTimestamps(result.incomingPayment.parts, result.parts)
+        assertEquals(defaultAmount, result.amount)
+        assertEqualsIgnoreTimestamps(listOf(LightningIncomingPayment.Part.Htlc(defaultAmount, channelId, 12, null)), result.parts)
         checkDbPayment(result.incomingPayment, paymentHandler.db)
     }
 
@@ -173,15 +173,15 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val add = makeUpdateAddHtlc(5, channelId, paymentHandler, incomingPayment.paymentHash, makeMppPayload(amount2, totalAmount, paymentSecret))
             val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
-            val (expectedActions, expectedReceivedWith) = setOf(
+            val (expectedActions, parts) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, defaultPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 0, fundingFee = null),
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(5, defaultPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount2, channelId, 5, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, defaultPreimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount1, channelId, 0, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(5, defaultPreimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount2, channelId, 5, fundingFee = null),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
-            assertEquals(totalAmount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.parts)
+            assertEquals(totalAmount, result.amount)
+            assertEqualsIgnoreTimestamps(parts, result.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -198,7 +198,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val add = makeUpdateAddHtlc(0, channelId, paymentHandler, incomingPayment.paymentHash, makeMppPayload(amount1, totalAmount, paymentSecret))
             val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Pending>(result)
-            assertNull(result.incomingPayment.received)
+            assertTrue(result.incomingPayment.parts.isEmpty())
             assertTrue(result.actions.isEmpty())
             add
         }
@@ -210,7 +210,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         run {
             val result = paymentHandler.process(add1, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Pending>(result)
-            assertNull(result.incomingPayment.received)
+            assertTrue(result.incomingPayment.parts.isEmpty())
             assertTrue(result.actions.isEmpty())
         }
 
@@ -219,15 +219,15 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val add = makeUpdateAddHtlc(1, channelId, paymentHandler, incomingPayment.paymentHash, makeMppPayload(amount2, totalAmount, paymentSecret))
             val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
-            val (expectedActions, expectedReceivedWith) = setOf(
+            val (expectedActions, parts) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, defaultPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 0, fundingFee = null),
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, defaultPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount2, channelId, 1, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, defaultPreimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount1, channelId, 0, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, defaultPreimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount2, channelId, 1, fundingFee = null),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
-            assertEquals(totalAmount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.parts)
+            assertEquals(totalAmount, result.amount)
+            assertEqualsIgnoreTimestamps(parts, result.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -248,7 +248,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(TestConstants.fundingRates.fundingRates.first(), addLiquidity.fundingRate)
         assertEquals(listOf(willAddHtlc), addLiquidity.willAddHtlcs)
         // We don't update the payments DB: we're waiting to receive HTLCs after the open/splice.
-        assertNull(paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.received)
+        assertEquals(emptyList(), paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.parts)
     }
 
     @Test
@@ -265,7 +265,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertIs<AddLiquidityForIncomingPayment>(addLiquidity)
         assertEquals(555_556.sat, addLiquidity.requestedAmount)
         // We don't update the payments DB: we're waiting to receive HTLCs after the open/splice.
-        assertNull(paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.received)
+        assertEquals(emptyList(), paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.parts)
     }
 
     @Test
@@ -296,7 +296,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertEquals(incomingPayment.paymentPreimage, addLiquidity.preimage)
             assertEquals(amount * 2, addLiquidity.paymentAmount)
             assertEquals(2, addLiquidity.willAddHtlcs.size)
-            assertNull(paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.received)
+            assertEquals(emptyList(), paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.parts)
         }
     }
 
@@ -330,7 +330,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertEquals(incomingPayment.paymentPreimage, addLiquidity.preimage)
             assertEquals(totalAmount, addLiquidity.paymentAmount)
             assertEquals(2, addLiquidity.willAddHtlcs.size)
-            assertNull(paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.received)
+            assertEquals(emptyList(), paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.parts)
         }
     }
 
@@ -359,7 +359,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(defaultAmount, addLiquidity.paymentAmount)
         assertEquals(defaultAmount, addLiquidity.requestedAmount.toMilliSatoshi())
         assertEquals(TestConstants.fundingRates.fundingRates.first(), addLiquidity.fundingRate)
-        assertNull(paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.received)
+        assertEquals(emptyList(), paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.parts)
     }
 
     @Test
@@ -490,7 +490,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertEquals(incomingPayment.paymentPreimage, addLiquidity.preimage)
             assertEquals(amount2.truncateToSatoshi(), addLiquidity.requestedAmount)
             assertEquals(totalAmount, addLiquidity.paymentAmount)
-            assertNull(paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.received)
+            assertEquals(emptyList(), paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.parts)
         }
 
         // Step 3 of 3:
@@ -500,15 +500,15 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val htlc = makeUpdateAddHtlc(1, channelId, paymentHandler, incomingPayment.paymentHash, makeMppPayload(amount2, totalAmount, paymentSecret))
             val result = paymentHandler.process(htlc, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, TestConstants.fundingRates)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
-            val (expectedActions, expectedReceivedWith) = setOf(
+            val (expectedActions, parts) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 0, fundingFee = null),
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount2, channelId, 1, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount1, channelId, 0, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount2, channelId, 1, fundingFee = null),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
-            assertEquals(totalAmount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.parts)
+            assertEquals(totalAmount, result.amount)
+            assertEqualsIgnoreTimestamps(parts, result.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -544,7 +544,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertIs<WillFailHtlc>(willFailHtlc).also { assertEquals(willAddHtlc.id, it.id) }
             val failHtlc = ChannelCommand.Htlc.Settlement.Fail(0, ChannelCommand.Htlc.Settlement.Fail.Reason.Failure(TemporaryNodeFailure), commit = true)
             assertTrue(result.actions.contains(WrappedChannelCommand(channelId, failHtlc)))
-            assertNull(paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.received)
+            assertEquals(emptyList(), paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.parts)
         }
 
         // Step 3 of 4:
@@ -564,15 +564,15 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val htlc = makeUpdateAddHtlc(2, channelId, paymentHandler, incomingPayment.paymentHash, makeMppPayload(amount2, totalAmount, paymentSecret))
             val result = paymentHandler.process(htlc, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, TestConstants.fundingRates)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
-            val (expectedActions, expectedReceivedWith) = setOf(
+            val (expectedActions, parts) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 1, fundingFee = null),
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(2, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount2, channelId, 2, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount1, channelId, 1, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(2, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount2, channelId, 2, fundingFee = null),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
-            assertEquals(totalAmount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.parts)
+            assertEquals(totalAmount, result.amount)
+            assertEqualsIgnoreTimestamps(parts, result.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -610,7 +610,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(willAddHtlcs.map { it.id }.toSet(), willFailHtlcs.map { it.id }.toSet())
         val failHtlc = ChannelCommand.Htlc.Settlement.Fail(htlc.id, ChannelCommand.Htlc.Settlement.Fail.Reason.Failure(TemporaryNodeFailure), commit = true)
         assertTrue(result.actions.contains(WrappedChannelCommand(channelId, failHtlc)))
-        assertNull(paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.received)
+        assertEquals(emptyList(), paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.parts)
     }
 
     @Test
@@ -633,8 +633,8 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
                 null -> {
                     assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
                     assertEquals(listOf(SendOnTheFlyFundingMessage(AddFeeCredit(paymentHandler.nodeParams.chainHash, incomingPayment.paymentPreimage))), result.actions)
-                    assertEquals(totalAmount, result.received.amount)
-                    assertEquals(listOf(LightningIncomingPayment.Received.Part.FeeCredit(totalAmount)), result.received.parts)
+                    assertEquals(totalAmount, result.amount)
+                    assertEqualsIgnoreTimestamps(listOf(LightningIncomingPayment.Part.FeeCredit(totalAmount)), result.parts)
                     checkDbPayment(result.incomingPayment, paymentHandler.db)
                 }
                 else -> {
@@ -675,15 +675,15 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val willAddHtlc = makeWillAddHtlc(paymentHandler, incomingPayment.paymentHash, makeMppPayload(amount2, totalAmount, paymentSecret))
             val result = paymentHandler.process(willAddHtlc, feeCreditFeatures, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, TestConstants.fundingRates, currentFeeCredit = 0.msat)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
-            val (expectedActions, expectedReceivedWith) = setOf(
+            val (expectedActions, parts) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 0, fundingFee = null),
-                SendOnTheFlyFundingMessage(AddFeeCredit(paymentHandler.nodeParams.chainHash, incomingPayment.paymentPreimage)) to LightningIncomingPayment.Received.Part.FeeCredit(amount2),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount1, channelId, 0, fundingFee = null),
+                SendOnTheFlyFundingMessage(AddFeeCredit(paymentHandler.nodeParams.chainHash, incomingPayment.paymentPreimage)) to LightningIncomingPayment.Part.FeeCredit(amount2),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
-            assertEquals(totalAmount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.parts)
+            assertEquals(totalAmount, result.amount)
+            assertEqualsIgnoreTimestamps(parts, result.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -734,7 +734,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertEquals(totalAmount, addLiquidity.paymentAmount)
             assertEquals(105_000.sat, addLiquidity.requestedAmount)
             // We don't update the payments DB: we're waiting to receive HTLCs after the open/splice.
-            assertNull(paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.received)
+            assertEquals(emptyList(), paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.parts)
         }
     }
 
@@ -753,7 +753,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(totalAmount, addLiquidity.paymentAmount)
         assertEquals(100_001.sat, addLiquidity.requestedAmount)
         // We don't update the payments DB: we're waiting to receive HTLCs after the open/splice.
-        assertNull(paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.received)
+        assertEquals(emptyList(), paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.parts)
     }
 
     @Test
@@ -775,7 +775,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val addFeeCredit = result.actions.first()
             assertIs<SendOnTheFlyFundingMessage>(addFeeCredit)
             assertIs<AddFeeCredit>(addFeeCredit.message)
-            assertEquals(amount, result.received.amount)
+            assertEquals(amount, result.amount)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
 
@@ -794,7 +794,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertEquals(amount, addLiquidity.paymentAmount)
             assertEquals(104_000.sat, addLiquidity.requestedAmount)
             // We don't update the payments DB: we're waiting to receive HTLCs after the open/splice.
-            assertNull(paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.received)
+            assertEquals(emptyList(), paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.parts)
         }
     }
 
@@ -812,7 +812,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(totalAmount, addLiquidity.paymentAmount)
         assertEquals(110_000.sat, addLiquidity.requestedAmount)
         // We don't update the payments DB: we're waiting to receive HTLCs after the open/splice.
-        assertNull(paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.received)
+        assertEquals(emptyList(), paymentHandler.db.getLightningIncomingPayment(incomingPayment.paymentHash)?.parts)
     }
 
     @Test
@@ -875,15 +875,15 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertTrue(htlc.amountMsat < amount2)
             val result = paymentHandler.process(htlc, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, TestConstants.fundingRates)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
-            val (expectedActions, expectedReceivedWith) = setOf(
+            val (expectedActions, parts) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 0, fundingFee = null),
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount2 - purchase.fundingFee.amount, channelId, 1, purchase.fundingFee),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount1, channelId, 0, fundingFee = null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount2 - purchase.fundingFee.amount, channelId, 1, purchase.fundingFee),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
-            assertEquals(totalAmount - purchase.fundingFee.amount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.parts)
+            assertEquals(totalAmount - purchase.fundingFee.amount, result.amount)
+            assertEqualsIgnoreTimestamps(parts, result.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -927,14 +927,14 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val currentBlockHeight = TestConstants.defaultBlockHeight + 24
             val result = paymentHandler.process(htlc, Features.empty, currentBlockHeight, TestConstants.feeratePerKw, TestConstants.fundingRates)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
-            val (expectedActions, expectedReceivedWith) = setOf(
+            val (expectedActions, parts) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(7, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount, channelId, 7, fundingFee),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(7, incomingPayment.paymentPreimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount, channelId, 7, fundingFee),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
-            assertEquals(amount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.parts)
+            assertEquals(amount, result.amount)
+            assertEqualsIgnoreTimestamps(parts, result.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -983,8 +983,8 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, TestConstants.fundingRates)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
             assertEquals(listOf(WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, incomingPayment.paymentPreimage, commit = true))), result.actions)
-            assertEquals(defaultAmount - payment.fundingFee.amount, result.received.amount)
-            assertEquals(listOf(LightningIncomingPayment.Received.Part.Htlc(defaultAmount - payment.fundingFee.amount, channelId, 1, payment.fundingFee)), result.received.parts)
+            assertEquals(defaultAmount - payment.fundingFee.amount, result.amount)
+            assertEqualsIgnoreTimestamps(listOf(LightningIncomingPayment.Part.Htlc(defaultAmount - payment.fundingFee.amount, channelId, 1, payment.fundingFee)), result.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -1135,7 +1135,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val add2 = makeUpdateAddHtlc(5, randomBytes32(), paymentHandler, incomingPayment.paymentHash, makeMppPayload(defaultAmount / 2, defaultAmount, paymentSecret))
         val result2 = paymentHandler.process(add2, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
         assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result2)
-        assertEquals(defaultAmount, result2.received.amount)
+        assertEquals(defaultAmount, result2.amount)
         val expected = setOf(
             WrappedChannelCommand(add1.channelId, ChannelCommand.Htlc.Settlement.Fulfill(add1.id, incomingPayment.paymentPreimage, commit = true)),
             WrappedChannelCommand(add2.channelId, ChannelCommand.Htlc.Settlement.Fulfill(add2.id, incomingPayment.paymentPreimage, commit = true))
@@ -1145,7 +1145,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         // The second htlc is reprocessed (e.g. because our peer disconnected before we could send them the preimage).
         val result2b = paymentHandler.process(add2, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
         assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result2b)
-        assertEquals(defaultAmount, result2b.received.amount)
+        assertEquals(defaultAmount, result2b.amount)
         assertEquals(listOf(WrappedChannelCommand(add2.channelId, ChannelCommand.Htlc.Settlement.Fulfill(add2.id, incomingPayment.paymentPreimage, commit = true))), result2b.actions)
     }
 
@@ -1533,14 +1533,14 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         paymentHandler.db.receiveLightningPayment(
             paidInvoice.paymentHash,
             parts = listOf(
-                LightningIncomingPayment.Received.Part.Htlc(
+                LightningIncomingPayment.Part.Htlc(
                     amountReceived = 15_000_000.msat,
                     channelId = randomBytes32(),
                     htlcId = 42,
-                    fundingFee = null
+                    fundingFee = null,
+                    receivedAt = 101 // simulate incoming payment being paid before it expired
                 )
             ),
-            receivedAt = 101 // simulate incoming payment being paid before it expired
         )
 
         // create unexpired payment
@@ -1574,9 +1574,9 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val expected = ChannelCommand.Htlc.Settlement.Fulfill(add.id, preimage, commit = true)
         assertEquals(setOf(WrappedChannelCommand(add.channelId, expected)), result.actions.toSet())
 
-        assertEquals(result.incomingPayment.received, result.received)
-        assertEquals(defaultAmount, result.received.amount)
-        assertEquals(listOf(LightningIncomingPayment.Received.Part.Htlc(defaultAmount, add.channelId, 8, null)), result.received.parts)
+        assertEqualsIgnoreTimestamps(result.incomingPayment.parts, result.parts)
+        assertEquals(defaultAmount, result.amount)
+        assertEqualsIgnoreTimestamps(listOf(LightningIncomingPayment.Part.Htlc(defaultAmount, add.channelId, 8, null)), result.parts)
 
         checkDbPayment(result.incomingPayment, paymentHandler.db)
     }
@@ -1599,7 +1599,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val add = makeUpdateAddHtlc(0, channelId, paymentHandler, paymentHash, finalPayload, route.firstPathKey)
             val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Pending>(result)
-            assertNull(result.incomingPayment.received)
+            assertTrue(result.incomingPayment.parts.isEmpty())
             assertTrue(result.actions.isEmpty())
         }
 
@@ -1611,15 +1611,15 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val add = makeUpdateAddHtlc(1, channelId, paymentHandler, paymentHash, finalPayload, route.firstPathKey)
             val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
-            val (expectedActions, expectedReceivedWith) = setOf(
+            val (expectedActions, parts) = setOf(
                 // @formatter:off
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, preimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount1, channelId, 0, null),
-                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, preimage, commit = true)) to LightningIncomingPayment.Received.Part.Htlc(amount2, channelId, 1, null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(0, preimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount1, channelId, 0, null),
+                WrappedChannelCommand(channelId, ChannelCommand.Htlc.Settlement.Fulfill(1, preimage, commit = true)) to LightningIncomingPayment.Part.Htlc(amount2, channelId, 1, null),
                 // @formatter:on
             ).unzip()
             assertEquals(expectedActions.toSet(), result.actions.toSet())
-            assertEquals(totalAmount, result.received.amount)
-            assertEquals(expectedReceivedWith, result.received.parts)
+            assertEquals(totalAmount, result.amount)
+            assertEqualsIgnoreTimestamps(parts, result.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -1640,7 +1640,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         assertEquals(preimage, addLiquidity.preimage)
         assertEquals(defaultAmount, addLiquidity.paymentAmount)
         // We don't update the payments DB: we're waiting to receive HTLCs after the open/splice.
-        assertNull(paymentHandler.db.getLightningIncomingPayment(paymentHash)?.received)
+        assertNull(paymentHandler.db.getLightningIncomingPayment(paymentHash))
     }
 
     @Test
@@ -1679,10 +1679,10 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             assertIs<IncomingPaymentHandler.ProcessAddResult.Accepted>(result)
             val fulfill = ChannelCommand.Htlc.Settlement.Fulfill(add.id, preimage, commit = true)
             assertEquals(setOf(WrappedChannelCommand(add.channelId, fulfill)), result.actions.toSet())
-            assertEquals(result.incomingPayment.received, result.received)
-            assertEquals(defaultAmount - payment.fundingFee.amount, result.received.amount)
-            val parts = LightningIncomingPayment.Received.Part.Htlc(defaultAmount - payment.fundingFee.amount, add.channelId, 0, payment.fundingFee)
-            assertEquals(listOf(parts), result.received.parts)
+            assertEqualsIgnoreTimestamps(result.incomingPayment.parts, result.parts)
+            assertEquals(defaultAmount - payment.fundingFee.amount, result.amount)
+            val parts = LightningIncomingPayment.Part.Htlc(defaultAmount - payment.fundingFee.amount, add.channelId, 0, payment.fundingFee)
+            assertEqualsIgnoreTimestamps(listOf(parts), result.parts)
             checkDbPayment(result.incomingPayment, paymentHandler.db)
         }
     }
@@ -1719,7 +1719,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
             val add = makeUpdateAddHtlc(0, channelId, paymentHandler, paymentHash, finalPayload, route.firstPathKey)
             val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
             assertIs<IncomingPaymentHandler.ProcessAddResult.Pending>(result)
-            assertNull(result.incomingPayment.received)
+            assertTrue(result.incomingPayment.parts.isEmpty())
             assertTrue(result.actions.isEmpty())
         }
 
@@ -1773,6 +1773,18 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val defaultPaymentHash = Crypto.sha256(defaultPreimage).toByteVector32()
         val defaultAmount = 150_000_000.msat
         val feeCreditFeatures = Features(Feature.ExperimentalSplice to FeatureSupport.Optional, Feature.OnTheFlyFunding to FeatureSupport.Optional, Feature.FundingFeeCredit to FeatureSupport.Optional)
+
+        val IncomingPaymentHandler.ProcessAddResult.Accepted.amount: MilliSatoshi get() = this.parts.map { it.amountReceived }.sum()
+
+        fun LightningIncomingPayment.Part.resetTimestamp() = when (this) {
+            is LightningIncomingPayment.Part.Htlc -> copy(receivedAt = 0)
+            is LightningIncomingPayment.Part.FeeCredit -> copy(receivedAt = 0)
+        }
+
+        fun List<LightningIncomingPayment.Part>.resetTimestamp() = this.map { it.resetTimestamp() }
+
+        fun assertEqualsIgnoreTimestamps(expected: List<LightningIncomingPayment.Part>, actual: List<LightningIncomingPayment.Part>) =
+            assertEquals(expected.resetTimestamp(), actual.resetTimestamp())
 
         private fun makeCmdAddHtlc(destination: PublicKey, paymentHash: ByteVector32, finalPayload: PaymentOnion.FinalPayload): ChannelCommand.Htlc.Add {
             val onion = OutgoingPaymentPacket.buildOnion(listOf(destination), listOf(finalPayload), paymentHash, OnionRoutingPacket.PaymentPacketLength).packet
@@ -1882,7 +1894,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
                 }
             )
             assertEquals(incomingPayment.amount, dbPayment.amount)
-            assertEquals(incomingPayment.received?.parts, dbPayment.received?.parts)
+            assertEqualsIgnoreTimestamps(incomingPayment.parts, dbPayment.parts)
         }
 
         private suspend fun createFixture(invoiceAmount: MilliSatoshi?): Triple<IncomingPaymentHandler, LightningIncomingPayment, ByteVector32> {


### PR DESCRIPTION
We move from a flat model with a single `IncomingPayment` class and a combination of `Origin` + `ReceivedWith` parts to a hierarchical model.

This new model:
- makes incoming/outgoing databases symmetrical
- removes impossible combinations allowed in the previous model (e.g. an on-chain origin with a fee-credit part)
- removes hacks required for the handling of on-chain deposits, which were shoe-horned in what was originally a lightning-only model

Before:
```
Origin
   |
   `--- Invoice
   |
   `--- Offer
   |
   `--- SwapIn
   |
   `--- OnChain

ReceivedWith
      |
      `--- LightningPayment
      |
      `--- AddedToFeeCredit
      |
      `--- OnChainIncomingPayment
                    |
                    `--- NewChannel
                    |
                    `--- SpliceIn
```

After:
```
IncomingPayment
      |
      `--- LightningIncomingPayment
      |             |
      |             `--- Bolt11IncomingPayment
      |             |
      |             `--- Bolt12IncomingPayment
      |
      `--- OnChainIncomingPayment
                    |
                    `--- NewChannelIncomingPayment
                    |
                    `--- SpliceInIncomingPayment
                    |
                    `--- LegacySwapInIncomingPayment
                    |
                    `--- LegacyPayToOpenIncomingPayment

LightningIncomingPayment.Part
      |
      `--- Htlc
      |
      `--- FeeCredit
```

The handling of backward compatible data is tricky, especially for legacy pay-to-open/pay-to-splice, which can be a mix of lightning parts and on-chain parts, and either Bolt11 or Bolt12. Note that `Legacy*` classes are not used at all within `lightning-kmp`, they are just meant to handle pre-existing data in the database.

payment                        | old model                                     | new model
-------------------------------|-----------------------------------------------|------------------------
Plain Lightning Bolt11         | Origin=Invoice, ReceivedWith=LightningPayment | Bolt11IncomingPayment
Plain Lightning Bolt12         | Origin=Offer, ReceivedWith=LightningPayment   | Bolt12IncomingPayment
Pre-otf pay-to-open Bolt11     | Origin=Invoice, ReceivedWith=NewChannel       | LegacyPayToOpenIncomingPayment
Pre-otf pay-to-splice Bolt11   | Origin=Invoice, ReceivedWith=SpliceIn         | LegacyPayToOpenIncomingPayment
Pre-otf pay-to-open Bolt12     | Origin=Offer, ReceivedWith=NewChannel         | LegacyPayToOpenIncomingPayment
Pre-otf pay-to-splice Bolt12   | Origin=Offer, ReceivedWith=SpliceIn           | LegacyPayToOpenIncomingPayment
Legacy trusted swap-in         | Origin=SwapIn, ReceivedWith=NewChannel        | LegacySwapInIncomingPayment
Swap-in potentiam open         | Origin=OnChain, ReceivedWith=NewChannel       | NewChannelIncomingPayment
Swap-in potentiam splice       | Origin=OnChain, ReceivedWith=SpliceIn         | SpliceInIncomingPayment