### PR TITLE
Upgrade kotlin to 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.1.21-blue.svg?style=flat&logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.2.20-blue.svg?style=flat&logo=kotlin)](http://kotlinlang.org)
 [![Maven Central](https://img.shields.io/maven-central/v/fr.acinq.lightning/lightning-kmp-core)](https://search.maven.org/search?q=g:fr.acinq.lightning%20a:lightning-kmp*)
 ![Github Actions](https://github.com/ACINQ/lightning-kmp/actions/workflows/test.yml/badge.svg)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,19 @@
 [versions]
-kotlin = "2.1.21"
+kotlin = "2.2.20"
 kotlinx-coroutines = "1.10.2"
-kotlinx-datetime = "0.6.2"
-kotlinx-serialization = "1.8.1"
-ktor = "3.1.2"
+kotlinx-datetime = "0.7.1"
+kotlinx-serialization = "1.9.0"
+ktor = "3.3.0"
 bitcoinkmp = "0.26.0" # when upgrading bitcoin-kmp, keep secpjnijvm in sync!
 secpjnijvm = "0.19.0"
-kermit = "2.0.5"
-slf4j = "2.0.16"
+kermit = "2.0.8"
+slf4j = "2.0.17"
 
 # test dependencies
-test-kotlinx-io-core = "0.6.0"
+test-kotlinx-io-core = "0.8.0"
 test-bouncycastle = "1.64"
-test-logback = "1.5.16"
-test-sqlitejdbc = "3.32.3.3"
+test-logback = "1.5.19"
+test-sqlitejdbc = "3.50.3.0"
 
 [plugins]
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -65,7 +65,6 @@ kotlin {
                 api("fr.acinq.bitcoin:bitcoin-kmp:${libs.versions.bitcoinkmp.get()}")
                 api("org.jetbrains.kotlinx:kotlinx-coroutines-core:${libs.versions.kotlinx.coroutines.get()}")
                 api("org.jetbrains.kotlinx:kotlinx-serialization-core:${libs.versions.kotlinx.serialization.get()}")
-                api("org.jetbrains.kotlinx:kotlinx-serialization-cbor:${libs.versions.kotlinx.serialization.get()}")
                 api("org.jetbrains.kotlinx:kotlinx-serialization-json:${libs.versions.kotlinx.serialization.get()}")
                 api("org.jetbrains.kotlinx:kotlinx-datetime:${libs.versions.kotlinx.datetime.get()}")
                 api("co.touchlab:kermit:${libs.versions.kermit.get()}")

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/utils/time.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/utils/time.kt
@@ -1,7 +1,9 @@
 package fr.acinq.lightning.utils
 
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 fun currentTimestampMillis(): Long = Clock.System.now().toEpochMilliseconds()
 
 fun currentTimestampSeconds(): Long = currentTimestampMillis() / 1000


### PR DESCRIPTION
Let's take advantage of the upcoming major release to upgrade kotlin and other dependencies.

The main point of attention is a breaking change in `kotlinx-datetime`: see https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant.