### PR TITLE
Use correct max amount in splice out helpers

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -593,7 +593,7 @@ class Peer(
     suspend fun estimateFeeForSpliceOut(amount: Satoshi, scriptPubKey: ByteVector, targetFeerate: FeeratePerKw): Pair<FeeratePerKw, ChannelManagementFees>? {
         return channels.values
             .filterIsInstance<Normal>()
-            .firstOrNull { it.commitments.availableBalanceForSend() > amount }
+            .firstOrNull { it.commitments.availableBalanceForSend() >= amount }
             ?.let { channel ->
                 val weight = FundingContributions.computeWeightPaid(isInitiator = true, commitment = channel.commitments.active.first(), walletInputs = emptyList(), localOutputs = listOf(TxOut(amount, scriptPubKey)))
                 val (actualFeerate, miningFee) = client.computeSpliceCpfpFeerate(channel.commitments, targetFeerate, spliceWeight = weight, logger)
@@ -667,7 +667,7 @@ class Peer(
     suspend fun spliceOut(amount: Satoshi, scriptPubKey: ByteVector, feerate: FeeratePerKw): ChannelFundingResponse? {
         return channels.values
             .filterIsInstance<Normal>()
-            .firstOrNull { it.commitments.availableBalanceForSend() > amount }
+            .firstOrNull { it.commitments.availableBalanceForSend() >= amount }
             ?.let { channel ->
                 val spliceCommand = ChannelCommand.Commitment.Splice.Request(
                     replyTo = CompletableDeferred(),


### PR DESCRIPTION
Otherwise an off-by-one error ensues.

Specifically, Phoenix users that wish to splice out their entire balance will set an amount equal to their balance, and the result of `estimateFeeForSpliceOut` will be a confusing "no channel available".