### PR TITLE
Use docker instead of testnet3 for some ElectrumMiniWallet tests

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumDataTypes.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumDataTypes.kt
@@ -235,7 +235,7 @@ class JsonRPCResponseDeserializer(val json: Json) : KSerializer<JsonRPCResponse>
         val jsonObject = (decoder as? JsonDecoder)?.decodeJsonElement() as? JsonObject ?: throw SerializationException("Expected JsonObject")
         val error = jsonObject["error"]
         return if (error != null && error is JsonPrimitive && error.isString) {
-            JsonRPCResponse(id = (jsonObject["id"] as? JsonPrimitive)?.intOrNull ?: 0, error = JsonRPCError(code = 0, error.content))
+            JsonRPCResponse(id = (jsonObject["id"] as? JsonPrimitive)?.intOrNull ?: 0, jsonrpc = "2.0", error = JsonRPCError(code = 0, error.content))
         } else {
             json.decodeFromJsonElement(JsonRPCResponse.serializer(), jsonObject)
         }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/utils/jsonrpc.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/utils/jsonrpc.kt
@@ -92,7 +92,7 @@ fun String.asParam(): JsonRPCParam = JsonRPCString(this)
  * JSON-RPC result / error
  */
 @Serializable
-data class JsonRPCResponse(val id: Int? = 0, val result: JsonElement = JsonNull, val error: JsonRPCError? = null)
+data class JsonRPCResponse(val jsonrpc: String? = "2.0", val id: Int? = 0, val result: JsonElement = JsonNull, val error: JsonRPCError? = null)
 
 @Serializable
 data class JsonRPCError(val code: Int, val message: String)

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletIntegrationTest.kt
@@ -1,0 +1,91 @@
+package fr.acinq.lightning.blockchain.electrum
+
+import fr.acinq.bitcoin.*
+import fr.acinq.bitcoin.utils.runTrying
+import fr.acinq.lightning.SwapInParams
+import fr.acinq.lightning.blockchain.fee.FeeratePerKw
+import fr.acinq.lightning.crypto.LocalKeyManager
+import fr.acinq.lightning.io.TcpSocket
+import fr.acinq.lightning.io.TcpSocket.Builder.Companion.invoke
+import fr.acinq.lightning.tests.TestConstants
+import fr.acinq.lightning.tests.bitcoind.BitcoindService
+import fr.acinq.lightning.tests.utils.LightningTestSuite
+import fr.acinq.lightning.tests.utils.readEnvironmentVariable
+import fr.acinq.lightning.tests.utils.runSuspendBlocking
+import fr.acinq.lightning.tests.utils.runSuspendTest
+import fr.acinq.lightning.utils.ServerAddress
+import fr.acinq.lightning.utils.sat
+import fr.acinq.lightning.utils.toByteVector
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+class ElectrumMiniWalletIntegrationTest : LightningTestSuite() {
+
+    private val logger = loggerFactory.newLogger(this::class)
+    private val bitcoincli = BitcoindService
+    private val mnemonics = "bullet umbrella fringe token whip negative menu drill solid keep vacuum prepare".split(" ")
+    private val keyManager = LocalKeyManager(MnemonicCode.toSeed(mnemonics, "").toByteVector(), Chain.Regtest, TestConstants.aliceSwapInServerXpub)
+
+    init {
+        runSuspendBlocking {
+            withTimeout(10.seconds) {
+                while (runTrying { bitcoincli.getNetworkInfo() }.isFailure) {
+                    delay(0.5.seconds)
+                }
+            }
+            val address = bitcoincli.getNewAddress()
+            val address0 = keyManager.swapInOnChainWallet.getSwapInProtocol(0).address(Chain.Regtest)
+            bitcoincli.sendToAddress(address0, 1.0)
+            val address2 = keyManager.swapInOnChainWallet.getSwapInProtocol(2).address(Chain.Regtest)
+            bitcoincli.sendToAddress(address2, 1.0)
+        }
+    }
+
+
+    @OptIn(FlowPreview::class)
+    @Test
+    fun `derived addresses with gaps`() = runSuspendTest(timeout = 15.seconds) {
+        val chain = Chain.Regtest
+        val client = ElectrumClient(this, loggerFactory).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED), TcpSocket.Builder()) }
+        val wallet = ElectrumMiniWallet(chain.chainHash, client, this, logger)
+
+        wallet.addAddressGenerator(generator = { index -> keyManager.swapInOnChainWallet.getSwapInProtocol(index).address(chain) })
+
+        // This wallet has:
+        // index=0: 10000 sat + 11000 sat
+        // index=1: nothing
+        // index=2: 12000 sat
+        // index=3: nothing <-- will stop there
+
+        val walletState = wallet.walletStateFlow.debounce(5.seconds).first()
+        assertEquals(1, walletState.firstUnusedDerivedAddress?.second?.index)
+        assertEquals(3, walletState.lastDerivedAddress?.second?.index)
+    }
+
+    @OptIn(FlowPreview::class)
+    @Test
+    fun `derived addresses with gaps and no look-ahead`() = runSuspendTest(timeout = 15.seconds) {
+        val chain = Chain.Regtest
+        val client = ElectrumClient(this, loggerFactory).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED), TcpSocket.Builder()) }
+        val wallet = ElectrumMiniWallet(chain.chainHash, client, this, logger, lookAhead = 1u)
+        wallet.addAddressGenerator(generator = { index -> keyManager.swapInOnChainWallet.getSwapInProtocol(index).address(chain) })
+
+        // This wallet has:
+        // index=0: 10000 sat + 11000 sat
+        // index=1: nothing <-- will stop there
+        // index=2: 12000 sat
+        // index=3: nothing
+
+        val walletState = wallet.walletStateFlow.debounce(5.seconds).first()
+        assertEquals(1, walletState.firstUnusedDerivedAddress?.second?.index)
+        assertEquals(1, walletState.lastDerivedAddress?.second?.index)
+    }
+}

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumMiniWalletTest.kt
@@ -374,48 +374,4 @@ class ElectrumMiniWalletTest : LightningTestSuite() {
         wallet2.stop()
         client.stop()
     }
