### PR TITLE
Forbid concurrent payments with the same `payment_hash`

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
@@ -18,6 +18,7 @@ sealed class FinalFailure {
     fun toPaymentFailure(): OutgoingPaymentFailure = OutgoingPaymentFailure(this, listOf<LightningOutgoingPayment.Part.Status.Failed>())
 
     // @formatter:off
+    data object AlreadyInProgress : FinalFailure() { override fun toString(): String = "another payment is in progress for that invoice" }
     data object AlreadyPaid : FinalFailure() { override fun toString(): String = "this invoice has already been paid" }
     data object InvalidPaymentAmount : FinalFailure() { override fun toString(): String = "payment amount must be positive" }
     data object FeaturesNotSupported : FinalFailure() { override fun toString(): String = "payment request features not supported" }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
@@ -116,9 +116,13 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
             logger.error { "contract violation: caller is recycling uuid's" }
             return Failure(request, FinalFailure.InvalidPaymentId.toPaymentFailure())
         }
-        if (db.listLightningOutgoingPayments(request.paymentHash).find { it.status is LightningOutgoingPayment.Status.Succeeded } != null) {
+        if (db.listLightningOutgoingPayments(request.paymentHash).any { it.status is LightningOutgoingPayment.Status.Succeeded }) {
             logger.error { "invoice has already been paid" }
             return Failure(request, FinalFailure.AlreadyPaid.toPaymentFailure())
+        }
+        if (db.listLightningOutgoingPayments(request.paymentHash).any { it.status is LightningOutgoingPayment.Status.Pending }) {
+            logger.error { "another payment is in progress for that invoice" }
+            return Failure(request, FinalFailure.AlreadyInProgress.toPaymentFailure())
         }
         return sendPaymentInternal(request, listOf(), channels, currentBlockHeight, logger).fold({ it }, { it })
     }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
@@ -116,11 +116,12 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
             logger.error { "contract violation: caller is recycling uuid's" }
             return Failure(request, FinalFailure.InvalidPaymentId.toPaymentFailure())
         }
-        if (db.listLightningOutgoingPayments(request.paymentHash).any { it.status is LightningOutgoingPayment.Status.Succeeded }) {
+        val previousPayments = db.listLightningOutgoingPayments(request.paymentHash)
+        if (previousPayments.any { it.status is LightningOutgoingPayment.Status.Succeeded }) {
             logger.error { "invoice has already been paid" }
             return Failure(request, FinalFailure.AlreadyPaid.toPaymentFailure())
         }
-        if (db.listLightningOutgoingPayments(request.paymentHash).any { it.status is LightningOutgoingPayment.Status.Pending }) {
+        if (previousPayments.any { it.status is LightningOutgoingPayment.Status.Pending }) {
             logger.error { "another payment is in progress for that invoice" }
             return Failure(request, FinalFailure.AlreadyInProgress.toPaymentFailure())
         }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/payment/v1/Deserialization.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/payment/v1/Deserialization.kt
@@ -257,6 +257,7 @@ object Deserialization {
                 0x0a -> FinalFailure.RetryExhausted
                 0x0b -> FinalFailure.UnknownError
                 0x0c -> FinalFailure.WalletRestarted
+                0x0d -> FinalFailure.AlreadyInProgress
                 else -> error("unknown discriminator $failureDiscriminator for class ${LightningOutgoingPayment.Status.Failed::class}")
             },
             completedAt = readNumber()

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/payment/v1/Serialization.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/payment/v1/Serialization.kt
@@ -311,6 +311,8 @@ object Serialization {
                     write(0x0b)
                 FinalFailure.WalletRestarted ->
                     write(0x0c)
+                FinalFailure.AlreadyInProgress ->
+                    write(0x0d)
             }
             writeNumber(o.completedAt)
         }


### PR DESCRIPTION
Concurrent payments with the same `payment_hash` must be rejected, because if any of the payments succeeds, any node in the route could claim the full amount as soon as they learn the preimage.

We only checked that a payment didn't already succeed, but that is not enough: pending payments need to be considered too.