### PR TITLE
Simple close workflow: use our closing_complete instead of local signing nonces

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -4,7 +4,6 @@ import fr.acinq.bitcoin.*
 import fr.acinq.bitcoin.crypto.musig2.IndividualNonce
 import fr.acinq.bitcoin.utils.Either
 import fr.acinq.bitcoin.utils.Try
-import fr.acinq.bitcoin.utils.flatMap
 import fr.acinq.bitcoin.utils.runTrying
 import fr.acinq.lightning.CltvExpiryDelta
 import fr.acinq.lightning.MilliSatoshi
@@ -313,7 +312,6 @@ object Helpers {
                 return Either.Left(CannotGenerateClosingTx(commitment.channelId))
             }
             val localFundingKey = channelKeys.fundingKey(commitment.fundingTxIndex)
-            val localNonces = Transactions.CloserNonces.generate(localFundingKey.publicKey(), commitment.remoteFundingPubkey, commitment.fundingTxId)
             val tlvs = when (commitment.commitmentFormat) {
                 Transactions.CommitmentFormat.AnchorOutputs -> TlvStream(
                     setOfNotNull(
@@ -328,15 +326,16 @@ object Helpers {
                         // If we cannot create our partial signature for one of our closing txs, we just skip it.
                         // It will only happen if our peer sent an invalid nonce, in which case we cannot do anything anyway
                         // apart from eventually force-closing.
-                        fun localSig(tx: Transactions.ClosingTx, localNonce: Transactions.LocalNonce): ChannelSpendSignature.PartialSignatureWithNonce? {
+                        fun localSig(tx: Transactions.ClosingTx): ChannelSpendSignature.PartialSignatureWithNonce? {
+                            val localNonce = NonceGenerator.signingNonce(localFundingKey.publicKey(), commitment.remoteFundingPubkey, commitment.fundingTxId)
                             return tx.partialSign(localFundingKey, commitment.remoteFundingPubkey, mapOf(), localNonce, listOf(localNonce.publicNonce, remoteNonce)).right
                         }
 
                         TlvStream(
                             setOfNotNull(
-                                closingTxs.localAndRemote?.let { tx -> localSig(tx, localNonces.localAndRemote)?.let { ClosingCompleteTlv.CloserAndCloseeOutputsPartialSignature(it) } },
-                                closingTxs.localOnly?.let { tx -> localSig(tx, localNonces.localOnly)?.let { ClosingCompleteTlv.CloserOutputOnlyPartialSignature(it) } },
-                                closingTxs.remoteOnly?.let { tx -> localSig(tx, localNonces.remoteOnly)?.let { ClosingCompleteTlv.CloseeOutputOnlyPartialSignature(it) } }
+                                closingTxs.localAndRemote?.let { tx -> localSig(tx)?.let { ClosingCompleteTlv.CloserAndCloseeOutputsPartialSignature(it) } },
+                                closingTxs.localOnly?.let { tx -> localSig(tx)?.let { ClosingCompleteTlv.CloserOutputOnlyPartialSignature(it) } },
+                                closingTxs.remoteOnly?.let { tx -> localSig(tx)?.let { ClosingCompleteTlv.CloseeOutputOnlyPartialSignature(it) } }
                             )
                         )
                     }
@@ -454,7 +453,7 @@ object Helpers {
             commitment: FullCommitment,
             closingTxs: Transactions.ClosingTxs,
             closingSig: ClosingSig,
-            localCosingComplete: ClosingComplete?,
+            localClosingComplete: ClosingComplete?,
             remoteNonce: IndividualNonce?
         ): Either<ChannelException, Transactions.ClosingTx> {
             val closingTxsWithSig = listOfNotNull(
@@ -483,10 +482,10 @@ object Helpers {
                         }
                         is ChannelSpendSignature.PartialSignatureWithNonce -> {
                             val localSig = when {
-                                localCosingComplete == null -> null
-                                closingTx.tx.txOut.size == 2 -> localCosingComplete.closerAndCloseeOutputsPartialSig
-                                closingTx.toLocalOutput != null -> localCosingComplete.closerOutputOnlyPartialSig
-                                else -> localCosingComplete.closeeOutputOnlyPartialSig
+                                localClosingComplete == null -> null
+                                closingTx.tx.txOut.size == 2 -> localClosingComplete.closerAndCloseeOutputsPartialSig
+                                closingTx.toLocalOutput != null -> localClosingComplete.closerOutputOnlyPartialSig
+                                else -> localClosingComplete.closeeOutputOnlyPartialSig
                             }
                             if (localSig == null) return Either.Left(InvalidCloseSignature(commitment.channelId, closingTx.tx.txid))
 

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -289,7 +289,7 @@ object Helpers {
             feerate: FeeratePerKw,
             lockTime: Long,
             remoteNonce: IndividualNonce?
-        ): Either<ChannelException, Triple<Transactions.ClosingTxs, ClosingComplete, Transactions.CloserNonces>> {
+        ): Either<ChannelException, Pair<Transactions.ClosingTxs, ClosingComplete>> {
             val commitInput = commitment.commitInput(channelKeys)
             // We must convert the feerate to a fee: we must build dummy transactions to compute their weight.
             val closingFee = run {
@@ -343,7 +343,7 @@ object Helpers {
                 }
             }
             val closingComplete = ClosingComplete(commitment.channelId, localScriptPubkey, remoteScriptPubkey, closingFee.fee, lockTime, tlvs)
-            return Either.Right(Triple(closingTxs, closingComplete, localNonces))
+            return Either.Right(Pair(closingTxs, closingComplete))
         }
 
         /**
@@ -389,6 +389,9 @@ object Helpers {
                         else -> {
                             val (closingTx, remoteSig, sigToTlv) = preferred
                             val localFundingKey = channelKeys.fundingKey(commitment.fundingTxIndex)
+                            if (!closingTx.checkRemotePartialSignature(localFundingKey.publicKey(), commitment.remoteFundingPubkey, remoteSig, localNonce.publicNonce)) {
+                                return Either.Left(InvalidCloseSignature(commitment.channelId, closingTx.tx.txid))
+                            }
                             val localSig = closingTx.partialSign(localFundingKey, commitment.remoteFundingPubkey, mapOf(), localNonce, listOf(localNonce.publicNonce, remoteSig.nonce)).right
                             val signedTx = localSig?.let { closingTx.aggregateSigs(localFundingKey.publicKey(), commitment.remoteFundingPubkey, it, remoteSig, mapOf()).right }
                             if (localSig == null || signedTx == null) {
@@ -451,7 +454,7 @@ object Helpers {
             commitment: FullCommitment,
             closingTxs: Transactions.ClosingTxs,
             closingSig: ClosingSig,
-            localNonces: Transactions.CloserNonces?,
+            localCosingComplete: ClosingComplete?,
             remoteNonce: IndividualNonce?
         ): Either<ChannelException, Transactions.ClosingTx> {
             val closingTxsWithSig = listOfNotNull(
@@ -479,16 +482,18 @@ object Helpers {
                             }
                         }
                         is ChannelSpendSignature.PartialSignatureWithNonce -> {
-                            val localNonce = when {
-                                localNonces == null -> return Either.Left(InvalidCloseSignature(commitment.channelId, closingTx.tx.txid))
-                                closingTx.tx.txOut.size == 2 -> localNonces.localAndRemote
-                                closingTx.toLocalOutput != null -> localNonces.localOnly
-                                else -> localNonces.remoteOnly
+                            val localSig = when {
+                                localCosingComplete == null -> null
+                                closingTx.tx.txOut.size == 2 -> localCosingComplete.closerAndCloseeOutputsPartialSig
+                                closingTx.toLocalOutput != null -> localCosingComplete.closerOutputOnlyPartialSig
+                                else -> localCosingComplete.closeeOutputOnlyPartialSig
                             }
-                            val signedClosingTx = closingTx.partialSign(localFundingKey, commitment.remoteFundingPubkey, mapOf(), localNonce, listOf(localNonce.publicNonce, remoteSig.nonce))
-                                .flatMap { closingTx.aggregateSigs(localFundingKey.publicKey(), commitment.remoteFundingPubkey, it, remoteSig, mapOf()) }
-                                .map { closingTx.copy(tx = it) }
+                            if (localSig == null) return Either.Left(InvalidCloseSignature(commitment.channelId, closingTx.tx.txid))
+
+                            val signedClosingTx = closingTx.aggregateSigs(localFundingKey.publicKey(), commitment.remoteFundingPubkey, localSig, remoteSig, mapOf())
+                                .map { closingTx.copy(tx = it)  }
                                 .right ?: return Either.Left(InvalidCloseSignature(commitment.channelId, closingTx.tx.txid))
+
                             if (!signedClosingTx.validate(mapOf())) {
                                 Either.Left(InvalidCloseSignature(commitment.channelId, signedClosingTx.tx.txid))
                             } else {

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Channel.kt
@@ -484,7 +484,7 @@ sealed class ChannelStateWithCommitments : PersistedChannelState() {
                     cmd,
                     localCloseeNonce,
                     remoteCloseeNonce,
-                    localCloserNonces = null
+                    localClosingComplete = null
                 )
                 val actions1 = listOf(ChannelAction.Storage.StoreState(nextState))
                 Pair(nextState, actions + actions1)
@@ -504,13 +504,13 @@ sealed class ChannelStateWithCommitments : PersistedChannelState() {
                             cmd,
                             localCloseeNonce,
                             remoteCloseeNonce,
-                            localCloserNonces = null
+                            localClosingComplete = null
                         )
                         val actions1 = listOf(ChannelAction.Storage.StoreState(nextState))
                         Pair(nextState, actions + actions1)
                     }
                     is Either.Right -> {
-                        val (closingTxs, closingComplete, localCloserNonces) = closingResult.value
+                        val (closingTxs, closingComplete) = closingResult.value
                         val nextState =
                             Negotiating(
                                 commitments,
@@ -522,7 +522,7 @@ sealed class ChannelStateWithCommitments : PersistedChannelState() {
                                 cmd,
                                 localCloseeNonce,
                                 remoteCloseeNonce,
-                                localCloserNonces
+                                closingComplete
                             )
                         val actions1 = listOf(
                             ChannelAction.Storage.StoreState(nextState),

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Negotiating.kt
@@ -26,7 +26,7 @@ data class Negotiating(
     val closeCommand: ChannelCommand.Close.MutualClose?,
     val localCloseeNonce: Transactions.LocalNonce?,
     val remoteCloseeNonce: IndividualNonce?,
-    val localCloserNonces: Transactions.CloserNonces?,
+    val localClosingComplete: ClosingComplete?,
 ) : ChannelStateWithCommitments() {
     override val remoteNextCommitNonces: Map<TxId, IndividualNonce> = mapOf()
 
@@ -80,7 +80,7 @@ data class Negotiating(
                     }
                 }
                 is ClosingSig -> {
-                    when (val result = Helpers.Closing.receiveClosingSig(channelKeys(), commitments.latest, proposedClosingTxs.last(), cmd.message, localCloserNonces, remoteCloseeNonce)) {
+                    when (val result = Helpers.Closing.receiveClosingSig(channelKeys(), commitments.latest, proposedClosingTxs.last(), cmd.message, localClosingComplete, remoteCloseeNonce)) {
                         is Either.Left -> {
                             logger.warning { "invalid closing_sig: ${result.value.message}" }
                             Pair(this@Negotiating.copy(remoteCloseeNonce = cmd.message.nextCloseeNonce), listOf(ChannelAction.Message.Send(Warning(channelId, result.value.message))))
@@ -156,7 +156,7 @@ data class Negotiating(
                             handleCommandError(cmd, result.value)
                         }
                         is Either.Right -> {
-                            val (closingTxs, closingComplete, localCloserNonces) = result.value
+                            val (closingTxs, closingComplete) = result.value
                             logger.debug { "signing local mutual close transactions: $closingTxs" }
                             // If we never received our peer's closing_sig, the previous command was not completed, so we must complete now.
                             // If it was already completed because we received closing_sig, this will be a no-op.
@@ -165,7 +165,7 @@ data class Negotiating(
                                 closeCommand = cmd,
                                 localScript = closingComplete.closerScriptPubKey,
                                 proposedClosingTxs = proposedClosingTxs + closingTxs,
-                                localCloserNonces = localCloserNonces
+                                localClosingComplete = closingComplete
                             )
                             val actions = buildList {
                                 add(ChannelAction.Storage.StoreState(nextState))
@@ -180,7 +180,7 @@ data class Negotiating(
             is ChannelCommand.Funding -> unhandled(cmd)
             is ChannelCommand.Closing -> unhandled(cmd)
             is ChannelCommand.Connected -> unhandled(cmd)
-            is ChannelCommand.Disconnected -> Pair(Offline(this@Negotiating.copy(localCloseeNonce = null, remoteCloseeNonce = null, localCloserNonces = null)), listOf())
+            is ChannelCommand.Disconnected -> Pair(Offline(this@Negotiating.copy(localCloseeNonce = null, remoteCloseeNonce = null, localClosingComplete = null)), listOf())
         }
     }
 

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -257,7 +257,7 @@ data class Normal(
                                         closeCommand,
                                         localCloseeNonce,
                                         remoteShutdown.closeeNonce,
-                                        localCloserNonces = null
+                                        localClosingComplete = null
                                     )
                                 }
                             } else {

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
@@ -26,7 +26,6 @@
     JsonSerializers.IndividualNonceSerializer::class,
     JsonSerializers.PartialSignatureWithNonceSerializer::class,
     JsonSerializers.LocalNonceSerializer::class,
-    JsonSerializers.CloserNoncesSerializer::class,
     JsonSerializers.TxIdSerializer::class,
     JsonSerializers.KeyPathSerializer::class,
     JsonSerializers.SatoshiSerializer::class,
@@ -380,9 +379,6 @@ object JsonSerializers {
         },
         delegateSerializer = RemoteFundingStatusSurrogate.serializer()
     )
-
-    @Serializer(forClass = Transactions.CloserNonces::class)
-    object CloserNoncesSerializer
 
     @Serializer(forClass = Transactions.ClosingTx::class)
     object ClosingTxSerializer

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/json/JsonSerializers.kt
@@ -217,6 +217,9 @@ object JsonSerializers {
                 subclass(UpdateAddHtlcTlv.PathKey::class, UpdateAddHtlcTlvPathKeySerializer)
                 subclass(ShutdownTlv.ShutdownNonce::class, ShutdownTlvShutdownNonceSerializer)
                 subclass(ChannelReestablishTlv.NextLocalNonces::class, ChannelReestablishTlvNextLocalNoncesSerializer)
+                subclass(ClosingCompleteTlv.CloserAndCloseeOutputsPartialSignature::class, ClosingCompleteTlvCloserAndCloseeOutputsPartialSignatureSerializer)
+                subclass(ClosingCompleteTlv.CloserOutputOnlyPartialSignature::class, ClosingCompleteTlvCloserOutputOnlyPartialSignatureSerializer)
+                subclass(ClosingCompleteTlv.CloseeOutputOnlyPartialSignature::class, ClosingCompleteTlvCloseeOutputOnlyPartialSignatureSerializer)
             }
             contextual(Bolt11InvoiceSerializer)
             contextual(OfferSerializer)
@@ -574,6 +577,15 @@ object JsonSerializers {
 
     @Serializer(forClass = ClosingCompleteTlv::class)
     object ClosingCompleteTlvSerializer
+
+    @Serializer(forClass = ClosingCompleteTlv.CloserAndCloseeOutputsPartialSignature::class)
+    object ClosingCompleteTlvCloserAndCloseeOutputsPartialSignatureSerializer
+
+    @Serializer(forClass = ClosingCompleteTlv.CloserOutputOnlyPartialSignature::class)
+    object ClosingCompleteTlvCloserOutputOnlyPartialSignatureSerializer
+
+    @Serializer(forClass = ClosingCompleteTlv.CloseeOutputOnlyPartialSignature::class)
+    object ClosingCompleteTlvCloseeOutputOnlyPartialSignatureSerializer
 
     @Serializer(forClass = ClosingSigTlv::class)
     object ClosingSigTlvSerializer

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/channel/v4/Deserialization.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/channel/v4/Deserialization.kt
@@ -286,7 +286,7 @@ object Deserialization {
             closeCommand,
             localCloseeNonce = null,
             remoteCloseeNonce = null,
-            localCloserNonces = null
+            localClosingComplete = null
         )
     }
 
@@ -306,7 +306,7 @@ object Deserialization {
         closeCommand = readNullable { readCloseCommand() },
         localCloseeNonce = null,
         remoteCloseeNonce = null,
-        localCloserNonces = null
+        localClosingComplete = null
     )
 
     private fun Input.readClosing(): Closing = Closing(

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/channel/v5/Deserialization.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/serialization/channel/v5/Deserialization.kt
@@ -131,7 +131,7 @@ object Deserialization {
         publishedClosingTxs = readCollection { readClosingTx() }.toList(),
         waitingSinceBlock = readNumber(),
         closeCommand = readNullable { readCloseCommand() },
-        localCloserNonces = null,
+        localClosingComplete = null,
         remoteCloseeNonce = null,
         localCloseeNonce = null
     )

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/transactions/Transactions.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/transactions/Transactions.kt
@@ -1300,20 +1300,6 @@ object Transactions {
         data class PaidByThem(val fee: Satoshi) : ClosingTxFee()
     }
 
-    /**
-     * When sending [fr.acinq.lightning.wire.ClosingComplete], we use a different nonce for each closing transaction we create.
-     * We generate nonces for all variants of the closing transaction for simplicity, even though we never use them all.
-     */
-    data class CloserNonces(val localAndRemote: LocalNonce, val localOnly: LocalNonce, val remoteOnly: LocalNonce) {
-        companion object {
-            fun generate(localFundingKey: PublicKey, remoteFundingKey: PublicKey, fundingTxId: TxId): CloserNonces = CloserNonces(
-                NonceGenerator.signingNonce(localFundingKey, remoteFundingKey, fundingTxId),
-                NonceGenerator.signingNonce(localFundingKey, remoteFundingKey, fundingTxId),
-                NonceGenerator.signingNonce(localFundingKey, remoteFundingKey, fundingTxId),
-            )
-        }
-    }
-
     /** Each closing attempt can result in multiple potential closing transactions, depending on which outputs are included. */
     data class ClosingTxs(val localAndRemote: ClosingTx?, val localOnly: ClosingTx?, val remoteOnly: ClosingTx?) {
         val preferred: ClosingTx? = localAndRemote ?: localOnly ?: remoteOnly

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
@@ -36,173 +36,114 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertEquals(f.fundingParamsA.fundingAmount, fundingA + fundingB)
         assertEquals(f.fundingParamsA.fundingAmount, fundingA + fundingB)
 
-        data class Setup(val session: InteractiveTxSession, val sharedTxA: InteractiveTxSessionAction.SignSharedTx, val sharedTxB: InteractiveTxSessionAction.SignSharedTx , val signedTxB: PartiallySignedSharedTransaction)
+        val alice0 = InteractiveTxSession(f.nodeIdB, f.channelKeysA, f.keyManagerA.swapInOnChainWallet, f.fundingParamsA, 0, 0.msat, 0.msat, emptySet(), f.fundingContributionsA)
+        val bob0 = InteractiveTxSession(f.nodeIdA, f.channelKeysB, f.keyManagerB.swapInOnChainWallet, f.fundingParamsB, 0, 0.msat, 0.msat, emptySet(), f.fundingContributionsB)
 
-        fun setup(): Setup {
-            val alice0 = InteractiveTxSession(
-                f.nodeIdB,
-                f.channelKeysA,
-                f.keyManagerA.swapInOnChainWallet,
-                f.fundingParamsA,
-                0,
-                0.msat,
-                0.msat,
-                emptySet(),
-                f.fundingContributionsA
-            )
-            val bob0 = InteractiveTxSession(
-                f.nodeIdA,
-                f.channelKeysB,
-                f.keyManagerB.swapInOnChainWallet,
-                f.fundingParamsB,
-                0,
-                0.msat,
-                0.msat,
-                emptySet(),
-                f.fundingContributionsB
-            )
+        // 3 swap-in inputs, 2 legacy swap-in inputs, and 2 outputs from Alice
+        // 2 swap-in inputs, 2 legacy swap-in inputs, and 1 output from Bob
 
-            // 3 swap-in inputs, 2 legacy swap-in inputs, and 2 outputs from Alice
-            // 2 swap-in inputs, 2 legacy swap-in inputs, and 1 output from Bob
+        // Alice --- tx_add_input --> Bob
+        val (alice1, inputA1) = sendMessage<TxAddInput>(alice0)
+        assertEquals(0xfffffffdU, inputA1.sequence)
+        // Alice <-- tx_add_input --- Bob
+        val (bob1, inputB1) = receiveMessage<TxAddInput>(bob0, inputA1)
+        // Alice --- tx_add_input --> Bob
+        val (alice2, inputA2) = receiveMessage<TxAddInput>(alice1, inputB1)
+        // Alice <-- tx_add_input --- Bob
+        val (bob2, inputB2) = receiveMessage<TxAddInput>(bob1, inputA2)
+        // Alice --- tx_add_input --> Bob
+        val (alice3, inputA3) = receiveMessage<TxAddInput>(alice2, inputB2)
+        // Alice <-- tx_add_input --- Bob
+        val (bob3, inputB3) = receiveMessage<TxAddInput>(bob2, inputA3)
+        // Alice --- tx_add_input --> Bob
+        val (alice4, inputA4) = receiveMessage<TxAddInput>(alice3, inputB3)
+        // Alice <-- tx_add_input --- Bob
+        val (bob4, inputB4) = receiveMessage<TxAddInput>(bob3, inputA4)
+        // Alice --- tx_add_input --> Bob
+        val (alice5, inputA5) = receiveMessage<TxAddInput>(alice4, inputB4)
+        // Alice <-- tx_add_output --- Bob
+        val (bob5, outputB1) = receiveMessage<TxAddOutput>(bob4, inputA5)
+        // Alice --- tx_add_output --> Bob
+        val (alice6, outputA1) = receiveMessage<TxAddOutput>(alice5, outputB1)
+        // Alice <-- tx_complete --- Bob
+        val (bob6, txCompleteB1) = receiveMessage<TxComplete>(bob5, outputA1)
+        // Alice --- tx_add_output --> Bob
+        val (alice7, outputA2) = receiveMessage<TxAddOutput>(alice6, txCompleteB1)
+        // Alice <-- tx_complete --- Bob
+        val (bob7, txCompleteB2) = receiveMessage<TxComplete>(bob6, outputA2)
 
-            // Alice --- tx_add_input --> Bob
-            val (alice1, inputA1) = sendMessage<TxAddInput>(alice0)
-            assertEquals(0xfffffffdU, inputA1.sequence)
-            // Alice <-- tx_add_input --- Bob
-            val (bob1, inputB1) = receiveMessage<TxAddInput>(bob0, inputA1)
-            // Alice --- tx_add_input --> Bob
-            val (alice2, inputA2) = receiveMessage<TxAddInput>(alice1, inputB1)
-            // Alice <-- tx_add_input --- Bob
-            val (bob2, inputB2) = receiveMessage<TxAddInput>(bob1, inputA2)
-            // Alice --- tx_add_input --> Bob
-            val (alice3, inputA3) = receiveMessage<TxAddInput>(alice2, inputB2)
-            // Alice <-- tx_add_input --- Bob
-            val (bob3, inputB3) = receiveMessage<TxAddInput>(bob2, inputA3)
-            // Alice --- tx_add_input --> Bob
-            val (alice4, inputA4) = receiveMessage<TxAddInput>(alice3, inputB3)
-            // Alice <-- tx_add_input --- Bob
-            val (bob4, inputB4) = receiveMessage<TxAddInput>(bob3, inputA4)
-            // Alice --- tx_add_input --> Bob
-            val (alice5, inputA5) = receiveMessage<TxAddInput>(alice4, inputB4)
-            // Alice <-- tx_add_output --- Bob
-            val (bob5, outputB1) = receiveMessage<TxAddOutput>(bob4, inputA5)
-            // Alice --- tx_add_output --> Bob
-            val (alice6, outputA1) = receiveMessage<TxAddOutput>(alice5, outputB1)
-            // Alice <-- tx_complete --- Bob
-            val (bob6, txCompleteB1) = receiveMessage<TxComplete>(bob5, outputA1)
-            // Alice --- tx_add_output --> Bob
-            val (alice7, outputA2) = receiveMessage<TxAddOutput>(alice6, txCompleteB1)
-            // Alice <-- tx_complete --- Bob
-            val (bob7, txCompleteB2) = receiveMessage<TxComplete>(bob6, outputA2)
+        val sharedTxA = receiveFinalMessage(alice7, txCompleteB2).second
+        assertNotNull(sharedTxA.txComplete)
 
-            val sharedTxA = receiveFinalMessage(alice7, txCompleteB2).second
-            assertNotNull(sharedTxA.txComplete)
+        val (bob8, sharedTxB) = receiveFinalMessage(bob7, sharedTxA.txComplete)
+        assertNull(sharedTxB.txComplete)
 
-            val (bob8, sharedTxB) = receiveFinalMessage(bob7, sharedTxA.txComplete)
-            assertNull(sharedTxB.txComplete)
+        // Alice is responsible for adding the shared output.
+        assertNotEquals(outputA1.pubkeyScript, outputA2.pubkeyScript)
+        assertEquals(listOf(outputA1, outputA2).count { it.pubkeyScript == f.fundingParamsA.fundingPubkeyScript(f.channelKeysA) && it.amount == fundingA + fundingB }, 1)
 
-            // Alice is responsible for adding the shared output.
-            assertNotEquals(outputA1.pubkeyScript, outputA2.pubkeyScript)
-            assertEquals(
-                listOf(
-                    outputA1,
-                    outputA2
-                ).count { it.pubkeyScript == f.fundingParamsA.fundingPubkeyScript(f.channelKeysA) && it.amount == fundingA + fundingB },
-                1
-            )
+        assertEquals(sharedTxA.sharedTx.localAmountIn, 215_000_000.msat)
+        assertEquals(sharedTxA.sharedTx.remoteAmountIn, 205_000_000.msat)
+        assertEquals(sharedTxA.sharedTx.totalAmountIn, 420_000.sat)
+        assertEquals(sharedTxA.sharedTx.fees, 15_965.sat)
+        assertTrue(sharedTxB.sharedTx.localFees < sharedTxA.sharedTx.localFees)
 
-            assertEquals(sharedTxA.sharedTx.localAmountIn, 215_000_000.msat)
-            assertEquals(sharedTxA.sharedTx.remoteAmountIn, 205_000_000.msat)
-            assertEquals(sharedTxA.sharedTx.totalAmountIn, 420_000.sat)
-            assertEquals(sharedTxA.sharedTx.fees, 15_965.sat)
-            assertTrue(sharedTxB.sharedTx.localFees < sharedTxA.sharedTx.localFees)
+        // Bob sends signatures first as he contributed less than Alice.
+        val signedTxB = sharedTxB.sharedTx.sign(bob8, f.keyManagerB, f.fundingParamsB, f.nodeIdA).right!!
+        assertEquals(signedTxB.localSigs.swapInUserSigs.size, 2)
+        assertEquals(signedTxB.localSigs.swapInUserPartialSigs.size, 2)
+        assertEquals(signedTxB.localSigs.swapInServerSigs.size, 2)
+        assertEquals(signedTxB.localSigs.swapInServerPartialSigs.size, 3)
 
-            // Bob sends signatures first as he contributed less than Alice.
-            val signedTxB = sharedTxB.sharedTx.sign(bob8, f.keyManagerB, f.fundingParamsB, f.nodeIdA).right!!
-            assertEquals(signedTxB.localSigs.swapInUserSigs.size, 2)
-            assertEquals(signedTxB.localSigs.swapInUserPartialSigs.size, 2)
-            assertEquals(signedTxB.localSigs.swapInServerSigs.size, 2)
-            assertEquals(signedTxB.localSigs.swapInServerPartialSigs.size, 3)
+        // Alice detects invalid signatures from Bob.
+        val sigsInvalidTxId = signedTxB.localSigs.copy(txId = TxId(randomBytes32()))
+        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidTxId))
 
-            return Setup(alice7, sharedTxA, sharedTxB, signedTxB)
-        }
+        val sigsMissingUserSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserSigs }.toSet()))
+        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingUserSigs))
 
-        run {
-            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
-            val sigsInvalidTxId = signedTxB.localSigs.copy(txId = TxId(randomBytes32()))
-            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidTxId))
-        }
+        val sigsMissingUserPartialSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserPartialSigs }.toSet()))
+        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingUserPartialSigs))
 
