### PR TITLE
Use shared input's `txOut` in `shouldSignFirst`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
@@ -1147,7 +1147,7 @@ data class InteractiveTxSigningSession(
         }
 
         fun shouldSignFirst(isInitiator: Boolean, channelParams: ChannelParams, tx: SharedTransaction): Boolean {
-            val sharedAmountIn = tx.sharedInput?.let { it.localAmount + it.remoteAmount } ?: 0.msat
+            val sharedAmountIn = tx.sharedInput?.txOut?.amount?.toMilliSatoshi() ?: 0.msat
             val localAmountIn = tx.localInputs.map { it.txOut.amount }.sum().toMilliSatoshi() + if (isInitiator) sharedAmountIn else 0.msat
             val remoteAmountIn = tx.remoteInputs.map { it.txOut.amount }.sum().toMilliSatoshi() + if (isInitiator) 0.msat else sharedAmountIn
             return if (localAmountIn == remoteAmountIn) {


### PR DESCRIPTION
When deciding who must send `tx_signatures` first for a splice, we compute how much each node contributes to the splice transaction by adding the amount of the `tx_add_input` they have sent.

For the shared input (current channel output), instead of using the `txOut` amount, we previously summed the balance of each node in the channel. The result is the same when there are no pending HTLCs, but when there are pending HTLCs, it underestimates the amount of this input.

This is hard to reproduce (and test) because it requires both nodes to contribute to the splice while having large pending HTLCs that tilt the balance in favor of the wrong side.