### PR TITLE
Remove amount-based confirmation scaling

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -116,7 +116,7 @@ data class RecipientCltvExpiryParams(val min: CltvExpiryDelta, val max: CltvExpi
  * @param htlcMinimum minimum accepted HTLC value.
  * @param toRemoteDelayBlocks number of blocks our peer will have to wait before they get their main output back in case they force-close a channel.
  * @param maxToLocalDelayBlocks maximum number of blocks we will have to wait before we get our main output back in case we force-close a channel.
- * @param minDepthBlocks minimum depth of a transaction before we consider it safely confirmed: note that it will be scaled based on the amount at stake.
+ * @param minDepthBlocks minimum depth of a transaction before we consider it safe from reorgs.
  * @param feeBase base fee used in our channel_update: since our channels are private and we don't relay payments, this will be basically ignored.
  * @param feeProportionalMillionths proportional fee used in our channel_update: since our channels are private and we don't relay payments, this will be basically ignored.
  * @param pingInterval delay between ping messages.
@@ -236,7 +236,7 @@ data class NodeParams(
         bolt11InvoiceExpiry = 24.hours,
         bolt12InvoiceExpiry = 24.hours,
         htlcMinimum = 1000.msat,
-        minDepthBlocks = 3,
+        minDepthBlocks = 8,
         toRemoteDelayBlocks = CltvExpiryDelta(2016),
         maxToLocalDelayBlocks = CltvExpiryDelta(1008),
         feeBase = 1000.msat,
@@ -259,22 +259,6 @@ data class NodeParams(
             )
         ),
     )