-        run {
-            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
-            val sigsMissingUserSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserSigs }.toSet()))
-            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingUserSigs))
-        }
+        val sigsMissingServerSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInServerSigs }.toSet()))
+        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingServerSigs))
 
-        run {
-            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
-            val sigsMissingUserPartialSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserPartialSigs }.toSet()))
-            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingUserPartialSigs))
-        }
+        val sigsMissingServerPartialSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInServerPartialSigs }.toSet()))
+        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingServerPartialSigs))
 
-        run {
-            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
-            val sigsMissingServerSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInServerSigs }.toSet()))
-            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingServerSigs))
-        }
+        val invalidUserSigs = signedTxB.localSigs.swapInUserSigs.map { randomBytes64() }
+        val sigsInvalidUserSig = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserSigs }.toSet() + TxSignaturesTlv.SwapInUserSigs(invalidUserSigs)))
+        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidUserSig))
 
-        run {
-            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
-            val sigsMissingServerPartialSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInServerPartialSigs }.toSet()))
-            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingServerPartialSigs))
-        }
-        run {
-            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
-            val invalidUserSigs = signedTxB.localSigs.swapInUserSigs.map { randomBytes64() }
-            val sigsInvalidUserSig = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserSigs }.toSet() + TxSignaturesTlv.SwapInUserSigs(invalidUserSigs)))
-            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidUserSig))
-        }
+        val invalidPartialUserSigs = signedTxB.localSigs.swapInUserPartialSigs.map { TxSignaturesTlv.PartialSignature(randomBytes32(), it.localNonce, it.remoteNonce) }
+        val sigsInvalidUserPartialSig =
+            signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserPartialSigs }.toSet() + TxSignaturesTlv.SwapInUserPartialSigs(invalidPartialUserSigs)))
+        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidUserPartialSig))
 