-
-    @OptIn(FlowPreview::class)
-    @Test
-    fun `derived addresses with gaps`() = runSuspendTest(timeout = 15.seconds) {
-        val client = connectToTestnet3Server()
-        val chain = Chain.Testnet3
-        val wallet = ElectrumMiniWallet(chain.chainHash, client, this, logger)
-
-        val mnemonics = "bullet umbrella fringe token whip negative menu drill solid keep vacuum prepare".split(" ")
-        val keyManager = LocalKeyManager(MnemonicCode.toSeed(mnemonics, "").toByteVector(), chain, TestConstants.aliceSwapInServerXpub)
-        wallet.addAddressGenerator(generator = { index -> keyManager.swapInOnChainWallet.getSwapInProtocol(index).address(chain) })
-
-        // This wallet has:
-        // index=0: 10000 sat + 11000 sat
-        // index=1: nothing
-        // index=2: 12000 sat
-        // index=3: nothing <-- will stop there
-
-        val walletState = wallet.walletStateFlow.debounce(5.seconds).first()
-        assertEquals(1, walletState.firstUnusedDerivedAddress?.second?.index)
-        assertEquals(3, walletState.lastDerivedAddress?.second?.index)
-    }
-
-    @OptIn(FlowPreview::class)
-    @Test
-    fun `derived addresses with gaps and no look-ahead`() = runSuspendTest(timeout = 15.seconds) {
-        val client = connectToTestnet3Server()
-        val chain = Chain.Testnet3
-        val wallet = ElectrumMiniWallet(chain.chainHash, client, this, logger, lookAhead = 1u)
-
-        val mnemonics = "bullet umbrella fringe token whip negative menu drill solid keep vacuum prepare".split(" ")
-        val keyManager = LocalKeyManager(MnemonicCode.toSeed(mnemonics, "").toByteVector(), chain, TestConstants.aliceSwapInServerXpub)
-        wallet.addAddressGenerator(generator = { index -> keyManager.swapInOnChainWallet.getSwapInProtocol(index).address(chain) })
-
-        // This wallet has:
-        // index=0: 10000 sat + 11000 sat
-        // index=1: nothing <-- will stop there
-        // index=2: 12000 sat
-        // index=3: nothing
-
-        val walletState = wallet.walletStateFlow.debounce(5.seconds).first()
-        assertEquals(1, walletState.firstUnusedDerivedAddress?.second?.index)
-        assertEquals(1, walletState.lastDerivedAddress?.second?.index)
-    }
 }

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumRequestTest.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumRequestTest.kt
@@ -80,7 +80,7 @@ class ElectrumRequestTest : LightningTestSuite() {
             appendLine()
         }
         val response = json.decodeFromString(ElectrumResponseDeserializer, jsonRpc)
