### PR TITLE
Keep features as a `ByteVector` in Bolt12 TLVs

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
@@ -174,7 +174,7 @@ class OfferManager(val nodeParams: NodeParams, val walletParams: WalletParams, v
                     minHtlc = minHtlc,
                     // Payments are allowed to overpay at most two times the invoice amount.
                     maxHtlc = amount * 2,
-                    allowedFeatures = Features.empty
+                    allowedFeatures = ByteVector.empty
                 )
                 // Once the invoice expires, the blinded path shouldn't be usable anymore.
                 // We assume 10 minutes between each block to convert the invoice expiry to a cltv_expiry_delta.

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/Bolt12InvoiceTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/Bolt12InvoiceTestsCommon.kt
@@ -75,7 +75,7 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
             )
         ).write().toByteVector()
         val blindedRoute = RouteBlinding.create(sessionKey, listOf(nodeId), listOf(selfPayload)).route
-        val paymentInfo = PaymentInfo(1.msat, 2, CltvExpiryDelta(3), 4.msat, 5.msat, Features.empty)
+        val paymentInfo = PaymentInfo(1.msat, 2, CltvExpiryDelta(3), 4.msat, 5.msat, ByteVector.empty)
         return PaymentBlindedContactInfo(ContactInfo.BlindedPath(blindedRoute), paymentInfo)
     }
 
@@ -202,7 +202,7 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
         assertTrue(invoice.validateFor(request).isRight)
         val withInvalidFeatures = signInvoice(Bolt12Invoice(TlvStream(invoice.records.records.map {
             when (it) {
-                is InvoiceFeatures -> InvoiceFeatures(Features(Feature.BasicMultiPartPayment to FeatureSupport.Mandatory))
+                is InvoiceFeatures -> InvoiceFeatures(Features(Feature.BasicMultiPartPayment to FeatureSupport.Mandatory).toByteArray().toByteVector())
                 else -> it
             }
         }.toSet())), nodeKey)
@@ -240,7 +240,7 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
             InvoiceRequestAmount(15000.msat),
             InvoiceRequestPayerId(payerKey.publicKey()),
             InvoiceRequestPayerNote("I am Batman"),
-            OfferFeatures(Features(Feature.VariableLengthOnion to FeatureSupport.Mandatory))
+            OfferFeatures(Features(Feature.VariableLengthOnion to FeatureSupport.Mandatory).toByteArray().toByteVector())
         )
         val signature =
             signSchnorr(InvoiceRequest.signatureTag, rootHash(TlvStream(tlvs)), payerKey)
@@ -309,7 +309,7 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
             OfferIssuerId(nodeKey.publicKey()),
             InvoiceRequestPayerId(randomKey().publicKey()),
             InvoicePaths(listOf(createPaymentBlindedRoute(randomKey().publicKey()).route)),
-            InvoiceBlindedPay(listOf(PaymentInfo(0.msat, 0, CltvExpiryDelta(0), 0.msat, 765432.msat, Features.empty))),
+            InvoiceBlindedPay(listOf(PaymentInfo(0.msat, 0, CltvExpiryDelta(0), 0.msat, 765432.msat, ByteVector.empty))),
             InvoiceCreatedAt(123456789L),
             InvoicePaymentHash(randomBytes32()),
             InvoiceAmount(1684.msat),
@@ -343,7 +343,7 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
             nodeKey.publicKey(),
             PrivateKey.fromHex("f0442c17bdd2cefe4a4ede210f163b068bb3fea6113ffacea4f322de7aa9737b"),
             ByteVector.fromHex("76030536ba732cdc4e7bb0a883750bab2e88cb3dddd042b1952c44b4849c86bb")
-        ).copy(paymentInfo = PaymentInfo(2345.msat, 765, CltvExpiryDelta(324), 1000.msat, amount, Features.empty))
+        ).copy(paymentInfo = PaymentInfo(2345.msat, 765, CltvExpiryDelta(324), 1000.msat, amount, ByteVector.empty))
         val quantity = 57L
         val payerKey = PublicKey.fromHex("024a8d96f4d13c4219f211b8a8e7b4ab7a898fd1b2e90274ca5a8737a9eda377f8")
         val payerNote = "I'm Bob"
@@ -358,7 +358,7 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
                 OfferChains(listOf(chain)),
                 OfferAmount(amount),
                 OfferDescription(description),
