### PR TITLE
[RFC] Allow to create and persist offers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=fr.acinq.lightning
-version=1.8.5-SNAPSHOT
+version=1.8.6-SNAPSHOT
 # gradle
 org.gradle.jvmargs=-Xmx1536m
 org.gradle.parallel=true

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -197,6 +197,10 @@ publishing {
             }
         }
     }
+
+    repositories {
+        mavenLocal()
+    }
 }
 
 // Disable cross compilation

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/Databases.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/Databases.kt
@@ -3,4 +3,5 @@ package fr.acinq.lightning.db
 interface Databases {
     val channels: ChannelsDb
     val payments: PaymentsDb
+    val offers: OffersDb
 }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/OffersDb.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/OffersDb.kt
@@ -1,0 +1,22 @@
+package fr.acinq.lightning.db
+
+import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.lightning.wire.OfferTypes
+
+/**
+ * This interface is used to store the offers created by the user.
+ *
+ * An implementor of this interface should keep in mind that an
+ * offer could be reconstructed using the `secret`, amount and/or
+ * description.
+ */
+interface OffersDb {
+    /* Add a new offer just created by the user */
+    suspend fun addOffer(offer: OfferTypes.Offer, secret: PrivateKey)
+
+    /* List all the offers stored in the db and the secret */
+    suspend fun listOffers(): List<Pair<PrivateKey, OfferTypes.Offer>>
+
+    /* Revoke an offer by a given secret */
+    suspend fun revokingOffer(secret: PrivateKey)
+}

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -348,6 +348,10 @@ class Peer(
                 previousState = it
             }
         }