-        assertEquals(Either.Right(JsonRPCResponse(null, JsonNull, JsonRPCError(-32700, "messages must be encoded in UTF-8"))), response)
+        assertEquals(Either.Right(JsonRPCResponse("2.0", null, JsonNull, JsonRPCError(-32700, "messages must be encoded in UTF-8"))), response)
     }
 
     @Test
@@ -98,6 +98,6 @@ class ElectrumRequestTest : LightningTestSuite() {
             appendLine()
         }
         val response = json.decodeFromString(ElectrumResponseDeserializer, jsonRpc)
-        assertEquals(Either.Right(JsonRPCResponse(4, JsonNull, JsonRPCError(0, """sendrawtransaction RPC error: {"code":-27,"message":"Transaction already in block chain"}"""))), response)
+        assertEquals(Either.Right(JsonRPCResponse("2.0", 4, JsonNull, JsonRPCError(0, """sendrawtransaction RPC error: {"code":-27,"message":"Transaction already in block chain"}"""))), response)
     }
 }

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
@@ -1,6 +1,7 @@
 package fr.acinq.lightning.blockchain.electrum
 
 import fr.acinq.bitcoin.*
+import fr.acinq.bitcoin.Bitcoin.addressToPublicKeyScript
 import fr.acinq.bitcoin.SigHash.SIGHASH_ALL
 import fr.acinq.bitcoin.utils.runTrying
 import fr.acinq.lightning.blockchain.WatchConfirmed
@@ -43,7 +44,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
         val client = ElectrumClient(this, loggerFactory).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED), TcpSocket.Builder()) }
         val watcher = ElectrumWatcher(client, this, loggerFactory)
 
-        val (address, _) = bitcoincli.getNewAddress()
+        val address = bitcoincli.getNewAddress()
         val tx = bitcoincli.sendToAddress(address, 1.0)
 
         val listener = watcher.openWatchNotificationsFlow()
@@ -70,7 +71,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
         val client = ElectrumClient(this, loggerFactory).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED), TcpSocket.Builder()) }
         val watcher = ElectrumWatcher(client, this, loggerFactory)
 
-        val (address, _) = bitcoincli.getNewAddress()
+        val address = bitcoincli.getNewAddress()
         val tx = bitcoincli.sendToAddress(address, 1.0)
 
         bitcoincli.generateBlocks(5)
@@ -98,33 +99,23 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
         val client = ElectrumClient(this, loggerFactory).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED), TcpSocket.Builder()) }
         val watcher = ElectrumWatcher(client, this, loggerFactory)
 
-        val (address, privateKey) = bitcoincli.getNewAddress()
+        val address = bitcoincli.getNewAddress()
+        val addressScript = Script.write(addressToPublicKeyScript(Chain.Regtest.chainHash, address).right!!).byteVector()
         val tx = bitcoincli.sendToAddress(address, 1.0)
 
         // find the output for the address we generated and create a tx that spends it
         val pos = tx.txOut.indexOfFirst {
-            it.publicKeyScript == Script.write(Script.pay2wpkh(privateKey.publicKey())).byteVector()
+            it.publicKeyScript == addressScript
         }
         assertTrue(pos != -1)
 
         val tmp = Transaction(
             version = 2,
             txIn = listOf(TxIn(OutPoint(tx, pos.toLong()), signatureScript = emptyList(), sequence = TxIn.SEQUENCE_FINAL)),
-            txOut = listOf(TxOut(tx.txOut[pos].amount - 1000.sat, publicKeyScript = Script.pay2wpkh(privateKey.publicKey()))),
+            txOut = listOf(TxOut(tx.txOut[pos].amount - 1000.sat, publicKeyScript = addressScript)),
             lockTime = 0
         )
