### PR TITLE
[WIP] [RFC] offer: be able to create an offer with description 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=fr.acinq.lightning
-version=1.8.5-SNAPSHOT
+version=1.8.6-SNAPSHOT
 # gradle
 org.gradle.jvmargs=-Xmx1536m
 org.gradle.parallel=true

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -271,4 +271,18 @@ data class NodeParams(
         // If we add a new feature that we would like to use by default, we will need to explicitly create a new offer.
         return OfferTypes.Offer.createBlindedOffer(amount = null, description = null, this, trampolineNodeId, Features.empty, sessionKey)
     }
+
+    /**
+     * FIXME(vincenzopalazzo): Add docs
+     */
+    fun offer(amount: MilliSatoshi?, description: String?, trampolineNodeId: PublicKey): Pair<OfferTypes.Offer, PrivateKey> {
+        // We generate a deterministic blindingSecret based on:
+        //  - a custom tag indicating that this is used in the Bolt 12 context
+        //  - our trampoline node, which is used as an introduction node for the offer's blinded path
+        //  - our private key, which ensures that nobody else can generate the same blindingSecret
+        // FIXME: there is some problem if I change the string prefix? yes I tried and the LSP was rejecting my code
+        val blindingSecret = PrivateKey(Crypto.sha256("bolt 12 default offer".toByteArray(Charsets.UTF_8).byteVector() + trampolineNodeId.value + nodePrivateKey.value).byteVector32())
+        // FIXME: it should be included some additional feature
+        return OfferTypes.Offer.createBlindedOffer(amount = amount, description = description, this, trampolineNodeId, Features.empty, blindingSecret)
+    }
 }


### PR DESCRIPTION
## PR Proposal: Support for Offers with Descriptions in phoenixd

I started exploring `phoenixd` to enable the creation of offers with custom descriptions, allowing users to specify the purpose of their payments.

It is widely recognized that `phoenixd` is one of the best solutions for regular users to operate their own node without having to navigate the complexities of the Lightning Network. However, in the Phoenix mobile wallet, there is currently no option to create offers with custom descriptions beyond the default one. While this limitation exists for valid reasons, I believe it is possible to support this type of offer on the server side. Doing so could unlock new use cases for using Phoenix.

This PR aims to introduce support for creating offers with custom descriptions that work seamlessly with the LSP, just like the default offers.

### Current Status

This PR is a work-in-progress because I believe there are changes required on the LSP side to handle and fetch this new type of invoice. 

I have a partially working version of `phoenixd` based on this commit: [phoenixd branch with description offers](https://github.com/vincenzopalazzo/phoenixd/tree/macros/description-offers). While the modifications in `phoenixd` are functional, the feature is not fully operational due to the LSP's current limitations. I would need guidance on how to modify the LSP to support these changes.

### Request for Feedback

I am opening this PR to gather feedback from the team regarding the following points:

1. Is there interest in supporting offers with custom descriptions in `phoenixd`?
2. If this is not a priority at the moment, I would like to volunteer to maintain this part of the code if it requires ongoing attention.

## Missing steps

- [ ] Polish the code and remove some fixme around the current solution
- [ ] Implementing persistance for the offer generates
- [ ] Adding the endpoint in phoenixd to create an offer with description
- [X] Resolve the LSP part that now it is rejecting the fetchinvoice message for a no default offer