### PR TITLE
Manage dependencies with a version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,31 @@
+[versions]
+kotlin = "1.9.23"
+kotlinx-coroutines = "1.7.3"
+kotlinx-serialization = "1.6.2"
+ktor = "2.3.7"
+
+[plugins]
+multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+dokka = { id = "org.jetbrains.dokka", version = "1.9.10" }
+
+[libraries]
+bitcoinkmp = { group = "fr.acinq.bitcoin", name = "bitcoin-kmp", version = "0.20.0" } # when upgrading bitcoin-kmp, keep secpJniJvmVersion in sync!
+secpjnijvm = { group = "fr.acinq.secp256k1", name = "secp256k1-kmp-jni-jvm", version = "0.15.0" }
+kermit = { group = "co.touchlab", name = "kermit", version = "2.0.2" }
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version = "0.6.0" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
+kotlinx-serialization-cbor = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-cbor", version.ref = "kotlinx-serialization" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+ktor-network = { group = "io.ktor", name = "ktor-network", version.ref = "ktor" }
+ktor-network-tls = { group = "io.ktor", name = "ktor-network-tls", version.ref = "ktor" }
+ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktor-client-auth = { group = "io.ktor", name = "ktor-client-auth", version.ref = "ktor" }
+ktor-client-json = { group = "io.ktor", name = "ktor-client-json", version.ref = "ktor" }
+ktor-client-contentnegotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-ios = { group = "io.ktor", name = "ktor-client-ios", version.ref = "ktor" }
+ktor-client-darwin = { group = "io.ktor", name = "ktor-client-darwin", version.ref = "ktor" }
+ktor-client-curl = { group = "io.ktor", name = "ktor-client-curl", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,31 +1,21 @@
 [versions]
 kotlin = "1.9.23"
 kotlinx-coroutines = "1.7.3"
+kotlinx-datetime = "0.6.0"
 kotlinx-serialization = "1.6.2"
 ktor = "2.3.7"
+bitcoinkmp = "0.20.0" # when upgrading bitcoin-kmp, keep secpjnijvm in sync!
+secpjnijvm = "0.15.0"
+kermit = "2.0.2"
+slf4j = "1.7.36"
+
+# test dependencies
+test-kodein-memory = "0.12.0"
+test-bouncycastle = "1.64"
+test-logback = "1.2.3"
+test-sqlitejdbc = "3.32.3.3"
 
 [plugins]
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version = "1.9.10" }
-
-[libraries]
-bitcoinkmp = { group = "fr.acinq.bitcoin", name = "bitcoin-kmp", version = "0.20.0" } # when upgrading bitcoin-kmp, keep secpJniJvmVersion in sync!
-secpjnijvm = { group = "fr.acinq.secp256k1", name = "secp256k1-kmp-jni-jvm", version = "0.15.0" }
-kermit = { group = "co.touchlab", name = "kermit", version = "2.0.2" }
-kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version = "0.6.0" }
-kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
-kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
-kotlinx-serialization-cbor = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-cbor", version.ref = "kotlinx-serialization" }
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
-ktor-network = { group = "io.ktor", name = "ktor-network", version.ref = "ktor" }
-ktor-network-tls = { group = "io.ktor", name = "ktor-network-tls", version.ref = "ktor" }
-ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
-ktor-client-auth = { group = "io.ktor", name = "ktor-client-auth", version.ref = "ktor" }
-ktor-client-json = { group = "io.ktor", name = "ktor-client-json", version.ref = "ktor" }
-ktor-client-contentnegotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
-ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
-ktor-client-ios = { group = "io.ktor", name = "ktor-client-ios", version.ref = "ktor" }
-ktor-client-darwin = { group = "io.ktor", name = "ktor-client-darwin", version.ref = "ktor" }
-ktor-client-curl = { group = "io.ktor", name = "ktor-client-curl", version.ref = "ktor" }
-ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -56,20 +56,20 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api(libs.bitcoinkmp)
-                api(libs.kotlinx.datetime)
-                api(libs.kotlinx.coroutines.core)
-                api(libs.kotlinx.serialization.core)
-                api(libs.kotlinx.serialization.cbor)
-                api(libs.kotlinx.serialization.json)
-                api(libs.ktor.network)
-                api(libs.ktor.network.tls)
-                implementation(libs.ktor.client.core)
-                implementation(libs.ktor.client.auth)
-                implementation(libs.ktor.client.json)
-                implementation(libs.ktor.client.contentnegotiation)
-                implementation(libs.ktor.serialization.kotlinx.json)
-                api(libs.kermit)
+                api("fr.acinq.bitcoin:bitcoin-kmp:${libs.versions.bitcoinkmp.get()}")
+                api("org.jetbrains.kotlinx:kotlinx-coroutines-core:${libs.versions.kotlinx.coroutines.get()}")
+                api("org.jetbrains.kotlinx:kotlinx-serialization-core:${libs.versions.kotlinx.serialization.get()}")
+                api("org.jetbrains.kotlinx:kotlinx-serialization-cbor:${libs.versions.kotlinx.serialization.get()}")
+                api("org.jetbrains.kotlinx:kotlinx-serialization-json:${libs.versions.kotlinx.serialization.get()}")
+                api("org.jetbrains.kotlinx:kotlinx-datetime:${libs.versions.kotlinx.datetime.get()}")
+                api("co.touchlab:kermit:${libs.versions.kermit.get()}")
+                api("io.ktor:ktor-network:${libs.versions.ktor.get()}")
+                api("io.ktor:ktor-network-tls:${libs.versions.ktor.get()}")
+                api("io.ktor:ktor-client-core:${libs.versions.ktor.get()}")
+                api("io.ktor:ktor-client-auth:${libs.versions.ktor.get()}")
+                api("io.ktor:ktor-client-json:${libs.versions.ktor.get()}")
+                api("io.ktor:ktor-client-content-negotiation:${libs.versions.ktor.get()}")
+                api("io.ktor:ktor-serialization-kotlinx-json:${libs.versions.ktor.get()}")
             }
         }
 
