### PR TITLE
Reject offers with some fields present but empty

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt12Invoice.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/Bolt12Invoice.kt
@@ -160,7 +160,7 @@ data class Bolt12Invoice(val records: TlvStream<InvoiceTlv>) : PaymentRequest() 
                 is Either.Right -> {}
             }
             if (records.get<InvoiceAmount>() == null) return Either.Left(MissingRequiredTlv(170))
-            if (records.get<InvoicePaths>()?.paths?.isEmpty() != false) return Either.Left(MissingRequiredTlv(160))
+            if (records.get<InvoicePaths>() == null) return Either.Left(MissingRequiredTlv(160))
             if (records.get<InvoiceBlindedPay>()?.paymentInfos?.size != records.get<InvoicePaths>()?.paths?.size) return Either.Left(MissingRequiredTlv(162))
             if (records.get<InvoiceNodeId>() == null) return Either.Left(MissingRequiredTlv(176))
             if (records.get<InvoiceCreatedAt>() == null) return Either.Left(MissingRequiredTlv(164))

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/wire/OfferTypes.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/wire/OfferTypes.kt
@@ -85,6 +85,7 @@ object OfferTypes {
         companion object : TlvValueReader<OfferChains> {
             const val tag: Long = 2
             override fun read(input: Input): OfferChains {
+                require(input.availableBytes > 0) { "offer_chains must not be empty" }
                 val chains = ArrayList<BlockHash>()
                 while (input.availableBytes > 0) {
                     chains.add(BlockHash(LightningCodecs.bytes(input, 32)))
@@ -125,6 +126,7 @@ object OfferTypes {
         companion object : TlvValueReader<OfferCurrency> {
             const val tag: Long = 6
             override fun read(input: Input): OfferCurrency {
+                require(input.availableBytes == 3) { "offer_currency must be 3 bytes long" }
                 return OfferCurrency(LightningCodecs.bytes(input, input.availableBytes).decodeToString(throwOnInvalidSequence = true))
             }
         }
@@ -217,6 +219,7 @@ object OfferTypes {
         companion object : TlvValueReader<OfferPaths> {
             const val tag: Long = 16
             override fun read(input: Input): OfferPaths {
+                require(input.availableBytes > 0) { "offer_paths must not be empty" }
                 val paths = ArrayList<ContactInfo.BlindedPath>()
                 while (input.availableBytes > 0) {
                     val path = readPath(input)
@@ -427,6 +430,7 @@ object OfferTypes {
         companion object : TlvValueReader<InvoicePaths> {
             const val tag: Long = 160
             override fun read(input: Input): InvoicePaths {
+                require(input.availableBytes > 0) { "invoice_paths must not be empty" }
                 val paths = ArrayList<ContactInfo.BlindedPath>()
                 while (input.availableBytes > 0) {
                     val path = readPath(input)
@@ -486,6 +490,7 @@ object OfferTypes {
         companion object : TlvValueReader<InvoiceBlindedPay> {
             const val tag: Long = 162
             override fun read(input: Input): InvoiceBlindedPay {
+                require(input.availableBytes > 0) { "invoice_blindedpay must not be empty" }
                 val paymentInfos = ArrayList<PaymentInfo>()
                 while (input.availableBytes > 0) {
                     paymentInfos.add(readPaymentInfo(input))

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/wire/OfferTypesTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/wire/OfferTypesTestsCommon.kt
@@ -609,6 +609,7 @@ class OfferTypesTestsCommon : LightningTestSuite() {
             "lno1pgx9getnwss8vetrw3hhyucsespjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k8qzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgqpqqqqqqqqqqqqqqqqqqqqqqqqqqqzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqqzq3zyg3zyg3zygszqqqqyqqqqsqqvpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsq",
             "lno1l6jm7eelleemqeee", // invalid TLV field length
             "lno1zmls9mk8y3wkklfvevcrszlmu23kfrxh49px20665dqwmn4p72pksese", // invalid TLV field length
+            "lno1qgqpqqq", // empty offer paths
         )
         invalidOffers.forEach {
             assertTrue(Offer.decode(it).isFailure)


### PR DESCRIPTION
Offers or invoices where the fields `offer_chains`, `offer_paths`, `invoice_paths`, `invoice_blindedpay` are present but empty are considered invalid. While the spec does not necessarily rejects them explicitly, they can't be paid.
Also checks that `offer_currency` is 3 bytes long.

Fixed https://github.com/ACINQ/lightning-kmp/issues/799