-        run {
-            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
-            val invalidPartialUserSigs = signedTxB.localSigs.swapInUserPartialSigs.map { TxSignaturesTlv.PartialSignature(randomBytes32(), it.localNonce, it.remoteNonce) }
-            val sigsInvalidUserPartialSig = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserPartialSigs }.toSet() + TxSignaturesTlv.SwapInUserPartialSigs(invalidPartialUserSigs)))
-            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidUserPartialSig))
-        }
+        val invalidServerSigs = signedTxB.localSigs.swapInServerSigs.map { randomBytes64() }
+        val sigsInvalidServerSig = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInServerSigs }.toSet() + TxSignaturesTlv.SwapInServerSigs(invalidServerSigs)))
+        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidServerSig))
 
-        run {
-            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
-            val invalidServerSigs = signedTxB.localSigs.swapInServerSigs.map { randomBytes64() }
-            val sigsInvalidServerSig = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInServerSigs }.toSet() + TxSignaturesTlv.SwapInServerSigs(invalidServerSigs)))
-            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidServerSig))
-        }
+        val invalidPartialServerSigs = signedTxB.localSigs.swapInServerPartialSigs.map { TxSignaturesTlv.PartialSignature(randomBytes32(), it.localNonce, it.remoteNonce) }
+        val sigsInvalidServerPartialSig = signedTxB.localSigs.copy(tlvs = TlvStream(TxSignaturesTlv.SwapInUserPartialSigs(signedTxB.localSigs.swapInUserPartialSigs), TxSignaturesTlv.SwapInServerPartialSigs(invalidPartialServerSigs)))
+        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidServerPartialSig))
 
