### PR TITLE
Increase maximum number of accepted HTLCs to 19

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/NodeParams.kt
@@ -223,7 +223,7 @@ data class NodeParams(
             feerateTolerance = FeerateTolerance(ratioLow = 0.01, ratioHigh = 100.0)
         ),
         maxHtlcValueInFlightMsat = 20_000_000_000L,
-        maxAcceptedHtlcs = 12,
+        maxAcceptedHtlcs = 19,
         expiryDeltaBlocks = CltvExpiryDelta(144),
         // We use a long expiry delta here for a few reasons:
         //  - we want to ensure we're able to get HTLC-success txs confirmed if our peer ignores our preimage

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/serialization/channel/StateSerializationTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/serialization/channel/StateSerializationTestsCommon.kt
@@ -91,8 +91,8 @@ class StateSerializationTestsCommon : LightningTestSuite() {
                 .maxOf { it.size }
         }
 
-        // with 12 incoming payments and 12 outgoing payments, our encrypted backup stays below the 65k limit for peer storage
-        assertTrue(peerStorageSize(12, 12) <= 65_000)
+        // with 19 incoming payments and 18 outgoing payments, our encrypted backup stays below the 65k limit for peer storage
+        assertTrue(peerStorageSize(19, 19) <= 65_000)
     }
 
     @Test


### PR DESCRIPTION
https://github.com/ACINQ/lightning-kmp/pull/800 included a lot of improvements on our data structure and removed data that was either redondant or could be re-computed. This means that serialised channel states are smaller, and we can increase the number of pending HTLCs to 19 and stay below the 65 Kb size limit for LN messages.

Note that this applies to new channels only: existing ones will still use the previous value of 12 pending HTLCs.