-
-        val sig = Transaction.signInput(
-            tmp,
-            0,
-            Script.pay2pkh(privateKey.publicKey()),
-            SIGHASH_ALL,
-            tx.txOut[pos].amount,
-            SigVersion.SIGVERSION_WITNESS_V0,
-            privateKey
-        ).byteVector()
-
-        val spendingTx = tmp.updateWitness(0, ScriptWitness(listOf(sig, privateKey.publicKey().value)))
+        val spendingTx = bitcoincli.signTransaction(tmp)
         Transaction.correctlySpends(spendingTx, listOf(tx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
         val listener = watcher.openWatchNotificationsFlow()
@@ -155,33 +146,23 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
         val client = ElectrumClient(this, loggerFactory)
         val watcher = ElectrumWatcher(client, this, loggerFactory)
 
-        val (address, privateKey) = bitcoincli.getNewAddress()
+        val address = bitcoincli.getNewAddress()
+        val addressScript = Script.write(addressToPublicKeyScript(Chain.Regtest.chainHash, address).right!!).byteVector()
         val tx = bitcoincli.sendToAddress(address, 1.0)
 
         // find the output for the address we generated and create a tx that spends it
         val pos = tx.txOut.indexOfFirst {
-            it.publicKeyScript == Script.write(Script.pay2wpkh(privateKey.publicKey())).byteVector()
+            it.publicKeyScript == addressScript
         }
         assertTrue(pos != -1)
 
         val tmp = Transaction(
             version = 2,
             txIn = listOf(TxIn(OutPoint(tx, pos.toLong()), signatureScript = emptyList(), sequence = TxIn.SEQUENCE_FINAL)),
-            txOut = listOf(TxOut(tx.txOut[pos].amount - 1000.sat, publicKeyScript = Script.pay2wpkh(privateKey.publicKey()))),
+            txOut = listOf(TxOut(tx.txOut[pos].amount - 1000.sat, publicKeyScript = addressScript)),
             lockTime = 0
         )
-
-        val sig = Transaction.signInput(
-            tmp,
-            0,
-            Script.pay2pkh(privateKey.publicKey()),
-            SIGHASH_ALL,
-            tx.txOut[pos].amount,
-            SigVersion.SIGVERSION_WITNESS_V0,
-            privateKey
-        ).byteVector()
-
-        val spendingTx = tmp.updateWitness(0, ScriptWitness(listOf(sig, privateKey.publicKey().value)))
+        val spendingTx = bitcoincli.signTransaction(tmp)
         Transaction.correctlySpends(spendingTx, listOf(tx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
         val listener = watcher.openWatchNotificationsFlow()
@@ -214,12 +195,13 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
         val client = ElectrumClient(this, loggerFactory).apply { connect(ServerAddress("localhost", 51001, TcpSocket.TLS.DISABLED), TcpSocket.Builder()) }
         val watcher = ElectrumWatcher(client, this, loggerFactory)
 
-        val (address, privateKey) = bitcoincli.getNewAddress()
+        val address = bitcoincli.getNewAddress()
+        val addressScript = Script.write(addressToPublicKeyScript(Chain.Regtest.chainHash, address).right!!).byteVector()
         val tx = bitcoincli.sendToAddress(address, 1.0)
 
         // find the output for the address we generated and create a tx that spends it
         val pos = tx.txOut.indexOfFirst {
-            it.publicKeyScript == Script.write(Script.pay2wpkh(privateKey.publicKey())).byteVector()
+            it.publicKeyScript == addressScript
         }
         assertTrue(pos != -1)
 
@@ -227,20 +209,10 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
             val tmp = Transaction(
                 version = 2,
                 txIn = listOf(TxIn(OutPoint(tx, pos.toLong()), signatureScript = emptyList(), sequence = TxIn.SEQUENCE_FINAL)),
-                txOut = listOf(TxOut(tx.txOut[pos].amount - 1000.sat, publicKeyScript = Script.pay2wpkh(privateKey.publicKey()))),
+                txOut = listOf(TxOut(tx.txOut[pos].amount - 1000.sat, publicKeyScript = addressScript)),
                 lockTime = 0
             )
-
-            val sig = Transaction.signInput(
-                tmp,
-                0,
-                Script.pay2pkh(privateKey.publicKey()),
-                SIGHASH_ALL,
-                tx.txOut[pos].amount,
-                SigVersion.SIGVERSION_WITNESS_V0,
-                privateKey
-            ).byteVector()
-            val signedTx = tmp.updateWitness(0, ScriptWitness(listOf(sig, privateKey.publicKey().value)))
+            val signedTx = bitcoincli.signTransaction(tmp)
             Transaction.correctlySpends(signedTx, listOf(tx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
             signedTx
         }
@@ -300,14 +272,15 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
         val initialBlockCount = bitcoincli.getBlockCount() // 150
         awaitForBlockCount(0)
 
-        val (_, privateKey) = bitcoincli.getNewAddress()
+        val address = bitcoincli.getNewAddress()
+        val addressScript = Script.write(addressToPublicKeyScript(Chain.Regtest.chainHash, address).right!!).byteVector()
 
         // tx1 has an absolute delay but no relative delay
         val fundTx = bitcoincli.fundTransaction(
             Transaction(
                 version = 2,
                 txIn = listOf(),
-                txOut = listOf(TxOut(150000.sat, Script.pay2wpkh(privateKey.publicKey()))),
+                txOut = listOf(TxOut(150000.sat, addressScript)),
                 lockTime = (initialBlockCount + 5).toLong()
             ), true, 250.sat
         )
@@ -326,13 +299,13 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
         checkIfExistsInMempool(tx1)
 
         // tx2 has a relative delay but no absolute delay
-        val tx2 = bitcoincli.createSpendP2WPKH(
-            parentTx = tx1,
-            privateKey = privateKey,
-            to = privateKey.publicKey(),
-            fee = 10000.sat,
-            sequence = 2,
-            lockTime = 0
+        val tx2 = bitcoincli.signTransaction(
+            Transaction(
+                version = 2,
+                txIn = listOf(TxIn(OutPoint(tx1, tx1.txOut.indexOfFirst { it.publicKeyScript == addressScript }.toLong()), sequence = 2)),
+                txOut = listOf(TxOut(150000.sat - 10000.sat, addressToPublicKeyScript(Chain.Regtest.chainHash, address).right!!)),
+                lockTime = 0
+            )
         )
 
         watcher.watch(WatchConfirmed(ByteVector32.Zeroes, tx1, 1, WatchConfirmed.ChannelFundingDepthOk))
@@ -350,13 +323,13 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
         checkIfExistsInMempool(tx2)
 
         // tx3 has both relative and absolute delays
-        val tx3 = bitcoincli.createSpendP2WPKH(
-            parentTx = tx2,
-            privateKey = privateKey,
-            to = privateKey.publicKey(),
-            10000.sat,
-            sequence = 1,
-            lockTime = (bitcoincli.getBlockCount() + 5).toLong()
+        val tx3 = bitcoincli.signTransaction(
+            Transaction(
+                version = 2,
+                txIn = listOf(TxIn(OutPoint(tx2, tx2.txOut.indexOfFirst { it.publicKeyScript == addressScript }.toLong()), sequence = 1)),
+                txOut = listOf(TxOut(150000.sat - 10000.sat - 10000.sat, addressToPublicKeyScript(Chain.Regtest.chainHash, address).right!!)),
+                lockTime = (bitcoincli.getBlockCount() + 5).toLong()
+            )
         )
 
         watcher.watch(WatchConfirmed(ByteVector32.Zeroes, tx2, 1, WatchConfirmed.ChannelFundingDepthOk))

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumWatcherIntegrationTest.kt
@@ -303,7 +303,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
             Transaction(
                 version = 2,
                 txIn = listOf(TxIn(OutPoint(tx1, tx1.txOut.indexOfFirst { it.publicKeyScript == addressScript }.toLong()), sequence = 2)),
-                txOut = listOf(TxOut(150000.sat - 10000.sat, addressToPublicKeyScript(Chain.Regtest.chainHash, address).right!!)),
+                txOut = listOf(TxOut(150000.sat - 10000.sat, addressScript)),
                 lockTime = 0
             )
         )
@@ -327,7 +327,7 @@ class ElectrumWatcherIntegrationTest : LightningTestSuite() {
             Transaction(
                 version = 2,
                 txIn = listOf(TxIn(OutPoint(tx2, tx2.txOut.indexOfFirst { it.publicKeyScript == addressScript }.toLong()), sequence = 1)),
-                txOut = listOf(TxOut(150000.sat - 10000.sat - 10000.sat, addressToPublicKeyScript(Chain.Regtest.chainHash, address).right!!)),
+                txOut = listOf(TxOut(150000.sat - 10000.sat - 10000.sat, addressScript)),
                 lockTime = (bitcoincli.getBlockCount() + 5).toLong()
             )
         )

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/tests/bitcoind/BitcoinJsonRPCClient.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/tests/bitcoind/BitcoinJsonRPCClient.kt
@@ -21,7 +21,7 @@ object BitcoinJsonRPCClient {
     private const val ssl: Boolean = false
 
     private val scheme = if (ssl) "https" else "http"
-    private val serviceUri = "$scheme://$host:$port/" // wallet/ specifies to use the default bitcoind wallet, named ""
+    private val serviceUri = "$scheme://$host:$port/"
 
     private val httpClient = HttpClient {
         install(ContentNegotiation) {

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/tests/bitcoind/BitcoinJsonRPCClient.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/tests/bitcoind/BitcoinJsonRPCClient.kt
@@ -21,7 +21,7 @@ object BitcoinJsonRPCClient {
     private const val ssl: Boolean = false
 
     private val scheme = if (ssl) "https" else "http"
-    private val serviceUri = "$scheme://$host:$port/wallet/" // wallet/ specifies to use the default bitcoind wallet, named ""
+    private val serviceUri = "$scheme://$host:$port/" // wallet/ specifies to use the default bitcoind wallet, named ""
 
     private val httpClient = HttpClient {
         install(ContentNegotiation) {

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/tests/bitcoind/BitcoindService.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/tests/bitcoind/BitcoindService.kt
@@ -14,10 +14,9 @@ object BitcoindService {
     suspend fun getBlockCount(): Int = client.sendRequest<GetBlockCountResponse>(GetBlockCount).blockcount
     suspend fun getRawMempool(): List<String> = client.sendRequest<GetRawMempoolResponse>(GetRawMempool).txids
 
-    suspend fun getNewAddress(): Pair<String, PrivateKey> {
+    suspend fun getNewAddress(): String {
         val response: GetNewAddressResponse = client.sendRequest(GetNewAddress)
-        val privateKey = getPrivateKey(response.address)
-        return response.address to privateKey
+        return response.address
     }
 
     suspend fun getPrivateKey(address: String): PrivateKey {
@@ -32,7 +31,7 @@ object BitcoindService {
     }
 
     suspend fun generateBlocks(blockCount: Int) {
-        val (address, _) = getNewAddress()
+        val address = getNewAddress()
         val response: GenerateToAddressResponse = client.sendRequest(GenerateToAddress(blockCount, address))
         check(blockCount == response.blocks.size)
     }

--- a/testing/cmd.inc.sh
+++ b/testing/cmd.inc.sh
@@ -23,7 +23,7 @@ function btc_create {
         -p 18444:18444 \
         -p 29000:29000 \
         -p 29001:29001 \
-        ruimarinho/bitcoin-core:0.20.1 \
+        bitcoin/bitcoin:29.1 \
         -printtoconsole \
         -regtest=1 \
         -server=1 \
@@ -38,6 +38,7 @@ function btc_create {
 
     docker start bitcoind
     sleep 2
+    docker exec bitcoind bitcoin-cli -regtest -rpcuser=foo -rpcpassword=bar -named createwallet wallet_name=descwallet descriptors=true load_on_startup=true
     $basedir/gen-blocks.sh 150
     docker stop -t 2 bitcoind
 }


### PR DESCRIPTION
testnet3 electrum servers are unreliable which caused our CI to fail. Tests that required a testnet3 electrum servers (to verify how we handle gap in address history) have been modified to run against a local regtest docker electrum server, like our ElectrumWatcher integration tests.
We also upgrade bitcoind docker image from 0.20.1 (which did not understand addresses use in our swap-in protocol)  to 29.1.

Replaces https://github.com/ACINQ/lightning-kmp/pull/853