### PR TITLE
Update build documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -34,8 +34,8 @@ cd lightning-kmp
 To build the project library and install it locally, you can run:
 
 ```sh
-./gradlew :build
-./gradlew :publishToMavenLocal
+./gradlew build
+./gradlew publishToMavenLocal
 ```
 
 To run all tests on all platforms:


### PR DESCRIPTION
While working on the library, I noticed that I couldn't access it in the Maven local repository. After some research, I discovered that the build system was no longer compatible with the local Maven repository.

I'm a bit rusty with Gradle, so please let me know if I'm missing anything here!

Additionally, I included a small update to the documentation by describing the error in the commit message.