@@ -77,43 +77,43 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.kodein.memory:klio-files:0.12.0")
+                implementation("org.kodein.memory:klio-files:${libs.versions.test.kodein.memory.get()}")
             }
         }
 
         jvmMain {
             dependencies {
-                api(libs.ktor.client.okhttp)
-                implementation(libs.secpjnijvm)
-                implementation("org.slf4j:slf4j-api:1.7.36")
+                api("io.ktor:ktor-client-okhttp:${libs.versions.ktor.get()}")
+                implementation("fr.acinq.secp256k1:secp256k1-kmp-jni-jvm:${libs.versions.secpjnijvm.get()}")
+                implementation("org.slf4j:slf4j-api:${libs.versions.slf4j.get()}")
             }
         }
 
         jvmTest {
             dependencies {
                 implementation(kotlin("test-junit"))
-                implementation("org.bouncycastle:bcprov-jdk15on:1.64")
-                implementation("ch.qos.logback:logback-classic:1.2.3")
-                implementation("org.xerial:sqlite-jdbc:3.32.3.3")
+                implementation("org.bouncycastle:bcprov-jdk15on:${libs.versions.test.bouncycastle.get()}")
+                implementation("ch.qos.logback:logback-classic:${libs.versions.test.logback.get()}")
+                implementation("org.xerial:sqlite-jdbc:${libs.versions.test.sqlitejdbc.get()}")
             }
         }
 
         if (currentOs.isMacOsX) {
             iosMain {
                 dependencies {
-                    implementation(libs.ktor.client.ios)
+                    api("io.ktor:ktor-client-ios:${libs.versions.ktor.get()}")
                 }
             }
             macosMain {
                 dependencies {
-                    implementation(libs.ktor.client.darwin)
+                    api("io.ktor:ktor-client-darwin:${libs.versions.ktor.get()}")
                 }
             }
         }
 
         linuxMain {
             dependencies {
-                implementation(libs.ktor.client.curl)
+                api("io.ktor:ktor-client-curl:${libs.versions.ktor.get()}")
             }
         }
 

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -4,9 +4,9 @@ import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTes
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
 
 plugins {
-    kotlin("multiplatform") version "1.9.23"
-    kotlin("plugin.serialization") version "1.9.23"
-    id("org.jetbrains.dokka") version "1.9.10"
+    alias(libs.plugins.multiplatform)
+    alias(libs.plugins.serialization)
+    alias(libs.plugins.dokka)
     `maven-publish`
 }
 

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -13,17 +13,6 @@ plugins {
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 
 kotlin {
-
-    val bitcoinKmpVersion = "0.20.0" // when upgrading bitcoin-kmp, keep secpJniJvmVersion in sync!
-    val secpJniJvmVersion = "0.15.0"
-
-    val serializationVersion = "1.6.2"
-    val coroutineVersion = "1.7.3"
-    val datetimeVersion = "0.6.0"
-    val ktorVersion = "2.3.7"
-    fun ktor(module: String) = "io.ktor:ktor-$module:$ktorVersion"
-    val kermitLoggerVersion = "2.0.2"
-
     jvm {
         compilations.all {
             kotlinOptions.jvmTarget = "1.8"
@@ -67,20 +56,20 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api("fr.acinq.bitcoin:bitcoin-kmp:$bitcoinKmpVersion")
-                api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion")
-                api("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
-                api("org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion")
-                api("org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion")
-                api("org.jetbrains.kotlinx:kotlinx-datetime:$datetimeVersion")
-                api("co.touchlab:kermit:$kermitLoggerVersion")
-                api(ktor("network"))
-                api(ktor("network-tls"))
-                implementation(ktor("client-core"))
-                implementation(ktor("client-auth"))
-                implementation(ktor("client-json"))
-                implementation(ktor("client-content-negotiation"))
-                implementation(ktor("serialization-kotlinx-json"))
+                api(libs.bitcoinkmp)
+                api(libs.kotlinx.datetime)
+                api(libs.kotlinx.coroutines.core)
+                api(libs.kotlinx.serialization.core)
+                api(libs.kotlinx.serialization.cbor)
+                api(libs.kotlinx.serialization.json)
+                api(libs.ktor.network)
+                api(libs.ktor.network.tls)
+                implementation(libs.ktor.client.core)
+                implementation(libs.ktor.client.auth)
+                implementation(libs.ktor.client.json)
+                implementation(libs.ktor.client.contentnegotiation)
+                implementation(libs.ktor.serialization.kotlinx.json)
+                api(libs.kermit)
             }
         }
 
@@ -94,8 +83,8 @@ kotlin {
 
         jvmMain {
             dependencies {
-                api(ktor("client-okhttp"))
-                implementation("fr.acinq.secp256k1:secp256k1-kmp-jni-jvm:$secpJniJvmVersion")
+                api(libs.ktor.client.okhttp)
+                implementation(libs.secpjnijvm)
                 implementation("org.slf4j:slf4j-api:1.7.36")
             }
         }
@@ -112,19 +101,19 @@ kotlin {
         if (currentOs.isMacOsX) {
             iosMain {
                 dependencies {
-                    implementation(ktor("client-ios"))
+                    implementation(libs.ktor.client.ios)
                 }
             }
             macosMain {
                 dependencies {
-                    implementation(ktor("client-darwin"))
+                    implementation(libs.ktor.client.darwin)
                 }
             }
         }
 
         linuxMain {
             dependencies {
-                implementation(ktor("client-curl"))
+                implementation(libs.ktor.client.curl)
             }
         }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,37 +14,6 @@ dependencyResolutionManagement {
         mavenCentral()
         google()
     }
-    versionCatalogs {
-        create("libs") {
-            library("bitcoinkmp", "fr.acinq.bitcoin", "bitcoin-kmp").version("0.20.0") // when upgrading bitcoin-kmp, keep secpJniJvmVersion in sync!
-            library("secpjnijvm", "fr.acinq.secp256k1", "secp256k1-kmp-jni-jvm").version("0.15.0")
-
-            library("kotlinx-datetime", "org.jetbrains.kotlinx", "kotlinx-datetime").version("0.6.0")
-
-            version("kotlinx-coroutines", "1.7.3")
-            library("kotlinx-coroutines-core", "org.jetbrains.kotlinx", "kotlinx-coroutines-core").versionRef("kotlinx-coroutines")
-
-            version("kotlinx-serialization", "1.6.2")
-            library("kotlinx-serialization-core", "org.jetbrains.kotlinx", "kotlinx-serialization-core").versionRef("kotlinx-serialization")
-            library("kotlinx-serialization-cbor", "org.jetbrains.kotlinx", "kotlinx-serialization-cbor").versionRef("kotlinx-serialization")
-            library("kotlinx-serialization-json", "org.jetbrains.kotlinx", "kotlinx-serialization-json").versionRef("kotlinx-serialization")
-
-            version("ktor", "2.3.7")
-            library("ktor-network", "io.ktor", "ktor-network").versionRef("ktor")
-            library("ktor-network-tls", "io.ktor", "ktor-network-tls").versionRef("ktor")
-            library("ktor-client-core", "io.ktor", "ktor-client-core").versionRef("ktor")
-            library("ktor-client-auth", "io.ktor", "ktor-client-auth").versionRef("ktor")
-            library("ktor-client-json", "io.ktor", "ktor-client-json").versionRef("ktor")
-            library("ktor-client-contentnegotiation", "io.ktor", "ktor-client-content-negotiation").versionRef("ktor")
-            library("ktor-client-okhttp", "io.ktor", "ktor-client-okhttp").versionRef("ktor")
-            library("ktor-client-ios", "io.ktor", "ktor-client-ios").versionRef("ktor")
-            library("ktor-client-darwin", "io.ktor", "ktor-client-darwin").versionRef("ktor")
-            library("ktor-client-curl", "io.ktor", "ktor-client-curl").versionRef("ktor")
-            library("ktor-serialization-kotlinx-json", "io.ktor", "ktor-serialization-kotlinx-json").versionRef("ktor")
-
-            library("kermit", "co.touchlab", "kermit").version("2.0.2")
-        }
-    }
 }
 
 rootProject.name = "lightning-kmp"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,37 @@ dependencyResolutionManagement {
         mavenCentral()
         google()
     }
+    versionCatalogs {
+        create("libs") {
+            library("bitcoinkmp", "fr.acinq.bitcoin", "bitcoin-kmp").version("0.20.0") // when upgrading bitcoin-kmp, keep secpJniJvmVersion in sync!
+            library("secpjnijvm", "fr.acinq.secp256k1", "secp256k1-kmp-jni-jvm").version("0.15.0")
+
+            library("kotlinx-datetime", "org.jetbrains.kotlinx", "kotlinx-datetime").version("0.6.0")
+
+            version("kotlinx-coroutines", "1.7.3")
+            library("kotlinx-coroutines-core", "org.jetbrains.kotlinx", "kotlinx-coroutines-core").versionRef("kotlinx-coroutines")
+
+            version("kotlinx-serialization", "1.6.2")
+            library("kotlinx-serialization-core", "org.jetbrains.kotlinx", "kotlinx-serialization-core").versionRef("kotlinx-serialization")
+            library("kotlinx-serialization-cbor", "org.jetbrains.kotlinx", "kotlinx-serialization-cbor").versionRef("kotlinx-serialization")
+            library("kotlinx-serialization-json", "org.jetbrains.kotlinx", "kotlinx-serialization-json").versionRef("kotlinx-serialization")
+
+            version("ktor", "2.3.7")
+            library("ktor-network", "io.ktor", "ktor-network").versionRef("ktor")
+            library("ktor-network-tls", "io.ktor", "ktor-network-tls").versionRef("ktor")
+            library("ktor-client-core", "io.ktor", "ktor-client-core").versionRef("ktor")
+            library("ktor-client-auth", "io.ktor", "ktor-client-auth").versionRef("ktor")
+            library("ktor-client-json", "io.ktor", "ktor-client-json").versionRef("ktor")
+            library("ktor-client-contentnegotiation", "io.ktor", "ktor-client-content-negotiation").versionRef("ktor")
+            library("ktor-client-okhttp", "io.ktor", "ktor-client-okhttp").versionRef("ktor")
+            library("ktor-client-ios", "io.ktor", "ktor-client-ios").versionRef("ktor")
+            library("ktor-client-darwin", "io.ktor", "ktor-client-darwin").versionRef("ktor")
+            library("ktor-client-curl", "io.ktor", "ktor-client-curl").versionRef("ktor")
+            library("ktor-serialization-kotlinx-json", "io.ktor", "ktor-serialization-kotlinx-json").versionRef("ktor")
+
+            library("kermit", "co.touchlab", "kermit").version("2.0.2")
+        }
+    }
 }
 
 rootProject.name = "lightning-kmp"


### PR DESCRIPTION
[Version catalog](https://docs.gradle.org/current/userguide/version_catalogs.html) is the best practice for managing dependencies. It makes it easier to track and update versions, and allows to centralize dependencies in a multi-module context. It is an alternative to the `buildSrc` workaround used in some of our projects.

This PR does not update libraries versions.

Each commit offers an alternative approach:
a) define the version catalog in `settings.gradle`
b) define the version catalog in `libs.versions.toml`
c) only manage versions (not full dependencies) in the version catalog

Option c) has my preference because we get all the benefit of centralizing versions, but we don't really need to define all dependencies in the version catalog if they are not used by several modules.