### PR TITLE
Implement Bolt12 payer proofs

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -1,6 +1,7 @@
 package fr.acinq.lightning.db
 
 import fr.acinq.bitcoin.*
+import fr.acinq.bitcoin.utils.Try
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.ShortChannelId
 import fr.acinq.lightning.payment.*
@@ -212,7 +213,19 @@ data class Bolt12IncomingPayment(
     override val parts: List<Part> = emptyList(),
     override val liquidityPurchaseDetails: LiquidityAds.LiquidityTransactionDetails? = null,
     override val createdAt: Long = currentTimestampMillis()
-) : LightningIncomingPayment(preimage)
+) : LightningIncomingPayment(preimage) {
+    /** Verify that the provided payment proof is valid and applies to this payment. */
+    fun verifyPayerProof(proof: String): Boolean {
+        return when (val p = PayerProof.decode(proof)) {
+            is Try.Success -> {
+                val sigsOk = p.result.verifySigs()
+                val matchesPayments = p.result.paymentHash == paymentHash
+                return sigsOk && matchesPayments
+            }
+            is Try.Failure -> false
+        }
+    }
+}
 
 /** Trustless swap-in (dual-funding or splice-in) */
 sealed class OnChainIncomingPayment : IncomingPayment() {
@@ -376,6 +389,21 @@ data class LightningOutgoingPayment(
         // For a swap-out, recipientAmount is the amount paid to the swap service. It contains the swap-out fee, but not the routing fee.
         is Details.SwapOut -> recipientAmount + routingFee
         else -> recipientAmount + fees
+    }
+
+    /** Return the Bolt12 payment proof, if this was a Bolt12 payment for which we received the preimage. */
+    fun payerProof(note: String? = null): PayerProof? {
+        return when (status) {
+            is Status.Succeeded -> when (details) {
+                is Details.Blinded -> {
+                    // We include the minimal amount of details from the invoice in our proof for privacy.
+                    val fields = PayerProof.Companion.IncludedFields()
+                    PayerProof.create(details.paymentRequest, status.preimage, details.payerKey, fields, note)
+                }
+                else -> null
+            }
+            else -> null
+        }
     }
 
     sealed class Details {

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/PayerProof.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/PayerProof.kt
@@ -1,0 +1,455 @@
+package fr.acinq.lightning.payment
+
+import fr.acinq.bitcoin.*
+import fr.acinq.bitcoin.io.ByteArrayOutput
+import fr.acinq.bitcoin.utils.Either
+import fr.acinq.bitcoin.utils.Try
+import fr.acinq.bitcoin.utils.flatMap
+import fr.acinq.bitcoin.utils.runTrying
+import fr.acinq.lightning.wire.*
+import fr.acinq.lightning.wire.OfferTypes.InvoiceAmount
+import fr.acinq.lightning.wire.OfferTypes.InvoiceBlindedPay
+import fr.acinq.lightning.wire.OfferTypes.InvoiceCreatedAt
+import fr.acinq.lightning.wire.OfferTypes.InvoiceFallbacks
+import fr.acinq.lightning.wire.OfferTypes.InvoiceFeatures
+import fr.acinq.lightning.wire.OfferTypes.InvoiceNodeId
+import fr.acinq.lightning.wire.OfferTypes.InvoicePaths
+import fr.acinq.lightning.wire.OfferTypes.InvoicePaymentHash
+import fr.acinq.lightning.wire.OfferTypes.InvoicePreimage
+import fr.acinq.lightning.wire.OfferTypes.InvoiceRelativeExpiry
+import fr.acinq.lightning.wire.OfferTypes.InvoiceRequestAmount
+import fr.acinq.lightning.wire.OfferTypes.InvoiceRequestChain
+import fr.acinq.lightning.wire.OfferTypes.InvoiceRequestFeatures
+import fr.acinq.lightning.wire.OfferTypes.InvoiceRequestMetadata
+import fr.acinq.lightning.wire.OfferTypes.InvoiceRequestPayerId
+import fr.acinq.lightning.wire.OfferTypes.InvoiceRequestPayerNote
+import fr.acinq.lightning.wire.OfferTypes.InvoiceRequestQuantity
+import fr.acinq.lightning.wire.OfferTypes.InvoiceTlv
+import fr.acinq.lightning.wire.OfferTypes.LeafHashes
+import fr.acinq.lightning.wire.OfferTypes.MissingHashes
+import fr.acinq.lightning.wire.OfferTypes.OfferAbsoluteExpiry
+import fr.acinq.lightning.wire.OfferTypes.OfferAmount
+import fr.acinq.lightning.wire.OfferTypes.OfferChains
+import fr.acinq.lightning.wire.OfferTypes.OfferCurrency
+import fr.acinq.lightning.wire.OfferTypes.OfferDescription
+import fr.acinq.lightning.wire.OfferTypes.OfferFeatures
+import fr.acinq.lightning.wire.OfferTypes.OfferIssuer
+import fr.acinq.lightning.wire.OfferTypes.OfferIssuerId
+import fr.acinq.lightning.wire.OfferTypes.OfferMetadata
+import fr.acinq.lightning.wire.OfferTypes.OfferPaths
+import fr.acinq.lightning.wire.OfferTypes.OfferQuantityMax
+import fr.acinq.lightning.wire.OfferTypes.OmittedTlvs
+import fr.acinq.lightning.wire.OfferTypes.PayerProofTlv
+import fr.acinq.lightning.wire.OfferTypes.ProofNote
+import fr.acinq.lightning.wire.OfferTypes.ProofSignature
+import fr.acinq.lightning.wire.OfferTypes.Signature
+
+/**
+ * Bolt12 payer proofs provide a cryptographic proof that a given Bolt12 invoice was paid.
+ * It doesn't reveal all the fields of the invoice, only the necessary ones.
+ */
+data class PayerProof(val records: TlvStream<PayerProofTlv>) {
+    val paymentHash: ByteVector32 = records.get<InvoicePaymentHash>()!!.hash
+    val preimage: ByteVector32 = records.get<InvoicePreimage>()!!.preimage
+    val invoiceNodeId: PublicKey = records.get<InvoiceNodeId>()!!.nodeId
+    val payerId: PublicKey = records.get<InvoiceRequestPayerId>()!!.publicKey
+
+    fun verifySigs(): Boolean {
+        when (validate(records)) {
+            is Either.Left -> return false
+            is Either.Right -> {
+                // The proof signature must be valid: it signs all non-signature TLVs using the invreq_payer_id.
+                val payerSig = records.get<ProofSignature>()!!.signature
+                val payerId = records.get<InvoiceRequestPayerId>()!!.publicKey
+                val proofRootHash = OfferTypes.rootHash(TlvStream(records.records.filterNot { it is Signature || it is ProofSignature }.toSet(), records.unknown))
+                if (!OfferTypes.verifySchnorr(signatureTag, proofRootHash, payerSig, payerId)) {
+                    return false
+                }
+                // The proof must contain enough data to reconstruct the invoice merkle root.
+                val leafNonces = records.get<LeafHashes>()?.hashes ?: listOf()
+                val markers = records.get<OmittedTlvs>()?.missing ?: listOf()
+                val missingHashes = records.get<MissingHashes>()?.missing ?: listOf()
+                // Disclosed invoice merkle-tree leaves: invoice fields (excluding the invoice signature) and unknown TLVs.
+                val knownLeaves = records.records
+                    .filterNot { it is Signature }
+                    .filterIsInstance<InvoiceTlv>()
+                    .map { EncodedTlv(it.tag, it.write().byteVector()) }
+                val disclosedLeaves = (knownLeaves + records.unknown.map { EncodedTlv(it.tag, it.value) }).sortedBy { it.tag }
+                val tagSet = disclosedLeaves.map { it.tag }.toSet()
+                // The omitted_tlvs field cannot contain the number of an included invoice TLV field.
+                // The leaf_hashes field must contain exactly one hash for each non-signature invoice TLV field.
+                if (leafNonces.size != disclosedLeaves.size || markers.any { tagSet.contains(it) }) {
+                    return false
+                }
+                // We combine disclosed and omitted leaves and sort them.
+                val allLeavesExceptMetadata = run {
+                    val disclosedWithNonce = disclosedLeaves
+                        .zip(leafNonces)
+                        .map { (tlv, nonce) -> Pair(tlv.tag, LeafWithNonce(tlv, nonce)) }
+                    val undisclosed: List<Pair<Long, LeafWithNonce?>> = markers.map { Pair(it, null) }
+                    (disclosedWithNonce + undisclosed).sortedBy { it.first }
+                }
+                // Each omitted leaf's marker must equal the previous leaf's value + 1 (with 0 implied for the always-omitted invreq_metadata at tag 0).
+                val omittedLeavesOk = allLeavesExceptMetadata.withIndex().all { (i, leaf) ->
+                    when {
+                        leaf.second != null -> true
+                        leaf.second == null && i == 0 -> leaf.first == 1L
+                        else -> {
+                            val previous = allLeavesExceptMetadata[i - 1].first
+                            val expected = if (previous == 239L) 1_000_000_000L else previous + 1
+                            leaf.first == expected
+                        }
+                    }
+                }
+                if (!omittedLeavesOk) {
+                    return false
+                }
+                // The first leaf is always the implicitly-omitted invreq_metadata.
+                val allLeaves = (listOf(null) + allLeavesExceptMetadata.map { it.second })
+                return when (val invoiceRootHash = PayerProofTree.merkleRoot(allLeaves, missingHashes)) {
+                    is Either.Left -> false
+                    is Either.Right -> {
+                        // The invoice signature must be valid against invoice_node_id over the reconstructed merkle root.
+                        val invoiceSig = records.get<Signature>()!!.signature
+                        val invoiceNodeId = records.get<InvoiceNodeId>()!!.nodeId
+                        OfferTypes.verifySchnorr(Bolt12Invoice.signatureTag, invoiceRootHash.value, invoiceSig, invoiceNodeId)
+                    }
+                }
+            }
+        }
+    }
+
+    override fun toString(): String {
+        val data = tlvSerializer.write(records)
+        return Bech32.encodeBytes(hrp, data, Bech32.Encoding.Beck32WithoutChecksum)
+    }
+
+    companion object {
+        val hrp = "lnp"
+        val signatureTag: ByteVector = ByteVector(("lightning" + "payer_proof" + "proof_signature").encodeToByteArray())
+
+        /** Specifies which optional fields from the invoice should be included in the payer proof. */
+        data class IncludedFields(
+            val offerChains: Boolean = false,
+            val offerMetadata: Boolean = false,
+            val offerCurrency: Boolean = false,
+            val offerAmount: Boolean = false,
+            val offerDescription: Boolean = false,
+            val offerFeatures: Boolean = false,
+            val offerAbsoluteExpiry: Boolean = false,
+            val offerPaths: Boolean = false,
+            val offerIssuer: Boolean = false,
+            val offerQuantityMax: Boolean = false,
+            val offerNodeId: Boolean = false,
+            val invoiceRequestChain: Boolean = false,
+            val invoiceRequestAmount: Boolean = false,
+            val invoiceRequestFeatures: Boolean = false,
+            val invoiceRequestQuantity: Boolean = false,
+            val invoiceRequestPayerNote: Boolean = false,
+            val invoicePaths: Boolean = false,
+            val invoiceBlindedPay: Boolean = false,
+            val invoiceCreatedAt: Boolean = false,
+            val invoiceRelativeExpiry: Boolean = false,
+            val invoiceAmount: Boolean = false,
+            val invoiceFallbacks: Boolean = false,
+            val unknown: Set<Long> = emptySet()
+        )
+
+        fun create(invoice: Bolt12Invoice, preimage: ByteVector32, payerKey: PrivateKey, fields: IncludedFields, note: String?): PayerProof {
+            // Valid Bolt12 invoices always contain the invreq_metadata field: it is used as a hashing nonce to prevent brute-forcing private fields.
+            val invreqMetadata = invoice.records.get<InvoiceRequestMetadata>()!!
+            // We select invoice fields that we want to include in our payer proof.
+            val knownLeaves: Set<Pair<InvoiceTlv, Boolean>> = invoice.records.records
+                .filterNot { it is Signature }
+                .map { tlv ->
+                    when (tlv) {
+                        is OfferChains -> Pair(tlv, fields.offerChains)
+                        is OfferMetadata -> Pair(tlv, fields.offerMetadata)
+                        is OfferCurrency -> Pair(tlv, fields.offerCurrency)
+                        is OfferAmount -> Pair(tlv, fields.offerAmount)
+                        is OfferDescription -> Pair(tlv, fields.offerDescription)
+                        is OfferFeatures -> Pair(tlv, fields.offerFeatures)
+                        is OfferAbsoluteExpiry -> Pair(tlv, fields.offerAbsoluteExpiry)
+                        is OfferPaths -> Pair(tlv, fields.offerPaths)
+                        is OfferIssuer -> Pair(tlv, fields.offerIssuer)
+                        is OfferQuantityMax -> Pair(tlv, fields.offerQuantityMax)
+                        is OfferIssuerId -> Pair(tlv, fields.offerNodeId)
+                        is InvoiceRequestMetadata -> Pair(tlv, false)
+                        is InvoiceRequestChain -> Pair(tlv, fields.invoiceRequestChain)
+                        is InvoiceRequestAmount -> Pair(tlv, fields.invoiceRequestAmount)
+                        is InvoiceRequestFeatures -> Pair(tlv, fields.invoiceRequestFeatures)
+                        is InvoiceRequestQuantity -> Pair(tlv, fields.invoiceRequestQuantity)
+                        is InvoiceRequestPayerId -> Pair(tlv, true)
+                        is InvoiceRequestPayerNote -> Pair(tlv, fields.invoiceRequestPayerNote)
+                        is InvoicePaths -> Pair(tlv, fields.invoicePaths)
+                        is InvoiceBlindedPay -> Pair(tlv, fields.invoiceBlindedPay)
+                        is InvoiceCreatedAt -> Pair(tlv, fields.invoiceCreatedAt)
+                        is InvoiceRelativeExpiry -> Pair(tlv, fields.invoiceRelativeExpiry)
+                        is InvoicePaymentHash -> Pair(tlv, true)
+                        is InvoiceAmount -> Pair(tlv, fields.invoiceAmount)
+                        is InvoiceFallbacks -> Pair(tlv, fields.invoiceFallbacks)
+                        is InvoiceFeatures -> Pair(tlv, true)
+                        is InvoiceNodeId -> Pair(tlv, true)
+                        is Signature -> Pair(tlv, false) // already filtered out above
+                    }
+                }.toSet()
+            // We must also include unknown TLVs, otherwise the merkle tree will be incomplete.
+            val unknownLeaves: Set<Pair<GenericTlv, Boolean>> = invoice.records.unknown.map { tlv ->
+                Pair(tlv, fields.unknown.contains(tlv.tag))
+            }.toSet()
+            // We convert everything to generic TLVs to combine known and unknown leaves.
+            val leaves = (knownLeaves + unknownLeaves)
+                .sortedBy { it.first.tag }
+                .map { (tlv, included) -> PayerProofTree.Leaf(EncodedTlv(tlv.tag, tlv.write().byteVector()), included) }
+            // We include the leaf nonce for each invoice TLV we include in the payer proof.
+            val leafNonces = leaves.filter { it.included }.map { PayerProofTree.leafNonce(invreqMetadata, it.tlv) }
+            val omittedTlvs = leaves.fold(Pair<List<Long>, Long?>(listOf(), null)) { (omitted, previousTlv), leaf ->
+                when {
+                    // This TLV is included in the payer proof, so we don't add an entry (it is not omitted).
+                    // However, we tell the next TLV that they need to use a marker higher than the current TLV tag.
+                    leaf.included -> Pair(omitted, leaf.tlv.tag)
+                    // The invreq_metadata field is always implicitly omitted (not included in omitted fields).
+                    leaf.tlv.tag == 0L -> Pair(omitted, previousTlv)
+                    else -> {
+                        // This TLV is not included in the payer proof: we add an entry with a marker.
+                        val markerNumber = when {
+                            previousTlv != null -> previousTlv + 1
+                            omitted.isEmpty() -> 1L
+                            else -> when {
+                                // We skip other the range [240;1_000_000_000[
+                                omitted.last() == 239L -> 1_000_000_000L
+                                else -> omitted.last() + 1
+                            }
+                        }
+                        Pair(omitted + listOf(markerNumber), null)
+                    }
+                }
+            }.first
+            val proofTree = PayerProofTree.create(leaves)
+            val missingHashes = PayerProofTree.computeMissingHashes(proofTree, invreqMetadata)
+            val includedInvoiceTlvs = knownLeaves.filter { it.second }.map { it.first }.toSet<PayerProofTlv>()
+            val payerProofTlvs = setOfNotNull(
+                InvoicePreimage(preimage),
+                LeafHashes(leafNonces),
+                if (omittedTlvs.isNotEmpty()) OmittedTlvs(omittedTlvs) else null,
+                if (missingHashes.isNotEmpty()) MissingHashes(missingHashes) else null,
+                note?.let { ProofNote(it) },
+            )
+            val includedUnknownTlvs = unknownLeaves.filter { it.second }.map { it.first }.toSet()
+            // The invoice signature is included in the final payer proof but is excluded from the proof merkle root (signature fields are never signed).
+            // Note that the invreq_metadata isn't disclosed in the proof: we will use the first TLV as a hashing nonce instead.
+            val proofSig = OfferTypes.signSchnorr(signatureTag, OfferTypes.rootHash(TlvStream(includedInvoiceTlvs + payerProofTlvs, includedUnknownTlvs)), payerKey)
+            val finalTlvs = TlvStream(includedInvoiceTlvs + setOfNotNull(invoice.records.get<Signature>()) + payerProofTlvs + setOf(ProofSignature(proofSig)), includedUnknownTlvs)
+            return PayerProof(finalTlvs)
+        }
+
+        /** We combine known and unknown TLVs into a generic form to aggregate them. */
+        data class EncodedTlv(val tag: Long, val value: ByteVector) {
+            fun write(): ByteArray {
+                val out = ByteArrayOutput()
+                LightningCodecs.writeBigSize(tag, out)
+                LightningCodecs.writeBigSize(value.size().toLong(), out)
+                LightningCodecs.writeBytes(value, out)
+                return out.toByteArray()
+            }
+        }
+
+        /** When validating a proof, the leaf nonce is directly provided to avoid brute-forcing omitted fields. */
+        data class LeafWithNonce(val tlv: EncodedTlv, val nonce: ByteVector32)
+
+        sealed class PayerProofTree {
+            /** True if all leaves of that subtree are included. */
+            abstract val included: Boolean
+            /** The invreq_metadata (mandatory) field is used as a nonce to provide randomness. */
+            abstract fun hash(invreqMetadata: InvoiceRequestMetadata): ByteVector32
+
+            data class Leaf(val tlv: EncodedTlv, override val included: Boolean) : PayerProofTree() {
+                override fun hash(invreqMetadata: InvoiceRequestMetadata): ByteVector32 {
+                    val nonce = leafNonce(invreqMetadata, tlv)
+                    return combine(nonce, OfferTypes.hash("LnLeaf".encodeToByteArray(), tlv.write()).byteVector32())
+                }
+            }
+
+            data class Branch(val left: PayerProofTree, val right: PayerProofTree, override val included: Boolean) : PayerProofTree() {
+                override fun hash(invreqMetadata: InvoiceRequestMetadata): ByteVector32 {
+                    return combine(left.hash(invreqMetadata), right.hash(invreqMetadata))
+                }
+            }
+
+            companion object {
+                fun create(leaves: List<Leaf>): PayerProofTree = merkleTree(leaves, 0, leaves.size)
+
+                fun computeMissingHashes(tree: PayerProofTree, invreqMetadata: InvoiceRequestMetadata): List<ByteVector32> {
+                    return when {
+                        !tree.included -> listOf(tree.hash(invreqMetadata))
+                        tree is Leaf -> listOf()
+                        tree is Branch -> when {
+                            // Post-order DFS: at each internal node with exactly one fully-omitted branch, emit that branch's hash
+                            // *after* recursing into the other (mixed) branch.
+                            tree.left.included && tree.right.included -> computeMissingHashes(tree.left, invreqMetadata) + computeMissingHashes(tree.right, invreqMetadata)
+                            !tree.left.included && tree.right.included -> computeMissingHashes(tree.right, invreqMetadata) + listOf(tree.left.hash(invreqMetadata))
+                            tree.left.included && !tree.right.included -> computeMissingHashes(tree.left, invreqMetadata) + listOf(tree.right.hash(invreqMetadata))
+                            else -> listOf() // unreachable: parent's `included` would be false
+                        }
+                        else -> listOf()
+                    }
+                }
+
+                /** Leaves are combined with a nonce acting as a neighbor leaf. */
+                fun leafNonce(invreqMetadata: InvoiceRequestMetadata, tlv: EncodedTlv): ByteVector32 {
+                    val encodedMetadata = EncodedTlv(invreqMetadata.tag, invreqMetadata.write().byteVector()).write()
+                    val encodedTlvTag = run {
+                        val out = ByteArrayOutput()
+                        LightningCodecs.writeBigSize(tlv.tag, out)
+                        out.toByteArray()
+                    }
+                    return OfferTypes.hash("LnNonce".encodeToByteArray() + encodedMetadata, encodedTlvTag).byteVector32()
+                }
+
+                fun combine(h1: ByteVector32, h2: ByteVector32): ByteVector32 = when {
+                    LexicographicalOrdering.isLessThan(h1, h2) -> OfferTypes.hash("LnBranch".encodeToByteArray(), h1.toByteArray() + h2.toByteArray()).byteVector32()
+                    else -> OfferTypes.hash("LnBranch".encodeToByteArray(), h2.toByteArray() + h1.toByteArray()).byteVector32()
+                }
+
+                fun merkleTree(leaves: List<Leaf>, i: Int, j: Int): PayerProofTree {
+                    return when {
+                        j - i == 1 -> leaves[i]
+                        else -> {
+                            val k = i + previousPowerOfTwo(j - i)
+                            val left = merkleTree(leaves, i, k)
+                            val right = merkleTree(leaves, k, j)
+                            Branch(left, right, left.included || right.included)
+                        }
+                    }
+                }
+
+                fun merkleRoot(leaves: List<LeafWithNonce?>, missingHashes: List<ByteVector32>): Either<String, ByteVector32> {
+                    return merkleRoot(leaves, missingHashes, 0, leaves.size).flatMap { (root, remainingHashes) ->
+                        when {
+                            remainingHashes.isNotEmpty() -> Either.Left("invalid payer proof: missing_hashes not empty after recomputing invoice merkle root")
+                            root == null -> Either.Left("invalid payer proof: cannot recompute invoice merkle root")
+                            else -> Either.Right(root)
+                        }
+
+                    }
+                }
+
+                /** Recompute the merkle root, consuming missing_hashes in post-order DFS (smallest TLV first). */
+                private fun merkleRoot(leaves: List<LeafWithNonce?>, missingHashes: List<ByteVector32>, i: Int, j: Int): Either<String, Pair<ByteVector32?, List<ByteVector32>>> {
+                    return if (j - i == 1) {
+                        // We've reached a leaf: it is either included or omitted, but doesn't consume any missing hash yet.
+                        when (val leaf = leaves[i]) {
+                            null -> Either.Right(Pair(null, missingHashes))
+                            else -> {
+                                val hash = combine(leaf.nonce, OfferTypes.hash("LnLeaf".encodeToByteArray(), leaf.tlv.write()).byteVector32())
+                                Either.Right(Pair(hash, missingHashes))
+                            }
+                        }
+                    } else {
+                        val k = i + previousPowerOfTwo(j - i)
+                        when (val leftSide = merkleRoot(leaves, missingHashes, i, k)) {
+                            is Either.Left -> leftSide
+                            is Either.Right -> {
+                                val (leftRoot, remainingHashesAfterLeft) = leftSide.value
+                                when (val rightSide = merkleRoot(leaves, remainingHashesAfterLeft, k, j)) {
+                                    is Either.Left -> rightSide
+                                    is Either.Right -> {
+                                        val (rightRoot, remainingHashes) = rightSide.value
+                                        when {
+                                            // Both subtrees are (at least partially) included.
+                                            leftRoot != null && rightRoot != null -> Either.Right(Pair(combine(leftRoot, rightRoot), remainingHashes))
+                                            // Both subtrees are fully omitted: the parent tree is fully omitted as well.
+                                            leftRoot == null && rightRoot == null -> Either.Right(Pair(null, remainingHashes))
+                                            // One of the subtrees is omitted: we use missing_hashes to get its merkle root.
+                                            leftRoot != null && rightRoot == null && remainingHashes.isNotEmpty() -> Either.Right(Pair(combine(leftRoot, remainingHashes.first()), remainingHashes.drop(1)))
+                                            leftRoot == null && rightRoot != null && remainingHashes.isNotEmpty() -> Either.Right(Pair(combine(remainingHashes.first(), rightRoot), remainingHashes.drop(1)))
+                                            // One of the subtrees is omitted, but we don't have missing hashes to consume left.
+                                            else -> Either.Left("cannot recompute invoice merkle root: missing_hashes is incomplete")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                fun previousPowerOfTwo(n: Int): Int {
+                    var p = 1
+                    while (p < n) {
+                        p = p shl 1
+                    }
+                    return p shr 1
+                }
+            }
+        }
+
+        val tlvSerializer = TlvStreamSerializer(
+            false, @Suppress("UNCHECKED_CAST") mapOf(
+                // Invoice part that must be copy-pasted from the Bolt12 invoice serializer.
+                InvoiceRequestMetadata.tag to InvoiceRequestMetadata as TlvValueReader<PayerProofTlv>,
+                OfferChains.tag to OfferChains as TlvValueReader<PayerProofTlv>,
+                OfferMetadata.tag to OfferMetadata as TlvValueReader<PayerProofTlv>,
+                OfferCurrency.tag to OfferCurrency as TlvValueReader<PayerProofTlv>,
+                OfferAmount.tag to OfferAmount as TlvValueReader<PayerProofTlv>,
+                OfferDescription.tag to OfferDescription as TlvValueReader<PayerProofTlv>,
+                OfferFeatures.tag to OfferFeatures as TlvValueReader<PayerProofTlv>,
+                OfferAbsoluteExpiry.tag to OfferAbsoluteExpiry as TlvValueReader<PayerProofTlv>,
+                OfferPaths.tag to OfferPaths as TlvValueReader<PayerProofTlv>,
+                OfferIssuer.tag to OfferIssuer as TlvValueReader<PayerProofTlv>,
+                OfferQuantityMax.tag to OfferQuantityMax as TlvValueReader<PayerProofTlv>,
+                OfferIssuerId.tag to OfferIssuerId as TlvValueReader<PayerProofTlv>,
+                InvoiceRequestChain.tag to InvoiceRequestChain as TlvValueReader<PayerProofTlv>,
+                InvoiceRequestAmount.tag to InvoiceRequestAmount as TlvValueReader<PayerProofTlv>,
+                InvoiceRequestFeatures.tag to InvoiceRequestFeatures as TlvValueReader<PayerProofTlv>,
+                InvoiceRequestQuantity.tag to InvoiceRequestQuantity as TlvValueReader<PayerProofTlv>,
+                InvoiceRequestPayerId.tag to InvoiceRequestPayerId as TlvValueReader<PayerProofTlv>,
+                InvoiceRequestPayerNote.tag to InvoiceRequestPayerNote as TlvValueReader<PayerProofTlv>,
+                InvoicePaths.tag to InvoicePaths as TlvValueReader<PayerProofTlv>,
+                InvoiceBlindedPay.tag to InvoiceBlindedPay as TlvValueReader<PayerProofTlv>,
+                InvoiceCreatedAt.tag to InvoiceCreatedAt as TlvValueReader<PayerProofTlv>,
+                InvoiceRelativeExpiry.tag to InvoiceRelativeExpiry as TlvValueReader<PayerProofTlv>,
+                InvoicePaymentHash.tag to InvoicePaymentHash as TlvValueReader<PayerProofTlv>,
+                InvoiceAmount.tag to InvoiceAmount as TlvValueReader<PayerProofTlv>,
+                InvoiceFallbacks.tag to InvoiceFallbacks as TlvValueReader<PayerProofTlv>,
+                InvoiceFeatures.tag to InvoiceFeatures as TlvValueReader<PayerProofTlv>,
+                InvoiceNodeId.tag to InvoiceNodeId as TlvValueReader<PayerProofTlv>,
+                Signature.tag to Signature as TlvValueReader<PayerProofTlv>,
+                // Payer proof part.
+                ProofSignature.tag to ProofSignature as TlvValueReader<PayerProofTlv>,
+                InvoicePreimage.tag to InvoicePreimage as TlvValueReader<PayerProofTlv>,
+                OmittedTlvs.tag to OmittedTlvs as TlvValueReader<PayerProofTlv>,
+                MissingHashes.tag to MissingHashes as TlvValueReader<PayerProofTlv>,
+                LeafHashes.tag to LeafHashes as TlvValueReader<PayerProofTlv>,
+                ProofNote.tag to ProofNote as TlvValueReader<PayerProofTlv>,
+            )
+        )
+
+        private fun validate(records: TlvStream<PayerProofTlv>): Either<InvalidTlvPayload, PayerProof> {
+            if (records.get<InvoiceRequestPayerId>() == null) return Either.Left(MissingRequiredTlv(InvoiceRequestPayerId.tag))
+            if (records.get<InvoicePaymentHash>() == null) return Either.Left(MissingRequiredTlv(InvoicePaymentHash.tag))
+            if (records.get<InvoiceNodeId>() == null) return Either.Left(MissingRequiredTlv(InvoiceNodeId.tag))
+            if (records.get<Signature>() == null) return Either.Left(MissingRequiredTlv(Signature.tag))
+            if (records.get<ProofSignature>() == null) return Either.Left(MissingRequiredTlv(ProofSignature.tag))
+            if (records.get<InvoicePreimage>() == null) return Either.Left(MissingRequiredTlv(InvoicePreimage.tag))
+            // The preimage must match the invoice's payment_hash.
+            if (Crypto.sha256(records.get<InvoicePreimage>()!!.preimage).byteVector32() != records.get<InvoicePaymentHash>()!!.hash) return Either.Left(InvalidTlvValue(InvoicePreimage.tag))
+            val omittedTlvs = records.get<OmittedTlvs>()?.missing ?: listOf()
+            if (omittedTlvs.size != omittedTlvs.distinct().size) return Either.Left(InvalidTlvValue(OmittedTlvs.tag))
+            if (omittedTlvs.sorted() != omittedTlvs) return Either.Left(InvalidTlvValue(OmittedTlvs.tag))
+            if (!omittedTlvs.all { (it in 1..239) || (it in 1_000_000_000L..3_999_999_999L) }) return Either.Left(InvalidTlvValue(OmittedTlvs.tag))
+            return Either.Right(PayerProof(records))
+        }
+
+        fun decode(input: String): Try<PayerProof> = runTrying {
+            val (prefix, encoded, encoding) = Bech32.decodeBytes(input.lowercase(), true)
+            require(prefix == hrp)
+            require(encoding == Bech32.Encoding.Beck32WithoutChecksum)
+            val tlvs = tlvSerializer.read(encoded)
+            when (val proof = validate(tlvs)) {
+                is Either.Left -> throw IllegalArgumentException(proof.value.toString())
+                is Either.Right -> proof.value
+            }
+        }
+    }
+
+}

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/wire/OfferTypes.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/wire/OfferTypes.kt
@@ -62,7 +62,9 @@ object OfferTypes {
 
     sealed class Bolt12Tlv : Tlv
 
-    sealed class InvoiceTlv : Bolt12Tlv()
+    sealed class PayerProofTlv : Bolt12Tlv()
+
+    sealed class InvoiceTlv : PayerProofTlv()
 
     sealed class InvoiceRequestTlv : InvoiceTlv()
 
@@ -657,6 +659,110 @@ object OfferTypes {
         }
     }
 
+    /** The payer signs the payer proof. */
+    data class ProofSignature(val signature: ByteVector64) : PayerProofTlv() {
+        override val tag: Long get() = ProofSignature.tag
+
+        override fun write(out: Output) {
+            LightningCodecs.writeBytes(signature, out)
+        }
+
+        companion object : TlvValueReader<ProofSignature> {
+            const val tag: Long = 241
+            override fun read(input: Input): ProofSignature {
+                return ProofSignature(ByteVector64(LightningCodecs.bytes(input, input.availableBytes)))
+            }
+        }
+    }
+
+    /** Preimage matching the invoice's [InvoicePaymentHash]. */
+    data class InvoicePreimage(val preimage: ByteVector32) : PayerProofTlv() {
+        override val tag: Long get() = InvoicePreimage.tag
+
+        override fun write(out: Output) {
+            LightningCodecs.writeBytes(preimage, out)
+        }
+
+        companion object : TlvValueReader<InvoicePreimage> {
+            const val tag: Long = 1001
+            override fun read(input: Input): InvoicePreimage {
+                return InvoicePreimage(ByteVector32(LightningCodecs.bytes(input, input.availableBytes)))
+            }
+        }
+    }
+
+    /** The payer may omit some invoice TLVs for privacy reasons. */
+    data class OmittedTlvs(val missing: List<Long>) : PayerProofTlv() {
+        override val tag: Long get() = OmittedTlvs.tag
+
+        override fun write(out: Output) {
+            missing.forEach { tlv -> LightningCodecs.writeBigSize(tlv, out) }
+        }
+
+        companion object : TlvValueReader<OmittedTlvs> {
+            const val tag: Long = 1002
+            override fun read(input: Input): OmittedTlvs {
+                val tlvs = ArrayList<Long>()
+                while (input.availableBytes > 0) {
+                    tlvs.add(LightningCodecs.bigSize(input))
+                }
+                return OmittedTlvs(tlvs.toList())
+            }
+        }
+    }
+
+    /** The payer must include the missing parts of the invoice TLV merkle tree. */
+    data class MissingHashes(val missing: List<ByteVector32>) : PayerProofTlv() {
+        override val tag: Long get() = MissingHashes.tag
+
+        override fun write(out: Output) {
+            missing.forEach { hash -> LightningCodecs.writeBytes(hash, out) }
+        }
+
+        companion object : TlvValueReader<MissingHashes> {
+            const val tag: Long = 1003
+            override fun read(input: Input): MissingHashes {
+                val count = input.availableBytes / 32
+                val missing = (0 until count).map { LightningCodecs.bytes(input, 32).byteVector32() }
+                return MissingHashes(missing)
+            }
+        }
+    }
+
+    /** The payer must include a nonce hash for each invoice TLV included in the payer proof. */
+    data class LeafHashes(val hashes: List<ByteVector32>) : PayerProofTlv() {
+        override val tag: Long get() = LeafHashes.tag
+
+        override fun write(out: Output) {
+            hashes.forEach { hash -> LightningCodecs.writeBytes(hash, out) }
+        }
+
+        companion object : TlvValueReader<LeafHashes> {
+            const val tag: Long = 1004
+            override fun read(input: Input): LeafHashes {
+                val count = input.availableBytes / 32
+                val missing = (0 until count).map { LightningCodecs.bytes(input, 32).byteVector32() }
+                return LeafHashes(missing)
+            }
+        }
+    }
+
+    /** An optional challenge may be included in the payer proof. */
+    data class ProofNote(val note: String) : PayerProofTlv() {
+        override val tag: Long get() = ProofNote.tag
+
+        override fun write(out: Output) {
+            LightningCodecs.writeBytes(note.encodeToByteArray(), out)
+        }
+
+        companion object : TlvValueReader<ProofNote> {
+            const val tag: Long = 1005
+            override fun read(input: Input): ProofNote {
+                return ProofNote(LightningCodecs.bytes(input, input.availableBytes).decodeToString(throwOnInvalidSequence = true))
+            }
+        }
+    }
+
     private fun isOfferTlv(tlv: GenericTlv): Boolean {
         // Offer TLVs are in the range [1, 79] or [1000000000, 1999999999].
         return tlv.tag in 1..79 || tlv.tag in 1000000000..1999999999
@@ -1055,6 +1161,7 @@ object OfferTypes {
     }
 
     fun <T : Tlv> rootHash(tlvStream: TlvStream<T>): ByteVector32 {
+        // This encoding step ensures that the resulting tlvs are ordered and that we combine known and unknown TLVs.
         val encodedTlvs = (tlvStream.records + tlvStream.unknown).sortedBy { it.tag }.map { tlv ->
             val out = ByteArrayOutput()
             LightningCodecs.writeBigSize(tlv.tag, out)
@@ -1064,6 +1171,9 @@ object OfferTypes {
             LightningCodecs.writeBytes(data, out)
             Pair(tag, out.toByteArray())
         }
+        // The first TLV in the stream is used as a hashing nonce for all leaves of the tree, to ensure that
+        // their values cannot be brute-forced when omitted in payer proofs. For Bolt12 invoices and invoice
+        // requests this is invreq_metadata (tag 0); for payer proofs it's the lowest-tag disclosed TLV.
         val nonceKey = "LnNonce".encodeToByteArray() + encodedTlvs[0].second
 
         fun previousPowerOfTwo(n: Int): Int {
@@ -1092,7 +1202,7 @@ object OfferTypes {
         return ByteVector32(merkleTree(0, encodedTlvs.size))
     }
 
-    private fun hash(tag: ByteArray, msg: ByteArray): ByteArray {
+    fun hash(tag: ByteArray, msg: ByteArray): ByteArray {
         val tagHash = Crypto.sha256(tag)
         return Crypto.sha256(tagHash + tagHash + msg)
     }
@@ -1109,7 +1219,8 @@ object OfferTypes {
     }
 
     /** We often need to remove the signature field to compute the merkle root. */
-    fun <T : Bolt12Tlv> removeSignature(records: TlvStream<T>): TlvStream<T> =
-        TlvStream(records.records.filter { it !is Signature }.toSet(), records.unknown)
+    fun <T : Bolt12Tlv> removeSignature(records: TlvStream<T>): TlvStream<T> {
+        return TlvStream(records.records.filter { it !is Signature }.toSet(), records.unknown)
+    }
 
 }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/wire/TlvCodecs.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/wire/TlvCodecs.kt
@@ -33,6 +33,7 @@ interface TlvValueReader<T : Tlv> {
 sealed class InvalidTlvPayload { abstract val tag: Long }
 data class CannotDecodeTlv(override val tag: Long) : InvalidTlvPayload() { override fun toString(): String = "cannot decode tlv (tag=$tag)" }
 data class MissingRequiredTlv(override val tag: Long) : InvalidTlvPayload() { override fun toString(): String = "missing required tlv (tag=$tag)" }
+data class InvalidTlvValue(override val tag: Long) : InvalidTlvPayload() { override fun toString(): String = "invalid tlv value (tag=$tag)" }
 data class ForbiddenTlv(override val tag: Long) : InvalidTlvPayload() { override fun toString(): String = "forbidden tlv (tag=$tag)" }
 // @formatter:on
 

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/PayerProofTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/PayerProofTestsCommon.kt
@@ -1,0 +1,103 @@
+package fr.acinq.lightning.payment
+
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.ByteVector64
+import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.lightning.tests.utils.LightningTestSuite
+import fr.acinq.lightning.tests.utils.TestHelpers
+import fr.acinq.lightning.wire.OfferTypes
+import kotlinx.serialization.json.Json
+import kotlin.test.*
+
+class PayerProofTestsCommon : LightningTestSuite() {
+
+    @Test
+    fun `official test vectors`() {
+        val payerKey = PrivateKey.fromHex("4242424242424242424242424242424242424242424242424242424242424242")
+        testCases.valid_vectors.forEach { t ->
+            val invoice = Bolt12Invoice.fromString(t.input.invoice).get()
+            assertEquals(OfferTypes.rootHash(OfferTypes.removeSignature(invoice.records)), ByteVector32.fromValidHex(t.working.invoice_merkle_root))
+            val preimage = ByteVector32.fromValidHex(t.input.preimage)
+            val includedFields = PayerProof.Companion.IncludedFields(
+                offerChains = t.input.invoice_fields.any { it.type == 2L && it.included },
+                offerMetadata = t.input.invoice_fields.any { it.type == 4L && it.included },
+                offerCurrency = t.input.invoice_fields.any { it.type == 6L && it.included },
+                offerAmount = t.input.invoice_fields.any { it.type == 8L && it.included },
+                offerDescription = t.input.invoice_fields.any { it.type == 10L && it.included },
+                offerFeatures = t.input.invoice_fields.any { it.type == 12L && it.included },
+                offerAbsoluteExpiry = t.input.invoice_fields.any { it.type == 14L && it.included },
+                offerPaths = t.input.invoice_fields.any { it.type == 16L && it.included },
+                offerIssuer = t.input.invoice_fields.any { it.type == 18L && it.included },
+                offerQuantityMax = t.input.invoice_fields.any { it.type == 20L && it.included },
+                offerNodeId = t.input.invoice_fields.any { it.type == 22L && it.included },
+                invoiceRequestChain = t.input.invoice_fields.any { it.type == 80L && it.included },
+                invoiceRequestAmount = t.input.invoice_fields.any { it.type == 82L && it.included },
+                invoiceRequestFeatures = t.input.invoice_fields.any { it.type == 84L && it.included },
+                invoiceRequestQuantity = t.input.invoice_fields.any { it.type == 86L && it.included },
+                invoiceRequestPayerNote = t.input.invoice_fields.any { it.type == 89L && it.included },
+                invoicePaths = t.input.invoice_fields.any { it.type == 160L && it.included },
+                invoiceBlindedPay = t.input.invoice_fields.any { it.type == 162L && it.included },
+                invoiceCreatedAt = t.input.invoice_fields.any { it.type == 164L && it.included },
+                invoiceRelativeExpiry = t.input.invoice_fields.any { it.type == 166L && it.included },
+                invoiceAmount = t.input.invoice_fields.any { it.type == 170L && it.included },
+                invoiceFallbacks = t.input.invoice_fields.any { it.type == 172L && it.included },
+                unknown = t.input.invoice_fields.filter { it.type > 250L && it.included }.map { it.type }.toSet()
+            )
+            if (t.name == "empty_proof_omitted_tlvs_explicit") {
+                // This test vector verifies that we correctly handle an explicitly included empty proof_omitted_tlvs field.
+                val decoded = PayerProof.decode(t.result.bech32)
+                assertTrue(decoded.isSuccess)
+                assertEquals(ByteVector64.fromValidHex(t.result.payer_sig), decoded.get().records.get<OfferTypes.ProofSignature>()?.signature)
+                assertTrue(decoded.get().verifySigs())
+                // Since we omit the proof_omitted_tlvs field when it's empty, we don't generate the same proof, which is fine.
+                assertNotEquals(t.result.bech32, PayerProof.create(invoice, preimage, payerKey, includedFields, t.input.note).toString())
+            } else {
+                val payerProof = PayerProof.create(invoice, preimage, payerKey, includedFields, t.input.note)
+                assertNotNull(payerProof.records.get<OfferTypes.LeafHashes>())
+                payerProof.records.get<OfferTypes.LeafHashes>()?.let { assertEquals(it.hashes, t.working.proof_leaf_hashes.map { h -> ByteVector32.fromValidHex(h) }.toList()) }
+                payerProof.records.get<OfferTypes.OmittedTlvs>()?.let { assertEquals(it.missing, t.working.proof_omitted_tlvs.toList()) }
+                payerProof.records.get<OfferTypes.MissingHashes>()?.let { assertEquals(it.missing, t.working.proof_missing_hashes.map { h -> ByteVector32.fromValidHex(h) }.toList()) }
+                assertNotNull(payerProof.records.get<OfferTypes.ProofSignature>())
+                assertEquals(ByteVector64.fromValidHex(t.result.payer_sig), payerProof.records.get<OfferTypes.ProofSignature>()?.signature)
+                assertEquals(t.result.bech32, payerProof.toString())
+                assertTrue(PayerProof.decode(t.result.bech32).isSuccess)
+                assertEquals(payerProof, PayerProof.decode(t.result.bech32).get())
+                assertTrue(payerProof.verifySigs())
+            }
+        }
+        testCases.invalid_vectors.forEach { t ->
+            val isValid = PayerProof.decode(t.bech32).map { it.verifySigs() }.getOrElse { false }
+            assertFalse(isValid)
+        }
+    }
+
+    companion object {
+        @kotlinx.serialization.Serializable
+        data class InvalidTestVector(val reason: String, val bech32: String)
+
+        @kotlinx.serialization.Serializable
+        data class TestVectorResult(val payer_sig: String, val bech32: String)
+
+        @kotlinx.serialization.Serializable
+        data class TestVectorWorking(val invoice_merkle_root: String, val proof_leaf_hashes: Array<String>, val proof_omitted_tlvs: Array<Long>, val proof_missing_hashes: Array<String>)
+
+        @kotlinx.serialization.Serializable
+        data class InvoiceField(val type: Long, val included: Boolean)
+
+        @kotlinx.serialization.Serializable
+        data class TestVectorInput(val invoice: String, val preimage: String, val note: String?, val invoice_fields: Array<InvoiceField>)
+
+        @kotlinx.serialization.Serializable
+        data class ValidTestVector(val name: String, val input: TestVectorInput, val working: TestVectorWorking, val result: TestVectorResult)
+
+        @kotlinx.serialization.Serializable
+        data class TestVectors(val valid_vectors: Array<ValidTestVector>, val invalid_vectors: Array<InvalidTestVector>)
+
+        val format = Json {
+            ignoreUnknownKeys = true
+            explicitNulls = false
+        }
+        val testCases = format.decodeFromString<TestVectors>(TestHelpers.readResourceAsString("payer_proof_tests.json"))
+    }
+
+}

--- a/modules/core/src/commonTest/resources/payer_proof_tests.json
+++ b/modules/core/src/commonTest/resources/payer_proof_tests.json
@@ -1,0 +1,969 @@
+{
+    "payer_secret": "4242424242424242424242424242424242424242424242424242424242424242",
+    "keys": {
+        "offer_issuer_id": {
+            "secret": "4646464646464646464646464646464646464646464646464646464646464646",
+            "pubkey": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382"
+        },
+        "invreq_payer_id": {
+            "secret": "4242424242424242424242424242424242424242424242424242424242424242",
+            "pubkey": "0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c"
+        },
+        "first_node_id": {
+            "secret": "4343434343434343434343434343434343434343434343434343434343434343",
+            "pubkey": "027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007"
+        },
+        "first_path_key": {
+            "secret": "4444444444444444444444444444444444444444444444444444444444444444",
+            "pubkey": "032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991"
+        },
+        "blinded_node_id": {
+            "secret": "4545454545454545454545454545454545454545454545454545454545454545",
+            "pubkey": "02edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145"
+        },
+        "invoice_node_id": {
+            "secret": "4646464646464646464646464646464646464646464646464646464646464646",
+            "pubkey": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382"
+        }
+    },
+    "valid_vectors": [
+        {
+            "name": "full_disclosure",
+            "input": {
+                "invoice": "lni1qqgqqqqqqqqqqqqqqqqqqqqqqqqqq93pqf9u9gcjv52n7pl8pc96kzrjfe4ctcshlrxk9r8tv2t5y3amfyecy5szq059sggry3jnatzrgjyqqtxqdwlm0ug0uxyerc6lnljrqtd75mfr20wq4vw2qasz0uc7h32x9s0aecdhxlk075kn046aafpuuyw8f5j652t3vha2yqrsxtqt0nu4xf9q05znnzeyq96dcrptu3zdj6c4n2nv0aa3ue5xszv3qypwm2aaz66peqm3hyh09uzvzxzmfupmdhx49w5m0rva0jyu3u3pz3gqzqqqqqqqqqqqqqqqqqqqqqqqqqq2y8qqqqqqzqqqqqpqqqcqqqqqqqqqqqzqqqqqqqqqqqq9qqq2gpr82fuc32pqwtxkappzcsrlkmgfs6g0zyct0hkhashh7hsaxz7e65slq9fkx7f65qsrazhq6zqqqqqqqqqqqqqqqqqqqzczzqjtc233yeg48ur7wrst4vy8ynntsh3p07xdv2xwkc5hgfrmkjfnstcyp7aextn2n4d5mzx2phwfe70cejyqaaq78my4wndgna3ymwyc4vlf60kke258g33nhp23vldqpygemxp54ecl0vr0qfejm3xpm6atq4mlavkstcqszss",
+                "invoice_hex": "0010000000000000000000000000000000001621024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382520203e858210324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1ca076027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e6686809910102edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145001000000000000000000000000000000000a21c00000001000000020003000000000000000400000000000000050000a40467527988a82072cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793aa0203e8ae0d08000000000000000000000000b021024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382f040fbb932e6a9d5b4d88ca0ddc9cf9f8cc880ef41e3ec9574da89f624db898ab3e9d3ed6caa8744633b855167da009119d9834ae71f7b06f02732dc4c1debab0577feb2d05e010142",
+                "preimage": "0101010101010101010101010101010101010101010101010101010101010101",
+                "invoice_fields": [
+                    {
+                        "type": 0,
+                        "len": 16,
+                        "hex": "00000000000000000000000000000000",
+                        "included": false
+                    },
+                    {
+                        "type": 22,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382",
+                        "included": true
+                    },
+                    {
+                        "type": 82,
+                        "len": 2,
+                        "hex": "03e8",
+                        "included": true
+                    },
+                    {
+                        "type": 88,
+                        "len": 33,
+                        "hex": "0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c",
+                        "included": true
+                    },
+                    {
+                        "type": 160,
+                        "len": 118,
+                        "hex": "027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e6686809910102edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145001000000000000000000000000000000000",
+                        "included": true
+                    },
+                    {
+                        "type": 162,
+                        "len": 28,
+                        "hex": "00000001000000020003000000000000000400000000000000050000",
+                        "included": true
+                    },
+                    {
+                        "type": 164,
+                        "len": 4,
+                        "hex": "67527988",
+                        "included": true
+                    },
+                    {
+                        "type": 168,
+                        "len": 32,
+                        "hex": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793",
+                        "included": true
+                    },
+                    {
+                        "type": 170,
+                        "len": 2,
+                        "hex": "03e8",
+                        "included": true
+                    },
+                    {
+                        "type": 174,
+                        "len": 13,
+                        "hex": "08000000000000000000000000",
+                        "included": true
+                    },
+                    {
+                        "type": 176,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382",
+                        "included": true
+                    },
+                    {
+                        "type": 240,
+                        "len": 64,
+                        "hex": "fbb932e6a9d5b4d88ca0ddc9cf9f8cc880ef41e3ec9574da89f624db898ab3e9d3ed6caa8744633b855167da009119d9834ae71f7b06f02732dc4c1debab0577",
+                        "included": false
+                    },
+                    {
+                        "type": 3000000001,
+                        "len": 1,
+                        "hex": "42",
+                        "included": true
+                    }
+                ]
+            },
+            "working": {
+                "invoice_merkle_root": "cb9e0c81bb39fc244f9f523c748ab4de0e09f1a5fef74359c2e1f7cc7cdc7447",
+                "invoice_sighash": "538aab18f82285032db132cecf7275ba2cbb462ef1f4d151588f836d0ce47aae",
+                "invoice_signature": "fbb932e6a9d5b4d88ca0ddc9cf9f8cc880ef41e3ec9574da89f624db898ab3e9d3ed6caa8744633b855167da009119d9834ae71f7b06f02732dc4c1debab0577",
+                "proof_merkle_root": "d461a2dd3099e2c43ccef4c3c8d36f720948fe21712ea94dceccb4bddb0c9e5e",
+                "proof_leaf_hashes": [
+                    "8c9057ed88f3c5a6b6441dcac3b5e4cefb3615904d7362b86e78427fb695f461",
+                    "8dc54a97453dee6f207fa5216a30f1567442712ca98852bc789b73885029283c",
+                    "f2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67",
+                    "f54f80c94a87383f2a8ef7c3e461c62b67a51da5bccf6cd96a7dbab29bea51fa",
+                    "7849b8b856e1d2a63d9ce7dc1a78e05cbb2def1f5d7709c48e8707e0a59fe51e",
+                    "19e7e4eee6bf56c6c589fe50035490c1a7c91b753cb8007c4b52838a6772f997",
+                    "f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1a",
+                    "dc0b8de03f1a0b0531bff146982d7d613ef6e1ef8d3bdd9590971fc18d835ffb",
+                    "c14cfffaa314261bcbb2ed4ca24d5717bb608d8a6cc9910790bc1d49af7858ab",
+                    "7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cb",
+                    "abaab91b367e30fea7026daf9f2590bb7e9cc31db8221f4013c67289e38f22c8"
+                ],
+                "proof_omitted_tlvs": [],
+                "proof_missing_hashes": [
+                    "0b510ba4c6884d603159ced2f0ca21e772424b59e52a2191bbfbcf07377805a1"
+                ]
+            },
+            "result": {
+                "payer_sig": "4961333409f453b5518fcbc662936fcb46e6c1db8d963c44b67d5677f0ffce3ac5c42293d1bc1298b0d67320a772e20a06c069dfa7079df9207b675357735dd7",
+                "proof_fields": [
+                    {
+                        "type": 22,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382"
+                    },
+                    {
+                        "type": 82,
+                        "len": 2,
+                        "hex": "03e8"
+                    },
+                    {
+                        "type": 88,
+                        "len": 33,
+                        "hex": "0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c"
+                    },
+                    {
+                        "type": 160,
+                        "len": 118,
+                        "hex": "027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e6686809910102edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145001000000000000000000000000000000000"
+                    },
+                    {
+                        "type": 162,
+                        "len": 28,
+                        "hex": "00000001000000020003000000000000000400000000000000050000"
+                    },
+                    {
+                        "type": 164,
+                        "len": 4,
+                        "hex": "67527988"
+                    },
+                    {
+                        "type": 168,
+                        "len": 32,
+                        "hex": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793"
+                    },
+                    {
+                        "type": 170,
+                        "len": 2,
+                        "hex": "03e8"
+                    },
+                    {
+                        "type": 174,
+                        "len": 13,
+                        "hex": "08000000000000000000000000"
+                    },
+                    {
+                        "type": 176,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382"
+                    },
+                    {
+                        "type": 240,
+                        "len": 64,
+                        "hex": "fbb932e6a9d5b4d88ca0ddc9cf9f8cc880ef41e3ec9574da89f624db898ab3e9d3ed6caa8744633b855167da009119d9834ae71f7b06f02732dc4c1debab0577"
+                    },
+                    {
+                        "type": 241,
+                        "len": 64,
+                        "hex": "4961333409f453b5518fcbc662936fcb46e6c1db8d963c44b67d5677f0ffce3ac5c42293d1bc1298b0d67320a772e20a06c069dfa7079df9207b675357735dd7"
+                    },
+                    {
+                        "type": 1001,
+                        "len": 32,
+                        "hex": "0101010101010101010101010101010101010101010101010101010101010101"
+                    },
+                    {
+                        "type": 1003,
+                        "len": 32,
+                        "hex": "0b510ba4c6884d603159ced2f0ca21e772424b59e52a2191bbfbcf07377805a1"
+                    },
+                    {
+                        "type": 1004,
+                        "len": 352,
+                        "hex": "8c9057ed88f3c5a6b6441dcac3b5e4cefb3615904d7362b86e78427fb695f4618dc54a97453dee6f207fa5216a30f1567442712ca98852bc789b73885029283cf2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67f54f80c94a87383f2a8ef7c3e461c62b67a51da5bccf6cd96a7dbab29bea51fa7849b8b856e1d2a63d9ce7dc1a78e05cbb2def1f5d7709c48e8707e0a59fe51e19e7e4eee6bf56c6c589fe50035490c1a7c91b753cb8007c4b52838a6772f997f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1adc0b8de03f1a0b0531bff146982d7d613ef6e1ef8d3bdd9590971fc18d835ffbc14cfffaa314261bcbb2ed4ca24d5717bb608d8a6cc9910790bc1d49af7858ab7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cbabaab91b367e30fea7026daf9f2590bb7e9cc31db8221f4013c67289e38f22c8"
+                    },
+                    {
+                        "type": 3000000001,
+                        "len": 1,
+                        "hex": "42"
+                    }
+                ],
+                "bech32": "lnp1zcssyj7z5vfx29flqlnsuzatppeyu6u9ugtl3ntz3n4k996zg7a5jvuz2gpq86zcyypjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k89qwcp87v0tc4rzc87uuxmn0m8l2tfh6aw75s7wz8r56fd299ckt74zqpcr9s9he72nyjs86pfe3vjqzaxups47g3xedv2e4fk877c7v6rgpxgszqhd4w73ddqusdcmjthj7pxprpd57qakmn2jh2dh3kwhezwg7gs3g5qpqqqqqqqqqqqqqqqqqqqqqqqqqq9zrsqqqqqpqqqqqqsqqvqqqqqqqqqqqpqqqqqqqqqqqqzsqq9yq3n4y7vg4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0ya2qgp73tsdpqqqqqqqqqqqqqqqqqqqpvppqf9u9gcjv52n7pl8pc96kzrjfe4ctcshlrxk9r8tv2t5y3amfyec9uzqlwun9e4f6k6d3r9qmhyul8uvezqw7s0raj2hfk5f7cjdhzv2k05a8mtv42r5gcems4gk0ksqjyvanq62uu0hkphsyuedcnqaaw4s2al3gpykzve5p8698d233l9uvc5ndl95dekpmwxev0zyke74valsll8r43wyy2far0qjnzcdvueq5aewyzsxcp5alfc8nhujq7m82dthxhwhl5p7jgqpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpq87s86eqpdgshfxx3pxkqv2eemf0pj3puaeyyj6eu54zrydml08swdmcqksl6qlvl5qkprys2lkc3u7956myg8w2cw67fnhmxc2eqntnv2uxu7zz07mftarp3hz549698hhx7grl55sk5v832e6yyufv4xy990rcndecs5pf9q709h40tuctu08d3878cfx5y2qehur27rjg5v2z8w7suf3570pauel4f7qvjj588qlj4rhhc0jxr33tv7j3mfdueakdj6nah2efh6j3lfuynw9c2msa9f3annnacxncupwtkt00rawhwzwy36rs0c99nlj3ux08unhwd06kcmzcnljsqd2fpsd8eydh209cqp7yk55r3fnh97vh7qv3cdgqqfr42judpgvk3x98jjlnm6yesft3z7xexxhlke20psddczuduql35zc9xxllz35c947kz0hku8hc6w7ajkgfw87p3kp4l77pfnll4gc5ycduhvhdfj3y64chhdsgmznvexgs0y9ur4y677zc4dlf9dmmncuyxeg0dnt7a99kw5l2nhe4xdcskpx7u6r26dm9zkjuh2a2hydnvl3sl6nsymd0nujepwm7nnp3mwpzraqp83nj383c7gkgl6edqhspq9pq"
+            }
+        },
+        {
+            "name": "minimal_disclosure",
+            "input": {
+                "invoice": "lni1qqgqqqqqqqqqqqqqqqqqqqqqqqqqq93pqf9u9gcjv52n7pl8pc96kzrjfe4ctcshlrxk9r8tv2t5y3amfyecy5szq059sggry3jnatzrgjyqqtxqdwlm0ug0uxyerc6lnljrqtd75mfr20wq4vw2qasz0uc7h32x9s0aecdhxlk075kn046aafpuuyw8f5j652t3vha2yqrsxtqt0nu4xf9q05znnzeyq96dcrptu3zdj6c4n2nv0aa3ue5xszv3qypwm2aaz66peqm3hyh09uzvzxzmfupmdhx49w5m0rva0jyu3u3pz3gqzqqqqqqqqqqqqqqqqqqqqqqqqqq2y8qqqqqqzqqqqqpqqqcqqqqqqqqqqqzqqqqqqqqqqqq9qqq2gpr82fuc32pqwtxkappzcsrlkmgfs6g0zyct0hkhashh7hsaxz7e65slq9fkx7f65qsrazczzqjtc233yeg48ur7wrst4vy8ynntsh3p07xdv2xwkc5hgfrmkjfnstcyqz3nyfzk3d42umkj2gqjh4l7zpevq04aefl6gnu4kql3e5ymu29s4q7fcvsst9uvmqx6q6yhje3vsraqple9pnxuf5vtwz0l68r6uvvs",
+                "invoice_hex": "0010000000000000000000000000000000001621024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382520203e858210324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1ca076027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e6686809910102edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145001000000000000000000000000000000000a21c00000001000000020003000000000000000400000000000000050000a40467527988a82072cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793aa0203e8b021024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382f0400a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319",
+                "preimage": "0101010101010101010101010101010101010101010101010101010101010101",
+                "invoice_fields": [
+                    {
+                        "type": 0,
+                        "len": 16,
+                        "hex": "00000000000000000000000000000000",
+                        "included": false
+                    },
+                    {
+                        "type": 22,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382",
+                        "included": false
+                    },
+                    {
+                        "type": 82,
+                        "len": 2,
+                        "hex": "03e8",
+                        "included": false
+                    },
+                    {
+                        "type": 88,
+                        "len": 33,
+                        "hex": "0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c",
+                        "included": true
+                    },
+                    {
+                        "type": 160,
+                        "len": 118,
+                        "hex": "027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e6686809910102edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145001000000000000000000000000000000000",
+                        "included": false
+                    },
+                    {
+                        "type": 162,
+                        "len": 28,
+                        "hex": "00000001000000020003000000000000000400000000000000050000",
+                        "included": false
+                    },
+                    {
+                        "type": 164,
+                        "len": 4,
+                        "hex": "67527988",
+                        "included": false
+                    },
+                    {
+                        "type": 168,
+                        "len": 32,
+                        "hex": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793",
+                        "included": true
+                    },
+                    {
+                        "type": 170,
+                        "len": 2,
+                        "hex": "03e8",
+                        "included": false
+                    },
+                    {
+                        "type": 176,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382",
+                        "included": true
+                    },
+                    {
+                        "type": 240,
+                        "len": 64,
+                        "hex": "0a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319",
+                        "included": false
+                    }
+                ]
+            },
+            "working": {
+                "invoice_merkle_root": "0501ea6d4ad9fe7fce7edd5e3795987bd409d66c5709c2a17f9c0dfb839e3d8e",
+                "invoice_sighash": "41ce7b274b0e73e60dd6abf4fa51ccae892b161adc24d4099f620b12c59a03e5",
+                "invoice_signature": "0a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319",
+                "proof_merkle_root": "ccc704b73e8190c71bf2ac3661d631c8c5ac502b78641708c8e61c0a1c8ebb72",
+                "proof_leaf_hashes": [
+                    "f2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67",
+                    "f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1a",
+                    "7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cb"
+                ],
+                "proof_omitted_tlvs": [
+                    1,
+                    2,
+                    89,
+                    90,
+                    91,
+                    169
+                ],
+                "proof_missing_hashes": [
+                    "bf8cb2b1d6fa9bcdcab501b59f82c65c506b7f43514737f7197f1fcfeaebad41",
+                    "b9406f4ce526a6a0d4e0b3a63ed89a832e31cb9939dfe1a7b5dd7232d32c02ab",
+                    "cd9c44b53b31700c9ed0e3330ce425f7f18fac2fc1d566a34468439274f0e316",
+                    "9f9830f2c3070cfbad13fde30ee36cd7143591164ed12040a9cd595c96840ac9",
+                    "998ab7fa9c743fb9dbdb0d8d46fbe3ad333400bd07f328dcdb6008790bc9d2db"
+                ]
+            },
+            "result": {
+                "payer_sig": "cebc25d40a2d927b5ebcab8400f542fbb7a8f462e8dd802bb13e050b9bf293b7457c19b46a476740f97c9d6ec141f23434c5d4fa253a1d2eb8896ebad99455cc",
+                "proof_fields": [
+                    {
+                        "type": 88,
+                        "len": 33,
+                        "hex": "0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c"
+                    },
+                    {
+                        "type": 168,
+                        "len": 32,
+                        "hex": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793"
+                    },
+                    {
+                        "type": 176,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382"
+                    },
+                    {
+                        "type": 240,
+                        "len": 64,
+                        "hex": "0a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319"
+                    },
+                    {
+                        "type": 241,
+                        "len": 64,
+                        "hex": "cebc25d40a2d927b5ebcab8400f542fbb7a8f462e8dd802bb13e050b9bf293b7457c19b46a476740f97c9d6ec141f23434c5d4fa253a1d2eb8896ebad99455cc"
+                    },
+                    {
+                        "type": 1001,
+                        "len": 32,
+                        "hex": "0101010101010101010101010101010101010101010101010101010101010101"
+                    },
+                    {
+                        "type": 1002,
+                        "len": 6,
+                        "hex": "0102595a5ba9"
+                    },
+                    {
+                        "type": 1003,
+                        "len": 160,
+                        "hex": "bf8cb2b1d6fa9bcdcab501b59f82c65c506b7f43514737f7197f1fcfeaebad41b9406f4ce526a6a0d4e0b3a63ed89a832e31cb9939dfe1a7b5dd7232d32c02abcd9c44b53b31700c9ed0e3330ce425f7f18fac2fc1d566a34468439274f0e3169f9830f2c3070cfbad13fde30ee36cd7143591164ed12040a9cd595c96840ac9998ab7fa9c743fb9dbdb0d8d46fbe3ad333400bd07f328dcdb6008790bc9d2db"
+                    },
+                    {
+                        "type": 1004,
+                        "len": 96,
+                        "hex": "f2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1a7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cb"
+                    }
+                ],
+                "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyk26tw5l6qlt5zlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjm07s8mrq7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenlqxgux5qqy364fwxs5xtgnznef0eaazvcy4c30rvnrtlmv48scxn7j2mhh83cgdjs7mxha62tvaf7480n2vm3pvzdae5x45mk29d9ev"
+            }
+        },
+        {
+            "name": "with_note",
+            "input": {
+                "invoice": "lni1qqgqqqqqqqqqqqqqqqqqqqqqqqqqq93pqf9u9gcjv52n7pl8pc96kzrjfe4ctcshlrxk9r8tv2t5y3amfyecy5szq059sggry3jnatzrgjyqqtxqdwlm0ug0uxyerc6lnljrqtd75mfr20wq4vw2qasz0uc7h32x9s0aecdhxlk075kn046aafpuuyw8f5j652t3vha2yqrsxtqt0nu4xf9q05znnzeyq96dcrptu3zdj6c4n2nv0aa3ue5xszv3qypwm2aaz66peqm3hyh09uzvzxzmfupmdhx49w5m0rva0jyu3u3pz3gqzqqqqqqqqqqqqqqqqqqqqqqqqqq2y8qqqqqqzqqqqqpqqqcqqqqqqqqqqqzqqqqqqqqqqqq9qqq2gpr82fuc32pqwtxkappzcsrlkmgfs6g0zyct0hkhashh7hsaxz7e65slq9fkx7f65qsrazczzqjtc233yeg48ur7wrst4vy8ynntsh3p07xdv2xwkc5hgfrmkjfnstcyqz3nyfzk3d42umkj2gqjh4l7zpevq04aefl6gnu4kql3e5ymu29s4q7fcvsst9uvmqx6q6yhje3vsraqple9pnxuf5vtwz0l68r6uvvs",
+                "invoice_hex": "0010000000000000000000000000000000001621024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382520203e858210324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1ca076027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e6686809910102edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145001000000000000000000000000000000000a21c00000001000000020003000000000000000400000000000000050000a40467527988a82072cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793aa0203e8b021024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382f0400a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319",
+                "preimage": "0101010101010101010101010101010101010101010101010101010101010101",
+                "note": "test note",
+                "invoice_fields": [
+                    {
+                        "type": 0,
+                        "len": 16,
+                        "hex": "00000000000000000000000000000000",
+                        "included": false
+                    },
+                    {
+                        "type": 22,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382",
+                        "included": false
+                    },
+                    {
+                        "type": 82,
+                        "len": 2,
+                        "hex": "03e8",
+                        "included": false
+                    },
+                    {
+                        "type": 88,
+                        "len": 33,
+                        "hex": "0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c",
+                        "included": true
+                    },
+                    {
+                        "type": 160,
+                        "len": 118,
+                        "hex": "027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e6686809910102edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145001000000000000000000000000000000000",
+                        "included": false
+                    },
+                    {
+                        "type": 162,
+                        "len": 28,
+                        "hex": "00000001000000020003000000000000000400000000000000050000",
+                        "included": false
+                    },
+                    {
+                        "type": 164,
+                        "len": 4,
+                        "hex": "67527988",
+                        "included": false
+                    },
+                    {
+                        "type": 168,
+                        "len": 32,
+                        "hex": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793",
+                        "included": true
+                    },
+                    {
+                        "type": 170,
+                        "len": 2,
+                        "hex": "03e8",
+                        "included": false
+                    },
+                    {
+                        "type": 176,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382",
+                        "included": true
+                    },
+                    {
+                        "type": 240,
+                        "len": 64,
+                        "hex": "0a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319",
+                        "included": false
+                    }
+                ]
+            },
+            "working": {
+                "invoice_merkle_root": "0501ea6d4ad9fe7fce7edd5e3795987bd409d66c5709c2a17f9c0dfb839e3d8e",
+                "invoice_sighash": "41ce7b274b0e73e60dd6abf4fa51ccae892b161adc24d4099f620b12c59a03e5",
+                "invoice_signature": "0a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319",
+                "proof_merkle_root": "327c38426d1d557f3669f19cdb440187e312679eadcfb61a9a8dcb0098639467",
+                "proof_leaf_hashes": [
+                    "f2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67",
+                    "f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1a",
+                    "7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cb"
+                ],
+                "proof_omitted_tlvs": [
+                    1,
+                    2,
+                    89,
+                    90,
+                    91,
+                    169
+                ],
+                "proof_missing_hashes": [
+                    "bf8cb2b1d6fa9bcdcab501b59f82c65c506b7f43514737f7197f1fcfeaebad41",
+                    "b9406f4ce526a6a0d4e0b3a63ed89a832e31cb9939dfe1a7b5dd7232d32c02ab",
+                    "cd9c44b53b31700c9ed0e3330ce425f7f18fac2fc1d566a34468439274f0e316",
+                    "9f9830f2c3070cfbad13fde30ee36cd7143591164ed12040a9cd595c96840ac9",
+                    "998ab7fa9c743fb9dbdb0d8d46fbe3ad333400bd07f328dcdb6008790bc9d2db"
+                ]
+            },
+            "result": {
+                "payer_sig": "2a47f98770ae814119d682a7b19f7ce9e050a3bb49d9b0a031c46d9cb57a3075ddc23a742f6d33bc4ec8e1778327494bea76d2ee564625e99bfb95cc209a7722",
+                "proof_fields": [
+                    {
+                        "type": 88,
+                        "len": 33,
+                        "hex": "0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c"
+                    },
+                    {
+                        "type": 168,
+                        "len": 32,
+                        "hex": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793"
+                    },
+                    {
+                        "type": 176,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382"
+                    },
+                    {
+                        "type": 240,
+                        "len": 64,
+                        "hex": "0a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319"
+                    },
+                    {
+                        "type": 241,
+                        "len": 64,
+                        "hex": "2a47f98770ae814119d682a7b19f7ce9e050a3bb49d9b0a031c46d9cb57a3075ddc23a742f6d33bc4ec8e1778327494bea76d2ee564625e99bfb95cc209a7722"
+                    },
+                    {
+                        "type": 1001,
+                        "len": 32,
+                        "hex": "0101010101010101010101010101010101010101010101010101010101010101"
+                    },
+                    {
+                        "type": 1002,
+                        "len": 6,
+                        "hex": "0102595a5ba9"
+                    },
+                    {
+                        "type": 1003,
+                        "len": 160,
+                        "hex": "bf8cb2b1d6fa9bcdcab501b59f82c65c506b7f43514737f7197f1fcfeaebad41b9406f4ce526a6a0d4e0b3a63ed89a832e31cb9939dfe1a7b5dd7232d32c02abcd9c44b53b31700c9ed0e3330ce425f7f18fac2fc1d566a34468439274f0e3169f9830f2c3070cfbad13fde30ee36cd7143591164ed12040a9cd595c96840ac9998ab7fa9c743fb9dbdb0d8d46fbe3ad333400bd07f328dcdb6008790bc9d2db"
+                    },
+                    {
+                        "type": 1004,
+                        "len": 96,
+                        "hex": "f2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1a7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cb"
+                    },
+                    {
+                        "type": 1005,
+                        "len": 9,
+                        "hex": "74657374206e6f7465"
+                    }
+                ],
+                "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qz53lesac2aq2pr8tg9fa3na7wnczs5wa5nkds5qcugmvuk4arqawacga8gtmdxw7yaj8pw7pjwj2tafmd9mjkgcj7nxlmjhxzpxnhyt7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyk26tw5l6qlt5zlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjm07s8mrq7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenlqxgux5qqy364fwxs5xtgnznef0eaazvcy4c30rvnrtlmv48scxn7j2mhh83cgdjs7mxha62tvaf7480n2vm3pvzdae5x45mk29d9e07s8mgfw3jhxapqdehhgeg"
+            }
+        },
+        {
+            "name": "left_subtree_omitted",
+            "input": {
+                "invoice": "lni1qqgqqqqqqqqqqqqqqqqqqqqqqqqqq93pqf9u9gcjv52n7pl8pc96kzrjfe4ctcshlrxk9r8tv2t5y3amfyecy5szq059sggry3jnatzrgjyqqtxqdwlm0ug0uxyerc6lnljrqtd75mfr20wq4vw2qasz0uc7h32x9s0aecdhxlk075kn046aafpuuyw8f5j652t3vha2yqrsxtqt0nu4xf9q05znnzeyq96dcrptu3zdj6c4n2nv0aa3ue5xszv3qypwm2aaz66peqm3hyh09uzvzxzmfupmdhx49w5m0rva0jyu3u3pz3gqzqqqqqqqqqqqqqqqqqqqqqqqqqq2y8qqqqqqzqqqqqpqqqcqqqqqqqqqqqzqqqqqqqqqqqq9qqq2gpr82fuc32pqwtxkappzcsrlkmgfs6g0zyct0hkhashh7hsaxz7e65slq9fkx7f65qsrazczzqjtc233yeg48ur7wrst4vy8ynntsh3p07xdv2xwkc5hgfrmkjfnstcyqz3nyfzk3d42umkj2gqjh4l7zpevq04aefl6gnu4kql3e5ymu29s4q7fcvsst9uvmqx6q6yhje3vsraqple9pnxuf5vtwz0l68r6uvvs",
+                "invoice_hex": "0010000000000000000000000000000000001621024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382520203e858210324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1ca076027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e6686809910102edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145001000000000000000000000000000000000a21c00000001000000020003000000000000000400000000000000050000a40467527988a82072cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793aa0203e8b021024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382f0400a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319",
+                "preimage": "0101010101010101010101010101010101010101010101010101010101010101",
+                "invoice_fields": [
+                    {
+                        "type": 0,
+                        "len": 16,
+                        "hex": "00000000000000000000000000000000",
+                        "included": false
+                    },
+                    {
+                        "type": 22,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382",
+                        "included": false
+                    },
+                    {
+                        "type": 82,
+                        "len": 2,
+                        "hex": "03e8",
+                        "included": false
+                    },
+                    {
+                        "type": 88,
+                        "len": 33,
+                        "hex": "0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c",
+                        "included": true
+                    },
+                    {
+                        "type": 160,
+                        "len": 118,
+                        "hex": "027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e6686809910102edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145001000000000000000000000000000000000",
+                        "included": false
+                    },
+                    {
+                        "type": 162,
+                        "len": 28,
+                        "hex": "00000001000000020003000000000000000400000000000000050000",
+                        "included": false
+                    },
+                    {
+                        "type": 164,
+                        "len": 4,
+                        "hex": "67527988",
+                        "included": false
+                    },
+                    {
+                        "type": 168,
+                        "len": 32,
+                        "hex": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793",
+                        "included": true
+                    },
+                    {
+                        "type": 170,
+                        "len": 2,
+                        "hex": "03e8",
+                        "included": true
+                    },
+                    {
+                        "type": 176,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382",
+                        "included": true
+                    },
+                    {
+                        "type": 240,
+                        "len": 64,
+                        "hex": "0a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319",
+                        "included": false
+                    }
+                ]
+            },
+            "working": {
+                "invoice_merkle_root": "0501ea6d4ad9fe7fce7edd5e3795987bd409d66c5709c2a17f9c0dfb839e3d8e",
+                "invoice_sighash": "41ce7b274b0e73e60dd6abf4fa51ccae892b161adc24d4099f620b12c59a03e5",
+                "invoice_signature": "0a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319",
+                "proof_merkle_root": "1b0bab09a5fcccec19eb3aaafbbfa4075944fd1f65691ed715fbbc17a59b3651",
+                "proof_leaf_hashes": [
+                    "f2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67",
+                    "f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1a",
+                    "dc0b8de03f1a0b0531bff146982d7d613ef6e1ef8d3bdd9590971fc18d835ffb",
+                    "7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cb"
+                ],
+                "proof_omitted_tlvs": [
+                    1,
+                    2,
+                    89,
+                    90,
+                    91
+                ],
+                "proof_missing_hashes": [
+                    "bf8cb2b1d6fa9bcdcab501b59f82c65c506b7f43514737f7197f1fcfeaebad41",
+                    "b9406f4ce526a6a0d4e0b3a63ed89a832e31cb9939dfe1a7b5dd7232d32c02ab",
+                    "cd9c44b53b31700c9ed0e3330ce425f7f18fac2fc1d566a34468439274f0e316",
+                    "9f9830f2c3070cfbad13fde30ee36cd7143591164ed12040a9cd595c96840ac9"
+                ]
+            },
+            "result": {
+                "payer_sig": "ed03ec58d5ac676539486bb6e8d6f389b6375b6693ffdf30a93919590d744fa393f945a5de3bb57d65c7f61def1cefa8aa038725b15bf0fa797dfd08ca97538a",
+                "proof_fields": [
+                    {
+                        "type": 88,
+                        "len": 33,
+                        "hex": "0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c"
+                    },
+                    {
+                        "type": 168,
+                        "len": 32,
+                        "hex": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793"
+                    },
+                    {
+                        "type": 170,
+                        "len": 2,
+                        "hex": "03e8"
+                    },
+                    {
+                        "type": 176,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382"
+                    },
+                    {
+                        "type": 240,
+                        "len": 64,
+                        "hex": "0a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319"
+                    },
+                    {
+                        "type": 241,
+                        "len": 64,
+                        "hex": "ed03ec58d5ac676539486bb6e8d6f389b6375b6693ffdf30a93919590d744fa393f945a5de3bb57d65c7f61def1cefa8aa038725b15bf0fa797dfd08ca97538a"
+                    },
+                    {
+                        "type": 1001,
+                        "len": 32,
+                        "hex": "0101010101010101010101010101010101010101010101010101010101010101"
+                    },
+                    {
+                        "type": 1002,
+                        "len": 5,
+                        "hex": "0102595a5b"
+                    },
+                    {
+                        "type": 1003,
+                        "len": 128,
+                        "hex": "bf8cb2b1d6fa9bcdcab501b59f82c65c506b7f43514737f7197f1fcfeaebad41b9406f4ce526a6a0d4e0b3a63ed89a832e31cb9939dfe1a7b5dd7232d32c02abcd9c44b53b31700c9ed0e3330ce425f7f18fac2fc1d566a34468439274f0e3169f9830f2c3070cfbad13fde30ee36cd7143591164ed12040a9cd595c96840ac9"
+                    },
+                    {
+                        "type": 1004,
+                        "len": 128,
+                        "hex": "f2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1adc0b8de03f1a0b0531bff146982d7d613ef6e1ef8d3bdd9590971fc18d835ffb7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cb"
+                    }
+                ],
+                "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0ya2qgp73vppqf9u9gcjv52n7pl8pc96kzrjfe4ctcshlrxk9r8tv2t5y3amfyec9uzqpgejy3tgk64wdmf9yqft6llpqukq867u5layf72mq0cu6zd79zc2s0yuxgg9j7xdsrdqdztevckgp7sqlujsenwy6x9hp8lar3awxx03grks8mzc6kkxwefefp4md6xk7wymvd6mv6fllhes4yu3jkgdw3868ylegkjauwa404ju0asaauwwl292qwrjtv2m7ra8jl0apr9fw5u2l5p7jgqpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpq87s86s9qyp9jkjml5p7hq9l3jetr4h6n0xu4dgpkk0c93ju2p4h7s63gumlwxtlrl8746adgxu5qm6vu5n2dgx5uze6v0kcn2pjuvwtnyualcd8khwhyvkn9sp2hnvugj6nkvtspj0dpcenpnjztal337kzlsw4v635g6zrjf60pcckn7vrpukrqux0htgnlh3sacmv6u2rtygkfmgjqs9fe4v4e95yptyl6qlvsredat6lxzlremvfl37zf4pzsxdlq6hsuj9rzs3mh58zvd8nc00x0uqers6sqqj8249c6zsedzv2099l8h5fnqjhz9udjvd0ldj57rq6ms9cmcplrg9s2vdl79rfsttavyl0dc0035aam9vsju0urrvrtlahay4h0w0rssm9pakd0m55ke6na2wlx5ehzzcymmngdtfhv526tjc"
+            }
+        },
+        {
+            "name": "empty_proof_omitted_tlvs_explicit",
+            "input": {
+                "invoice": "lni1qqgqqqqqqqqqqqqqqqqqqqqqqqqqq93pqf9u9gcjv52n7pl8pc96kzrjfe4ctcshlrxk9r8tv2t5y3amfyecy5szq059sggry3jnatzrgjyqqtxqdwlm0ug0uxyerc6lnljrqtd75mfr20wq4vw2qasz0uc7h32x9s0aecdhxlk075kn046aafpuuyw8f5j652t3vha2yqrsxtqt0nu4xf9q05znnzeyq96dcrptu3zdj6c4n2nv0aa3ue5xszv3qypwm2aaz66peqm3hyh09uzvzxzmfupmdhx49w5m0rva0jyu3u3pz3gqzqqqqqqqqqqqqqqqqqqqqqqqqqq2y8qqqqqqzqqqqqpqqqcqqqqqqqqqqqzqqqqqqqqqqqq9qqq2gpr82fuc32pqwtxkappzcsrlkmgfs6g0zyct0hkhashh7hsaxz7e65slq9fkx7f65qsrazczzqjtc233yeg48ur7wrst4vy8ynntsh3p07xdv2xwkc5hgfrmkjfnstcyqz3nyfzk3d42umkj2gqjh4l7zpevq04aefl6gnu4kql3e5ymu29s4q7fcvsst9uvmqx6q6yhje3vsraqple9pnxuf5vtwz0l68r6uvvs",
+                "invoice_hex": "0010000000000000000000000000000000001621024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382520203e858210324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1ca076027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e6686809910102edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145001000000000000000000000000000000000a21c00000001000000020003000000000000000400000000000000050000a40467527988a82072cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793aa0203e8b021024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382f0400a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319",
+                "preimage": "0101010101010101010101010101010101010101010101010101010101010101",
+                "invoice_fields": [
+                    {
+                        "type": 0,
+                        "len": 16,
+                        "hex": "00000000000000000000000000000000",
+                        "included": false
+                    },
+                    {
+                        "type": 22,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382",
+                        "included": true
+                    },
+                    {
+                        "type": 82,
+                        "len": 2,
+                        "hex": "03e8",
+                        "included": true
+                    },
+                    {
+                        "type": 88,
+                        "len": 33,
+                        "hex": "0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c",
+                        "included": true
+                    },
+                    {
+                        "type": 160,
+                        "len": 118,
+                        "hex": "027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e6686809910102edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145001000000000000000000000000000000000",
+                        "included": true
+                    },
+                    {
+                        "type": 162,
+                        "len": 28,
+                        "hex": "00000001000000020003000000000000000400000000000000050000",
+                        "included": true
+                    },
+                    {
+                        "type": 164,
+                        "len": 4,
+                        "hex": "67527988",
+                        "included": true
+                    },
+                    {
+                        "type": 168,
+                        "len": 32,
+                        "hex": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793",
+                        "included": true
+                    },
+                    {
+                        "type": 170,
+                        "len": 2,
+                        "hex": "03e8",
+                        "included": true
+                    },
+                    {
+                        "type": 176,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382",
+                        "included": true
+                    },
+                    {
+                        "type": 240,
+                        "len": 64,
+                        "hex": "0a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319",
+                        "included": false
+                    }
+                ]
+            },
+            "working": {
+                "invoice_merkle_root": "0501ea6d4ad9fe7fce7edd5e3795987bd409d66c5709c2a17f9c0dfb839e3d8e",
+                "invoice_sighash": "41ce7b274b0e73e60dd6abf4fa51ccae892b161adc24d4099f620b12c59a03e5",
+                "invoice_signature": "0a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319",
+                "proof_merkle_root": "a98cbee700b100ede32c19f9525264d51a105751fb27e790dad011bb38415b89",
+                "proof_leaf_hashes": [
+                    "8c9057ed88f3c5a6b6441dcac3b5e4cefb3615904d7362b86e78427fb695f461",
+                    "8dc54a97453dee6f207fa5216a30f1567442712ca98852bc789b73885029283c",
+                    "f2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67",
+                    "f54f80c94a87383f2a8ef7c3e461c62b67a51da5bccf6cd96a7dbab29bea51fa",
+                    "7849b8b856e1d2a63d9ce7dc1a78e05cbb2def1f5d7709c48e8707e0a59fe51e",
+                    "19e7e4eee6bf56c6c589fe50035490c1a7c91b753cb8007c4b52838a6772f997",
+                    "f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1a",
+                    "dc0b8de03f1a0b0531bff146982d7d613ef6e1ef8d3bdd9590971fc18d835ffb",
+                    "7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cb"
+                ],
+                "proof_omitted_tlvs": [],
+                "proof_missing_hashes": [
+                    "0b510ba4c6884d603159ced2f0ca21e772424b59e52a2191bbfbcf07377805a1"
+                ]
+            },
+            "result": {
+                "payer_sig": "dffe62d6446c182f2503e780fce09fc5cf310ef14a54f65dd1df124039b7a897f2940470ac0f9857f826b232289c0ac4e6927ca67d805167fb0add352f88add1",
+                "proof_fields": [
+                    {
+                        "type": 22,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382"
+                    },
+                    {
+                        "type": 82,
+                        "len": 2,
+                        "hex": "03e8"
+                    },
+                    {
+                        "type": 88,
+                        "len": 33,
+                        "hex": "0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c"
+                    },
+                    {
+                        "type": 160,
+                        "len": 118,
+                        "hex": "027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e6686809910102edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145001000000000000000000000000000000000"
+                    },
+                    {
+                        "type": 162,
+                        "len": 28,
+                        "hex": "00000001000000020003000000000000000400000000000000050000"
+                    },
+                    {
+                        "type": 164,
+                        "len": 4,
+                        "hex": "67527988"
+                    },
+                    {
+                        "type": 168,
+                        "len": 32,
+                        "hex": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793"
+                    },
+                    {
+                        "type": 170,
+                        "len": 2,
+                        "hex": "03e8"
+                    },
+                    {
+                        "type": 176,
+                        "len": 33,
+                        "hex": "024bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382"
+                    },
+                    {
+                        "type": 240,
+                        "len": 64,
+                        "hex": "0a33224568b6aae6ed252012bd7fe1072c03ebdca7fa44f95b03f1cd09be28b0a83c9c32105978cd80da068979662c80fa00ff250ccdc4d18b709ffd1c7ae319"
+                    },
+                    {
+                        "type": 241,
+                        "len": 64,
+                        "hex": "dffe62d6446c182f2503e780fce09fc5cf310ef14a54f65dd1df124039b7a897f2940470ac0f9857f826b232289c0ac4e6927ca67d805167fb0add352f88add1"
+                    },
+                    {
+                        "type": 1001,
+                        "len": 32,
+                        "hex": "0101010101010101010101010101010101010101010101010101010101010101"
+                    },
+                    {
+                        "type": 1002,
+                        "len": 0,
+                        "hex": ""
+                    },
+                    {
+                        "type": 1003,
+                        "len": 32,
+                        "hex": "0b510ba4c6884d603159ced2f0ca21e772424b59e52a2191bbfbcf07377805a1"
+                    },
+                    {
+                        "type": 1004,
+                        "len": 288,
+                        "hex": "8c9057ed88f3c5a6b6441dcac3b5e4cefb3615904d7362b86e78427fb695f4618dc54a97453dee6f207fa5216a30f1567442712ca98852bc789b73885029283cf2deaf5f30be3ced89fc7c24d422819bf06af0e48a31423bbd0e2634f3c3de67f54f80c94a87383f2a8ef7c3e461c62b67a51da5bccf6cd96a7dbab29bea51fa7849b8b856e1d2a63d9ce7dc1a78e05cbb2def1f5d7709c48e8707e0a59fe51e19e7e4eee6bf56c6c589fe50035490c1a7c91b753cb8007c4b52838a6772f997f0191c35000247554b8d0a196898a794bf3de89982571178d931affb654f0c1adc0b8de03f1a0b0531bff146982d7d613ef6e1ef8d3bdd9590971fc18d835ffb7e92b77b9e3843650f6cd7ee94b6753ea9df3533710b04dee686ad376515a5cb"
+                    }
+                ],
+                "bech32": "lnp1zcssyj7z5vfx29flqlnsuzatppeyu6u9ugtl3ntz3n4k996zg7a5jvuz2gpq86zcyypjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k89qwcp87v0tc4rzc87uuxmn0m8l2tfh6aw75s7wz8r56fd299ckt74zqpcr9s9he72nyjs86pfe3vjqzaxups47g3xedv2e4fk877c7v6rgpxgszqhd4w73ddqusdcmjthj7pxprpd57qakmn2jh2dh3kwhezwg7gs3g5qpqqqqqqqqqqqqqqqqqqqqqqqqqq9zrsqqqqqpqqqqqqsqqvqqqqqqqqqqqpqqqqqqqqqqqqzsqq9yq3n4y7vg4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0ya2qgp73vppqf9u9gcjv52n7pl8pc96kzrjfe4ctcshlrxk9r8tv2t5y3amfyec9uzqpgejy3tgk64wdmf9yqft6llpqukq867u5layf72mq0cu6zd79zc2s0yuxgg9j7xdsrdqdztevckgp7sqlujsenwy6x9hp8lar3awxx03gr0luckkg3kpste9q0ncpl8qnlzu7vgw7999faja6803yspek75f0u55q3c2cruc2luzdv3j9zwq438xjf72vlvq29nlkzkax5hc3tw3l5p7jgqpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpq87s86sql5p7kgqt2y96f35gf4srzkww6tcv5g08wfpykk099gserwlmeurnw7q9587s8m8aqysgeyzhaky083dxkezpmjkrkhjva7ekzkgy6umzhph8ssnlk62lgcvdc49fw3faaehjqla9y94rpu2kw3p8zt9f3pftc7ymwwy9q2fg8nedat6lxzlremvfl37zf4pzsxdlq6hsuj9rzs3mh58zvd8nc00x0a20sry54pec8u4gaa7ru3suv2m855w6t0x0dnvk5ld6k2d755060pym3wzku8f2v0vuulwp578qtjajmmclt4msn3ywsur7pfvlu50pnelyamnt74kxckylu5qr2jgvrf7frd6newqq03949qu2vae0n9lsrywr2qqzga25hrg2r95f3fu5hu773xvz2ugh3kf34lak2ncvrtwqhr0q8udqkpf3hlc5dxpd04snaahpa7xnhhv4jzt3lsvdsd0lkl5jkaaeuwzrv58ke4lwjjm8204fmu6nxugtqn0wdp4dxaj3tfwt"
+            }
+        }
+    ],
+    "invalid_vectors": [
+        {
+            "reason": "missing_invreq_payer_id",
+            "bech32": "lnp14qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyk26tw5l6qlt5zlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjm07s8mrq7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenlqxgux5qqy364fwxs5xtgnznef0eaazvcy4c30rvnrtlmv48scxn7j2mhh83cgdjs7mxha62tvaf7480n2vm3pvzdae5x45mk29d9ev"
+        },
+        {
+            "reason": "missing_invoice_payment_hash",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cukqssyj7z5vfx29flqlnsuzatppeyu6u9ugtl3ntz3n4k996zg7a5jvuz7pqq5vezg45td2hxa5jjqy4a0lsswtqra0w207jyl9ds8uwdpxlz3v9g8jwryyze0rxcpksx39ukvtyqlgq07fgvehzdrzmsnl73c7hrr8c5pn4uyh2q5tvj0d0te2uyqr6597ah4r6x96xasq4mz0s9pwdl9yahg47pndr2gan5p7tun4hvzs0jxs6vt486y5ap6t4c39ht4kv52hx06qlfyqqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsrlgragrqzqjetfd6nlgrawstlr9jk8t04x7de26srdvlstr9c5rt0ap4z3eh7uvh7870at466sdegph5eefx56sdfc9n5cld3x5r9ccuhxfemls60dwawgedxtqz40xec3948vchqry76r3nxr8yyhmlrrav9lqa2e4rg35y8yn57r33d8ucxrevxpcvlwk38l0rpm3ke4c5xkg3vnk3ypq2nn2etjtggzkfnx9t075uwslmnk7mpkx5d7lr45engq9aqlej3hxmvqy8jz7f6tdl6qlvvredat6lxzlremvfl37zf4pzsxdlq6hsuj9rzs3mh58zvd8nc00x0uqers6sqqj8249c6zsedzv2099l8h5fnqjhz9udjvd0ldj57rq606ftw7u78ppk2rmv6lhffdn4865a7dfnwy9sfhhxs6knweg45h9s"
+        },
+        {
+            "reason": "missing_invoice_node_id",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0ylsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyk26tw5l6qlt5zlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjm07s8mrq7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenlqxgux5qqy364fwxs5xtgnznef0eaazvcy4c30rvnrtlmv48scxn7j2mhh83cgdjs7mxha62tvaf7480n2vm3pvzdae5x45mk29d9ev"
+        },
+        {
+            "reason": "missing_signature",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qh3gr8tcfw5pgkey767hj4cgq84gtam0285vt5dmqptkylq2zum72fmw3turx6x53m8gruhe8twc9qlydp5ch205ff6r5ht3ztwhtveg4wvl5p7jgqpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpq87s86sxqyp9jkjm487s86aqh7xt9vwkl2dumj44qx6elqkxt3gxkl6r29rn0ace0u0ul6ht44qmjsr0fnjjdf4q6nst8f37mzdgxt33ewvnnhlp576a6u3j6vkq927dn3zt2we3wqxfa58rxvxwgf0h7x86ct7p64n2x3rggwf8fu8rz60esv8jcvrse7adz077xrhrdnt3gdv3ze8dzgzq48x4jhykss9vnxv2klafcaplh8dakrvdgma78tfnxsqt6pln9rwdkcqg0y9un5kml5p7cc8jm6h47v978nkcnlruyn2z9qvm7p40pey2x9prh0gwyc608s77vlcpj8p4qqpyw42t359pj6yc572t700gnxp9wytcmyc6l7m9fuxp5l5jkaaeuwzrv58ke4lwjjm8204fmu6nxugtqn0wdp4dxaj3tfwt"
+        },
+        {
+            "reason": "missing_proof_preimage",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86sxqyp9jkjm487s86aqh7xt9vwkl2dumj44qx6elqkxt3gxkl6r29rn0ace0u0ul6ht44qmjsr0fnjjdf4q6nst8f37mzdgxt33ewvnnhlp576a6u3j6vkq927dn3zt2we3wqxfa58rxvxwgf0h7x86ct7p64n2x3rggwf8fu8rz60esv8jcvrse7adz077xrhrdnt3gdv3ze8dzgzq48x4jhykss9vnxv2klafcaplh8dakrvdgma78tfnxsqt6pln9rwdkcqg0y9un5kml5p7cc8jm6h47v978nkcnlruyn2z9qvm7p40pey2x9prh0gwyc608s77vlcpj8p4qqpyw42t359pj6yc572t700gnxp9wytcmyc6l7m9fuxp5l5jkaaeuwzrv58ke4lwjjm8204fmu6nxugtqn0wdp4dxaj3tfwt"
+        },
+        {
+            "reason": "missing_proof_missing_hashes",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyk26tw5l6qlvvredat6lxzlremvfl37zf4pzsxdlq6hsuj9rzs3mh58zvd8nc00x0uqers6sqqj8249c6zsedzv2099l8h5fnqjhz9udjvd0ldj57rq606ftw7u78ppk2rmv6lhffdn4865a7dfnwy9sfhhxs6knweg45h9s"
+        },
+        {
+            "reason": "missing_proof_leaf_hashes",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyk26tw5l6qlt5zlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjmv"
+        },
+        {
+            "reason": "missing_proof_signature",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84ccel5p7jgqpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpq87s86sxqyp9jkjm487s86aqh7xt9vwkl2dumj44qx6elqkxt3gxkl6r29rn0ace0u0ul6ht44qmjsr0fnjjdf4q6nst8f37mzdgxt33ewvnnhlp576a6u3j6vkq927dn3zt2we3wqxfa58rxvxwgf0h7x86ct7p64n2x3rggwf8fu8rz60esv8jcvrse7adz077xrhrdnt3gdv3ze8dzgzq48x4jhykss9vnxv2klafcaplh8dakrvdgma78tfnxsqt6pln9rwdkcqg0y9un5kml5p7cc8jm6h47v978nkcnlruyn2z9qvm7p40pey2x9prh0gwyc608s77vlcpj8p4qqpyw42t359pj6yc572t700gnxp9wytcmyc6l7m9fuxp5l5jkaaeuwzrv58ke4lwjjm8204fmu6nxugtqn0wdp4dxaj3tfwt"
+        },
+        {
+            "reason": "wrong_proof_preimage",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq06ql2qcqsyk26tw5l6qlt5zlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjm07s8mrq7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenlqxgux5qqy364fwxs5xtgnznef0eaazvcy4c30rvnrtlmv48scxn7j2mhh83cgdjs7mxha62tvaf7480n2vm3pvzdae5x45mk29d9ev"
+        },
+        {
+            "reason": "proof_omitted_tlvs_not_ascending",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyk2649dl6qlt5zlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjm07s8mrq7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenlqxgux5qqy364fwxs5xtgnznef0eaazvcy4c30rvnrtlmv48scxn7j2mhh83cgdjs7mxha62tvaf7480n2vm3pvzdae5x45mk29d9ev"
+        },
+        {
+            "reason": "proof_omitted_tlvs_contains_zero",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2quqqzqjetfd6nlgrawstlr9jk8t04x7de26srdvlstr9c5rt0ap4z3eh7uvh7870at466sdegph5eefx56sdfc9n5cld3x5r9ccuhxfemls60dwawgedxtqz40xec3948vchqry76r3nxr8yyhmlrrav9lqa2e4rg35y8yn57r33d8ucxrevxpcvlwk38l0rpm3ke4c5xkg3vnk3ypq2nn2etjtggzkfnx9t075uwslmnk7mpkx5d7lr45engq9aqlej3hxmvqy8jz7f6tdl6qlvvredat6lxzlremvfl37zf4pzsxdlq6hsuj9rzs3mh58zvd8nc00x0uqers6sqqj8249c6zsedzv2099l8h5fnqjhz9udjvd0ldj57rq606ftw7u78ppk2rmv6lhffdn4865a7dfnwy9sfhhxs6knweg45h9s"
+        },
+        {
+            "reason": "proof_omitted_tlvs_contains_signature_field",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2quqsyk26tw5lrlgrawstlr9jk8t04x7de26srdvlstr9c5rt0ap4z3eh7uvh7870at466sdegph5eefx56sdfc9n5cld3x5r9ccuhxfemls60dwawgedxtqz40xec3948vchqry76r3nxr8yyhmlrrav9lqa2e4rg35y8yn57r33d8ucxrevxpcvlwk38l0rpm3ke4c5xkg3vnk3ypq2nn2etjtggzkfnx9t075uwslmnk7mpkx5d7lr45engq9aqlej3hxmvqy8jz7f6tdl6qlvvredat6lxzlremvfl37zf4pzsxdlq6hsuj9rzs3mh58zvd8nc00x0uqers6sqqj8249c6zsedzv2099l8h5fnqjhz9udjvd0ldj57rq606ftw7u78ppk2rmv6lhffdn4865a7dfnwy9sfhhxs6knweg45h9s"
+        },
+        {
+            "reason": "proof_omitted_tlvs_contains_proof_field",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2pyqsyk26tw5l6qlfl5p7hg9l3jetr4h6n0xu4dgpkk0c93ju2p4h7s63gumlwxtlrl8746adgxu5qm6vu5n2dgx5uze6v0kcn2pjuvwtnyualcd8khwhyvkn9sp2hnvugj6nkvtspj0dpcenpnjztal337kzlsw4v635g6zrjf60pcckn7vrpukrqux0htgnlh3sacmv6u2rtygkfmgjqs9fe4v4e95yptyenz4hl2w8g0aem0dsmr2xl0366ve5qz7s0uegmndkqzrep0ya9klaq0kxpuk74a0np03uakylclpy6s3grxlsdtcwfz33ggam6r3xxneu8hn87qv3cdgqqfr42judpgvk3x98jjlnm6yesft3z7xexxhlke20psd8ay4h0w0rssm9pakd0m55ke6na2wlx5ehzzcymmngdtfhv526tjc"
+        },
+        {
+            "reason": "proof_omitted_tlvs_contains_high_field",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2pvqsyk26tw5lamnt9qq06qlt5zlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjm07s8mrq7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenlqxgux5qqy364fwxs5xtgnznef0eaazvcy4c30rvnrtlmv48scxn7j2mhh83cgdjs7mxha62tvaf7480n2vm3pvzdae5x45mk29d9ev"
+        },
+        {
+            "reason": "proof_omitted_tlvs_contains_included_tlv_field",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2quqsykzetfd6nlgrawstlr9jk8t04x7de26srdvlstr9c5rt0ap4z3eh7uvh7870at466sdegph5eefx56sdfc9n5cld3x5r9ccuhxfemls60dwawgedxtqz40xec3948vchqry76r3nxr8yyhmlrrav9lqa2e4rg35y8yn57r33d8ucxrevxpcvlwk38l0rpm3ke4c5xkg3vnk3ypq2nn2etjtggzkfnx9t075uwslmnk7mpkx5d7lr45engq9aqlej3hxmvqy8jz7f6tdl6qlvvredat6lxzlremvfl37zf4pzsxdlq6hsuj9rzs3mh58zvd8nc00x0uqers6sqqj8249c6zsedzv2099l8h5fnqjhz9udjvd0ldj57rq606ftw7u78ppk2rmv6lhffdn4865a7dfnwy9sfhhxs6knweg45h9s"
+        },
+        {
+            "reason": "proof_omitted_tlvs_not_sequential",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyktyv4n06qlt5zlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjm07s8mrq7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenlqxgux5qqy364fwxs5xtgnznef0eaazvcy4c30rvnrtlmv48scxn7j2mhh83cgdjs7mxha62tvaf7480n2vm3pvzdae5x45mk29d9ev"
+        },
+        {
+            "reason": "proof_leaf_hashes_too_few",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyk26tw5l6qlt5zlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjm07s8mzq7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenlqxgux5qqy364fwxs5xtgnznef0eaazvcy4c30rvnrtlmv48scxs"
+        },
+        {
+            "reason": "proof_leaf_hashes_too_many",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyk26tw5l6qlt5zlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjm07s8myq7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenlqxgux5qqy364fwxs5xtgnznef0eaazvcy4c30rvnrtlmv48scxn7j2mhh83cgdjs7mxha62tvaf7480n2vm3pvzdae5x45mk29d9evqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+        },
+        {
+            "reason": "proof_missing_hashes_too_few",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyk26tw5l6qltszlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4j0aq0kxpuk74a0np03uakylclpy6s3grxlsdtcwfz33ggam6r3xxneu8hn87qv3cdgqqfr42judpgvk3x98jjlnm6yesft3z7xexxhlke20psd8ay4h0w0rssm9pakd0m55ke6na2wlx5ehzzcymmngdtfhv526tjc"
+        },
+        {
+            "reason": "proof_missing_hashes_too_many",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyk26tw5l6qltczlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjmvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplgra3s09h40tuctu08d3878cfx5y2qehur27rjg5v2z8w7suf3570pauelsrywr2qqzga25hrg2r95f3fu5hu773xvz2ugh3kf34lak2ncvrflf9dmmncuyxeg0dnt7a99kw5l2nhe4xdcskpx7u6r26dm9zkjuk"
+        },
+        {
+            "reason": "wrong_invoice_signature",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9nxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qva0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyk26tw5l6qlt5zlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjm07s8mrq7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenlqxgux5qqy364fwxs5xtgnznef0eaazvcy4c30rvnrtlmv48scxn7j2mhh83cgdjs7mxha62tvaf7480n2vm3pvzdae5x45mk29d9ev"
+        },
+        {
+            "reason": "wrong_proof_signature",
+            "bech32": "lnp1tqssxfr986kyx3ygqqkvq6alklcslcvfj834l8lyxqkmafkjx57up2cu4qs89ntwss3vgplmd5ycdy83zv9hmmt7ctmltcwnp0va2g0sz5mr0yasyypyhs4rzfj320c8uu8qh2cgwf8xhp0zzluv6c5vad3fwsj8hdyn8qhsgq9rxgj9dzm24ehdy5sp90tluyrjcqltmjnl538etvplrngfhc5tp2punsepqktcekqd5p5f09nzeq86qrlj2rxdcngckuyll5w84cce79qvl0p96s9zmynmt672hpqq74p0hdag733w3hvq9wcnupgtn0ef8d690svmg6j8vaq0jlyadmq5ru35xnzaf7398gwjawyfd6adn9z4en7s86fqqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyql6ql2qcqsyk26tw5l6qlt5zlcev436mafhnw2k5qmt8uzcew9q6mlgdg5wdlhr9l3lnl2awk5rw2qdaxw2f4x5r2wpvax8mvf4qewx89ejwwluxnmthtjxtfjcq4tekwyfdfmx9cqe8ksuveseep97lccltp0c82kdg6ydppeya8suvtflxps7tpswr8m45flmccwudkdw9p4jytya5fqgz5u6k2uj6zq4jve32ml48r587uahkcd34r0hcadxv6qp0g87v5dekmqppushjwjm07s8mrq7t027heshc7wmz0u0sjdgg5pn0cx4u8y3gc5ywaapcnrfu7rmenlqxgux5qqy364fwxs5xtgnznef0eaazvcy4c30rvnrtlmv48scxn7j2mhh83cgdjs7mxha62tvaf7480n2vm3pvzdae5x45mk29d9ev"
+        },
+        {
+            "reason": "contains_invreq_metadata",
+            "bech32": "lnp1qqq5ykppqvjx204vgdzgsqpvcp4mldl3plscny0rt707gvpdh6ndydfacz43e2pqwtxkappzcsrlkmgfs6g0zyct0hkhashh7hsaxz7e65slq9fkx7fmqggzf0p2xyn9z5ls0ecwpw4ssujwdwz7y9lce43ge6mzjapy0w6fxwp0qsq2xv3y269k4tnw6ffqz27hlcg89sp7hh98lfz0jkcr78xsn03gkz5re8pjzpvh3nvqmgrgj7tx9jq05q8ly5xvm3x33dcfllgu0t33nu2qe67zt4q29kf8kh4u4wzqpa2zlwm63arzarwcq2a38czshxljjwm52lqek34ywe6ql97f6mkpg8ergdx96naz2wsa96ugjm46mx29tn8aq05jqqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpl5p75pspqfv45kafl5p7hg9l3jetr4h6n0xu4dgpkk0c93ju2p4h7s63gumlwxtlrl8746adgxu5qm6vu5n2dgx5uze6v0kcn2pjuvwtnyualcd8khwhyvkn9sp2hnvugj6nkvtspj0dpcenpnjztal337kzlsw4v635g6zrjf60pcckn7vrpukrqux0htgnlh3sacmv6u2rtygkfmgjqs9fe4v4e95yptyenz4hl2w8g0aem0dsmr2xl0366ve5qz7s0uegmndkqzrep0ya9klaq0kxpuk74a0np03uakylclpy6s3grxlsdtcwfz33ggam6r3xxneu8hn87qv3cdgqqfr42judpgvk3x98jjlnm6yesft3z7xexxhlke20psd8ay4h0w0rssm9pakd0m55ke6na2wlx5ehzzcymmngdtfhv526tjc"
+        }
+    ]
+}


### PR DESCRIPTION
Bolt12 payer proofs are a standard way of proving to a receiver that we made a specific payment. By leveraging the payer key, they provide stronger guarantees than simply sharing the payment preimage (and will be compatible with PTLCs in the future).

This is specified in lightning/bolts#1295.