### PR TITLE
Stateless offers

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/message/OnionMessages.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/message/OnionMessages.kt
@@ -152,7 +152,7 @@ object OnionMessages {
      * @param blindedPrivateKey private key of the blinded node id used in our blinded path.
      * @param pathId path_id that we included in our blinded path for ourselves.
      */
-    data class DecryptedMessage(val content: MessageOnion, val blindedPrivateKey: PrivateKey, val pathId: ByteVector)
+    data class DecryptedMessage(val content: MessageOnion, val blindedPrivateKey: PrivateKey, val pathId: ByteVector?)
 
     fun decryptMessage(privateKey: PrivateKey, msg: OnionMessage, logger: MDCLogger): DecryptedMessage? {
         val blindedPrivateKey = RouteBlinding.derivePrivateKey(privateKey, msg.pathKey)
@@ -182,7 +182,7 @@ object OnionMessages {
                                     val nextMessage = OnionMessage(relayInfo.value.nextPathKeyOverride ?: nextPathKey, decrypted.value.nextPacket)
                                     decryptMessage(privateKey, nextMessage, logger)
                                 }
-                                decrypted.value.isLastPacket -> DecryptedMessage(message, blindedPrivateKey, relayInfo.value.pathId ?: ByteVector32.Zeroes)
+                                decrypted.value.isLastPacket -> DecryptedMessage(message, blindedPrivateKey, relayInfo.value.pathId)
                                 else -> {
                                     logger.warning { "ignoring onion message for which we're not the destination (next_node_id=${relayInfo.value.nextNodeId}, path_id=${relayInfo.value.pathId?.toHex()})" }
                                     null

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
@@ -1,6 +1,7 @@
 package fr.acinq.lightning.payment
 
 import fr.acinq.bitcoin.*
+import fr.acinq.bitcoin.crypto.Pack
 import fr.acinq.bitcoin.utils.Either.Left
 import fr.acinq.bitcoin.utils.Either.Right
 import fr.acinq.lightning.*
@@ -19,7 +20,6 @@ import fr.acinq.lightning.message.OnionMessages.buildMessage
 import fr.acinq.lightning.utils.currentTimestampMillis
 import fr.acinq.lightning.utils.toByteVector
 import fr.acinq.lightning.wire.*
-import fr.acinq.lightning.wire.OfferTypes.OfferTlv
 import kotlinx.coroutines.flow.MutableSharedFlow
 
 sealed class OnionMessageAction {
@@ -53,7 +53,11 @@ class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, v
         val replyPathId = randomBytes32()
         pendingInvoiceRequests[replyPathId] = PendingInvoiceRequest(payOffer, request)
         // We add dummy hops to the reply path: this way the receiver only learns that we're at most 3 hops away from our peer.
-        val replyPathHops = listOf(IntermediateNode(EncodedNodeId.WithPublicKey.Plain(remoteNodeId)), IntermediateNode(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId)), IntermediateNode(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId)))
+        val replyPathHops = listOf(
+            IntermediateNode(EncodedNodeId.WithPublicKey.Plain(remoteNodeId)),
+            IntermediateNode(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId)),
+            IntermediateNode(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId)),
+        )
         val lastHop = Destination.Recipient(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId), replyPathId)
         val replyPath = OnionMessages.buildRoute(randomKey(), replyPathHops, lastHop)
         val messageContent = TlvStream(OnionMessagePayloadTlv.ReplyPath(replyPath), OnionMessagePayloadTlv.InvoiceRequest(request.records))