-        run {
-            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
-            val invalidPartialServerSigs = signedTxB.localSigs.swapInServerPartialSigs.map { TxSignaturesTlv.PartialSignature(randomBytes32(), it.localNonce, it.remoteNonce) }
-            val sigsInvalidServerPartialSig = signedTxB.localSigs.copy(tlvs = TlvStream(TxSignaturesTlv.SwapInUserPartialSigs(signedTxB.localSigs.swapInUserPartialSigs), TxSignaturesTlv.SwapInServerPartialSigs(invalidPartialServerSigs)))
-            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidServerPartialSig))
-        }
-
-        run {
-            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
-            // The resulting transaction is valid and has the right feerate.
-            val signedTxA = sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
-            assertNotNull(signedTxA)
-            assertEquals(signedTxA.localSigs.swapInUserSigs.size, 2)
-            assertEquals(signedTxA.localSigs.swapInUserPartialSigs.size, 3)
-            assertEquals(signedTxA.localSigs.swapInServerSigs.size, 2)
-            assertEquals(signedTxA.localSigs.swapInServerPartialSigs.size, 2)
-            val signedTx = signedTxA.signedTx
-            assertEquals(signedTxA.localSigs.txId, signedTx.txid)
-            assertEquals(signedTxB.localSigs.txId, signedTx.txid)
-            assertEquals(signedTx.lockTime, 42)
-            assertEquals(signedTx.txIn.size, 9)
-            assertEquals(signedTx.txOut.size, 3)
-            Transaction.correctlySpends(signedTx, (sharedTxA.sharedTx.localInputs + sharedTxB.sharedTx.localInputs).map { it.previousTx }, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-            val feerate = Transactions.fee2rate(signedTxA.tx.fees, signedTx.weight())
-            assertTrue(targetFeerate <= feerate && feerate <= targetFeerate * 1.25, "unexpected feerate (target=$targetFeerate actual=$feerate)")
-        }
+        // The resulting transaction is valid and has the right feerate.
+        val signedTxA = sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
+        assertNotNull(signedTxA)
+        assertEquals(signedTxA.localSigs.swapInUserSigs.size, 2)
+        assertEquals(signedTxA.localSigs.swapInUserPartialSigs.size, 3)
+        assertEquals(signedTxA.localSigs.swapInServerSigs.size, 2)
+        assertEquals(signedTxA.localSigs.swapInServerPartialSigs.size, 2)
+        val signedTx = signedTxA.signedTx
+        assertEquals(signedTxA.localSigs.txId, signedTx.txid)
+        assertEquals(signedTxB.localSigs.txId, signedTx.txid)
+        assertEquals(signedTx.lockTime, 42)
+        assertEquals(signedTx.txIn.size, 9)
+        assertEquals(signedTx.txOut.size, 3)
+        Transaction.correctlySpends(signedTx, (sharedTxA.sharedTx.localInputs + sharedTxB.sharedTx.localInputs).map { it.previousTx }, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+        val feerate = Transactions.fee2rate(signedTxA.tx.fees, signedTx.weight())
+        assertTrue(targetFeerate <= feerate && feerate <= targetFeerate * 1.25, "unexpected feerate (target=$targetFeerate actual=$feerate)")
     }
 
     @Test

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/InteractiveTxTestsCommon.kt
@@ -36,114 +36,173 @@ class InteractiveTxTestsCommon : LightningTestSuite() {
         assertEquals(f.fundingParamsA.fundingAmount, fundingA + fundingB)
         assertEquals(f.fundingParamsA.fundingAmount, fundingA + fundingB)
 
-        val alice0 = InteractiveTxSession(f.nodeIdB, f.channelKeysA, f.keyManagerA.swapInOnChainWallet, f.fundingParamsA, 0, 0.msat, 0.msat, emptySet(), f.fundingContributionsA)
-        val bob0 = InteractiveTxSession(f.nodeIdA, f.channelKeysB, f.keyManagerB.swapInOnChainWallet, f.fundingParamsB, 0, 0.msat, 0.msat, emptySet(), f.fundingContributionsB)
+        data class Setup(val session: InteractiveTxSession, val sharedTxA: InteractiveTxSessionAction.SignSharedTx, val sharedTxB: InteractiveTxSessionAction.SignSharedTx , val signedTxB: PartiallySignedSharedTransaction)
 
-        // 3 swap-in inputs, 2 legacy swap-in inputs, and 2 outputs from Alice
-        // 2 swap-in inputs, 2 legacy swap-in inputs, and 1 output from Bob
+        fun setup(): Setup {
+            val alice0 = InteractiveTxSession(
+                f.nodeIdB,
+                f.channelKeysA,
+                f.keyManagerA.swapInOnChainWallet,
+                f.fundingParamsA,
+                0,
+                0.msat,
+                0.msat,
+                emptySet(),
+                f.fundingContributionsA
+            )
+            val bob0 = InteractiveTxSession(
+                f.nodeIdA,
+                f.channelKeysB,
+                f.keyManagerB.swapInOnChainWallet,
+                f.fundingParamsB,
+                0,
+                0.msat,
+                0.msat,
+                emptySet(),
+                f.fundingContributionsB
+            )
 
-        // Alice --- tx_add_input --> Bob
-        val (alice1, inputA1) = sendMessage<TxAddInput>(alice0)
-        assertEquals(0xfffffffdU, inputA1.sequence)
-        // Alice <-- tx_add_input --- Bob
-        val (bob1, inputB1) = receiveMessage<TxAddInput>(bob0, inputA1)
-        // Alice --- tx_add_input --> Bob
-        val (alice2, inputA2) = receiveMessage<TxAddInput>(alice1, inputB1)
-        // Alice <-- tx_add_input --- Bob
-        val (bob2, inputB2) = receiveMessage<TxAddInput>(bob1, inputA2)
-        // Alice --- tx_add_input --> Bob
-        val (alice3, inputA3) = receiveMessage<TxAddInput>(alice2, inputB2)
-        // Alice <-- tx_add_input --- Bob
-        val (bob3, inputB3) = receiveMessage<TxAddInput>(bob2, inputA3)
-        // Alice --- tx_add_input --> Bob
-        val (alice4, inputA4) = receiveMessage<TxAddInput>(alice3, inputB3)
-        // Alice <-- tx_add_input --- Bob
-        val (bob4, inputB4) = receiveMessage<TxAddInput>(bob3, inputA4)
-        // Alice --- tx_add_input --> Bob
-        val (alice5, inputA5) = receiveMessage<TxAddInput>(alice4, inputB4)
-        // Alice <-- tx_add_output --- Bob
-        val (bob5, outputB1) = receiveMessage<TxAddOutput>(bob4, inputA5)
-        // Alice --- tx_add_output --> Bob
-        val (alice6, outputA1) = receiveMessage<TxAddOutput>(alice5, outputB1)
-        // Alice <-- tx_complete --- Bob
-        val (bob6, txCompleteB1) = receiveMessage<TxComplete>(bob5, outputA1)
-        // Alice --- tx_add_output --> Bob
-        val (alice7, outputA2) = receiveMessage<TxAddOutput>(alice6, txCompleteB1)
-        // Alice <-- tx_complete --- Bob
-        val (bob7, txCompleteB2) = receiveMessage<TxComplete>(bob6, outputA2)
+            // 3 swap-in inputs, 2 legacy swap-in inputs, and 2 outputs from Alice
+            // 2 swap-in inputs, 2 legacy swap-in inputs, and 1 output from Bob
 
-        val sharedTxA = receiveFinalMessage(alice7, txCompleteB2).second
-        assertNotNull(sharedTxA.txComplete)
+            // Alice --- tx_add_input --> Bob
+            val (alice1, inputA1) = sendMessage<TxAddInput>(alice0)
+            assertEquals(0xfffffffdU, inputA1.sequence)
+            // Alice <-- tx_add_input --- Bob
+            val (bob1, inputB1) = receiveMessage<TxAddInput>(bob0, inputA1)
+            // Alice --- tx_add_input --> Bob
+            val (alice2, inputA2) = receiveMessage<TxAddInput>(alice1, inputB1)
+            // Alice <-- tx_add_input --- Bob
+            val (bob2, inputB2) = receiveMessage<TxAddInput>(bob1, inputA2)
+            // Alice --- tx_add_input --> Bob
+            val (alice3, inputA3) = receiveMessage<TxAddInput>(alice2, inputB2)
+            // Alice <-- tx_add_input --- Bob
+            val (bob3, inputB3) = receiveMessage<TxAddInput>(bob2, inputA3)
+            // Alice --- tx_add_input --> Bob
+            val (alice4, inputA4) = receiveMessage<TxAddInput>(alice3, inputB3)
+            // Alice <-- tx_add_input --- Bob
+            val (bob4, inputB4) = receiveMessage<TxAddInput>(bob3, inputA4)
+            // Alice --- tx_add_input --> Bob
+            val (alice5, inputA5) = receiveMessage<TxAddInput>(alice4, inputB4)
+            // Alice <-- tx_add_output --- Bob
+            val (bob5, outputB1) = receiveMessage<TxAddOutput>(bob4, inputA5)
+            // Alice --- tx_add_output --> Bob
+            val (alice6, outputA1) = receiveMessage<TxAddOutput>(alice5, outputB1)
+            // Alice <-- tx_complete --- Bob
+            val (bob6, txCompleteB1) = receiveMessage<TxComplete>(bob5, outputA1)
+            // Alice --- tx_add_output --> Bob
+            val (alice7, outputA2) = receiveMessage<TxAddOutput>(alice6, txCompleteB1)
+            // Alice <-- tx_complete --- Bob
+            val (bob7, txCompleteB2) = receiveMessage<TxComplete>(bob6, outputA2)
 
-        val (bob8, sharedTxB) = receiveFinalMessage(bob7, sharedTxA.txComplete)
-        assertNull(sharedTxB.txComplete)
+            val sharedTxA = receiveFinalMessage(alice7, txCompleteB2).second
+            assertNotNull(sharedTxA.txComplete)
 
-        // Alice is responsible for adding the shared output.
-        assertNotEquals(outputA1.pubkeyScript, outputA2.pubkeyScript)
-        assertEquals(listOf(outputA1, outputA2).count { it.pubkeyScript == f.fundingParamsA.fundingPubkeyScript(f.channelKeysA) && it.amount == fundingA + fundingB }, 1)
+            val (bob8, sharedTxB) = receiveFinalMessage(bob7, sharedTxA.txComplete)
+            assertNull(sharedTxB.txComplete)
 
-        assertEquals(sharedTxA.sharedTx.localAmountIn, 215_000_000.msat)
-        assertEquals(sharedTxA.sharedTx.remoteAmountIn, 205_000_000.msat)
-        assertEquals(sharedTxA.sharedTx.totalAmountIn, 420_000.sat)
-        assertEquals(sharedTxA.sharedTx.fees, 15_965.sat)
-        assertTrue(sharedTxB.sharedTx.localFees < sharedTxA.sharedTx.localFees)
+            // Alice is responsible for adding the shared output.
+            assertNotEquals(outputA1.pubkeyScript, outputA2.pubkeyScript)
+            assertEquals(
+                listOf(
+                    outputA1,
+                    outputA2
+                ).count { it.pubkeyScript == f.fundingParamsA.fundingPubkeyScript(f.channelKeysA) && it.amount == fundingA + fundingB },
+                1
+            )
 
-        // Bob sends signatures first as he contributed less than Alice.
-        val signedTxB = sharedTxB.sharedTx.sign(bob8, f.keyManagerB, f.fundingParamsB, f.nodeIdA).right!!
-        assertEquals(signedTxB.localSigs.swapInUserSigs.size, 2)
-        assertEquals(signedTxB.localSigs.swapInUserPartialSigs.size, 2)
-        assertEquals(signedTxB.localSigs.swapInServerSigs.size, 2)
-        assertEquals(signedTxB.localSigs.swapInServerPartialSigs.size, 3)
+            assertEquals(sharedTxA.sharedTx.localAmountIn, 215_000_000.msat)
+            assertEquals(sharedTxA.sharedTx.remoteAmountIn, 205_000_000.msat)
+            assertEquals(sharedTxA.sharedTx.totalAmountIn, 420_000.sat)
+            assertEquals(sharedTxA.sharedTx.fees, 15_965.sat)
+            assertTrue(sharedTxB.sharedTx.localFees < sharedTxA.sharedTx.localFees)
 
-        // Alice detects invalid signatures from Bob.
-        val sigsInvalidTxId = signedTxB.localSigs.copy(txId = TxId(randomBytes32()))
-        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidTxId))
+            // Bob sends signatures first as he contributed less than Alice.
+            val signedTxB = sharedTxB.sharedTx.sign(bob8, f.keyManagerB, f.fundingParamsB, f.nodeIdA).right!!
+            assertEquals(signedTxB.localSigs.swapInUserSigs.size, 2)
+            assertEquals(signedTxB.localSigs.swapInUserPartialSigs.size, 2)
+            assertEquals(signedTxB.localSigs.swapInServerSigs.size, 2)
+            assertEquals(signedTxB.localSigs.swapInServerPartialSigs.size, 3)
 
-        val sigsMissingUserSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserSigs }.toSet()))
-        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingUserSigs))
+            return Setup(alice7, sharedTxA, sharedTxB, signedTxB)
+        }
 
