### PR TITLE
Add look-ahead to on-chain wallet

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInWallet.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/SwapInWallet.kt
@@ -31,7 +31,7 @@ class SwapInWallet(
         scope.launch {
             // address rotation
             wallet.walletStateFlow
-                .map { it.lastDerivedAddress }
+                .map { it.firstUnusedDerivedAddress }
                 .filterNotNull()
                 .distinctUntilChanged()
                 .collect { (address, derived) ->

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumUtils.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumUtils.kt
@@ -5,12 +5,14 @@ import fr.acinq.lightning.tests.utils.testLoggerFactory
 import fr.acinq.lightning.utils.ServerAddress
 import kotlinx.coroutines.CoroutineScope
 
+val ElectrumTestnet3ServerAddress = ServerAddress("electrum.blockstream.info", 60002, TcpSocket.TLS.UNSAFE_CERTIFICATES)
 val ElectrumTestnet4ServerAddress = ServerAddress("mempool.space", 40002, TcpSocket.TLS.UNSAFE_CERTIFICATES)
 val ElectrumMainnetServerAddress = ServerAddress("electrum.acinq.co", 50002, TcpSocket.TLS.UNSAFE_CERTIFICATES)
 
 suspend fun connectToElectrumServer(scope: CoroutineScope, addr: ServerAddress): ElectrumClient =
     ElectrumClient(scope, testLoggerFactory).apply { connect(addr, TcpSocket.Builder()) }
 
+suspend fun CoroutineScope.connectToTestnet3Server(): ElectrumClient = connectToElectrumServer(this, ElectrumTestnet3ServerAddress)
 suspend fun CoroutineScope.connectToTestnet4Server(): ElectrumClient = connectToElectrumServer(this, ElectrumTestnet4ServerAddress)
 
 suspend fun CoroutineScope.connectToMainnetServer(): ElectrumClient = connectToElectrumServer(this, ElectrumMainnetServerAddress)


### PR DESCRIPTION
Addresses are rotated as soon as an unconfirmed transaction is detected, with no look-ahead. A typical scenario is:
1. user sends tx1 to addr(n)
2. wallet rotates to addr(n+1)
3. user rbfs tx1 with tx2, but sends to current address, which is now addr(n+1)
4. user restarts wallet
5. wallet now stops at addr(n) which is unused, never looking for addr(n+1)

We add a simple look-ahead mechanism where we look for 3 addresses (by default) past the first unused index.

cc @dpad85 