@@ -77,8 +81,13 @@ class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, v
         return OnionMessages.decryptMessage(nodeParams.nodePrivateKey, msg, logger)?.let { decrypted ->
             val invoiceRequestTlvs = decrypted.content.records.get<OnionMessagePayloadTlv.InvoiceRequest>()?.tlvs
             when {
-                invoiceRequestTlvs != null ->
-                    receiveInvoiceRequest(invoiceRequestTlvs, decrypted.pathId, decrypted.blindedPrivateKey, decrypted.content.replyPath, remoteChannelUpdates, currentBlockHeight)
+                invoiceRequestTlvs != null -> when (val invoiceRequest = OfferTypes.InvoiceRequest.validate(invoiceRequestTlvs)) {
+                    is Left -> {
+                        logger.warning { "received invalid invoice_request: ${invoiceRequest.value}" }
+                        null
+                    }
+                    is Right -> receiveInvoiceRequest(invoiceRequest.value, decrypted.pathId, decrypted.blindedPrivateKey, decrypted.content.replyPath, remoteChannelUpdates, currentBlockHeight)
+                }
                 pendingInvoiceRequests.containsKey(decrypted.pathId) -> {
                     val (payOffer, request) = pendingInvoiceRequests[decrypted.pathId]!!
                     pendingInvoiceRequests.remove(decrypted.pathId)
@@ -121,86 +130,81 @@ class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, v
         }
     }
 
-    private fun receiveInvoiceRequest(requestTlvs: TlvStream<OfferTypes.InvoiceRequestTlv>, pathId: ByteVector?, blindedPrivateKey: PrivateKey, replyPath: RouteBlinding.BlindedRoute?, remoteChannelUpdates: List<ChannelUpdate>, currentBlockHeight: Int): OnionMessageAction.SendMessage? {
-        return OfferTypes.InvoiceRequest.validate(requestTlvs).fold({
-            logger.warning { "invalid invoice request: $it" }
-            null
-        }, { request ->
-            // We must use the most restrictive minimum HTLC value between local and remote.
-            val minHtlc = (listOf(nodeParams.htlcMinimum) + remoteChannelUpdates.map { it.htlcMinimumMsat }).max()
-            return when {
-                replyPath == null -> {
-                    logger.warning { "offerId:${request.offer.offerId} ignoring invoice request: no reply path" }
-                    null
-                }
-                !nodeParams.isOurOffer(walletParams.trampolineNode.id, request.offer, pathId, blindedPrivateKey) -> {
-                    logger.warning { "ignoring invoice request for offer that is not ours" }
-                    null
-                }
-                !request.isValid() -> {
-                    logger.warning { "offerId:${request.offer.offerId} ignoring invalid invoice request" }
-                    sendInvoiceError("ignoring invalid invoice request", replyPath)
-                }
-                request.requestedAmount < minHtlc -> {
-                    logger.warning { "offerId:${request.offer.offerId} amount too low (amount=${request.requestedAmount} minHtlc=$minHtlc)" }
-                    sendInvoiceError("amount too low, minimum amount = $minHtlc", replyPath)
-                }
-                else -> {
-                    val amount = request.requestedAmount
-                    val preimage = randomBytes32()
-                    val truncatedPayerNote = request.payerNote?.let {
-                        if (it.length <= 64) {
-                            it
-                        } else {
-                            it.take(63) + "…"
-                        }
+    private fun receiveInvoiceRequest(request: OfferTypes.InvoiceRequest, pathId: ByteVector?, blindedPrivateKey: PrivateKey, replyPath: RouteBlinding.BlindedRoute?, remoteChannelUpdates: List<ChannelUpdate>, currentBlockHeight: Int): OnionMessageAction.SendMessage? {
+        // We must use the most restrictive minimum HTLC value between local and remote.
+        val minHtlc = (listOf(nodeParams.htlcMinimum) + remoteChannelUpdates.map { it.htlcMinimumMsat }).max()
+        return when {
+            replyPath == null -> {
+                logger.warning { "offerId:${request.offer.offerId} ignoring invoice request: no reply path" }
+                null
+            }
+            !isOurOffer(request.offer, pathId, blindedPrivateKey) -> {
+                logger.warning { "ignoring invoice request for offer that is not ours" }
+                null
+            }
+            !request.isValid() -> {
+                logger.warning { "offerId:${request.offer.offerId} ignoring invalid invoice request" }
+                sendInvoiceError("ignoring invalid invoice request", replyPath)
+            }
+            request.requestedAmount < minHtlc -> {
+                logger.warning { "offerId:${request.offer.offerId} amount too low (amount=${request.requestedAmount} minHtlc=$minHtlc)" }
+                sendInvoiceError("amount too low, minimum amount = $minHtlc", replyPath)
+            }
+            else -> {
+                val amount = request.requestedAmount
+                val preimage = randomBytes32()
+                val truncatedPayerNote = request.payerNote?.let {
+                    if (it.length <= 64) {
+                        it
+                    } else {
+                        it.take(63) + "…"
                     }
-                    val metadata = OfferPaymentMetadata.V1(request.offer.offerId, amount, preimage, request.payerId, truncatedPayerNote, request.quantity, currentTimestampMillis()).toPathId(nodeParams.nodePrivateKey)
-                    val recipientPayload = RouteBlindingEncryptedData(TlvStream(RouteBlindingEncryptedDataTlv.PathId(metadata))).write().toByteVector()
-                    val cltvExpiryDelta = remoteChannelUpdates.maxOfOrNull { it.cltvExpiryDelta } ?: walletParams.invoiceDefaultRoutingFees.cltvExpiryDelta
-                    val paymentInfo = OfferTypes.PaymentInfo(
-                        feeBase = remoteChannelUpdates.maxOfOrNull { it.feeBaseMsat } ?: walletParams.invoiceDefaultRoutingFees.feeBase,
-                        feeProportionalMillionths = remoteChannelUpdates.maxOfOrNull { it.feeProportionalMillionths } ?: walletParams.invoiceDefaultRoutingFees.feeProportional,
-                        // We include our min_final_cltv_expiry_delta in the path, but we *don't* include it in the payment_relay field
-                        // for our trampoline node (below). This ensures that we will receive payments with at least this final expiry delta.
-                        // This ensures that even when payers haven't received the latest block(s) or don't include a safety margin in the
-                        // expiry they use, we can still safely receive their payment.
-                        cltvExpiryDelta = cltvExpiryDelta + nodeParams.minFinalCltvExpiryDelta,
-                        minHtlc = minHtlc,
-                        // Payments are allowed to overpay at most two times the invoice amount.
-                        maxHtlc = amount * 2,
-                        allowedFeatures = Features.empty
+                }
+                val metadata = OfferPaymentMetadata.V1(request.offer.offerId, amount, preimage, request.payerId, truncatedPayerNote, request.quantity, currentTimestampMillis()).toPathId(nodeParams.nodePrivateKey)
+                val recipientPayload = RouteBlindingEncryptedData(TlvStream(RouteBlindingEncryptedDataTlv.PathId(metadata))).write().toByteVector()
+                val cltvExpiryDelta = remoteChannelUpdates.maxOfOrNull { it.cltvExpiryDelta } ?: walletParams.invoiceDefaultRoutingFees.cltvExpiryDelta
+                val paymentInfo = OfferTypes.PaymentInfo(
+                    feeBase = remoteChannelUpdates.maxOfOrNull { it.feeBaseMsat } ?: walletParams.invoiceDefaultRoutingFees.feeBase,
+                    feeProportionalMillionths = remoteChannelUpdates.maxOfOrNull { it.feeProportionalMillionths } ?: walletParams.invoiceDefaultRoutingFees.feeProportional,
+                    // We include our min_final_cltv_expiry_delta in the path, but we *don't* include it in the payment_relay field
+                    // for our trampoline node (below). This ensures that we will receive payments with at least this final expiry delta.
+                    // This ensures that even when payers haven't received the latest block(s) or don't include a safety margin in the
+                    // expiry they use, we can still safely receive their payment.
+                    cltvExpiryDelta = cltvExpiryDelta + nodeParams.minFinalCltvExpiryDelta,
+                    minHtlc = minHtlc,
+                    // Payments are allowed to overpay at most two times the invoice amount.
+                    maxHtlc = amount * 2,
+                    allowedFeatures = Features.empty
+                )
+                // Once the invoice expires, the blinded path shouldn't be usable anymore.
+                // We assume 10 minutes between each block to convert the invoice expiry to a cltv_expiry_delta.
+                // When paying the invoice, payers may add any number of blocks to the current block height to protect recipient privacy.
+                // We assume that they won't add more than 720 blocks, which is reasonable because adding a large delta increases the risk
+                // that intermediate nodes reject the payment because they don't want their funds potentially locked for a long duration.
+                val pathExpiry = (paymentInfo.cltvExpiryDelta + CltvExpiryDelta(720) + (nodeParams.bolt12InvoiceExpiry.inWholeMinutes.toInt() / 10)).toCltvExpiry(currentBlockHeight.toLong())
+                val remoteNodePayload = RouteBlindingEncryptedData(
+                    TlvStream(
+                        RouteBlindingEncryptedDataTlv.OutgoingNodeId(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId)),
+                        RouteBlindingEncryptedDataTlv.PaymentRelay(cltvExpiryDelta, paymentInfo.feeProportionalMillionths, paymentInfo.feeBase),
+                        RouteBlindingEncryptedDataTlv.PaymentConstraints(pathExpiry, paymentInfo.minHtlc)
                     )
-                    // Once the invoice expires, the blinded path shouldn't be usable anymore.
-                    // We assume 10 minutes between each block to convert the invoice expiry to a cltv_expiry_delta.
-                    // When paying the invoice, payers may add any number of blocks to the current block height to protect recipient privacy.
-                    // We assume that they won't add more than 720 blocks, which is reasonable because adding a large delta increases the risk
-                    // that intermediate nodes reject the payment because they don't want their funds potentially locked for a long duration.
-                    val pathExpiry = (paymentInfo.cltvExpiryDelta + CltvExpiryDelta(720) + (nodeParams.bolt12InvoiceExpiry.inWholeMinutes.toInt() / 10)).toCltvExpiry(currentBlockHeight.toLong())
-                    val remoteNodePayload = RouteBlindingEncryptedData(
-                        TlvStream(
-                            RouteBlindingEncryptedDataTlv.OutgoingNodeId(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId)),
-                            RouteBlindingEncryptedDataTlv.PaymentRelay(cltvExpiryDelta, paymentInfo.feeProportionalMillionths, paymentInfo.feeBase),
-                            RouteBlindingEncryptedDataTlv.PaymentConstraints(pathExpiry, paymentInfo.minHtlc)
-                        )
-                    ).write().toByteVector()
-                    val blindedRoute = RouteBlinding.create(randomKey(), listOf(remoteNodeId, nodeParams.nodeId), listOf(remoteNodePayload, recipientPayload)).route
-                    val path = Bolt12Invoice.Companion.PaymentBlindedContactInfo(OfferTypes.ContactInfo.BlindedPath(blindedRoute), paymentInfo)
-                    val invoice = Bolt12Invoice(request, preimage, blindedPrivateKey, nodeParams.bolt12InvoiceExpiry.inWholeSeconds, nodeParams.features.bolt12Features(), listOf(path))
-                    val destination = Destination.BlindedPath(replyPath)
-                    when (val invoiceMessage = buildMessage(randomKey(), randomKey(), intermediateNodes(destination), destination, TlvStream(OnionMessagePayloadTlv.Invoice(invoice.records)))) {
-                        is Left -> {
-                            logger.warning { "offerId:${request.offer.offerId} ignoring invoice request, could not build onion message: ${invoiceMessage.value}" }
-                            sendInvoiceError("failed to build onion message", replyPath)
-                        }
-                        is Right -> {
-                            logger.info { "sending BOLT 12 invoice with amount=${invoice.amount}, paymentHash=${invoice.paymentHash}, payerId=${invoice.invoiceRequest.payerId} to introduction node ${destination.route.firstNodeId}" }
-                            OnionMessageAction.SendMessage(invoiceMessage.value)
-                        }
+                ).write().toByteVector()
+                val blindedRoute = RouteBlinding.create(randomKey(), listOf(remoteNodeId, nodeParams.nodeId), listOf(remoteNodePayload, recipientPayload)).route
+                val path = Bolt12Invoice.Companion.PaymentBlindedContactInfo(OfferTypes.ContactInfo.BlindedPath(blindedRoute), paymentInfo)
+                val invoice = Bolt12Invoice(request, preimage, blindedPrivateKey, nodeParams.bolt12InvoiceExpiry.inWholeSeconds, nodeParams.features.bolt12Features(), listOf(path))
+                val destination = Destination.BlindedPath(replyPath)
+                when (val invoiceMessage = buildMessage(randomKey(), randomKey(), intermediateNodes(destination), destination, TlvStream(OnionMessagePayloadTlv.Invoice(invoice.records)))) {
+                    is Left -> {
+                        logger.warning { "offerId:${request.offer.offerId} ignoring invoice request, could not build onion message: ${invoiceMessage.value}" }
+                        sendInvoiceError("failed to build onion message", replyPath)
+                    }
+                    is Right -> {
+                        logger.info { "sending BOLT 12 invoice with amount=${invoice.amount}, paymentHash=${invoice.paymentHash}, payerId=${invoice.invoiceRequest.payerId} to introduction node ${destination.route.firstNodeId}" }
+                        OnionMessageAction.SendMessage(invoiceMessage.value)
                     }
                 }
             }
-        })
+        }
     }
 
     private fun sendInvoiceError(message: String, replyPath: RouteBlinding.BlindedRoute): OnionMessageAction.SendMessage? {
@@ -222,5 +226,46 @@ class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, v
             is Destination.Recipient -> destination.nodeId.publicKey != remoteNodeId
         }
         return if (needIntermediateHop) listOf(IntermediateNode(EncodedNodeId.WithPublicKey.Plain(remoteNodeId))) else listOf()
+    }
+
+    /** This function verifies that the offer provided was generated by us. */
+    private fun isOurOffer(offer: OfferTypes.Offer, pathId: ByteVector?, blindedPrivateKey: PrivateKey): Boolean = when {
+        pathId != null && pathId.size() != 32 -> false
+        else -> {
+            val expected = deterministicOffer(nodeParams.chainHash, nodeParams.nodePrivateKey, walletParams.trampolineNode.id, offer.amount, offer.description, pathId?.let { ByteVector32(it) })
+            expected == Pair(offer, blindedPrivateKey)
+        }
+    }
+
+    companion object {
+        /**
+         * We always generate offers deterministically, based on a secret derived from our node's private key and (optionally) a random nonce.
+         * This way we never need to persist our offers: we can instead simply verify, when we receive an invoice_request, that the offer it contains was generated by us.
+         */
+        fun deterministicOffer(
+            chainHash: BlockHash,
+            nodePrivateKey: PrivateKey,
+            trampolineNodeId: PublicKey,
+            amount: MilliSatoshi?,
+            description: String?,
+            pathId: ByteVector32?,
+        ): Pair<OfferTypes.Offer, PrivateKey> {
+            // We generate a deterministic session key based on:
+            //  - a custom tag indicating that this is used in the Bolt 12 context
+            //  - the offer parameters (amount, description and pathId)
+            //  - our trampoline node, which is used as an introduction node for the offer's blinded path
+            //  - our private key, which ensures that nobody else can generate the same path key secret
+            val tweak = when {
+                amount == null && description == null && pathId == null -> "bolt 12 default offer".encodeToByteArray().byteVector()
+                else -> {
+                    "bolt 12 deterministic offer".encodeToByteArray().byteVector() +
+                            Crypto.sha256("offer amount".encodeToByteArray() + (amount?.let { Pack.writeInt64BE(it.msat) } ?: ByteArray(0))) +
+                            Crypto.sha256("offer description".encodeToByteArray() + (description?.encodeToByteArray() ?: ByteArray(0))) +
+                            Crypto.sha256("offer path_id".encodeToByteArray().byteVector() + (pathId ?: ByteVector.empty))
+                }
+            }
+            val sessionKey = PrivateKey(Crypto.sha256(tweak + trampolineNodeId.value + nodePrivateKey.value).byteVector32())
+            return OfferTypes.Offer.createBlindedOffer(chainHash, nodePrivateKey, trampolineNodeId, amount, description, Features.empty, sessionKey, pathId)
+        }
     }
 }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
@@ -141,12 +141,12 @@ class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, v
                     logger.warning { "offerId:${request.offer.offerId} ignoring invalid invoice request" }
                     sendInvoiceError("ignoring invalid invoice request", replyPath)
                 }
-                request.requestedAmount() < minHtlc -> {
-                    logger.warning { "offerId:${request.offer.offerId} amount too low (amount=${request.requestedAmount()} minHtlc=$minHtlc)" }
+                request.requestedAmount < minHtlc -> {
+                    logger.warning { "offerId:${request.offer.offerId} amount too low (amount=${request.requestedAmount} minHtlc=$minHtlc)" }
                     sendInvoiceError("amount too low, minimum amount = $minHtlc", replyPath)
                 }
                 else -> {
-                    val amount = request.requestedAmount()
+                    val amount = request.requestedAmount
                     val preimage = randomBytes32()
                     val truncatedPayerNote = request.payerNote?.let {
                         if (it.length <= 64) {

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/message/OnionMessagesTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/message/OnionMessagesTestsCommon.kt
@@ -130,7 +130,7 @@ class OnionMessagesTestsCommon {
         assertEquals(Either.Right(EncodedNodeId(dave.publicKey())), nextNodeId3)
         val decrypted = decryptMessage(dave, onionForDave, logger)!!
         assertNotNull(decrypted)
-        assertEquals("01234567", decrypted.pathId.toHex())
+        assertEquals("01234567", decrypted.pathId?.toHex())
     }
 
     @Test
@@ -220,7 +220,7 @@ class OnionMessagesTestsCommon {
         assertEquals(Either.Right(EncodedNodeId(destination.publicKey())), nextNodeId)
         val decrypted = decryptMessage(destination, message2, logger)!!
         assertNotNull(decrypted)
-        assertEquals("01234567", decrypted.pathId.toHex())
+        assertEquals("01234567", decrypted.pathId?.toHex())
     }
 
     @Test

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
@@ -4,6 +4,7 @@ import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.PrivateKey
 import fr.acinq.bitcoin.utils.Either
 import fr.acinq.lightning.*
+import fr.acinq.lightning.Lightning.randomBytes32
 import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.crypto.RouteBlinding
 import fr.acinq.lightning.crypto.sphinx.DecryptedPacket
@@ -63,7 +64,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
         // Alice and Bob use the same trampoline node.
         val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
         val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
-        val offer = aliceOfferManager.makeAnonymousOffer(1000.msat, "test offer")
+        val offer = TestConstants.Alice.nodeParams.randomOffer(aliceTrampolineKey.publicKey(), 1000.msat, "test offer").first
 
         // Bob sends an invoice request to Alice.
         val currentBlockHeight = 0
@@ -98,7 +99,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
         // Alice and Bob use different trampoline nodes.
         val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
         val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, bobWalletParams, MutableSharedFlow(replay = 10), logger)
-        val offer = aliceOfferManager.makeDeterministicOffer(null, null)
+        val offer = TestConstants.Alice.nodeParams.randomOffer(aliceTrampolineKey.publicKey(), null, null).first
 
         // Bob sends an invoice request to Alice.
         val payOffer = PayOffer(UUID.randomUUID(), randomKey(), null, 5500.msat, offer, 20.seconds)
@@ -131,7 +132,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
     fun `invoice request timed out`() = runSuspendTest {
         val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
         val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
-        val offer = aliceOfferManager.makeAnonymousOffer(null, "amountless offer")
+        val offer = TestConstants.Alice.nodeParams.randomOffer(aliceTrampolineKey.publicKey(), null, "amountless offer").first
 
         // Bob sends an invoice request to Alice.
         val payOffer = PayOffer(UUID.randomUUID(), randomKey(), null, 5500.msat, offer, 20.seconds)
@@ -153,7 +154,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
     fun `duplicate invoice request`() = runSuspendTest {
         val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
         val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
-        val offer = aliceOfferManager.makeDeterministicOffer(null, "deterministic amountless offer")
+        val offer = TestConstants.Alice.nodeParams.randomOffer(aliceTrampolineKey.publicKey(), null, "deterministic amountless offer").first
 
         // Bob sends two invoice requests to Alice.
         val payOffer = PayOffer(UUID.randomUUID(), randomKey(), null, 5500.msat, offer, 20.seconds)
@@ -178,7 +179,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
     fun `receive invalid invoice request`() = runSuspendTest {
         val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
         val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
-        val offer = aliceOfferManager.makeAnonymousOffer(null, null)
+        val offer = TestConstants.Alice.nodeParams.randomOffer(aliceTrampolineKey.publicKey(), null, null).first
 
         // Bob sends an invalid invoice request to Alice.
         val payOffer = PayOffer(UUID.randomUUID(), randomKey(), null, 5500.msat, offer, 20.seconds)
@@ -192,7 +193,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
         // Alice and Bob use the same trampoline node.
         val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
         val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
-        val offer = aliceOfferManager.makeAnonymousOffer(null, "tip")
+        val offer = TestConstants.Alice.nodeParams.randomOffer(aliceTrampolineKey.publicKey(), null, "tip").first
 
         // Bob sends an invoice request to Alice.
         val payOffer = PayOffer(UUID.randomUUID(), randomKey(), null, 5500.msat, offer, 20.seconds)
@@ -210,7 +211,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
         // Alice and Bob use the same trampoline node.
         val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
         val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
-        val offer = aliceOfferManager.makeAnonymousOffer(50_000.msat, "coffee")
+        val offer = TestConstants.Alice.nodeParams.randomOffer(aliceTrampolineKey.publicKey(), 50_000.msat, "coffee").first
 
         // Bob sends an invoice request to Alice that pays less than the offer amount.
         val payOffer = PayOffer(UUID.randomUUID(), randomKey(), null, 40_000.msat, offer, 20.seconds)
@@ -231,7 +232,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
         // Alice and Bob use the same trampoline node.
         val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
         val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
-        val offer = aliceOfferManager.makeAnonymousOffer(null, null)
+        val offer = TestConstants.Alice.nodeParams.randomOffer(aliceTrampolineKey.publicKey(), null, null).first
 
         // Bob sends an invoice request to Alice that pays less than the minimum htlc amount.
         val payOffer = PayOffer(UUID.randomUUID(), randomKey(), null, 10.msat, offer, 20.seconds)
@@ -252,7 +253,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
         // Alice and Bob use the same trampoline node.
         val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
         val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
-        val offer = aliceOfferManager.makeAnonymousOffer(1000.msat, "tea")
+        val offer = TestConstants.Alice.nodeParams.randomOffer(aliceTrampolineKey.publicKey(), 1000.msat, "tea").first
 
         // Bob sends an invoice request to Alice.
         val payerNote = "Thanks for all the fish"
@@ -281,7 +282,7 @@ class OfferManagerTestsCommon : LightningTestSuite() {
         // Alice and Bob use the same trampoline node.
         val aliceOfferManager = OfferManager(TestConstants.Alice.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
         val bobOfferManager = OfferManager(TestConstants.Bob.nodeParams, aliceWalletParams, MutableSharedFlow(replay = 10), logger)
-        val offer = aliceOfferManager.makeDeterministicOffer(1000.msat, "tea")
+        val offer = TestConstants.Alice.nodeParams.randomOffer(aliceTrampolineKey.publicKey(), 1000.msat, "tea").first
 
         // Bob sends an invoice request to Alice.
         val payerNote = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/wire/OfferTypesTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/wire/OfferTypesTestsCommon.kt
@@ -217,12 +217,13 @@ class OfferTypesTestsCommon : LightningTestSuite() {
         val tlvsWithoutSignature = setOf(
             InvoiceRequestMetadata(ByteVector.fromHex("abcdef")),
             OfferIssuerId(nodeId),
+            InvoiceRequestAmount(10000.msat),
             InvoiceRequestPayerId(payerKey.publicKey()),
         )
         val signature = signSchnorr(InvoiceRequest.signatureTag, rootHash(TlvStream(tlvsWithoutSignature)), payerKey)
         val tlvs = tlvsWithoutSignature + Signature(signature)
         val invoiceRequest = InvoiceRequest(TlvStream(tlvs))
-        val encoded = "lnr1qqp6hn00zcssxr0juddeytv7nwawhk9nq9us0arnk8j8wnsq8r2e86vzgtfneupetqssynwewhp70gwlp4chhm53g90jt9fpnx7rpmrzla3zd0nvxymm8e0p7pq06rwacy8756zgl3hdnsyfepq573astyz94rgn9uhxlyqj4gdyk6q8q0yrv6al909v3435amuvjqvkuq6k8fyld78r8srdyx7wnmwsdu"
+        val encoded = "lnr1qqp6hn00zcssxr0juddeytv7nwawhk9nq9us0arnk8j8wnsq8r2e86vzgtfneupe2gpzwyzcyypymkt4c0n6rhcdw9a7ay2ptuje2gvehscwcchlvgntump3x7e7tc0sgzhxcvjdh925x0jyyxzrdc5s2mwqtmpf4zezd7mg094lmcwqh3xyw2n6jdzkl80jj2euh48s00wtgad9j7wyt67rnth3dqq0fa0usrxm"
         assertEquals(invoiceRequest, InvoiceRequest.decode(encoded).get())
         assertNull(invoiceRequest.offer.amount)
         assertNull(invoiceRequest.offer.description)


### PR DESCRIPTION
We introduce `offerManager.makeAnonymousOffer` and `offerManager.makeDeterministicOffer` which allow creating stateless offers. This way we can create an offer with a customized amount, description or any other field and the offer will still be payable if we erase and restore the wallet.