+
+        launch {
+            reloadOffersFromPersistance()
+        }
     }
 
     data class ConnectionJob(val job: Job, val socket: TcpSocket) {
@@ -750,6 +754,16 @@ class Peer(
         offerManager.registerOffer(offer, secret.value)
         db.offers.addOffer(offer, secret)
         return offer
+    }
+
+    /**
+     * Reload the offers from the database to allow to reuse custom offers across restarts.
+     */
+    suspend fun reloadOffersFromPersistance() {
+        val offers = db.offers.listOffers()
+        offers.forEach { (pathId, offer) ->
+            offerManager.registerOffer(offer, pathId.value)
+        }
     }
 
     // The (node_id, fcm_token) tuple only needs to be registered once.

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -741,6 +741,17 @@ class Peer(
         return incomingPaymentHandler.createInvoice(paymentPreimage, amount, description, extraHops, expiry ?: nodeParams.bolt11InvoiceExpiry)
     }
 
+    /** Creates a custom offer and register it with the `offerManager`.
+     *  @param secret A random private key for creating the blinded path of the offer. Must be unique to this offer.
+     *  The offer returned is deterministic, if you need to persist you just need to save the parameters used to create it.
+     */
+    fun createOffer(secret: PrivateKey, amount: MilliSatoshi?, description: String?): OfferTypes.Offer {
+        val pathId = secret.value
+        val (offer, _) = OfferTypes.Offer.createBlindedOffer(amount, description, nodeParams, remoteNodeId, Features.empty, secret, pathId)
+        offerManager.registerOffer(offer, pathId)
+        return offer
+    }
+
     // The (node_id, fcm_token) tuple only needs to be registered once.
     // And after that, only if the tuple changes (e.g. different fcm_token).
     fun registerFcmToken(token: String?) {

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -745,10 +745,10 @@ class Peer(
      *  @param secret A random private key for creating the blinded path of the offer. Must be unique to this offer.
      *  The offer returned is deterministic, if you need to persist you just need to save the parameters used to create it.
      */
-    fun createOffer(secret: PrivateKey, amount: MilliSatoshi?, description: String?): OfferTypes.Offer {
-        val pathId = secret.value
-        val (offer, _) = OfferTypes.Offer.createBlindedOffer(amount, description, nodeParams, remoteNodeId, Features.empty, secret, pathId)
-        offerManager.registerOffer(offer, pathId)
+    suspend fun createOffer(secret: PrivateKey, amount: MilliSatoshi?, description: String?): OfferTypes.Offer {
+        val (offer, _) = OfferTypes.Offer.createBlindedOffer(amount, description, nodeParams, remoteNodeId, Features.empty, secret)
+        offerManager.registerOffer(offer, secret.value)
+        db.offers.addOffer(offer, secret)
         return offer
     }
 

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/InMemoryDatabases.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/InMemoryDatabases.kt
@@ -6,9 +6,10 @@ package fr.acinq.lightning.db
  */
 data class InMemoryDatabases(
     override val channels: InMemoryChannelsDb,
-    override val payments: InMemoryPaymentsDb
+    override val payments: InMemoryPaymentsDb,
+    override val offers: InMemoryOffersDb
 ) : Databases {
     companion object {
-        operator fun invoke() = InMemoryDatabases(InMemoryChannelsDb(), InMemoryPaymentsDb())
+        operator fun invoke() = InMemoryDatabases(InMemoryChannelsDb(), InMemoryPaymentsDb(), InMemoryOffersDb())
     }
 }

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/InMemoryOffersDb.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/InMemoryOffersDb.kt
@@ -1,0 +1,20 @@
+package fr.acinq.lightning.db
+
+import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.lightning.wire.OfferTypes
+
+class InMemoryOffersDb: OffersDb {
+    private val offers = HashMap<PrivateKey, OfferTypes.Offer>()
+    
+    override suspend fun addOffer(offer: OfferTypes.Offer, secret: PrivateKey) {
+        offers.put(secret, offer)
+    }
+
+    override suspend fun listOffers(): List<Pair<PrivateKey, OfferTypes.Offer>> {
+        return offers.toList()
+    }
+
+    override suspend fun revokingOffer(secret: PrivateKey) {
+        offers.remove(secret)
+    }
+}

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
@@ -4,6 +4,7 @@ import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.PrivateKey
 import fr.acinq.bitcoin.utils.Either
 import fr.acinq.lightning.*
+import fr.acinq.lightning.Lightning.randomBytes32
 import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.crypto.RouteBlinding
 import fr.acinq.lightning.crypto.sphinx.DecryptedPacket
@@ -51,6 +52,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
 
     private fun createOffer(offerManager: OfferManager, amount: MilliSatoshi? = null): OfferTypes.Offer {
         val blindingSecret = randomKey()
+        val pathId = randomBytes32()
         val (offer, _) = OfferTypes.Offer.createBlindedOffer(
             amount,
             "Blockaccino",
@@ -58,8 +60,9 @@ class OfferManagerTestsCommon : LightningTestSuite() {
             offerManager.walletParams.trampolineNode.id,
             offerManager.nodeParams.features,
             blindingSecret,
+            pathId,
         )
-        offerManager.registerOffer(offer, null)
+        offerManager.registerOffer(offer, pathId)
         return offer
     }
 

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
@@ -52,7 +52,6 @@ class OfferManagerTestsCommon : LightningTestSuite() {
 
     private fun createOffer(offerManager: OfferManager, amount: MilliSatoshi? = null): OfferTypes.Offer {
         val blindingSecret = randomKey()
-        val pathId = randomBytes32()
         val (offer, _) = OfferTypes.Offer.createBlindedOffer(
             amount,
             "Blockaccino",
@@ -60,9 +59,8 @@ class OfferManagerTestsCommon : LightningTestSuite() {
             offerManager.walletParams.trampolineNode.id,
             offerManager.nodeParams.features,
             blindingSecret,
-            pathId,
         )
-        offerManager.registerOffer(offer, pathId)
+        offerManager.registerOffer(offer, null)
         return offer
     }
 


### PR DESCRIPTION
This is my first version of the solution based on the @thomash-acinq PR to allow creating and making persistent offers that contain an amount and/or a description.

I would like to gain some feedback on the solution proposed and also on the Database interface to find possible optimization.

This is part of the discussion https://github.com/ACINQ/lightning-kmp/pull/729#issuecomment-2490804397

Based on https://github.com/ACINQ/lightning-kmp/pull/678
Build on top https://github.com/ACINQ/lightning-kmp/pull/742