### PR TITLE
Update build and publishing scripts

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,8 @@ kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.6.2"
 kotlinx-serialization = "1.8.1"
 ktor = "3.1.2"
-bitcoinkmp = "0.22.2" # when upgrading bitcoin-kmp, keep secpjnijvm in sync!
-secpjnijvm = "0.17.3"
+bitcoinkmp = "0.25.0" # when upgrading bitcoin-kmp, keep secpjnijvm in sync!
+secpjnijvm = "0.18.0"
 kermit = "2.0.5"
 slf4j = "2.0.16"
 

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/InteractiveTx.kt
@@ -733,7 +733,7 @@ data class InteractiveTxSession(
                     // Generate a secret nonce for this input if we don't already have one.
                     is InteractiveTxInput.LocalSwapIn -> when (secretNonces[inputOutgoing.serialId]) {
                         null -> {
-                            val secretNonce = Musig2.generateNonce(randomBytes32(), swapInKeys.userPrivateKey, listOf(swapInKeys.userPublicKey, swapInKeys.remoteServerPublicKey))
+                            val secretNonce = Musig2.generateNonce(randomBytes32(), swapInKeys.userPrivateKey, swapInKeys.userPublicKey, listOf(swapInKeys.userPublicKey, swapInKeys.remoteServerPublicKey), null, null)
                             secretNonces + (inputOutgoing.serialId to secretNonce)
                         }
                         else -> secretNonces
@@ -819,7 +819,7 @@ data class InteractiveTxSession(
             // Generate a secret nonce for this input if we don't already have one.
             is InteractiveTxInput.RemoteSwapIn -> when (secretNonces[input.serialId]) {
                 null -> {
-                    val secretNonce = Musig2.generateNonce(randomBytes32(), swapInKeys.localServerPrivateKey(remoteNodeId), listOf(input.userKey, input.serverKey))
+                    val secretNonce = Musig2.generateNonce(randomBytes32(), swapInKeys.localServerPrivateKey(remoteNodeId), input.serverKey, listOf(input.userKey, input.serverKey), null, null)
                     secretNonces + (input.serialId to secretNonce)
                 }
                 else -> secretNonces

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
@@ -514,8 +514,8 @@ class TransactionsTestsCommon : LightningTestSuite() {
             )
             // The first step of a musig2 signing session is to exchange nonces.
             // If participants are disconnected before the end of the signing session, they must start again with fresh nonces.
-            val userNonce = Musig2.generateNonce(randomBytes32(), userPrivateKey, listOf(userPrivateKey.publicKey(), serverPrivateKey.publicKey()))
-            val serverNonce = Musig2.generateNonce(randomBytes32(), serverPrivateKey, listOf(serverPrivateKey.publicKey(), userPrivateKey.publicKey()))
+            val userNonce = Musig2.generateNonce(randomBytes32(), userPrivateKey, userPrivateKey.publicKey(), listOf(userPrivateKey.publicKey(), serverPrivateKey.publicKey()), null, null)
+            val serverNonce = Musig2.generateNonce(randomBytes32(), serverPrivateKey, serverPrivateKey.publicKey(), listOf(serverPrivateKey.publicKey(), userPrivateKey.publicKey()), null, null)
 
             // Once they have each other's public nonce, they can produce partial signatures.
             val userSig = swapInProtocol.signSwapInputUser(tx, 0, swapInTx.txOut, userPrivateKey, userNonce.first, userNonce.second, serverNonce.second).right!!


### PR DESCRIPTION
Update build to use bitcoin-kmp 0.25.0 and secp256k1-kmp 0.18.0. 
Update publishing scripts to migrate from OSSRH to Central Publisher API.