### PR TITLE
Ignore invalid fallback address field in Bolt11 invoices

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt11Invoice.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt11Invoice.kt
@@ -41,7 +41,7 @@ data class Bolt11Invoice(
     val expirySeconds: Long? get() = tags.find { it is TaggedField.Expiry }?.run { (this as TaggedField.Expiry).expirySeconds }
     val minFinalExpiryDelta: CltvExpiryDelta? get() = tags.find { it is TaggedField.MinFinalCltvExpiry }?.run { CltvExpiryDelta((this as TaggedField.MinFinalCltvExpiry).cltvExpiryDelta) }
 
-    val fallbackAddress: String? = tags.find { it is TaggedField.FallbackAddress }?.run { (this as TaggedField.FallbackAddress).toAddress(prefix) }
+    val fallbackAddress: String? = tags.find { it is TaggedField.FallbackAddress }?.runCatching { (this as TaggedField.FallbackAddress).toAddress(prefix) }?.getOrNull()
 
     override val features: Features get() = tags.filterIsInstance<TaggedField.Features>().firstOrNull()?.run { Features(this.bits) } ?: Features.empty
 

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/Bolt11InvoiceTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/Bolt11InvoiceTestsCommon.kt
@@ -577,6 +577,13 @@ class Bolt11InvoiceTestsCommon : LightningTestSuite() {
         assertEquals(encodedInvoice, reencodedInvoice)
     }
 
+    @Test
+    fun `ignore invalid fallback address field`() {
+        val s = "lnbc100n1p5x4tkxpp5pxpzs4s3d02s8x44j5x2eavhdzzkt7xptrhskgauvnlh3qnd9avssp5kmunu4w5fq2j0m8fymn84fn05mfwfg4rzep4pufc5zfea48xutlsxq9z0rgqnp4qvyndeaqzman7h898jxm98dzkm0mlrsx36s93smrur7h0azyyuxc5rzjq25carzepgd4vqsyn44jrk85ezrpju92xyrk9apw4cdjh6yrwt5jgqqqqrt49lmtcqqqqqqqqqqq86qq9qrzjqwghf7zxvfkxq5a6sr65g0gdkv768p83mhsnt0msszapamzx2qvuxqqqqrt49lmtcqqqqqqqqqqq86qq9qcqzpghp5jr3y6ssyqxw33tj8qfmhf2gvugjuevk6u68z6f36xepne32yry8qfpml2dgykq3nsm929a282xwa4lryq5yfsxj6d8m6yge3yj387jpj6uhgyc9d0y9qyyssqv09p0awxd36jmx3snve2urf7e4snxjt9k8j665jpkvrewfu0zlt90ah7r3wg97ywg30xktdtt6rr848vk0evwyc3htclva63h7t35vsq38rrkw"
+        val invoice = Bolt11Invoice.read(s).get()
+        assertEquals(s, invoice.write())
+    }
+
     companion object {
         fun createInvoiceUnsafe(
             amount: MilliSatoshi? = null,


### PR DESCRIPTION
We were rejecting the invoice as invalid, but spec says we should ignore:

> The f field allows on-chain fallback; however, this may not make sense
for tiny or time-sensitive payments. It's possible that new address forms will appear; thus, multiple f fields (in an implied preferred order) help with transition, and f fields with versions 19-31 will be ignored by readers.

> MUST skip over f fields that use an unknown version.