### PR TITLE
Refactor and simplify stateless offers

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
@@ -1,6 +1,7 @@
 package fr.acinq.lightning.payment
 
 import fr.acinq.bitcoin.*
+import fr.acinq.bitcoin.crypto.Pack
 import fr.acinq.bitcoin.utils.Either.Left
 import fr.acinq.bitcoin.utils.Either.Right
 import fr.acinq.lightning.*
@@ -19,7 +20,6 @@ import fr.acinq.lightning.message.OnionMessages.buildMessage
 import fr.acinq.lightning.utils.currentTimestampMillis
 import fr.acinq.lightning.utils.toByteVector
 import fr.acinq.lightning.wire.*
-import fr.acinq.lightning.wire.OfferTypes.OfferTlv
 import kotlinx.coroutines.flow.MutableSharedFlow
 
 sealed class OnionMessageAction {
@@ -53,7 +53,11 @@ class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, v
         val replyPathId = randomBytes32()
         pendingInvoiceRequests[replyPathId] = PendingInvoiceRequest(payOffer, request)
         // We add dummy hops to the reply path: this way the receiver only learns that we're at most 3 hops away from our peer.
-        val replyPathHops = listOf(IntermediateNode(EncodedNodeId.WithPublicKey.Plain(remoteNodeId)), IntermediateNode(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId)), IntermediateNode(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId)))
+        val replyPathHops = listOf(
+            IntermediateNode(EncodedNodeId.WithPublicKey.Plain(remoteNodeId)),
+            IntermediateNode(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId)),
+            IntermediateNode(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId)),
+        )
         val lastHop = Destination.Recipient(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId), replyPathId)
         val replyPath = OnionMessages.buildRoute(randomKey(), replyPathHops, lastHop)
         val messageContent = TlvStream(OnionMessagePayloadTlv.ReplyPath(replyPath), OnionMessagePayloadTlv.InvoiceRequest(request.records))
