### PR TITLE
Don't allocate bytes for invalid sizes

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningCodecs.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningCodecs.kt
@@ -186,11 +186,9 @@ object LightningCodecs {
 
     @JvmStatic
     fun bytes(input: Input, size: Int): ByteArray {
+        require(size <= input.availableBytes) { "cannot read $size bytes from stream containing only ${input.availableBytes} bytes" }
         val blob = ByteArray(size)
-        if (size > 0) {
-            val count = input.read(blob, 0, blob.size)
-            require(count >= size) { "unexpected EOF" }
-        }
+        if (size > 0) input.read(blob, 0, blob.size)
         return blob
     }
 

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/wire/OfferTypesTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/wire/OfferTypesTestsCommon.kt
@@ -607,6 +607,8 @@ class OfferTypesTestsCommon : LightningTestSuite() {
             "lno1pqpzwyqkyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg",
             "lno1pgx9getnwss8vetrw3hhyuc",
             "lno1pgx9getnwss8vetrw3hhyucsespjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k8qzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgqpqqqqqqqqqqqqqqqqqqqqqqqqqqqzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqqzq3zyg3zyg3zygszqqqqyqqqqsqqvpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsq",
+            "lno1l6jm7eelleemqeee", // invalid TLV field length
+            "lno1zmls9mk8y3wkklfvevcrszlmu23kfrxh49px20665dqwmn4p72pksese", // invalid TLV field length
         )
         invalidOffers.forEach {
             assertTrue(Offer.decode(it).isFailure)


### PR DESCRIPTION
In our `bytes` codec, we allocate a byte array before checking that it doesn't exceed the remaining number of bytes in the stream. This is dumb, we should first validate the size before allocating memory.

Thanks @erickcestari for reporting this.