### PR TITLE
Emit `ChannelCloseOutgoingPayment` as soon as a mutual close tx is known

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -106,7 +106,7 @@ sealed class ChannelState {
 
     private fun ChannelContext.maybeEmitClosingEvents(oldState: ChannelState, newState: ChannelState): List<ChannelAction> {
         return when {
-            // ignore channel init transitions
+            // ignore init transitions from init or without a commitment
             oldState !is ChannelStateWithCommitments -> emptyList()
             // normal mutual close flow
             oldState is Negotiating && oldState.publishedClosingTxs.isEmpty() && newState is Negotiating && newState.publishedClosingTxs.isNotEmpty() -> emitMutualCloseEvents(newState, newState.publishedClosingTxs.first())
@@ -118,7 +118,6 @@ sealed class ChannelState {
             oldState !is Closing && newState is Closing && newState.nextRemoteCommitPublished is RemoteCommitPublished -> emitForceCloseEvents(newState, newState.nextRemoteCommitPublished.commitTx, ChannelClosingType.Remote)
             oldState !is Closing && newState is Closing && newState.futureRemoteCommitPublished is RemoteCommitPublished -> emitForceCloseEvents(newState, newState.futureRemoteCommitPublished.commitTx, ChannelClosingType.Remote)
             oldState !is Closing && newState is Closing && newState.revokedCommitPublished.isNotEmpty() -> emitForceCloseEvents(newState, newState.revokedCommitPublished.first().commitTx, ChannelClosingType.Revoked)
-
             else -> emptyList()
         }
     }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
@@ -188,7 +188,6 @@ data class Negotiating(
         )
         val actions = buildList {
             add(ChannelAction.Storage.StoreState(nextState))
-            addAll(emitClosingEvents(this@Negotiating, nextState.state))
             add(ChannelAction.Storage.SetLocked(signedClosingTx.tx.txid))
         }
         return Pair(nextState, actions)


### PR DESCRIPTION
As opposed to when the mutual close tx is confirmed.

This is a return to the behavior we had _before_ simple close. This behavior changed because with simple close, we now stay in `Negotiating` until a mutual close tx is confirmed. Before, we would go to `Closing` state as soon as a mutual close tx was known.

Note that we are currently not handling the case where a concurrent mutual close tx confirms (they can be rbfed). But we were already not handling the case where a concurrent alternate close type confirms (e.g. a force close overrides a mutual close).