@@ -77,8 +81,13 @@ class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, v
         return OnionMessages.decryptMessage(nodeParams.nodePrivateKey, msg, logger)?.let { decrypted ->
             val invoiceRequestTlvs = decrypted.content.records.get<OnionMessagePayloadTlv.InvoiceRequest>()?.tlvs
             when {
-                invoiceRequestTlvs != null ->
-                    receiveInvoiceRequest(invoiceRequestTlvs, decrypted.pathId, decrypted.blindedPrivateKey, decrypted.content.replyPath, remoteChannelUpdates, currentBlockHeight)
+                invoiceRequestTlvs != null -> when (val invoiceRequest = OfferTypes.InvoiceRequest.validate(invoiceRequestTlvs)) {
+                    is Left -> {
+                        logger.warning { "received invalid invoice_request: ${invoiceRequest.value}" }
+                        null
+                    }
+                    is Right -> receiveInvoiceRequest(invoiceRequest.value, decrypted.pathId, decrypted.blindedPrivateKey, decrypted.content.replyPath, remoteChannelUpdates, currentBlockHeight)
+                }
                 pendingInvoiceRequests.containsKey(decrypted.pathId) -> {
                     val (payOffer, request) = pendingInvoiceRequests[decrypted.pathId]!!
                     pendingInvoiceRequests.remove(decrypted.pathId)
@@ -121,86 +130,81 @@ class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, v
         }
     }
 
-    private fun receiveInvoiceRequest(requestTlvs: TlvStream<OfferTypes.InvoiceRequestTlv>, pathId: ByteVector?, blindedPrivateKey: PrivateKey, replyPath: RouteBlinding.BlindedRoute?, remoteChannelUpdates: List<ChannelUpdate>, currentBlockHeight: Int): OnionMessageAction.SendMessage? {
-        return OfferTypes.InvoiceRequest.validate(requestTlvs).fold({
-            logger.warning { "invalid invoice request: $it" }
-            null
-        }, { request ->
-            // We must use the most restrictive minimum HTLC value between local and remote.
-            val minHtlc = (listOf(nodeParams.htlcMinimum) + remoteChannelUpdates.map { it.htlcMinimumMsat }).max()
-            return when {
-                replyPath == null -> {
-                    logger.warning { "offerId:${request.offer.offerId} ignoring invoice request: no reply path" }
-                    null
-                }
-                !nodeParams.isOurOffer(walletParams.trampolineNode.id, request.offer, pathId, blindedPrivateKey) -> {
-                    logger.warning { "ignoring invoice request for offer that is not ours" }
-                    null
-                }
-                !request.isValid() -> {
-                    logger.warning { "offerId:${request.offer.offerId} ignoring invalid invoice request" }
-                    sendInvoiceError("ignoring invalid invoice request", replyPath)
-                }
-                request.requestedAmount < minHtlc -> {
-                    logger.warning { "offerId:${request.offer.offerId} amount too low (amount=${request.requestedAmount} minHtlc=$minHtlc)" }
-                    sendInvoiceError("amount too low, minimum amount = $minHtlc", replyPath)
-                }
-                else -> {
-                    val amount = request.requestedAmount
-                    val preimage = randomBytes32()
-                    val truncatedPayerNote = request.payerNote?.let {
-                        if (it.length <= 64) {
-                            it
-                        } else {
-                            it.take(63) + "…"
-                        }
+    private fun receiveInvoiceRequest(request: OfferTypes.InvoiceRequest, pathId: ByteVector?, blindedPrivateKey: PrivateKey, replyPath: RouteBlinding.BlindedRoute?, remoteChannelUpdates: List<ChannelUpdate>, currentBlockHeight: Int): OnionMessageAction.SendMessage? {
+        // We must use the most restrictive minimum HTLC value between local and remote.
+        val minHtlc = (listOf(nodeParams.htlcMinimum) + remoteChannelUpdates.map { it.htlcMinimumMsat }).max()
+        return when {
+            replyPath == null -> {
+                logger.warning { "offerId:${request.offer.offerId} ignoring invoice request: no reply path" }
+                null
+            }
+            !isOurOffer(request.offer, pathId, blindedPrivateKey) -> {
+                logger.warning { "ignoring invoice request for offer that is not ours" }
+                null
+            }
+            !request.isValid() -> {
+                logger.warning { "offerId:${request.offer.offerId} ignoring invalid invoice request" }
+                sendInvoiceError("ignoring invalid invoice request", replyPath)
+            }
+            request.requestedAmount < minHtlc -> {
+                logger.warning { "offerId:${request.offer.offerId} amount too low (amount=${request.requestedAmount} minHtlc=$minHtlc)" }
+                sendInvoiceError("amount too low, minimum amount = $minHtlc", replyPath)
+            }
+            else -> {
+                val amount = request.requestedAmount
+                val preimage = randomBytes32()
+                val truncatedPayerNote = request.payerNote?.let {
+                    if (it.length <= 64) {
+                        it
+                    } else {
+                        it.take(63) + "…"
                     }
-                    val metadata = OfferPaymentMetadata.V1(request.offer.offerId, amount, preimage, request.payerId, truncatedPayerNote, request.quantity, currentTimestampMillis()).toPathId(nodeParams.nodePrivateKey)
-                    val recipientPayload = RouteBlindingEncryptedData(TlvStream(RouteBlindingEncryptedDataTlv.PathId(metadata))).write().toByteVector()
-                    val cltvExpiryDelta = remoteChannelUpdates.maxOfOrNull { it.cltvExpiryDelta } ?: walletParams.invoiceDefaultRoutingFees.cltvExpiryDelta
-                    val paymentInfo = OfferTypes.PaymentInfo(
-                        feeBase = remoteChannelUpdates.maxOfOrNull { it.feeBaseMsat } ?: walletParams.invoiceDefaultRoutingFees.feeBase,
-                        feeProportionalMillionths = remoteChannelUpdates.maxOfOrNull { it.feeProportionalMillionths } ?: walletParams.invoiceDefaultRoutingFees.feeProportional,
-                        // We include our min_final_cltv_expiry_delta in the path, but we *don't* include it in the payment_relay field
-                        // for our trampoline node (below). This ensures that we will receive payments with at least this final expiry delta.
-                        // This ensures that even when payers haven't received the latest block(s) or don't include a safety margin in the
-                        // expiry they use, we can still safely receive their payment.
-                        cltvExpiryDelta = cltvExpiryDelta + nodeParams.minFinalCltvExpiryDelta,
-                        minHtlc = minHtlc,
-                        // Payments are allowed to overpay at most two times the invoice amount.
-                        maxHtlc = amount * 2,
-                        allowedFeatures = Features.empty
+                }
+                val metadata = OfferPaymentMetadata.V1(request.offer.offerId, amount, preimage, request.payerId, truncatedPayerNote, request.quantity, currentTimestampMillis()).toPathId(nodeParams.nodePrivateKey)
+                val recipientPayload = RouteBlindingEncryptedData(TlvStream(RouteBlindingEncryptedDataTlv.PathId(metadata))).write().toByteVector()
+                val cltvExpiryDelta = remoteChannelUpdates.maxOfOrNull { it.cltvExpiryDelta } ?: walletParams.invoiceDefaultRoutingFees.cltvExpiryDelta
+                val paymentInfo = OfferTypes.PaymentInfo(
+                    feeBase = remoteChannelUpdates.maxOfOrNull { it.feeBaseMsat } ?: walletParams.invoiceDefaultRoutingFees.feeBase,
+                    feeProportionalMillionths = remoteChannelUpdates.maxOfOrNull { it.feeProportionalMillionths } ?: walletParams.invoiceDefaultRoutingFees.feeProportional,
+                    // We include our min_final_cltv_expiry_delta in the path, but we *don't* include it in the payment_relay field
+                    // for our trampoline node (below). This ensures that we will receive payments with at least this final expiry delta.
+                    // This ensures that even when payers haven't received the latest block(s) or don't include a safety margin in the
+                    // expiry they use, we can still safely receive their payment.
+                    cltvExpiryDelta = cltvExpiryDelta + nodeParams.minFinalCltvExpiryDelta,
+                    minHtlc = minHtlc,
+                    // Payments are allowed to overpay at most two times the invoice amount.
+                    maxHtlc = amount * 2,
+                    allowedFeatures = Features.empty
+                )
+                // Once the invoice expires, the blinded path shouldn't be usable anymore.
+                // We assume 10 minutes between each block to convert the invoice expiry to a cltv_expiry_delta.
+                // When paying the invoice, payers may add any number of blocks to the current block height to protect recipient privacy.
+                // We assume that they won't add more than 720 blocks, which is reasonable because adding a large delta increases the risk
+                // that intermediate nodes reject the payment because they don't want their funds potentially locked for a long duration.
+                val pathExpiry = (paymentInfo.cltvExpiryDelta + CltvExpiryDelta(720) + (nodeParams.bolt12InvoiceExpiry.inWholeMinutes.toInt() / 10)).toCltvExpiry(currentBlockHeight.toLong())
+                val remoteNodePayload = RouteBlindingEncryptedData(
+                    TlvStream(
+                        RouteBlindingEncryptedDataTlv.OutgoingNodeId(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId)),
+                        RouteBlindingEncryptedDataTlv.PaymentRelay(cltvExpiryDelta, paymentInfo.feeProportionalMillionths, paymentInfo.feeBase),
+                        RouteBlindingEncryptedDataTlv.PaymentConstraints(pathExpiry, paymentInfo.minHtlc)
                     )
-                    // Once the invoice expires, the blinded path shouldn't be usable anymore.
-                    // We assume 10 minutes between each block to convert the invoice expiry to a cltv_expiry_delta.
-                    // When paying the invoice, payers may add any number of blocks to the current block height to protect recipient privacy.
-                    // We assume that they won't add more than 720 blocks, which is reasonable because adding a large delta increases the risk
-                    // that intermediate nodes reject the payment because they don't want their funds potentially locked for a long duration.
-                    val pathExpiry = (paymentInfo.cltvExpiryDelta + CltvExpiryDelta(720) + (nodeParams.bolt12InvoiceExpiry.inWholeMinutes.toInt() / 10)).toCltvExpiry(currentBlockHeight.toLong())
-                    val remoteNodePayload = RouteBlindingEncryptedData(
-                        TlvStream(
-                            RouteBlindingEncryptedDataTlv.OutgoingNodeId(EncodedNodeId.WithPublicKey.Wallet(nodeParams.nodeId)),
-                            RouteBlindingEncryptedDataTlv.PaymentRelay(cltvExpiryDelta, paymentInfo.feeProportionalMillionths, paymentInfo.feeBase),
-                            RouteBlindingEncryptedDataTlv.PaymentConstraints(pathExpiry, paymentInfo.minHtlc)
-                        )
-                    ).write().toByteVector()
-                    val blindedRoute = RouteBlinding.create(randomKey(), listOf(remoteNodeId, nodeParams.nodeId), listOf(remoteNodePayload, recipientPayload)).route
-                    val path = Bolt12Invoice.Companion.PaymentBlindedContactInfo(OfferTypes.ContactInfo.BlindedPath(blindedRoute), paymentInfo)
-                    val invoice = Bolt12Invoice(request, preimage, blindedPrivateKey, nodeParams.bolt12InvoiceExpiry.inWholeSeconds, nodeParams.features.bolt12Features(), listOf(path))
-                    val destination = Destination.BlindedPath(replyPath)
-                    when (val invoiceMessage = buildMessage(randomKey(), randomKey(), intermediateNodes(destination), destination, TlvStream(OnionMessagePayloadTlv.Invoice(invoice.records)))) {
-                        is Left -> {
-                            logger.warning { "offerId:${request.offer.offerId} ignoring invoice request, could not build onion message: ${invoiceMessage.value}" }
-                            sendInvoiceError("failed to build onion message", replyPath)
-                        }
-                        is Right -> {
-                            logger.info { "sending BOLT 12 invoice with amount=${invoice.amount}, paymentHash=${invoice.paymentHash}, payerId=${invoice.invoiceRequest.payerId} to introduction node ${destination.route.firstNodeId}" }
-                            OnionMessageAction.SendMessage(invoiceMessage.value)
-                        }
+                ).write().toByteVector()
+                val blindedRoute = RouteBlinding.create(randomKey(), listOf(remoteNodeId, nodeParams.nodeId), listOf(remoteNodePayload, recipientPayload)).route
+                val path = Bolt12Invoice.Companion.PaymentBlindedContactInfo(OfferTypes.ContactInfo.BlindedPath(blindedRoute), paymentInfo)
+                val invoice = Bolt12Invoice(request, preimage, blindedPrivateKey, nodeParams.bolt12InvoiceExpiry.inWholeSeconds, nodeParams.features.bolt12Features(), listOf(path))
+                val destination = Destination.BlindedPath(replyPath)
+                when (val invoiceMessage = buildMessage(randomKey(), randomKey(), intermediateNodes(destination), destination, TlvStream(OnionMessagePayloadTlv.Invoice(invoice.records)))) {
+                    is Left -> {
+                        logger.warning { "offerId:${request.offer.offerId} ignoring invoice request, could not build onion message: ${invoiceMessage.value}" }
+                        sendInvoiceError("failed to build onion message", replyPath)
+                    }
+                    is Right -> {
+                        logger.info { "sending BOLT 12 invoice with amount=${invoice.amount}, paymentHash=${invoice.paymentHash}, payerId=${invoice.invoiceRequest.payerId} to introduction node ${destination.route.firstNodeId}" }
+                        OnionMessageAction.SendMessage(invoiceMessage.value)
                     }
                 }
             }
-        })
+        }
     }
 
     private fun sendInvoiceError(message: String, replyPath: RouteBlinding.BlindedRoute): OnionMessageAction.SendMessage? {
@@ -222,5 +226,46 @@ class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, v
             is Destination.Recipient -> destination.nodeId.publicKey != remoteNodeId
         }
         return if (needIntermediateHop) listOf(IntermediateNode(EncodedNodeId.WithPublicKey.Plain(remoteNodeId))) else listOf()
+    }
+
+    /** This function verifies that the offer provided was generated by us. */
+    private fun isOurOffer(offer: OfferTypes.Offer, pathId: ByteVector?, blindedPrivateKey: PrivateKey): Boolean = when {
+        pathId != null && pathId.size() != 32 -> false
+        else -> {
+            val expected = deterministicOffer(nodeParams.chainHash, nodeParams.nodePrivateKey, walletParams.trampolineNode.id, offer.amount, offer.description, pathId?.let { ByteVector32(it) })
+            expected == Pair(offer, blindedPrivateKey)
+        }
+    }
+
+    companion object {
+        /**
+         * We always generate offers deterministically, based on a secret derived from our node's private key and (optionally) a random nonce.
+         * This way we never need to persist our offers: we can instead simply verify, when we receive an invoice_request, that the offer it contains was generated by us.
+         */
+        fun deterministicOffer(
+            chainHash: BlockHash,
+            nodePrivateKey: PrivateKey,
+            trampolineNodeId: PublicKey,
+            amount: MilliSatoshi?,
+            description: String?,
+            pathId: ByteVector32?,
+        ): Pair<OfferTypes.Offer, PrivateKey> {
+            // We generate a deterministic session key based on:
+            //  - a custom tag indicating that this is used in the Bolt 12 context
+            //  - the offer parameters (amount, description and pathId)
+            //  - our trampoline node, which is used as an introduction node for the offer's blinded path
+            //  - our private key, which ensures that nobody else can generate the same path key secret
+            val tweak = when {
+                amount == null && description == null && pathId == null -> "bolt 12 default offer".encodeToByteArray().byteVector()
+                else -> {
+                    "bolt 12 deterministic offer".encodeToByteArray().byteVector() +
+                            Crypto.sha256("offer amount".encodeToByteArray() + (amount?.let { Pack.writeInt64BE(it.msat) } ?: ByteArray(0))) +
+                            Crypto.sha256("offer description".encodeToByteArray() + (description?.encodeToByteArray() ?: ByteArray(0))) +
+                            Crypto.sha256("offer path_id".encodeToByteArray().byteVector() + (pathId ?: ByteVector.empty))
+                }
+            }
+            val sessionKey = PrivateKey(Crypto.sha256(tweak + trampolineNodeId.value + nodePrivateKey.value).byteVector32())
+            return OfferTypes.Offer.createBlindedOffer(chainHash, nodePrivateKey, trampolineNodeId, amount, description, Features.empty, sessionKey, pathId)
+        }
     }
 }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
@@ -141,12 +141,12 @@ class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, v
                     logger.warning { "offerId:${request.offer.offerId} ignoring invalid invoice request" }
                     sendInvoiceError("ignoring invalid invoice request", replyPath)
                 }
-                request.requestedAmount() < minHtlc -> {
-                    logger.warning { "offerId:${request.offer.offerId} amount too low (amount=${request.requestedAmount()} minHtlc=$minHtlc)" }
+                request.requestedAmount < minHtlc -> {
+                    logger.warning { "offerId:${request.offer.offerId} amount too low (amount=${request.requestedAmount} minHtlc=$minHtlc)" }
                     sendInvoiceError("amount too low, minimum amount = $minHtlc", replyPath)
                 }
                 else -> {
-                    val amount = request.requestedAmount()
+                    val amount = request.requestedAmount
                     val preimage = randomBytes32()
                     val truncatedPayerNote = request.payerNote?.let {
                         if (it.length <= 64) {


### PR DESCRIPTION
This PR targets #774 and should be reviewed commit-by-commit.

The first commit simply cleans up the `requestAmount` field for invoice requests.

The second commit refactors and slightly changes the crypto tweaks used for deterministic offers (more details in the commit message).