### PR TITLE
Update bitcoin-kmp and secp256k1-kmp

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,8 @@ kotlinx-coroutines = "1.10.1"
 kotlinx-datetime = "0.6.2"
 kotlinx-serialization = "1.8.0"
 ktor = "2.3.13"
-bitcoinkmp = "0.22.0" # when upgrading bitcoin-kmp, keep secpjnijvm in sync!
-secpjnijvm = "0.17.0"
+bitcoinkmp = "0.21.0" # when upgrading bitcoin-kmp, keep secpjnijvm in sync!
+secpjnijvm = "0.16.0" # just to trigger build...
 kermit = "2.0.5"
 slf4j = "2.0.16"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,8 @@ kotlinx-coroutines = "1.10.1"
 kotlinx-datetime = "0.6.2"
 kotlinx-serialization = "1.8.0"
 ktor = "2.3.13"
-bitcoinkmp = "0.21.0" # when upgrading bitcoin-kmp, keep secpjnijvm in sync!
-secpjnijvm = "0.16.0"
+bitcoinkmp = "0.22.0" # when upgrading bitcoin-kmp, keep secpjnijvm in sync!
+secpjnijvm = "0.17.0"
 kermit = "2.0.5"
 slf4j = "2.0.16"
 


### PR DESCRIPTION
bitcoin-kmp 0.22.0 and secp256k1-kmp 0.17.0 use kotlin 2.1.10 and are available on maven central.