### PR TITLE
(Minor) Move `HopDesc` to inner class

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -394,6 +394,13 @@ data class LightningOutgoingPayment(
         val status: Status,
         val createdAt: Long = currentTimestampMillis()
     ) {
+        data class HopDesc(val nodeId: PublicKey, val nextNodeId: PublicKey, val shortChannelId: ShortChannelId? = null) {
+            override fun toString(): String = when (shortChannelId) {
+                null -> "$nodeId->$nextNodeId"
+                else -> "$nodeId->$shortChannelId->$nextNodeId"
+            }
+        }
+
         sealed class Status {
             data object Pending : Status()
             sealed class Completed : Status() {
@@ -567,11 +574,4 @@ data class ChannelCloseOutgoingPayment(
 ) : OnChainOutgoingPayment() {
     override val amount: MilliSatoshi = (recipientAmount + miningFees).toMilliSatoshi()
     override val fees: MilliSatoshi = miningFees.toMilliSatoshi()
-}
-
-data class HopDesc(val nodeId: PublicKey, val nextNodeId: PublicKey, val shortChannelId: ShortChannelId? = null) {
-    override fun toString(): String = when (shortChannelId) {
-        null -> "$nodeId->$nextNodeId"
-        else -> "$nodeId->$shortChannelId->$nextNodeId"
-    }
 }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
@@ -9,8 +9,8 @@ import fr.acinq.lightning.channel.states.*
 import fr.acinq.lightning.crypto.sphinx.FailurePacket
 import fr.acinq.lightning.crypto.sphinx.PacketAndSecrets
 import fr.acinq.lightning.crypto.sphinx.SharedSecrets
-import fr.acinq.lightning.db.HopDesc
 import fr.acinq.lightning.db.LightningOutgoingPayment
+import fr.acinq.lightning.db.LightningOutgoingPayment.Part.HopDesc
 import fr.acinq.lightning.db.OutgoingPaymentsDb
 import fr.acinq.lightning.io.PayInvoice
 import fr.acinq.lightning.io.WrappedChannelCommand

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/payment/v1/Deserialization.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/payment/v1/Deserialization.kt
@@ -188,7 +188,7 @@ object Deserialization {
                 id = readUuid(),
                 amount = readNumber().msat,
                 route = readCollection {
-                    HopDesc(
+                    LightningOutgoingPayment.Part.HopDesc(
                         nodeId = readPublicKey(),
                         nextNodeId = readPublicKey(),
                         shortChannelId = readNullable { ShortChannelId(readNumber()) }

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/db/PaymentsDbTestsCommon.kt
@@ -1,10 +1,14 @@
 package fr.acinq.lightning.db
 
-import fr.acinq.bitcoin.*
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.Chain
+import fr.acinq.bitcoin.Crypto
+import fr.acinq.bitcoin.TxId
 import fr.acinq.bitcoin.utils.Either
 import fr.acinq.lightning.*
 import fr.acinq.lightning.Lightning.randomBytes32
 import fr.acinq.lightning.Lightning.randomKey
+import fr.acinq.lightning.db.LightningOutgoingPayment.Part.HopDesc
 import fr.acinq.lightning.payment.Bolt11Invoice
 import fr.acinq.lightning.payment.FinalFailure
 import fr.acinq.lightning.tests.utils.LightningTestSuite


### PR DESCRIPTION
For consistency with other classes in the same file.

This is a follow-up to #738.