-
-    /**
-     * Returns the number of confirmations needed to consider a transaction irrevocably confirmed
-     * and thus safe from reorgs. We make sure the cumulative block reward largely exceeds the
-     * transaction amount.
-     *
-     * @param amount amount at stake in this transaction.
-     * @return number of confirmations needed.
-     */
-    fun minDepth(amount: Satoshi): Long {
-        val blockReward = 3.125f // this will be too large after the halving in 2028
-        val scalingFactor = 10
-        val btc = amount.toLong().toDouble() / 100_000_000L
-        val blocksToReachFunding = (((scalingFactor * btc) / blockReward) + 1).toLong()
-        return max(minDepthBlocks.toLong(), blocksToReachFunding)
-    }
 
     /**
      * We generate a default, deterministic Bolt 12 offer based on the node's seed and its trampoline node.

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/WatcherTypes.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/WatcherTypes.kt
@@ -17,12 +17,12 @@ data class WatchConfirmed(
     val txId: TxId,
     // We need a public key script to use electrum apis.
     val publicKeyScript: ByteVector,
-    val minDepth: Long,
+    val minDepth: Int,
     val event: OnChainEvent,
 ) : Watch() {
     // If we have the entire transaction, we can get the redeemScript from the witness, and re-compute the publicKeyScript.
     // We support both p2pkh and p2wpkh scripts.
-    constructor(channelId: ByteVector32, tx: Transaction, minDepth: Long, event: OnChainEvent) : this(
+    constructor(channelId: ByteVector32, tx: Transaction, minDepth: Int, event: OnChainEvent) : this(
         channelId,
         tx.txid,
         if (tx.txOut.isEmpty()) ByteVector.empty else tx.txOut[0].publicKeyScript,

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcher.kt
@@ -247,7 +247,7 @@ class ElectrumWatcher(val client: IElectrumClient, val scope: CoroutineScope, lo
                                     val parentTxid = tx.txIn[0].outPoint.txid
                                     logger.info { "txid=${tx.txid} has a relative timeout of $csvTimeout blocks, watching parenttxid=$parentTxid tx=$tx" }
                                     val parentPublicKeyScript = WatchConfirmed.extractPublicKeyScript(tx.txIn.first().witness)
-                                    addWatch(WatchConfirmed(ByteVector32.Zeroes, parentTxid, parentPublicKeyScript, csvTimeout, WatchConfirmed.ParentTxConfirmed(tx)))
+                                    addWatch(WatchConfirmed(ByteVector32.Zeroes, parentTxid, parentPublicKeyScript, csvTimeout.toInt(), WatchConfirmed.ParentTxConfirmed(tx)))
                                 }
 
                                 cltvTimeout > blockCount -> {

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -586,10 +586,6 @@ data class Commitments(
     val remoteCommitIndex = active.first().remoteCommit.index
     val nextRemoteCommitIndex = remoteCommitIndex + 1
 
-    // While we have multiple active commitments, we use the min or max depending on the scenario.
-    val capacityMin = active.minOf { it.fundingAmount }
-    val capacityMax = active.maxOf { it.fundingAmount }
-
     fun availableBalanceForSend(): MilliSatoshi = active.minOf { it.availableBalanceForSend(params, changes) }
     fun availableBalanceForReceive(): MilliSatoshi = active.minOf { it.availableBalanceForReceive(params, changes) }
 

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -157,11 +157,7 @@ object Helpers {
     fun LoggingContext.watchConfirmedIfNeeded(nodeParams: NodeParams, channelId: ByteVector32, txs: List<Transaction>, irrevocablySpent: Map<OutPoint, Transaction>): List<ChannelAction.Blockchain.SendWatch> {
         val (skip, process) = txs.partition { it.inputsAlreadySpent(irrevocablySpent) }
         skip.forEach { tx -> logger.info { "no need to watch txid=${tx.txid}, it has already been confirmed" } }
-        return process.map { tx ->
-            // Those are channel force-close transactions, which don't include a change output: every output is potentially at stake.
-            val minDepth = nodeParams.minDepth(tx.txOut.map { it.amount }.sum())
-            ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, tx, minDepth, WatchConfirmed.ClosingTxConfirmed))
-        }
+        return process.map { tx -> ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, tx, nodeParams.minDepthBlocks, WatchConfirmed.ClosingTxConfirmed)) }
     }
 
     /** This helper method will watch txs only if the utxo they spend hasn't already been irrevocably spent. */

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -192,7 +192,7 @@ sealed class ChannelState {
 
     internal fun ChannelContext.doPublish(tx: ClosingTx, channelId: ByteVector32): List<ChannelAction.Blockchain> = listOf(
         ChannelAction.Blockchain.PublishTx(tx),
-        ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, tx.tx, staticParams.nodeParams.minDepth(tx.amountIn), WatchConfirmed.ClosingTxConfirmed))
+        ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, tx.tx, staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ClosingTxConfirmed))
     )
 
     internal suspend fun ChannelContext.handleLocalError(cmd: ChannelCommand, t: Throwable): Pair<ChannelState, List<ChannelAction>> {
@@ -458,7 +458,7 @@ sealed class ChannelStateWithCommitments : PersistedChannelState() {
             is Commitment -> {
                 logger.warning { "a commit tx for an older commitment has been published fundingTxId=${commitment.fundingTxId} fundingTxIndex=${commitment.fundingTxIndex}" }
                 // We try spending our latest commitment but we also watch their commitment: if it confirms, we will react by spending our corresponding outputs.
-                val watch = ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, w.spendingTx, staticParams.nodeParams.minDepth(commitments.capacityMax), WatchConfirmed.AlternativeCommitTxConfirmed))
+                val watch = ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, w.spendingTx, staticParams.nodeParams.minDepthBlocks, WatchConfirmed.AlternativeCommitTxConfirmed))
                 spendLocalCurrent().run { copy(second = second + watch) }
             }
             else -> {

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
@@ -61,7 +61,7 @@ data class Negotiating(
                                 val actions = listOf(
                                     ChannelAction.Storage.StoreState(nextState),
                                     ChannelAction.Blockchain.PublishTx(signedClosingTx),
-                                    ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, signedClosingTx.tx, staticParams.nodeParams.minDepth(signedClosingTx.amountIn), WatchConfirmed.ClosingTxConfirmed)),
+                                    ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, signedClosingTx.tx, staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ClosingTxConfirmed)),
                                     ChannelAction.Message.Send(closingSig)
                                 )
                                 Pair(nextState, actions)
