### PR TITLE
Correctly set `next_commitment_number` during splice reconnect

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
@@ -1028,6 +1028,11 @@ data class InteractiveTxSigningSession(
         is Either.Left -> localCommit.value.commitTx.input
         is Either.Right -> localCommit.value.publishableTxs.commitTx.input
     }
+    // This value tells our peer whether we need them to retransmit their commit_sig on reconnection or not.
+    val reconnectNextLocalCommitmentNumber = when (localCommit) {
+        is Either.Left -> localCommit.value.index
+        is Either.Right -> localCommit.value.index + 1
+    }
 
     fun receiveCommitSig(channelKeys: KeyManager.ChannelKeys, channelParams: ChannelParams, remoteCommitSig: CommitSig, currentBlockHeight: Long, logger: MDCLogger): Pair<InteractiveTxSigningSession, InteractiveTxSigningSessionAction> {
         return when (localCommit) {


### PR DESCRIPTION
As pointed out in https://github.com/lightning/bolts/pull/1214, when reconnecting a partially signed `interactive-tx` session, we should set `next_commitment_number` to the current commitment number if we haven't received our peer's `commit_sig`, which tells them they need to retransmit it.

More importantly, if our peer behaves correctly and sends us the current commitment number, we must not think that they're late and halt, waiting for them to send `error`. This commit fixes that by allowing our peers to use the current commitment number when they set `next_funding_txid`.

Note that we keep retransmitting our `commit_sig` regardless of the value our peer set in `next_commitment_number`, because we need to wait for them to have an opportunity to upgrade. In a future commit we will stop sending spurious `commit_sig`.

This PR must only be merged once https://github.com/ACINQ/eclair/pull/2965 has been deployed on the ACINQ node.