### PR TITLE
fixup! Rework liquidity purchase storage in DB (#749)

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -500,7 +500,7 @@ sealed class OnChainOutgoingPayment : OutgoingPayment() {
     /** If some liquidity was purchased, we paid a service fee on top of the mining fee. */
     override val fees: MilliSatoshi get() = miningFee.toMilliSatoshi() + serviceFee
 
-    val liquidityPurchaseDetails: LiquidityAds.LiquidityTransactionDetails? get() = liquidityPurchase?.let { LiquidityAds.LiquidityTransactionDetails(txId, miningFee, it) }
+    abstract val liquidityPurchaseDetails: LiquidityAds.LiquidityTransactionDetails?
 
     /** Helper method to facilitate updating child classes */
     fun setLocked(lockedAt: Long): OnChainOutgoingPayment =
@@ -537,6 +537,7 @@ data class SpliceOutgoingPayment(
     override val lockedAt: Long?,
 ) : OnChainOutgoingPayment() {
     override val amount: MilliSatoshi = recipientAmount.toMilliSatoshi() + fees
+    override val liquidityPurchaseDetails: LiquidityAds.LiquidityTransactionDetails? get() = liquidityPurchase?.let { LiquidityAds.LiquidityTransactionDetails(txId, miningFee, it) }
 }
 
 /** A splice transaction that only bumps the fees of the parent splice transactions. */
@@ -551,6 +552,7 @@ data class SpliceCpfpOutgoingPayment(
 ) : OnChainOutgoingPayment() {
     override val amount: MilliSatoshi = miningFee.toMilliSatoshi()
     override val liquidityPurchase: LiquidityAds.Purchase? = null
+    override val liquidityPurchaseDetails: LiquidityAds.LiquidityTransactionDetails? = null
 }
 
 /** An on-chain transaction that only purchases inbound liquidity, triggered by the wallet user. */
@@ -565,6 +567,7 @@ data class ManualLiquidityPurchasePayment(
     override val lockedAt: Long?,
 ) : OnChainOutgoingPayment() {
     override val amount: MilliSatoshi = fees
+    override val liquidityPurchaseDetails: LiquidityAds.LiquidityTransactionDetails get() = LiquidityAds.LiquidityTransactionDetails(txId, miningFee, liquidityPurchase)
 }
 
 /**
@@ -588,6 +591,7 @@ data class AutomaticLiquidityPurchasePayment(
     val incomingPaymentReceivedAt: Long?,
 ) : OnChainOutgoingPayment() {
     override val amount: MilliSatoshi = fees
+    override val liquidityPurchaseDetails: LiquidityAds.LiquidityTransactionDetails get() = LiquidityAds.LiquidityTransactionDetails(txId, miningFee, liquidityPurchase)
 }
 
 data class ChannelCloseOutgoingPayment(
@@ -612,4 +616,5 @@ data class ChannelCloseOutgoingPayment(
     }
     override val amount: MilliSatoshi = (recipientAmount + miningFee).toMilliSatoshi()
     override val liquidityPurchase: LiquidityAds.Purchase? = null
+    override val liquidityPurchaseDetails: LiquidityAds.LiquidityTransactionDetails? = null
 }

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -873,7 +873,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         //  - After the splice completes, Alice sends a second HTLC to Bob with the funding fee deduced
         //  - Bob accepts the MPP set
         run {
-            val fundingFee = purchase.liquidityPurchaseDetails?.htlcFundingFee
+            val fundingFee = purchase.liquidityPurchaseDetails.htlcFundingFee
             assertNotNull(fundingFee)
             val htlc = makeUpdateAddHtlc(1, channelId, paymentHandler, incomingPayment.paymentHash, makeMppPayload(amount2, totalAmount, paymentSecret), fundingFee = fundingFee)
             assertTrue(htlc.amountMsat < amount2)
@@ -926,7 +926,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         //  - After the splice completes, Alice sends a second HTLC to Bob without deducting the funding fee (it was paid from the channel balance)
         //  - Bob accepts the MPP set
         run {
-            val fundingFee = purchase.liquidityPurchaseDetails?.htlcFundingFee
+            val fundingFee = purchase.liquidityPurchaseDetails.htlcFundingFee
             assertNotNull(fundingFee)
             assertEquals(0.msat, fundingFee.amount)
             val htlc = makeUpdateAddHtlc(7, channelId, paymentHandler, incomingPayment.paymentHash, makeMppPayload(amount, amount, paymentSecret), fundingFee = fundingFee)
@@ -980,7 +980,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         )
         val payment = AutomaticLiquidityPurchasePayment(UUID.randomUUID(), purchase.fees.miningFee, channelId, TxId(randomBytes32()), purchase, 0, null, null, null)
         paymentHandler.db.addOutgoingPayment(payment)
-        val fundingFee = payment.liquidityPurchaseDetails?.htlcFundingFee
+        val fundingFee = payment.liquidityPurchaseDetails.htlcFundingFee
         assertNotNull(fundingFee)
 
         // Step 1 of 2:
@@ -1024,7 +1024,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         )
         val payment = AutomaticLiquidityPurchasePayment(UUID.randomUUID(), purchase.fees.miningFee, channelId, TxId(randomBytes32()), purchase, 0, null, null, null)
         paymentHandler.db.addOutgoingPayment(payment)
-        val fundingFee = payment.liquidityPurchaseDetails?.htlcFundingFee
+        val fundingFee = payment.liquidityPurchaseDetails.htlcFundingFee
         assertNotNull(fundingFee)
         assertTrue(fundingFee.amount > 0.msat)
 
@@ -1063,7 +1063,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         )
         val payment = AutomaticLiquidityPurchasePayment(UUID.randomUUID(), purchase.fees.miningFee, channelId, TxId(randomBytes32()), purchase, 0, null, null, null)
         paymentHandler.db.addOutgoingPayment(payment)
-        val fundingFee = payment.liquidityPurchaseDetails?.htlcFundingFee
+        val fundingFee = payment.liquidityPurchaseDetails.htlcFundingFee
         assertNotNull(fundingFee)
         assertEquals(0.msat, fundingFee.amount)
 
@@ -1091,7 +1091,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         )
         val payment = AutomaticLiquidityPurchasePayment(UUID.randomUUID(), purchase.fees.miningFee, channelId, TxId(randomBytes32()), purchase, 0, null, null, null)
         paymentHandler.db.addOutgoingPayment(payment)
-        val fundingFee = payment.liquidityPurchaseDetails?.htlcFundingFee
+        val fundingFee = payment.liquidityPurchaseDetails.htlcFundingFee
         assertNotNull(fundingFee)
 
         val add = makeUpdateAddHtlc(0, channelId, paymentHandler, incomingPayment.paymentHash, makeMppPayload(defaultAmount, defaultAmount, paymentSecret), fundingFee = fundingFee)
@@ -1727,7 +1727,7 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         )
         val payment = AutomaticLiquidityPurchasePayment(UUID.randomUUID(), purchase.fees.miningFee + 500.sat, channelId, TxId(randomBytes32()), purchase, 0, null, null, null)
         paymentHandler.db.addOutgoingPayment(payment)
-        val fundingFee = payment.liquidityPurchaseDetails?.htlcFundingFee
+        val fundingFee = payment.liquidityPurchaseDetails.htlcFundingFee
         assertNotNull(fundingFee)
         assertTrue(fundingFee.amount > 0.msat)
 


### PR DESCRIPTION
This makes `payment.liquidityPurchaseDetails` return a non-nullable value when the type has a non-nullable `LiquidityAds.Purchase`. It saves unsafe boilerplate when integrating.