### PR TITLE
Add a `succeededAt` timestamp to payments

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelAction.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/ChannelAction.kt
@@ -6,7 +6,7 @@ import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.NodeEvents
 import fr.acinq.lightning.blockchain.Watch
 import fr.acinq.lightning.channel.states.PersistedChannelState
-import fr.acinq.lightning.db.ChannelClosingType
+import fr.acinq.lightning.db.ChannelCloseOutgoingPayment.ChannelClosingType
 import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.UUID
 import fr.acinq.lightning.wire.*

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -15,7 +15,7 @@ import fr.acinq.lightning.channel.Helpers.Closing.claimRemoteCommitTxOutputs
 import fr.acinq.lightning.channel.Helpers.Closing.claimRevokedRemoteCommitTxOutputs
 import fr.acinq.lightning.channel.Helpers.Closing.getRemotePerCommitmentSecret
 import fr.acinq.lightning.crypto.KeyManager
-import fr.acinq.lightning.db.ChannelClosingType
+import fr.acinq.lightning.db.ChannelCloseOutgoingPayment.ChannelClosingType
 import fr.acinq.lightning.logging.LoggingContext
 import fr.acinq.lightning.logging.MDCLogger
 import fr.acinq.lightning.serialization.channel.Encryption.from

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/payment/v1/Deserialization.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/payment/v1/Deserialization.kt
@@ -303,12 +303,12 @@ object Deserialization {
         confirmedAt = readNullable { readNumber() },
         lockedAt = readNullable { readNumber() },
         closingType = when (val discriminator = read()) {
-            0x00 -> ChannelClosingType.Mutual
-            0x01 -> ChannelClosingType.Local
-            0x02 -> ChannelClosingType.Remote
-            0x03 -> ChannelClosingType.Revoked
-            0x04 -> ChannelClosingType.Other
-            else -> error("unknown discriminator $discriminator for class ${ChannelClosingType::class}")
+            0x00 -> ChannelCloseOutgoingPayment.ChannelClosingType.Mutual
+            0x01 -> ChannelCloseOutgoingPayment.ChannelClosingType.Local
+            0x02 -> ChannelCloseOutgoingPayment.ChannelClosingType.Remote
+            0x03 -> ChannelCloseOutgoingPayment.ChannelClosingType.Revoked
+            0x04 -> ChannelCloseOutgoingPayment.ChannelClosingType.Other
+            else -> error("unknown discriminator $discriminator for class ${ChannelCloseOutgoingPayment.ChannelClosingType::class}")
         }
     )
 }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/payment/v1/Serialization.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/payment/v1/Serialization.kt
@@ -354,11 +354,11 @@ object Serialization {
         writeNullable(confirmedAt) { writeNumber(it) }
         writeNullable(lockedAt) { writeNumber(it) }
         when (closingType) {
-            ChannelClosingType.Mutual -> write(0x00)
-            ChannelClosingType.Local -> write(0x01)
-            ChannelClosingType.Remote -> write(0x02)
-            ChannelClosingType.Revoked -> write(0x03)
-            ChannelClosingType.Other -> write(0x04)
+            ChannelCloseOutgoingPayment.ChannelClosingType.Mutual -> write(0x00)
+            ChannelCloseOutgoingPayment.ChannelClosingType.Local -> write(0x01)
+            ChannelCloseOutgoingPayment.ChannelClosingType.Remote -> write(0x02)
+            ChannelCloseOutgoingPayment.ChannelClosingType.Revoked -> write(0x03)
+            ChannelCloseOutgoingPayment.ChannelClosingType.Other -> write(0x04)
         }
     }
 }

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -9,7 +9,8 @@ import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.blockchain.fee.OnChainFeerates
 import fr.acinq.lightning.channel.states.*
 import fr.acinq.lightning.crypto.KeyManager
-import fr.acinq.lightning.db.ChannelClosingType
+import fr.acinq.lightning.db.ChannelCloseOutgoingPayment
+import fr.acinq.lightning.db.ChannelCloseOutgoingPayment.ChannelClosingType
 import fr.acinq.lightning.json.JsonSerializers
 import fr.acinq.lightning.logging.MDCLogger
 import fr.acinq.lightning.logging.mdc
@@ -303,7 +304,7 @@ object TestsHelper {
         actions1.has<ChannelAction.Storage.StoreState>()
         actions1.find<ChannelAction.Storage.StoreOutgoingPayment.ViaClose>().also {
             assertEquals(commitTx.txid, it.txId)
-            assertEquals(ChannelClosingType.Local, it.closingType)
+            assertEquals(ChannelCloseOutgoingPayment.ChannelClosingType.Local, it.closingType)
         }
 
         val localCommitPublished = s1.state.localCommitPublished

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/states/ClosingTestsCommon.kt
@@ -23,7 +23,7 @@ import fr.acinq.lightning.channel.TestsHelper.mutualCloseBob
 import fr.acinq.lightning.channel.TestsHelper.reachNormal
 import fr.acinq.lightning.channel.TestsHelper.remoteClose
 import fr.acinq.lightning.channel.TestsHelper.useAlternativeCommitSig
-import fr.acinq.lightning.db.ChannelClosingType
+import fr.acinq.lightning.db.ChannelCloseOutgoingPayment.ChannelClosingType
 import fr.acinq.lightning.tests.TestConstants
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.transactions.Scripts


### PR DESCRIPTION
Another follow-up to #722 and #738.

This allows separating between a _completed_ payment and a _successful_ payment.

Incoming payments are always successful when they are completed.

Outgoing payments may be completed, but unsuccessful. For example a Lightning outgoing payment is completed when all attempts have been exhausted but no route was found.