### PR TITLE
(Minor) Emit `PaymentSent` event for `LightningOutgoingPayment`s

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/NodeEvents.kt
@@ -1,8 +1,8 @@
 package fr.acinq.lightning
 
 import fr.acinq.bitcoin.ByteVector32
-import fr.acinq.bitcoin.PublicKey
 import fr.acinq.bitcoin.OutPoint
+import fr.acinq.bitcoin.PublicKey
 import fr.acinq.bitcoin.Satoshi
 import fr.acinq.lightning.blockchain.electrum.WalletState
 import fr.acinq.lightning.channel.ChannelManagementFees
@@ -12,7 +12,6 @@ import fr.acinq.lightning.channel.states.ChannelStateWithCommitments
 import fr.acinq.lightning.channel.states.Normal
 import fr.acinq.lightning.channel.states.WaitForFundingCreated
 import fr.acinq.lightning.db.IncomingPayment
-import fr.acinq.lightning.db.LightningIncomingPayment
 import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.utils.sum
 import fr.acinq.lightning.wire.Init

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandler.kt
@@ -237,6 +237,7 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
         val status = LightningOutgoingPayment.Status.Succeeded(preimage)
         val part = payment.pending.copy(status = LightningOutgoingPayment.Part.Status.Succeeded(preimage))
         val result = LightningOutgoingPayment(payment.request.paymentId, payment.request.amount, payment.request.recipient, payment.request.paymentDetails, listOf(part), status)
+        nodeParams._nodeEvents.emit(PaymentEvents.PaymentSent(result))
         return Success(payment.request, result, preimage)
     }
 
@@ -256,6 +257,7 @@ class OutgoingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
                 // NB: we reload the payment to ensure all parts status are updated
                 // this payment cannot be null
                 val succeeded = db.getLightningOutgoingPayment(payment.id)!!
+                nodeParams._nodeEvents.emit(PaymentEvents.PaymentSent(succeeded))
                 Success(request, succeeded, preimage)
             }
         }

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentHandlerTestsCommon.kt
@@ -21,6 +21,8 @@ import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.tests.utils.runSuspendTest
 import fr.acinq.lightning.utils.*
 import fr.acinq.lightning.wire.*
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.first
 import kotlin.test.*
 
 class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
@@ -270,8 +272,9 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
 
     private suspend fun testSinglePartTrampolinePayment(payment: PayInvoice, invoice: Bolt11Invoice, recipientKey: PrivateKey) {
         val (alice, _) = TestsHelper.reachNormal()
+        val listener = alice.staticParams.nodeParams._nodeEvents.asSharedFlow()
         val walletParams = defaultWalletParams.copy(trampolineFees = listOf(TrampolineFees(3.sat, 10_000, CltvExpiryDelta(144))))
-        val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, walletParams, InMemoryPaymentsDb())
+        val outgoingPaymentHandler = OutgoingPaymentHandler(alice.staticParams.nodeParams, walletParams, InMemoryPaymentsDb())
 
         val result = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to alice.state), TestConstants.defaultBlockHeight) as OutgoingPaymentHandler.Progress
         val (channelId, add) = findAddHtlcCommand(result)
@@ -312,6 +315,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
 
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
         assertDbPaymentSucceeded(outgoingPaymentHandler.db, payment.paymentId, amount = 200_000.msat, fees = 5_000.msat, partsCount = 1)
+        assertIs<PaymentEvents.PaymentSent>(listener.first())
     }
 
     @Test
@@ -584,6 +588,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
     @Test
     fun `success after a wallet restart`() = runSuspendTest {
         val (alice, _) = TestsHelper.reachNormal()
+        val listener = alice.staticParams.nodeParams._nodeEvents.asSharedFlow()
         val preimage = randomBytes32()
         val invoice = makeInvoice(amount = null, supportsTrampoline = true)
         val payment = PayInvoice(UUID.randomUUID(), 550_000.msat, LightningOutgoingPayment.Details.Normal(invoice))
@@ -591,7 +596,7 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
 
         // Step 1: a payment attempt is made.
         val add = run {
-            val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, db)
+            val outgoingPaymentHandler = OutgoingPaymentHandler(alice.staticParams.nodeParams, defaultWalletParams, db)
             val progress = outgoingPaymentHandler.sendPayment(payment, mapOf(alice.channelId to alice.state), TestConstants.defaultBlockHeight)
             assertIs<OutgoingPaymentHandler.Progress>(progress)
             findAddHtlcCommand(progress).second
@@ -599,13 +604,14 @@ class OutgoingPaymentHandlerTestsCommon : LightningTestSuite() {
 
         // Step 2: the wallet restarts and payment succeeds.
         run {
-            val outgoingPaymentHandler = OutgoingPaymentHandler(TestConstants.Alice.nodeParams, defaultWalletParams, db)
+            val outgoingPaymentHandler = OutgoingPaymentHandler(alice.staticParams.nodeParams, defaultWalletParams, db)
             val success = outgoingPaymentHandler.processAddSettledFulfilled(createRemoteFulfill(alice.channelId, add, preimage))
             assertIs<OutgoingPaymentHandler.Success>(success)
             assertEquals(preimage, success.preimage)
             assertEquals(1, success.payment.parts.size)
             assertEquals(payment, success.request)
             assertEquals(preimage, (success.payment.status as LightningOutgoingPayment.Status.Succeeded).preimage)
+            assertIs<PaymentEvents.PaymentSent>(listener.first())
         }
     }
 


### PR DESCRIPTION
We were only emitting those events for `OnChainOutgoingPayment`s.

This is useful for phoenixd websocket/webhook feature.