@@ -83,7 +83,7 @@ data class Negotiating(
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
                                 ChannelAction.Blockchain.PublishTx(signedClosingTx),
-                                ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, signedClosingTx.tx, staticParams.nodeParams.minDepth(signedClosingTx.amountIn), WatchConfirmed.ClosingTxConfirmed)),
+                                ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, signedClosingTx.tx, staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ClosingTxConfirmed)),
                             )
                             Pair(nextState, actions)
                         }
@@ -111,8 +111,7 @@ data class Negotiating(
                     is WatchSpent.ChannelSpent -> when {
                         publishedClosingTxs.any { it.tx.txid == watch.spendingTx.txid } -> {
                             // This is one of the transactions we already published, we watch for confirmations.
-                            val closingTx = publishedClosingTxs.first { it.tx.txid == watch.spendingTx.txid }
-                            val actions = listOf(ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.spendingTx, staticParams.nodeParams.minDepth(closingTx.amountIn), WatchConfirmed.ClosingTxConfirmed)))
+                            val actions = listOf(ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.spendingTx, staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ClosingTxConfirmed)))
                             Pair(this@Negotiating, actions)
                         }
                         proposedClosingTxs.flatMap { it.all }.any { it.tx.txid == watch.spendingTx.txid } -> {
@@ -122,7 +121,7 @@ data class Negotiating(
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
                                 ChannelAction.Blockchain.PublishTx(closingTx),
-                                ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.spendingTx, staticParams.nodeParams.minDepth(closingTx.amountIn), WatchConfirmed.ClosingTxConfirmed))
+                                ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.spendingTx, staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ClosingTxConfirmed))
                             )
                             Pair(nextState, actions)
                         }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -841,8 +841,7 @@ data class Normal(
     ): Pair<Normal, List<ChannelAction>> {
         logger.info { "sending tx_sigs" }
         // We watch for confirmation in all cases, to allow pruning outdated commitments when transactions confirm.
-        val fundingMinDepth = staticParams.nodeParams.minDepth(action.fundingTx.fundingParams.fundingAmount)
-        val watchConfirmed = WatchConfirmed(channelId, action.commitment.fundingTxId, action.commitment.commitInput.txOut.publicKeyScript, fundingMinDepth, WatchConfirmed.ChannelFundingDepthOk)
+        val watchConfirmed = WatchConfirmed(channelId, action.commitment.fundingTxId, action.commitment.commitInput.txOut.publicKeyScript, staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ChannelFundingDepthOk)
         val commitments = commitments.add(action.commitment).copy(remoteChannelData = remoteChannelData)
         val nextState = this@Normal.copy(commitments = commitments, spliceStatus = SpliceStatus.None)
         val actions = buildList {

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Offline.kt
@@ -97,7 +97,7 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
                     is WatchSpentTriggered -> when {
                         state is Negotiating && state.publishedClosingTxs.any { it.tx.txid == watch.spendingTx.txid } -> {
                             // This is one of the transactions we already published, we watch for confirmations.
-                            val actions = listOf(ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.spendingTx, staticParams.nodeParams.minDepth(state.commitments.capacityMax), WatchConfirmed.ClosingTxConfirmed)))
+                            val actions = listOf(ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.spendingTx, staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ClosingTxConfirmed)))
                             Pair(this@Offline, actions)
                         }
                         state is Negotiating && state.proposedClosingTxs.flatMap { it.all }.any { it.tx.txid == watch.spendingTx.txid } -> {
@@ -107,7 +107,7 @@ data class Offline(val state: PersistedChannelState) : ChannelState() {
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
                                 ChannelAction.Blockchain.PublishTx(closingTx),
-                                ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.spendingTx, staticParams.nodeParams.minDepth(state.commitments.capacityMax), WatchConfirmed.ClosingTxConfirmed))
+                                ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.spendingTx, staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ClosingTxConfirmed))
                             )
                             Pair(Offline(nextState), actions)
                         }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Syncing.kt
