### PR TITLE
Use testnet4 for electrum tests instead of testnet3

### DIFF
--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumUtils.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumUtils.kt
@@ -5,7 +5,7 @@ import fr.acinq.lightning.tests.utils.testLoggerFactory
 import fr.acinq.lightning.utils.ServerAddress
 import kotlinx.coroutines.CoroutineScope
 
-val ElectrumTestnet4ServerAddress = ServerAddress("mempool.space", 40002, TcpSocket.TLS.TRUSTED_CERTIFICATES())
+val ElectrumTestnet4ServerAddress = ServerAddress("mempool.space", 40002, TcpSocket.TLS.UNSAFE_CERTIFICATES)
 val ElectrumMainnetServerAddress = ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES)
 
 suspend fun connectToElectrumServer(scope: CoroutineScope, addr: ServerAddress): ElectrumClient =

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumUtils.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumUtils.kt
@@ -5,12 +5,12 @@ import fr.acinq.lightning.tests.utils.testLoggerFactory
 import fr.acinq.lightning.utils.ServerAddress
 import kotlinx.coroutines.CoroutineScope
 
-val ElectrumTestnetServerAddress = ServerAddress("testnet1.electrum.acinq.co", 51002, TcpSocket.TLS.UNSAFE_CERTIFICATES)
+val ElectrumTestnet4ServerAddress = ServerAddress("mempool.space", 40002, TcpSocket.TLS.TRUSTED_CERTIFICATES())
 val ElectrumMainnetServerAddress = ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES)
 
 suspend fun connectToElectrumServer(scope: CoroutineScope, addr: ServerAddress): ElectrumClient =
     ElectrumClient(scope, testLoggerFactory).apply { connect(addr, TcpSocket.Builder()) }
 
-suspend fun CoroutineScope.connectToTestnetServer(): ElectrumClient = connectToElectrumServer(this, ElectrumTestnetServerAddress)
+suspend fun CoroutineScope.connectToTestnet4Server(): ElectrumClient = connectToElectrumServer(this, ElectrumTestnet4ServerAddress)
 
 suspend fun CoroutineScope.connectToMainnetServer(): ElectrumClient = connectToElectrumServer(this, ElectrumMainnetServerAddress)

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInWalletTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInWalletTestsCommon.kt
@@ -18,9 +18,9 @@ class SwapInWalletTestsCommon : LightningTestSuite() {
     @Test
     fun `swap-in wallet test`() = runSuspendTest(timeout = 15.seconds) {
         val mnemonics = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" ")
-        val keyManager = LocalKeyManager(MnemonicCode.toSeed(mnemonics, "").toByteVector(), Chain.Testnet3, TestConstants.aliceSwapInServerXpub)
-        val client = connectToTestnetServer()
-        val wallet = SwapInWallet(Chain.Testnet3, keyManager.swapInOnChainWallet, client, this, loggerFactory)
+        val keyManager = LocalKeyManager(MnemonicCode.toSeed(mnemonics, "").toByteVector(), Chain.Testnet4, TestConstants.aliceSwapInServerXpub)
+        val client = connectToTestnet4Server()
+        val wallet = SwapInWallet(Chain.Testnet4, keyManager.swapInOnChainWallet, client, this, loggerFactory)
 
         // addresses 0 to 3 have funds on them, the current address is the 4th
         assertEquals(4, wallet.swapInAddressFlow.filterNotNull().first().second)


### PR DESCRIPTION
Testnet3 is bloated, slow and unreliable, making it hard to use for CI tests.