### PR TITLE
Follow BOLT1 handling for "no reply" pings: ignore, don't reply.

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/io/Peer.kt
@@ -1251,8 +1251,11 @@ class Peer(
                         }
                     }
                     is Ping -> {
-                        val pong = Pong(ByteVector(ByteArray(msg.pongLength)))
-                        peerConnection?.send(pong)
+                        // BOLT1: reply only if requested pong length is acceptable, otherwise silently ignore
+                        if (msg.pongLength <= 65532) {
+                            val pong = Pong(ByteVector(ByteArray(msg.pongLength)))
+                            peerConnection?.send(pong)
+                        }
                     }
                     is Pong -> {
                         logger.debug { "received pong" }


### PR DESCRIPTION
```
A node receiving a `ping` message:
  - if `num_pong_bytes` is less than 65532:
    - MUST respond by sending a `pong` message, with `byteslen` equal to `num_pong_bytes`.
  - otherwise (`num_pong_bytes` is **not** less than 65532):
    - MUST ignore the `ping`.
```

This allows for message padding.

See https://github.com/ACINQ/eclair/pull/3278 for the eclair variant.