### PR TITLE
Send normal failures for Bolt12 payments

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -702,7 +702,7 @@ data class Commitments(
             // we have already sent a fail/fulfill for this htlc
             CommitmentChanges.alreadyProposed(changes.localChanges.proposed, htlc.id) -> Either.Left(UnknownHtlcId(channelId, cmd.id))
             else -> {
-                when (val result = OutgoingPaymentPacket.buildHtlcFailure(nodeSecret, htlc.paymentHash, htlc.onionRoutingPacket, cmd.reason)) {
+                when (val result = OutgoingPaymentPacket.buildHtlcFailure(nodeSecret, htlc.paymentHash, htlc.onionRoutingPacket, htlc.pathKey, cmd.reason)) {
                     is Either.Right -> {
                         val fail = UpdateFailHtlc(channelId, cmd.id, result.value)
                         Either.Right(Pair(copy(changes = changes.addLocalProposal(fail)), fail))

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/wire/PaymentOnion.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/wire/PaymentOnion.kt
@@ -401,7 +401,6 @@ object PaymentOnion {
     data class ChannelRelayPayload(val records: TlvStream<OnionPaymentPayloadTlv>) : PerHopPayload() {
         val amountToForward = records.get<OnionPaymentPayloadTlv.AmountToForward>()!!.amount
         val outgoingCltv = records.get<OnionPaymentPayloadTlv.OutgoingCltv>()!!.cltv
-        val outgoingChannelId = records.get<OnionPaymentPayloadTlv.OutgoingChannelId>()!!.shortChannelId
 
         override fun write(out: Output) = tlvSerializer.write(records, out)
 
@@ -420,6 +419,16 @@ object PaymentOnion {
 
             fun create(outgoingChannelId: ShortChannelId, amountToForward: MilliSatoshi, outgoingCltv: CltvExpiry): ChannelRelayPayload =
                 ChannelRelayPayload(TlvStream(OnionPaymentPayloadTlv.AmountToForward(amountToForward), OnionPaymentPayloadTlv.OutgoingCltv(outgoingCltv), OnionPaymentPayloadTlv.OutgoingChannelId(outgoingChannelId)))
+        }
+    }
+
+    data class BlindedChannelRelayPayload(val records: TlvStream<OnionPaymentPayloadTlv>) : PerHopPayload() {
+        override fun write(out: Output) = tlvSerializer.write(records, out)
+
+        companion object : PerHopPayloadReader<BlindedChannelRelayPayload> {
+            override fun read(input: Input): Either<InvalidOnionPayload, BlindedChannelRelayPayload> {
+                return PerHopPayload.read(input).map { BlindedChannelRelayPayload(it) }
+            }
         }
     }
 

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandlerTestsCommon.kt
@@ -1768,8 +1768,8 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
 
         assertIs<IncomingPaymentHandler.ProcessAddResult.Rejected>(result)
-        val expectedFailure = InvalidOnionBlinding(hash(add.onionRoutingPacket))
-        val expected = ChannelCommand.Htlc.Settlement.FailMalformed(add.id, expectedFailure.onionHash, expectedFailure.code, commit = true)
+        val expectedFailure = IncorrectOrUnknownPaymentDetails(defaultAmount, TestConstants.defaultBlockHeight.toLong())
+        val expected = ChannelCommand.Htlc.Settlement.Fail(add.id, ChannelCommand.Htlc.Settlement.Fail.Reason.Failure(expectedFailure), commit = true)
         assertEquals(setOf(WrappedChannelCommand(add.channelId, expected)), result.actions.toSet())
     }
 
@@ -1819,8 +1819,8 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
 
         assertIs<IncomingPaymentHandler.ProcessAddResult.Rejected>(result)
-        val expectedFailure = InvalidOnionBlinding(hash(add.onionRoutingPacket))
-        val expected = ChannelCommand.Htlc.Settlement.FailMalformed(add.id, expectedFailure.onionHash, expectedFailure.code, commit = true)
+        val expectedFailure = IncorrectOrUnknownPaymentDetails(amountTooLow, TestConstants.defaultBlockHeight.toLong())
+        val expected = ChannelCommand.Htlc.Settlement.Fail(add.id, ChannelCommand.Htlc.Settlement.Fail.Reason.Failure(expectedFailure), commit = true)
         assertEquals(setOf(WrappedChannelCommand(add.channelId, expected)), result.actions.toSet())
     }
 
@@ -1835,8 +1835,8 @@ class IncomingPaymentHandlerTestsCommon : LightningTestSuite() {
         val result = paymentHandler.process(add, Features.empty, TestConstants.defaultBlockHeight, TestConstants.feeratePerKw, remoteFundingRates = null)
 
         assertIs<IncomingPaymentHandler.ProcessAddResult.Rejected>(result)
-        val expectedFailure = InvalidOnionBlinding(hash(add.onionRoutingPacket))
-        val expected = ChannelCommand.Htlc.Settlement.FailMalformed(add.id, expectedFailure.onionHash, expectedFailure.code, commit = true)
+        val expectedFailure = IncorrectOrUnknownPaymentDetails(metadata.amount, TestConstants.defaultBlockHeight.toLong())
+        val expected = ChannelCommand.Htlc.Settlement.Fail(add.id, ChannelCommand.Htlc.Settlement.Fail.Reason.Failure(expectedFailure), commit = true)
         assertEquals(setOf(WrappedChannelCommand(add.channelId, expected)), result.actions.toSet())
     }
 


### PR DESCRIPTION
Since we are always using 1-hop blinded paths from our LSP to ourselves, there are no public intermediate nodes that could be probed inside that blinded path. The requirement to always return malformed failure is thus unnecessary (and harmful for the payer who doesn't know why the payment failed). We now return normal failures in that case, which should be forwarded by our LSP to the upstream nodes.

This also fixes an issue where non-trampoline blinded payments were not correctly failed because the extraction of the onion shared secret did not uses the `path_key` to derive the blinded onion decryption key.