-        val sigsMissingUserPartialSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserPartialSigs }.toSet()))
-        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingUserPartialSigs))
+        run {
+            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
+            val sigsInvalidTxId = signedTxB.localSigs.copy(txId = TxId(randomBytes32()))
+            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidTxId))
+        }
 
-        val sigsMissingServerSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInServerSigs }.toSet()))
-        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingServerSigs))
+        run {
+            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
+            val sigsMissingUserSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserSigs }.toSet()))
+            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingUserSigs))
+        }
 
-        val sigsMissingServerPartialSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInServerPartialSigs }.toSet()))
-        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingServerPartialSigs))
+        run {
+            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
+            val sigsMissingUserPartialSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserPartialSigs }.toSet()))
+            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingUserPartialSigs))
+        }
 
-        val invalidUserSigs = signedTxB.localSigs.swapInUserSigs.map { randomBytes64() }
-        val sigsInvalidUserSig = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserSigs }.toSet() + TxSignaturesTlv.SwapInUserSigs(invalidUserSigs)))
-        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidUserSig))
+        run {
+            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
+            val sigsMissingServerSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInServerSigs }.toSet()))
+            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingServerSigs))
+        }
 
-        val invalidPartialUserSigs = signedTxB.localSigs.swapInUserPartialSigs.map { TxSignaturesTlv.PartialSignature(randomBytes32(), it.localNonce, it.remoteNonce) }
-        val sigsInvalidUserPartialSig =
-            signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserPartialSigs }.toSet() + TxSignaturesTlv.SwapInUserPartialSigs(invalidPartialUserSigs)))
-        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidUserPartialSig))
+        run {
+            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
+            val sigsMissingServerPartialSigs = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInServerPartialSigs }.toSet()))
+            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsMissingServerPartialSigs))
+        }
+        run {
+            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
+            val invalidUserSigs = signedTxB.localSigs.swapInUserSigs.map { randomBytes64() }
+            val sigsInvalidUserSig = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserSigs }.toSet() + TxSignaturesTlv.SwapInUserSigs(invalidUserSigs)))
+            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidUserSig))
+        }
 
