### PR TITLE
Add platform-specific http-client config

### DIFF
--- a/modules/core/src/appleMain/kotlin/fr/acinq/lightning/io/MyHttpClient.apple.kt
+++ b/modules/core/src/appleMain/kotlin/fr/acinq/lightning/io/MyHttpClient.apple.kt
@@ -1,0 +1,5 @@
+package fr.acinq.lightning.io
+
+import io.ktor.client.*
+
+actual fun MyHttpClient(block: HttpClientConfig<*>.() -> Unit): HttpClient = HttpClient(block)

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/mempool/MempoolSpaceClient.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/mempool/MempoolSpaceClient.kt
@@ -5,11 +5,11 @@ import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.blockchain.Feerates
 import fr.acinq.lightning.blockchain.IClient
 import fr.acinq.lightning.blockchain.fee.FeeratePerByte
+import fr.acinq.lightning.io.MyHttpClient
 import fr.acinq.lightning.logging.LoggerFactory
 import fr.acinq.lightning.logging.debug
 import fr.acinq.lightning.logging.warning
 import fr.acinq.lightning.utils.sat
-import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
@@ -17,7 +17,6 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -25,7 +24,7 @@ class MempoolSpaceClient(val mempoolUrl: Url, loggerFactory: LoggerFactory) : IC
 
     private val logger = loggerFactory.newLogger(this::class)
 
-    val client = HttpClient {
+    val client = MyHttpClient {
         install(ContentNegotiation) {
             json(json = Json {
                 prettyPrint = true

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/MyHttpClient.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/MyHttpClient.kt
@@ -1,0 +1,9 @@
+package fr.acinq.lightning.io
+
+import io.ktor.client.*
+
+// This allows setting platform and engine-specific parameters for the client.
+// It is particularly useful as a workaround for https://github.com/ktorio/ktor/pull/4758
+expect fun MyHttpClient(
+    block: HttpClientConfig<*>.() -> Unit = {}
+): HttpClient

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/tests/bitcoind/BitcoinJsonRPCClient.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/tests/bitcoind/BitcoinJsonRPCClient.kt
@@ -1,9 +1,9 @@
 package fr.acinq.lightning.tests.bitcoind
 
-import fr.acinq.lightning.logging.*
+import fr.acinq.lightning.io.MyHttpClient
+import fr.acinq.lightning.logging.debug
 import fr.acinq.lightning.tests.utils.testLoggerFactory
 import fr.acinq.lightning.utils.JsonRPCResponse
-import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.auth.*
 import io.ktor.client.plugins.auth.providers.*
@@ -23,7 +23,7 @@ object BitcoinJsonRPCClient {
     private val scheme = if (ssl) "https" else "http"
     private val serviceUri = "$scheme://$host:$port/wallet/" // wallet/ specifies to use the default bitcoind wallet, named ""
 
-    private val httpClient = HttpClient {
+    private val httpClient = MyHttpClient {
         install(ContentNegotiation) {
             json()
         }

--- a/modules/core/src/jvmMain/kotlin/fr/acinq/lightning/io/MyHttpClient.jvm.kt
+++ b/modules/core/src/jvmMain/kotlin/fr/acinq/lightning/io/MyHttpClient.jvm.kt
@@ -1,0 +1,5 @@
+package fr.acinq.lightning.io
+
+import io.ktor.client.*
+
+actual fun MyHttpClient(block: HttpClientConfig<*>.() -> Unit): HttpClient = HttpClient(block)

--- a/modules/core/src/linuxArm64Main/kotlin/fr/acinq/lightning/io/MyHttpClient.linuxArm64.kt
+++ b/modules/core/src/linuxArm64Main/kotlin/fr/acinq/lightning/io/MyHttpClient.linuxArm64.kt
@@ -1,0 +1,14 @@
+package fr.acinq.lightning.io
+
+import io.ktor.client.*
+import io.ktor.client.engine.curl.*
+
+actual fun MyHttpClient(block: HttpClientConfig<*>.() -> Unit): HttpClient = HttpClient {
+    engine {
+        // Workaround for https://github.com/ktorio/ktor/pull/4758
+        if (this is CurlClientEngineConfig) {
+            caPath = "/etc/ssl/certs"
+        }
+    }
+    block(this)
+}

--- a/modules/core/src/linuxX64Main/kotlin/fr/acinq/lightning/io/MyHttpClient.linuxX64.kt
+++ b/modules/core/src/linuxX64Main/kotlin/fr/acinq/lightning/io/MyHttpClient.linuxX64.kt
@@ -1,0 +1,5 @@
+package fr.acinq.lightning.io
+
+import io.ktor.client.*
+
+actual fun MyHttpClient(block: HttpClientConfig<*>.() -> Unit): HttpClient = HttpClient(block)


### PR DESCRIPTION
This is useful to work around an issue with the curl client on Linux Arm64.