-                OfferFeatures(Features.empty),
+                OfferFeatures(ByteVector.empty),
                 OfferIssuer(issuer),
                 OfferIssuerId(nodeKey.publicKey()),
                 InvoiceRequestChain(chain),
@@ -373,7 +373,7 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
                 InvoicePaymentHash(paymentHash),
                 InvoiceAmount(amount),
                 InvoiceFallbacks(fallbacks),
-                InvoiceFeatures(Features.empty),
+                InvoiceFeatures(ByteVector.empty),
                 InvoiceNodeId(nodeKey.publicKey()),
             ), setOf(GenericTlv(121, ByteVector.fromHex("010203")), GenericTlv(313, ByteVector.fromHex("baba")))
         )
@@ -531,5 +531,13 @@ class Bolt12InvoiceTestsCommon : LightningTestSuite() {
         assertEquals(invoice.nodeId, PublicKey.fromHex("024cc50d604f657094f8a2ff031ad6d888f9ac220a86b5949cdaaa5a5c03055d69"))
         assertEquals(invoice.paymentHash, ByteVector32.fromValidHex("14805a7006b96286e7b0a3f618c1cd7f1059f76da766044c5bfc3fa31d5e9442"))
         assertTrue(invoice.description == "yolo")
+    }
+
+    @Test
+    fun `invoice with non-minimally encoded feature bits`(){
+        val encodedInvoice = "lni1qqsyzre2s0lc77w5h33ck6540xxsyjehjl66f9tfp83w85zcxqyhltczyqrzymjxzydqkkw24ufxqslttwlj3s608f0rx2slc7etw0833zgs7zqyqh67zqq2qqgwsqktzd0na8g54f2r8secsaemc7ww2d6spl397celwcv20egnau2z8gp83d0dg7gvtkkvklnqlvp0erhq9nh9928rexerg578wnyew6dj6xczq2nqtavvd94k7jq2slng76uk560g6qeu38ru2gjjtdd4w9jxfqcc5qpnvvduearw4k75xdsgrc9ntzs274hwumtk5zwlrcr8yzwn8q0ry40f6lcmarq2nqkz9j2anajrlpchwwfguypms9x0uptvcsspwzjp3vg8srqx27crkqe8v9nzqaktzwwy5szk0rsq9sq7vhqncvv63mseqsx9lzmjraxhfnhc6f9tgnm05v7x0s4dhzwac9gruy44n9yht645cd4jzcssyjvcf2ptqztsenmzyw0e6kpx209mmmpal9ptutxpeygerepwh5rc2qsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzr6jqsae4jsq2spsyqqqtqss9g4l2s06jx69u2vtvezfmh07puh8pzhp76yddr7yvjpt2q38puqx5r7sgacrnpvghfhfzdzm9rertx4egjnarr2plwp26yfzcnv4ef536h9nu8lq9xyejhphnyv97axrqwr982vvedhfzj3cn5uhdymxwejfh55p2putqvpeskyt5m53x3dj3u34n2u5ff7334qlhq4dzy3vfk2u56gatje7rlsqgllx5cs3433fgn37scpz5ysn7df4tcfvgw5hgn998qut5l63vvmlv85xj4gj9rs6ja6gj45ddfjvwrcq9qthepk3xtpy4x8tsmmaqhas3v8k6chxp4ds8367lgw3q4mtpm5zmlr84tx4xpshtaxa0es0kcjuah80xt23pm08qprase5e2euq8ndvymuzcdznh78qyg28lw65wve2fpphd5zpwy4v3gfpa245dgtmqkp34gg8s4tfxytnx5vxhclwzmpzdy80jlfyznklk9t0karg42yvxqey68py3t0yg5rew5jke2sr6l5akw3r4x4cyp5f9ty27yjqtsn5ucqywkk84sxudl89xdxw34kvvtq67pk64r3kmyzz5dum0c66sjh7a5ylr6u38ycdmdq5rm7pp5m87rmsg7ntkqr4dcateeafrchaw085my236hxg47745nsrdtmjvnhy4a9ppd95g5m3u40wa0pcnmlhcm99xd0flh0484vht6ysx5cg5nmjxzaqsqv33sgptsrgmfuqgwjuvw5v58k379638h6hda8tqvpk4aexfmj27jsskj6y2dc72hhwhsufalmudjjnxh5lmh6n6kt4azgqg7en2fg446vmtj2zgncc9wv4sa8zhyxm60zadqlf664d8mhdx6g5g6cls2glkqdmayuvypt7fuljtswlmz4w5e8nkkpzr8m6txz7gzvfcexj9dmdhuhsx35lnwnmzm52vq2wgr49g25dwk4jlh0n2yq6yufpewngg7llkgxwqpr5nlruajj55sel09axp2tmkhaf2hkh2lsjyth098l2r2kfg7u9440ymwswpwd20j9zdp562ejm0yy0x68q4knmd6a6g4nz0a2nm3842yw4pdx8udqggqkxa03jwmrzzuzwp2mn6az3exhunlqcpmphsks3cur22l3hvzn74vqy0kf70r6hd5cy2va94czl9g594856j287cefqej8qlre5ewyc5l02wtsx0hcjr4jhup6z4rj46lmrylsr034r5w2csnsgcy83yz848lafh5wue9aue8grnpvghfhfzdzm9rertx4egjnarr2plwp26yfzcnv4ef536h9nu8lq86u0a3w8zcxwy9hj9gvdwv8fhahpdauyzmuegpkefl3xc798mft7qvpeskyt5m53x3dj3u34n2u5ff7334qlhq4dzy3vfk2u56gatje7rlsqg0xlmw039msmmqtt4jqkgqts08ervu9dsx05qwzr67dazwklna9yjzdker5mhmeghxde2jlu5gvl4wrshvrg6x6a0j7hqsgpcc3ngm0ucvftuq6k8q0tpgxknk3d3t8nc9p9frafrfndz788hkaut704urzsj06t45qy8qk5hewf9p3sej3m2xrwyk6ny5hg8t24aq50a7re8evssrd0nmtrpjttuj04nlhs8ygteqepyc6sg5lsdajrc63xjp26j7surx83vx5u4326qfk6vw0sqhme6cw9247ef75ymtz4mp3esduvl07ykrnzzre3aq5jgqzrzcj59yjdcvp38nq7uvdqwmnhvy0h7t9062znl8ly02k9d02tyxev6mf6we8ztfjrdu73wc6gctxg5lmgj4a8v8z9lzqdfvlsmcwzyznagl929pqqqqyfjqqqqqpszqcqqqqqqqqqq3xqqqqqqz0490jqqqgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpzvsqqqqqvqsxqqqqqqqqqqyfsqqqqqqnaftusqqzqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgnyqqqqqrqypsqqqqqqqqqpzvqqqqqqp4rw2vqqqsqqqqqqqqqqqqqqqqqqqqqqqqqzjqg6zm7ju2sgrmk0u67xstmskz34gfjfnjfxwvjltp3jsrd8rn40s7pgk8tzxwt64qgwu6egqtqggzfxvy4q4sp9cvea3z88uatqn98jaaas7ljs479nqujyv3usht6pu0qs8wdac52sykqfjnxg0xhva4fcv00hr4tqzjwkjnkayykkm9dnr97ladr5jjjx4xyjtun7ucye660akfv4nl9tupwnyemp0sasfxapvcw"
+        val invoice = Bolt12Invoice.fromString(encodedInvoice).get()
+        assertTrue(invoice.checkSignature())
+        assertEquals(invoice.amount, 1000000000.msat)
     }
 }

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/PaymentPacketTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/PaymentPacketTestsCommon.kt
@@ -170,7 +170,7 @@ class PaymentPacketTestsCommon : LightningTestSuite() {
         }
 
         fun createBlindedPaymentInfo(u: ChannelUpdate): OfferTypes.PaymentInfo {
-            return OfferTypes.PaymentInfo(u.feeBaseMsat, u.feeProportionalMillionths, u.cltvExpiryDelta, u.htlcMinimumMsat, u.htlcMaximumMsat!!, Features.empty)
+            return OfferTypes.PaymentInfo(u.feeBaseMsat, u.feeProportionalMillionths, u.cltvExpiryDelta, u.htlcMinimumMsat, u.htlcMaximumMsat!!, ByteVector.empty)
         }
     }
 


### PR DESCRIPTION
We always encode features using as few bytes as needed, however other implementations may use more bytes than needed. When they do in Bolt12 TLVs, our reencoding of the TLV is different and changes the hash. Instead we should keep the original encoding and only decode the field when needed.

Seee https://github.com/ACINQ/eclair/pull/3121