-        val invalidServerSigs = signedTxB.localSigs.swapInServerSigs.map { randomBytes64() }
-        val sigsInvalidServerSig = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInServerSigs }.toSet() + TxSignaturesTlv.SwapInServerSigs(invalidServerSigs)))
-        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidServerSig))
+        run {
+            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
+            val invalidPartialUserSigs = signedTxB.localSigs.swapInUserPartialSigs.map { TxSignaturesTlv.PartialSignature(randomBytes32(), it.localNonce, it.remoteNonce) }
+            val sigsInvalidUserPartialSig = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInUserPartialSigs }.toSet() + TxSignaturesTlv.SwapInUserPartialSigs(invalidPartialUserSigs)))
+            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidUserPartialSig))
+        }
 
-        val invalidPartialServerSigs = signedTxB.localSigs.swapInServerPartialSigs.map { TxSignaturesTlv.PartialSignature(randomBytes32(), it.localNonce, it.remoteNonce) }
-        val sigsInvalidServerPartialSig = signedTxB.localSigs.copy(tlvs = TlvStream(TxSignaturesTlv.SwapInUserPartialSigs(signedTxB.localSigs.swapInUserPartialSigs), TxSignaturesTlv.SwapInServerPartialSigs(invalidPartialServerSigs)))
-        assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidServerPartialSig))
+        run {
+            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
+            val invalidServerSigs = signedTxB.localSigs.swapInServerSigs.map { randomBytes64() }
+            val sigsInvalidServerSig = signedTxB.localSigs.copy(tlvs = TlvStream(signedTxB.localSigs.tlvs.records.filterNot { it is TxSignaturesTlv.SwapInServerSigs }.toSet() + TxSignaturesTlv.SwapInServerSigs(invalidServerSigs)))
+            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidServerSig))
+        }
 
