### PR TITLE
Use the offer description as default payer note

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
@@ -153,7 +153,7 @@ class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, v
             else -> {
                 val amount = request.requestedAmount
                 val preimage = randomBytes32()
-                val truncatedPayerNote = request.payerNote?.let {
+                val truncatedPayerNote = (request.payerNote ?: request.offer.description)?.let {
                     if (it.length <= 64) {
                         it
                     } else {


### PR DESCRIPTION
If no payer note is provided by the sender, we use the offer description. This may be revisited with a dedicated field in a future version of `OfferPaymentMetadata`.