### PR TITLE
Less aggressive security margin for otf payments

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/IncomingPaymentHandler.kt
@@ -361,7 +361,7 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val db: PaymentsDb) {
                             canAddToFeeCredit -> null
                             // We only initiate on-the-fly funding if the missing amount is greater than the fees paid.
                             // Otherwise our peer may not be able to claim the funding fees from the relayed HTLCs.
-                            (willAddHtlcAmount + currentFeeCredit) < fees.total * 2 -> LiquidityEvents.Rejected(
+                            (willAddHtlcAmount + currentFeeCredit) < (fees.miningFee * 1.5 + fees.serviceFee) -> LiquidityEvents.Rejected(
                                 requestedAmount.toMilliSatoshi(),
                                 fees.total.toMilliSatoshi(),
                                 LiquidityEvents.Source.OffChainPayment,


### PR DESCRIPTION
Liquidity fees depend on mining fees which are volatile, and may increase between the time when a user accepts otf liquidity, and the time when the LSP allocates the liquidity. We need to make sure that the user is able to afford the increase of cost, so we require the incoming payment + fee credit to be 2x the estimated fee.

But that is overkill because only the mining fee is volatile, not the liquidity fee. On top of that, the liquidity fee can be much greater than the mining fee for some use cases (e.g. phoenixd).