### PR TITLE
Add test for Bolt11 features minimal encoding

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt11Invoice.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt11Invoice.kt
@@ -419,7 +419,6 @@ data class Bolt11Invoice(
             }
         }
 
-
         data class Features(val bits: ByteVector) : TaggedField() {
             override val tag: Int5 = Features.tag
 


### PR DESCRIPTION
https://github.com/lightning/bolts/pull/1245 highlights that invoice writers must minimally encode Bolt11 features (and other fields). We were already correctly doing that, but tests were lacking.

https://github.com/lightning/bolts/pull/1242 added a test vector for invoices without payment secrets, which we're now verifying.