-        // The resulting transaction is valid and has the right feerate.
-        val signedTxA = sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
-        assertNotNull(signedTxA)
-        assertEquals(signedTxA.localSigs.swapInUserSigs.size, 2)
-        assertEquals(signedTxA.localSigs.swapInUserPartialSigs.size, 3)
-        assertEquals(signedTxA.localSigs.swapInServerSigs.size, 2)
-        assertEquals(signedTxA.localSigs.swapInServerPartialSigs.size, 2)
-        val signedTx = signedTxA.signedTx
-        assertEquals(signedTxA.localSigs.txId, signedTx.txid)
-        assertEquals(signedTxB.localSigs.txId, signedTx.txid)
-        assertEquals(signedTx.lockTime, 42)
-        assertEquals(signedTx.txIn.size, 9)
-        assertEquals(signedTx.txOut.size, 3)
-        Transaction.correctlySpends(signedTx, (sharedTxA.sharedTx.localInputs + sharedTxB.sharedTx.localInputs).map { it.previousTx }, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-        val feerate = Transactions.fee2rate(signedTxA.tx.fees, signedTx.weight())
-        assertTrue(targetFeerate <= feerate && feerate <= targetFeerate * 1.25, "unexpected feerate (target=$targetFeerate actual=$feerate)")
+        run {
+            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
+            val invalidPartialServerSigs = signedTxB.localSigs.swapInServerPartialSigs.map { TxSignaturesTlv.PartialSignature(randomBytes32(), it.localNonce, it.remoteNonce) }
+            val sigsInvalidServerPartialSig = signedTxB.localSigs.copy(tlvs = TlvStream(TxSignaturesTlv.SwapInUserPartialSigs(signedTxB.localSigs.swapInUserPartialSigs), TxSignaturesTlv.SwapInServerPartialSigs(invalidPartialServerSigs)))
+            assertNull(sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, sigsInvalidServerPartialSig))
+        }
+
+        run {
+            val (alice7, sharedTxA, sharedTxB, signedTxB) = setup()
+            // The resulting transaction is valid and has the right feerate.
+            val signedTxA = sharedTxA.sharedTx.sign(alice7, f.keyManagerA, f.fundingParamsA, f.nodeIdB).right?.addRemoteSigs(f.channelKeysA, f.fundingParamsA, signedTxB.localSigs)
+            assertNotNull(signedTxA)
+            assertEquals(signedTxA.localSigs.swapInUserSigs.size, 2)
+            assertEquals(signedTxA.localSigs.swapInUserPartialSigs.size, 3)
+            assertEquals(signedTxA.localSigs.swapInServerSigs.size, 2)
+            assertEquals(signedTxA.localSigs.swapInServerPartialSigs.size, 2)
+            val signedTx = signedTxA.signedTx
+            assertEquals(signedTxA.localSigs.txId, signedTx.txid)
+            assertEquals(signedTxB.localSigs.txId, signedTx.txid)
+            assertEquals(signedTx.lockTime, 42)
+            assertEquals(signedTx.txIn.size, 9)
+            assertEquals(signedTx.txOut.size, 3)
+            Transaction.correctlySpends(signedTx, (sharedTxA.sharedTx.localInputs + sharedTxB.sharedTx.localInputs).map { it.previousTx }, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+            val feerate = Transactions.fee2rate(signedTxA.tx.fees, signedTx.weight())
+            assertTrue(targetFeerate <= feerate && feerate <= targetFeerate * 1.25, "unexpected feerate (target=$targetFeerate actual=$feerate)")
+        }
     }
 
     @Test

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/TestsHelper.kt
@@ -165,7 +165,7 @@ data class LNChannel<out S : ChannelState>(
                 else -> state.copy(remoteNextCommitNonces = mapOf(), localCloseeNonce = null, spliceStatus = SpliceStatus.None)
             }
             is ShuttingDown -> state.copy(remoteNextCommitNonces = mapOf(), localCloseeNonce = null)
-            is Negotiating -> state.copy(localCloseeNonce = null, remoteCloseeNonce = null, localCloserNonces = null)
+            is Negotiating -> state.copy(localCloseeNonce = null, remoteCloseeNonce = null, localClosingComplete = null)
             else -> state
         }
 

--- a/modules/core/src/commonTest/resources/nonreg/v4/Negotiating_fac54067/data.json
+++ b/modules/core/src/commonTest/resources/nonreg/v4/Negotiating_fac54067/data.json
@@ -220,5 +220,5 @@
     },
     "localCloseeNonce": null,
     "remoteCloseeNonce": null,
-    "localCloserNonces": null
+    "localClosingComplete": null
 }


### PR DESCRIPTION
In the simple close session, which is never persisted, we just need to remember our closing_complete and the partial signatures it contains, instead of keeping our musig2 nonces and generating our partial signatures a second time to build the final closing tx when we receive our peer's partial signatures.

We also check our peer's partial signature and fail early if they're not valid, instead of building a fully sign closing tx and then verify that it is correct.