@@ -250,7 +250,7 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
                     is WatchSpentTriggered -> when {
                         state is Negotiating && state.publishedClosingTxs.any { it.tx.txid == watch.spendingTx.txid } -> {
                             // This is one of the transactions we already published, we watch for confirmations.
-                            val actions = listOf(ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.spendingTx, staticParams.nodeParams.minDepth(state.commitments.capacityMax), WatchConfirmed.ClosingTxConfirmed)))
+                            val actions = listOf(ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.spendingTx, staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ClosingTxConfirmed)))
                             Pair(this@Syncing, actions)
                         }
                         state is Negotiating && state.proposedClosingTxs.flatMap { it.all }.any { it.tx.txid == watch.spendingTx.txid } -> {
@@ -260,7 +260,7 @@ data class Syncing(val state: PersistedChannelState, val channelReestablishSent:
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
                                 ChannelAction.Blockchain.PublishTx(closingTx),
-                                ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.spendingTx, staticParams.nodeParams.minDepth(state.commitments.capacityMax), WatchConfirmed.ClosingTxConfirmed))
+                                ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, watch.spendingTx, staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ClosingTxConfirmed))
                             )
                             Pair(this@Syncing.copy(state = nextState), actions)
                         }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingConfirmed.kt
@@ -324,9 +324,8 @@ data class WaitForFundingConfirmed(
 
     private fun ChannelContext.sendRbfTxSigs(action: InteractiveTxSigningSessionAction.SendTxSigs, remoteChannelData: EncryptedChannelData): Pair<WaitForFundingConfirmed, List<ChannelAction>> {
         logger.info { "rbf funding tx created with txId=${action.fundingTx.txId}, ${action.fundingTx.sharedTx.tx.localInputs.size} local inputs, ${action.fundingTx.sharedTx.tx.remoteInputs.size} remote inputs, ${action.fundingTx.sharedTx.tx.localOutputs.size} local outputs and ${action.fundingTx.sharedTx.tx.remoteOutputs.size} remote outputs" }
-        val fundingMinDepth = staticParams.nodeParams.minDepth(action.fundingTx.fundingParams.fundingAmount)
-        logger.info { "will wait for $fundingMinDepth confirmations" }
-        val watchConfirmed = WatchConfirmed(channelId, action.commitment.fundingTxId, action.commitment.commitInput.txOut.publicKeyScript, fundingMinDepth, WatchConfirmed.ChannelFundingDepthOk)
+        logger.info { "will wait for ${staticParams.nodeParams.minDepthBlocks} confirmations" }
+        val watchConfirmed = WatchConfirmed(channelId, action.commitment.fundingTxId, action.commitment.commitInput.txOut.publicKeyScript, staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ChannelFundingDepthOk)
         val nextState = WaitForFundingConfirmed(
             commitments.add(action.commitment).copy(remoteChannelData = remoteChannelData),
             waitingSinceBlock,

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSigned.kt
@@ -107,8 +107,7 @@ data class WaitForFundingSigned(
     private fun ChannelContext.sendTxSigs(action: InteractiveTxSigningSessionAction.SendTxSigs, remoteChannelData: EncryptedChannelData): Pair<ChannelState, List<ChannelAction>> {
         logger.info { "funding tx created with txId=${action.fundingTx.txId}, ${action.fundingTx.sharedTx.tx.localInputs.size} local inputs, ${action.fundingTx.sharedTx.tx.remoteInputs.size} remote inputs, ${action.fundingTx.sharedTx.tx.localOutputs.size} local outputs and ${action.fundingTx.sharedTx.tx.remoteOutputs.size} remote outputs" }
         // We watch for confirmation in all cases, to allow pruning outdated commitments when transactions confirm.
-        val fundingMinDepth = staticParams.nodeParams.minDepth(action.fundingTx.fundingParams.fundingAmount)
-        val watchConfirmed = WatchConfirmed(channelId, action.commitment.fundingTxId, action.commitment.commitInput.txOut.publicKeyScript, fundingMinDepth, WatchConfirmed.ChannelFundingDepthOk)
+        val watchConfirmed = WatchConfirmed(channelId, action.commitment.fundingTxId, action.commitment.commitInput.txOut.publicKeyScript, staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ChannelFundingDepthOk)
         val commitments = Commitments(
             channelParams,
             CommitmentChanges.init(),
@@ -178,7 +177,7 @@ data class WaitForFundingSigned(
             }
             Pair(nextState, actions)
         } else {
-            logger.info { "will wait for $fundingMinDepth confirmations" }
+            logger.info { "will wait for ${staticParams.nodeParams.minDepthBlocks} confirmations" }
             val nextState = WaitForFundingConfirmed(
                 commitments,
                 currentBlockHeight.toLong(),

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForInit.kt
@@ -74,7 +74,7 @@ data object WaitForInit : ChannelState() {
                 // There can be multiple funding transactions due to rbf, and they can be unconfirmed in any state due to zero-conf.
                 val fundingTxWatches = when (cmd.state) {
                     is ChannelStateWithCommitments -> cmd.state.commitments.active.map { commitment ->
-                        val fundingMinDepth = staticParams.nodeParams.minDepth(commitment.fundingAmount)
+                        val fundingMinDepth = staticParams.nodeParams.minDepthBlocks
                         when (commitment.localFundingStatus) {
                             is LocalFundingStatus.UnconfirmedFundingTx -> WatchConfirmed(cmd.state.channelId, commitment.fundingTxId, commitment.commitInput.txOut.publicKeyScript, fundingMinDepth, WatchConfirmed.ChannelFundingDepthOk)
                             is LocalFundingStatus.ConfirmedFundingTx -> when (commitment.localFundingStatus.shortChannelId) {

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannel.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/WaitForOpenChannel.kt
@@ -39,7 +39,7 @@ data class WaitForOpenChannel(
                         is Either.Right -> {
                             val channelType = res.value
                             val channelFeatures = ChannelFeatures(channelType, localFeatures = localParams.features, remoteFeatures = remoteInit.features)
-                            val minimumDepth = if (staticParams.useZeroConf) 0 else staticParams.nodeParams.minDepth(open.fundingAmount)
+                            val minimumDepth = if (staticParams.useZeroConf) 0 else staticParams.nodeParams.minDepthBlocks
                             val channelKeys = keyManager.channelKeys(localParams.fundingKeyPath)
                             val localFundingPubkey = channelKeys.fundingPubKey(0)
                             val fundingScript = Helpers.Funding.makeFundingPubKeyScript(localFundingPubkey, open.fundingPubkey)
@@ -56,7 +56,7 @@ data class WaitForOpenChannel(
                                 dustLimit = localParams.dustLimit,
                                 maxHtlcValueInFlightMsat = localParams.maxHtlcValueInFlightMsat,
                                 htlcMinimum = localParams.htlcMinimum,
-                                minimumDepth = minimumDepth,
+                                minimumDepth = minimumDepth.toLong(),
                                 toSelfDelay = localParams.toSelfDelay,
                                 maxAcceptedHtlcs = localParams.maxAcceptedHtlcs,
                                 fundingPubkey = localFundingPubkey,

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannelTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForAcceptChannelTestsCommon.kt
@@ -209,7 +209,7 @@ class WaitForAcceptChannelTestsCommon : LightningTestSuite() {
             assertEquals(accept.channelType, channelType)
             when (zeroConf) {
                 true -> assertEquals(0, accept.minimumDepth)
-                false -> assertEquals(3, accept.minimumDepth)
+                false -> assertEquals(bob.staticParams.nodeParams.minDepthBlocks.toLong(), accept.minimumDepth)
             }
             return Triple(alice, bob1, accept)
         }

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/states/WaitForFundingSignedTestsCommon.kt
@@ -34,7 +34,7 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
                 assertIs<WaitForFundingConfirmed>(state.state)
                 assertEquals(actions.size, 5)
                 actions.hasOutgoingMessage<TxSignatures>().also { assertFalse(it.channelData.isEmpty()) }
-                actions.findWatch<WatchConfirmed>().also { assertEquals(WatchConfirmed(state.channelId, commitInput.outPoint.txid, commitInput.txOut.publicKeyScript, 3, WatchConfirmed.ChannelFundingDepthOk), it) }
+                actions.findWatch<WatchConfirmed>().also { assertEquals(WatchConfirmed(state.channelId, commitInput.outPoint.txid, commitInput.txOut.publicKeyScript, bob.staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ChannelFundingDepthOk), it) }
                 actions.find<ChannelAction.Storage.StoreIncomingPayment.ViaNewChannel>().also { assertEquals(TestConstants.bobFundingAmount.toMilliSatoshi(), it.amountReceived) }
                 actions.has<ChannelAction.Storage.StoreState>()
                 actions.find<ChannelAction.EmitEvent>().also { assertEquals(ChannelEvents.Created(state.state), it.event) }
@@ -150,7 +150,7 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
             assertTrue(actionsAlice2.hasOutgoingMessage<TxSignatures>().channelData.isEmpty())
             actionsAlice2.has<ChannelAction.Storage.StoreState>()
             val watchConfirmedAlice = actionsAlice2.findWatch<WatchConfirmed>()
-            assertEquals(WatchConfirmed(alice2.channelId, commitInput.outPoint.txid, commitInput.txOut.publicKeyScript, 3, WatchConfirmed.ChannelFundingDepthOk), watchConfirmedAlice)
+            assertEquals(WatchConfirmed(alice2.channelId, commitInput.outPoint.txid, commitInput.txOut.publicKeyScript, alice2.staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ChannelFundingDepthOk), watchConfirmedAlice)
             assertEquals(ChannelEvents.Created(alice2.state), actionsAlice2.find<ChannelAction.EmitEvent>().event)
             val fundingTx = actionsAlice2.find<ChannelAction.Blockchain.PublishTx>().tx
             assertEquals(fundingTx.txid, txSigsBob.txId)
@@ -177,7 +177,7 @@ class WaitForFundingSignedTestsCommon : LightningTestSuite() {
             assertTrue(actionsAlice2.hasOutgoingMessage<TxSignatures>().channelData.isEmpty())
             actionsAlice2.has<ChannelAction.Storage.StoreState>()
             val watchConfirmedAlice = actionsAlice2.findWatch<WatchConfirmed>()
-            assertEquals(WatchConfirmed(alice2.channelId, commitInput.outPoint.txid, commitInput.txOut.publicKeyScript, 3, WatchConfirmed.ChannelFundingDepthOk), watchConfirmedAlice)
+            assertEquals(WatchConfirmed(alice2.channelId, commitInput.outPoint.txid, commitInput.txOut.publicKeyScript, alice2.staticParams.nodeParams.minDepthBlocks, WatchConfirmed.ChannelFundingDepthOk), watchConfirmedAlice)
             val channelEvent = actionsAlice2.find<ChannelAction.Storage.StoreIncomingPayment.ViaNewChannel>()
             assertEquals(channelEvent.txId, txSigsBob.txId)
             val liquidityPurchase = channelEvent.liquidityPurchase

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/tests/TestConstants.kt
@@ -125,6 +125,7 @@ object TestConstants {
                 updateFeeMinDiffRatio = 0.1,
                 feerateTolerance = FeerateTolerance(ratioLow = 0.5, ratioHigh = 5.0)
             ),
+            minDepthBlocks = 3,
             maxHtlcValueInFlightMsat = 1_500_000_000L,
             maxAcceptedHtlcs = 100,
             toRemoteDelayBlocks = CltvExpiryDelta(144),


### PR DESCRIPTION
We previously scaled the number of confirmations based on the channel capacity: however, this doesn't really work with splicing, as shown by the following attack scenario:

- a malicious node opens a very large channel
- we thus wait for more confirmations to protect against reorgs
- they then send lightning payments until all of the balance is on our side of the channel
- we splice-out to shrink the channel to a minimal size
- if we thus us a smaller number of confirmations (because the channel is now small), the malicious node can perform this small reorg and publish one of their revoked commitment

There are more involved variations of this attack, which show that the real amount at stake is potentially much more than a single channel's current capacity. Instead of trying to find a complex solution that would likely have subtle edge cases, it's a lot simpler to always use a static number of confirmations that is large enough to protect against reorgs entirely.