### PR TITLE
Add an Electrum server list and other minor improvements

### DIFF
--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -221,7 +221,7 @@ publishing {
 afterEvaluate {
     val targets = when {
         currentOs.isLinux -> listOf()
-        else -> listOf("linuxX64")
+        else -> listOf("linuxX64", "linuxArm64")
     }.mapNotNull { kotlin.targets.findByName(it) as? KotlinNativeTarget }
 
     configure(targets) {

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -226,7 +226,6 @@ afterEvaluate {
 
     configure(targets) {
         compilations.all {
-            cinterops.all { tasks[interopProcessingTaskName].enabled = false }
             compileTaskProvider.get().enabled = false
             tasks[processResourcesTaskName].enabled = false
         }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumClient.kt
@@ -21,12 +21,12 @@ import kotlin.time.Duration.Companion.seconds
 
 sealed class ElectrumConnectionStatus {
     data class Closed(val reason: TcpSocket.IOException?) : ElectrumConnectionStatus()
-    data object Connecting : ElectrumConnectionStatus()
+    data class Connecting(val serverAddress: ServerAddress) : ElectrumConnectionStatus()
     data class Connected(val version: ServerVersionResponse, val height: Int, val header: BlockHeader) : ElectrumConnectionStatus()
 
     fun toConnectionState(): Connection = when (this) {
         is Closed -> Connection.CLOSED(this.reason)
-        Connecting -> Connection.ESTABLISHING
+        is Connecting -> Connection.ESTABLISHING
         is Connected -> Connection.ESTABLISHED
     }
 }
@@ -106,7 +106,7 @@ class ElectrumClient(
     private suspend fun openSocket(serverAddress: ServerAddress, socketBuilder: TcpSocket.Builder, timeout: Duration): TcpSocket? {
         var socket: TcpSocket? = null
         return try {
-            _connectionStatus.value = ElectrumConnectionStatus.Connecting
+            _connectionStatus.value = ElectrumConnectionStatus.Connecting(serverAddress)
             val (host, port, tls) = serverAddress
             logger.info { "attempting connection to electrumx instance [host=$host, port=$port, tls=$tls]" }
             withTimeout(timeout) {

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumServers.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumServers.kt
@@ -4,6 +4,9 @@ import fr.acinq.bitcoin.Chain
 import fr.acinq.lightning.io.TcpSocket
 import fr.acinq.lightning.utils.ServerAddress
 
+/**
+ * Based on: https://github.com/spesmilo/electrum/blob/master/electrum/chains/mainnet/servers.json
+ */
 object ElectrumServers {
 
     private fun electrumServer(host: String, port: Int = 50002): ServerAddress =
@@ -54,9 +57,6 @@ object ElectrumServers {
                         "By3WGCPnSVAnq3vVJyvABfcJQuhXoQ+nF48e3XbfQ1Gnj1Gy6ZB7ikTMOU1KTYzL" +
                         "A8FCjlZR1zNWRA+jHppqMcsCAwEAAQ=="
         ),
-//    electrumServer(host = "electrum.hodlister.co"), too slow
-//    electrumServer(host = "electrum3.hodlister.co"), too slow
-//    electrumServer(host = "electrum5.hodlister.co"), too slow
         electrumServer(
             host = "fortress.qtornado.com", publicKey =
                 "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAy7xI+hVU3rUSAyMMX8OI" +

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumServers.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumServers.kt
@@ -1,0 +1,180 @@
+package fr.acinq.lightning.blockchain.electrum
+
+import fr.acinq.bitcoin.Chain
+import fr.acinq.lightning.io.TcpSocket
+import fr.acinq.lightning.utils.ServerAddress
+
+object ElectrumServers {
+
+    private fun electrumServer(host: String, port: Int = 50002): ServerAddress =
+        ServerAddress(host = host, port = port, tls = TcpSocket.TLS.TRUSTED_CERTIFICATES())
+
+    private fun electrumServer(host: String, port: Int = 50002, publicKey: String): ServerAddress =
+        ServerAddress(host = host, port = port, tls = TcpSocket.TLS.PINNED_PUBLIC_KEY(publicKey))
+
+    val mainnetElectrumServers = listOf(
+        electrumServer(host = "electrum.acinq.co"),
+        electrumServer(
+            host = "VPS.hsmiths.com", publicKey =
+                "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAwaNR7gST8KEAwc7tGTZP" +
+                        "1T6qVhg+KjqY1LpvkZ8m1QBPh+j6HsTjB4+RiH1MerqMWVLD9dEZEYZsEUREySyb" +
+                        "G3szQ1nf+GZkn3XorKyvX29B0aZow3ZdAKwTXF51jwCE/G7j3UpteKIYoX/egoUq" +
+                        "G8k/N3q0jxUZXGEY33BhHGAdiuRAk70QDIUjh1zuPHVED9tE9fc/qeJ/ZlQbQHzK" +
+                        "Y820JcqR1JingTufVps26SyiOHO+jzlRGsO3qHpAmtc1ikEJt1dPS53Rcu8LojF0" +
+                        "kgKZ5oCgGSCWU/+T+8xffp/y5GrV7lxlFNNwM2HFLvx24r2ovYujMzd45VgQ+rIG" +
+                        "V1FcAVDXsarNtSV2R5YmyldScRnzR5IEHcPWPFXMuMvZR31COtD99pXsoS60JO9S" +
+                        "Bd7DMcbU/aXxlyfltla58JS3RV27Uem01YkIfx9d0QW07TXPRmWfQNQ1aZV4Iyfn" +
+                        "oWJnYRR36BOI3TIZKGBSFYvvojNh6noeRVp/BCDRmsi4lL3PLAAH3jKJ2jGjXnZ7" +
+                        "uQNlxsC6ZDL9yezndEjpRYQPYZLrUGOOuNKJReSHtWw83U6wd/5TyI8NRGkHZlCi" +
+                        "585YChjthLYR8fdfHR2sAvMf0pfqBQgV8sNQ3qIZdpaVZIr0wXucsKDGhsZO3Zym" +
+                        "FlzYsP0snim4LMNIlQ+W8N8CAwEAAQ=="
+        ),
+        electrumServer(
+            host = "electrum.emzy.de", publicKey =
+                "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAufqDv0nJICJPoP86wOPY" +
+                        "M/XIfFs6vmVrGEeBZmy9MmMNubulhnyE+sWuFhnIX+0uuFlJ18LJYFOIg0fAaFdN" +
+                        "5xh4vagBNXP9dCcxfVfMGfv9xBQZfWhKrDjC4DCJ82n3K+Q4RqpK/yS9GIZIcqrG" +
+                        "3rxELBZ8NHVPIXveW0PnagGeQ31NDdOAq9MBKiKRcmfKem5daUEo/xM4nTt+tOTx" +
+                        "l5sHicdQSCePHXewMXzmkM/Vw1rMJZKeTwnLX44TsppEi47fXUFcduB2+A1xHQIg" +
+                        "E9wa4Bqc2ZoUtKKBayeeU02C2SBFgVxtAWT6YESdcPP8u+pR7lADA7QZNUVNKMvM" +
+                        "NwIDAQAB"
+        ),
+        electrumServer(
+            host = "ecdsa.net", port = 110, publicKey =
+                "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAu1H7Mbtz/YJKdmCaKeaK" +
+                        "VUJ6G2VoWOo9yHZkJZHncc5mz/pN7f5QK3mJDakwaXTw64RY3w2P3SLhnujQDYtS" +
+                        "oVX9K278xv8yrJBNg6ts0UsORkdzqjxJ2FcoLB4r1HcYxaPYEw8hM4h7nGsZ7gHk" +
+                        "StTtaqIAmBNb4dv/kDPQ2HpdXTzJLIABkFL+BFW3nYrcKxYpZZDgn1kTMQhEIZYb" +
+                        "t5azXqVUVgR/ZRfu+2BliN5nPTLns0XrGS4tVPa00U68lOVje/wXv0HESdAbyl5h" +
+                        "sSTcb81djECD2uLk1oQo2N+/KAPaJnwPCLxpSolr8RUNXYDdwKdPz7vNngTw55GO" +
+                        "R+AIaeLXDFBZzHv+bsYOtyFhc5PUjhldaMIG72CbF6uTc1nEhLQdpJ0WTuDTT29D" +
+                        "uP4AI7D+nS5wJ9OSW7GA3gPUB5sKv/AWEhRgqqgJDQDw+zKYx++P9VZ0Ebk/chXK" +
+                        "j8IdusF8UsEkRy4TAONpgssIMVfb793lXnFP4/vEzUmxHEglLJ63r9eUtA7kph4f" +
+                        "KqIwnSPGFQ2NB37AqsXSdLeb0zcBPJ+rZK7TO9aUfG3toLcoQ1moi0k6J6dreTis" +
+                        "By3WGCPnSVAnq3vVJyvABfcJQuhXoQ+nF48e3XbfQ1Gnj1Gy6ZB7ikTMOU1KTYzL" +
+                        "A8FCjlZR1zNWRA+jHppqMcsCAwEAAQ=="
+        ),
+//    electrumServer(host = "electrum.hodlister.co"), too slow
+//    electrumServer(host = "electrum3.hodlister.co"), too slow
+//    electrumServer(host = "electrum5.hodlister.co"), too slow
+        electrumServer(
+            host = "fortress.qtornado.com", publicKey =
+                "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAy7xI+hVU3rUSAyMMX8OI" +
+                        "LdCs5m5Az1rzFL/8MTSnCBUnXY+YjmN8vFg8ktc/ebwSnjxCfjjXjPPcf0qSS2Xa" +
+                        "WZ3M7nAlzYLpZCTuGBWE2ZbQ30QzXiMzh3Ucum4EJUeGOTEDtisdCrv3jjDs/P96" +
+                        "UgR8MMA1fJqIpxAKnbEj5I9FX9t4eFVhYl6aiykJUFpV3aUZiDsqH8v5MiXCWHAc" +
+                        "EGx1nfzY/os5xYYm/w0+VJiyX6HN0AViA2zF1wnWZFRqwCWpffaZAAPQdYaJ+bGl" +
+                        "zR2PQneczw01EfJwMgb8QfMy3GbZFga7gT5NcZGzEAztL8Y7EzhtjcLksvhm5TB7" +
+                        "iZbvNlCTmyv6F/jm90sZZAwYsg+9Dzl5ciJTKigQnMbPlDaOiRUKXkdw114Q2emO" +
+                        "XKxs74fBl2g/XNO+3Jt7LSDrHEN38ygrHROxPbCTJmUawQ29KUBDULlnsWgzb9Ni" +
+                        "uWMdaPJTXPUQSEYcux1jkVED1l5vANds0bTgM3fipb1MhvFb2GYJiVJkwu342fiG" +
+                        "ADGpTzzjMqhsxevph8zh72MdaxyHCLlvk5OswTEoGNdo6ZFRBpmWDJF9zMnXCPEM" +
+                        "vk2PS8RRlECPNORxSDsu79uXVm0+VmhLshcLOEEb+9qhLid063YLZrwEqZJshbm9" +
+                        "Gcc9FdI7SUP85+RR9XnyL9cCAwEAAQ=="
+        ),
+        electrumServer(host = "electrum.blockstream.info"),
+        electrumServer(host = "blockstream.info", port = 700),
+        electrumServer(
+            host = "alviss.coinjoined.com",
+            publicKey = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr8Bmk8+FLFdI9IF+6jZW" +
+                    "pQ2He/8XuWvHgkI7gBylsLtprca+mRvs2ejZef/s6daffy70faQM4ub6NZx+Mg53" +
+                    "l/R3TAjQwPvu/3fVJfrUG9JvLvYBuBBoB/uKsFHXoa6OyEy8qd81Lvnx3vOb+DFA" +
+                    "JD2snJ110yjF4XmXXukdptmO/MsjVVEn1VX0kPORVrP6JC/W79+zskaulbOpeFC6" +
+                    "0j3Ss0a5blglUhVyJ49LZy+TvxXhss37VGkZak33Cz3oDEWMnvNWWMUmTdyDMDHH" +
+                    "z4hjsP6ltTWbfci6d99YmtW4fxMmcO7TlBka69Oq0QGhMxRtrwEUjDr6OUsI7GtL" +
+                    "vwIDAQAB"
+        ),
+        electrumServer(
+            host = "bitcoin.aranguren.org",
+            publicKey = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9IpKA+SdtQIQRcXPFBp0" +
+                    "XxgqOYWW6U1u7e/fOPrz+NF5gzwvhrmH7arRUrlztkhLGtUr2NmhbG6trBiQ95Ye" +
+                    "+VnGfgU3IXfnpsvXMOA5PCR3tJGpf40jD1fMYtF7gjdDYQlDYOxvuZg1KkZSJK76" +
+                    "Td8bGhrsDRkNMUi77dc0v+1ooTSL8Ha71aRgJzHRv4bOulxsZNteQW9nFeHnGklK" +
+                    "hm5xW+uDyo+gf5+1376c2sMupFOjPTzQT3EU3NAskTrNUNqJM/aXTzU9+pKw7DZU" +
+                    "e6g6ovN+mKTecFEcmLOnZOrwFDOmTP+x17gfKr/ECMgZzPhY0PiLLJKfDdEdoIiq" +
+                    "gQIDAQAB"
+        ),
+        electrumServer(
+            host = "bitcoins.sk", port = 56002,
+            publicKey = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtJBnSJ2+KWS5lwrnP0mC" +
+                    "zDcTwFozzGiLgrf72JupKBHFl2nuZUA98INgBlWljtpF8k6StBysTiYS5LFJ7u37" +
+                    "6oqlRTFjMT0oy8431y7mBq2QEgPzSJ9VqxM24FPnUEL/EyHB7JgzU77ACKGYa/Jz" +
+                    "X/S1W9ip0J9Rauc6/f/3c7mB6vlrbt3uREdEKOjJhQkLouDQgNSYw9ZKr7iS6Ruw" +
+                    "RzbAmT/MPg9zwFrPmh3KhlGRXnQowddY9z7M/a9CZ0JwjaG3abDBH5IdkMDIWY85" +
+                    "8pNjz3dTQUSfOimH/uRehee6x4xLFFMUxtpdkQCq8SEWlLhGBr6MRxkQZeoTR+F8" +
+                    "NwIDAQAB"
+        ),
+        electrumServer(
+            host = "btc.electroncash.dk", port = 60002,
+            publicKey = "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAv76pDl+g6Bo6kEXs6a94" +
+                    "1KTF4jTqXSTdy8XbZ83KeFsH9yOd6mj/x0JjOjmvvcygLnf3ka5PJIKZnbAv6tu0" +
+                    "oi2WJ8IgYmKxwkvoHjXF5Fcuow35t6pNqRxrc6K4kmI/t0CeJCb/oNjWV1n86vua" +
+                    "glrFBL/IvWptldmXXyXOsssd1Bh/GTILAX+CzaFtBlNZ/Z7AjhqH9g9ltlNddPc1" +
+                    "QYn1w/aUWTLXyXmOoOGKveScr3ioUQbDu1L2Llp6zGQbi0LRHKPEdtNeIyaoWMhE" +
+                    "rdBKlbHMDhsyXas1iDjFBP06Cd7oJeHI0oc5XIMSArJKB7NFfAswvmE2HB+H/gWK" +
+                    "Dot/nrHRZyZUB7DT3D/GK+ONfIQYCxgGd+SZ8RLC4/wVEN6rkyMFHaoHmXYmpCSR" +
+                    "uLz8LOf04Bjy9J0IFgVP7hvGC05l00lNopMiZ69AkOq1+PgfAlW+0zQLlo/88v0a" +
+                    "moxLby5+VrPs5MUMBEBDUjQFfFyJMX5PfZWtrMOdNQMFEnJ5NCSztJdyXXpPqvEf" +
+                    "5SD0NEC2qR+YUPqWS/vg0uccjoIrGJXMW2r2d/9jVATMTlx50djlhy+dF6j3iTRj" +
+                    "ti/pZHDJmeLcTw8JSKxvtPpds6dd0uWnFGI4BkzlYpIOTsjqKhWlHLDzrSGlWr5e" +
+                    "Z2JEj+rj0OqRAdpjDjWsNqECAwEAAQ=="
+        ),
+        electrumServer(
+            host = "electrum.bitaroo.net", publicKey = """
+                MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4vKkvxn3HA3QfpQ5tDZK
+                yfSVeI6tzc8WDF78FWOLoB+o4Lv00mIYcufZljpfz2JXSmYrDJG11EXtXe3W6PyQ
+                PvHUMaf7JkZjw0iaetfMMNVOaXJOTIpqTA0uIewgvnrJMF/F2Sua7PxVePkC1yN0
+                8QQ/jjfVeCX70XT4HiC8Nhu38aEerMXj7cJT+HMbffAem9Wo5qd8xORkAeuas2gR
+                hUMJNqPVpq6aAZ+hM1oRoI23aEaLpM7K2xiBOxdVcF0uxFLUbsoN4RUQ1a7uElOo
+                mkX06Gy/T+aaLJyPUWUnZqv7tRRln4cTHxBrRydznkEOsdQvYOvgWhRBOPF4ZoA/
+                uQIDAQAB
+            """.trimIndent().replace("\n", ""),
+        ),
+        electrumServer(host = "fulcrum.grey.pw", port = 51002),
+        electrumServer(
+            host = "fulcrum.sethforprivacy.com", port = 50002,
+            publicKey = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyHfrzqvuz0nrDCFfVRMx" +
+                    "E8XXG8a5rSyTqZx/rA3OmqFv4IAP8/j+CzWvgXyvuzjN0eloPouXqQGjXpBacspc" +
+                    "wZ35coJhGOHwHJVeGL94tE8ELwP0GhiPX3/HOyPy5YjCo7c1HzN7YFc0Epf32kfp" +
+                    "x8G/eMP9m321VYG9LaErk/aNikrfSRAmA+8rGetGRXoft2yU7I4WS7q6SdhW1Dvh" +
+                    "xhgF4PviVW8JT9eEBoedyjybNjhiTx+/AaBuYagtnUiHK+Mm3GjfMv8iqvxgLxef" +
+                    "LMlLJ0H5y3mByO1xFGXGHKckT9G/yu9nSiYe+SmXI+T6BpAlvXwKfb1suZLT3gXv" +
+                    "vwIDAQAB"
+        ),
+    )
+
+    val testnetElectrumServers = listOf(
+        electrumServer(
+            host = "testnet.qtornado.com", port = 51002, publicKey =
+                "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAwkLgqNkkTbwpV3gMdgDA" +
+                        "+jJFdzrOp8vIDT/qxVIox8NZ53pxPc2N44aeY1NJx4TyfpHUGcI7l+gxZfLr8a13" +
+                        "o3CIQSotDbZZdJhS6Ir5tT4iRqwZJch+HayTQf9rztv8OQWgrflWDzCiYtBA5PGx" +
+                        "6LEQWyah/xPPUbeANe/ndEzlfAhXjNcynSfrkikzTgFNBqnc5CcTkHjYgzCXqMwy" +
+                        "ZCD6kQTQG+eqIHSHul21dwUougfCWCR+P0zFA7LeUfPz2mLZktmGXjqTyYZ+0ZTU" +
+                        "gJz/MMZt9PDWGJZsHQzoFSCMicukKtnvZ4Q0gbPOoYp8+WjD4SH+WmC3MZdLagsi" +
+                        "05hUDdm7PHIM1VHQTALLGRnW3yTOaqhsvYGAM5UOkDcmgUqIr6IztHGWCKldfbhS" +
+                        "c4l7BIgvwW2M6FxYlSAcavIodNfvEC1ythdMzl8bZsBjGIOZ39WtiM0grgcg7bb8" +
+                        "W5ovZpLOXpzZBjS0zB0sZJnumjS+3jCSjy9rZXGUn3JmMdqtTV8RQxkB8OBJhFf5" +
+                        "qtMSZXiJIr9RH71VoJKjnds/hoILHuCKU3HOJeo0+4KSD8+q4g3tZLr/haIrsHg5" +
+                        "uifT9db6tDML1PTKpbHkW+f3w9PdhSmsNUUXrgNmQ0MoBhxV7U2Qcug3jX3xaf1P" +
+                        "gwWDg3nZZizhuvBceY0IYLECAwEAAQ=="
+        ),
+        electrumServer(host = "blockstream.info", port = 993),
+        electrumServer(
+            host = "testnet.aranguren.org", port = 51002, publicKey =
+                "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+RL/AH7wn08YKlRCswER" +
+                        "M0JBdGycRuGBgQbM0guzDxi7Ov01WB9AM0DX7GC09pAOefbRP8QzXEhyKO0qpnin" +
+                        "+5Vz4jKS+xv4zPGx2MpTqjJxzom/6v13cumZxWXMzVSeNUTjVp2sOPQ1JQaHqqjs" +
+                        "2lTgShWu+pAgKUH1KPWxMSz21cI+AQkT8NuuXe0USYYIeiXzyTpciIaBf50j6185" +
+                        "u+4bUwA3hvdPZyrkJDtSluJ0HiJzCSFlmNYNHLqbvZNAYrgUM3qJRTsvmD0JK6mm" +
+                        "8m7iXW4m6mKX22VgR93meD/3rdcrJ8FbMbVlkS3wimzcYezls9JytaXupyeRKhQj" +
+                        "TQIDAQAB"
+        ),
+    )
+
+    fun pickElectrumServer(chain: Chain) = when (chain) {
+        Chain.Mainnet -> mainnetElectrumServers.random()
+        Chain.Testnet3 -> testnetElectrumServers.random()
+        else -> error("unsupported chain")
+    }
+}

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumServersTest.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/blockchain/electrum/ElectrumServersTest.kt
@@ -1,0 +1,88 @@
+package fr.acinq.lightning.blockchain.electrum
+
+import fr.acinq.bitcoin.TxId
+import fr.acinq.lightning.blockchain.fee.FeeratePerByte
+import fr.acinq.lightning.io.TcpSocket
+import fr.acinq.lightning.tests.utils.runSuspendTest
+import fr.acinq.lightning.tests.utils.testLoggerFactory
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTimedValue
+
+
+/**
+ * This test checks if servers configured in the preset electrum list are valid.
+ *
+ * Public list of servers: https://github.com/spesmilo/electrum/blob/master/electrum/chains/mainnet/servers.json
+ *
+ * Some servers use self-signed certificates, for those we use a pinned pubkey. To update the public key manually:
+ * ```
+ * openssl s_client -connect host:port -servername host </dev/null 2>/dev/null | openssl x509 -pubkey -noout
+ * ```
+ */
+@Ignore
+class ElectrumServersTest {
+
+    @Test
+    fun `connect to testnet servers`() = runSuspendTest(timeout = 1.minutes) {
+        ElectrumServers.testnetElectrumServers.forEach { server ->
+            println("-------- testing [ ${server.host}:${server.port} ${server.tls::class.simpleName} ] --------")
+            val client = ElectrumClient(this, testLoggerFactory)
+            withTimeout(5.seconds) {
+                val (status, t) = measureTimedValue {
+                    client.connect(server, TcpSocket.Builder())
+                    client.connectionStatus.filterIsInstance<ElectrumConnectionStatus.Connected>().first()
+                }
+                println("✅ [${t.inWholeMilliseconds} ms] connected at height=${status.height}")
+                client
+            }
+            client.stop()
+        }
+    }
+
+    @Test
+    fun `connect to mainnet servers`() = runSuspendTest(timeout = 1.minutes) {
+        ElectrumServers.mainnetElectrumServers.forEach { server ->
+            println("-------- testing [ ${server.host}:${server.port} ${server.tls::class.simpleName} ] --------")
+            val client = ElectrumClient(this, testLoggerFactory)
+            try {
+                withTimeout(5.seconds) {
+                    val (status, t) = measureTimedValue {
+                        client.connect(server, TcpSocket.Builder())
+                        client.connectionStatus.filterIsInstance<ElectrumConnectionStatus.Connected>().first()
+                    }
+                    println("✅ [${t.inWholeMilliseconds} ms] connected at height=${status.height}")
+                }
+                // evaluate the server's estimate-fee performance
+                withTimeout(10.seconds) {
+                    val (fees, t) = measureTimedValue {
+                        client.estimateFees(1)
+                    }
+                    println("✅ [${t.inWholeMilliseconds} ms] next block is ${fees?.let { FeeratePerByte(it) }}")
+                }
+                // evaluate the server's get-confirmation count on a random transaction
+                withTimeout(10.seconds) {
+                    val (tx, t1) = measureTimedValue {
+                        client.getTx(TxId("6703c9dc67a2d66ec027b2aaa4016e72dcb7ecc5fe6f4a270a35bdf52f3c4eeb"))
+                    }
+                    assertNotNull(tx)
+                    println("✅ [${t1.inWholeMilliseconds} ms] tx found")
+                    val (conf, t2) = measureTimedValue {
+                        client.getConfirmations(tx)
+                    }
+                    println("✅ [${t2.inWholeMilliseconds} ms] tx reached $conf confs")
+                }
+            } catch(_: TimeoutCancellationException) {
+                println("❌ ${server.host}:${server.port} is too slow")
+            }
+            client.stop()
+        }
+    }
+}

--- a/modules/core/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
+++ b/modules/core/src/jvmMain/kotlin/fr/acinq/lightning/io/JvmTcpSocket.kt
@@ -121,8 +121,8 @@ class JvmTcpSocket(val socket: Socket) : TcpSocket {
                     if (serverKey == pinnedKey) {
                         logger.info { "successfully checked server's certificate against pinned pubkey" }
                     } else {
-                        logger.warning { "server's certificate does not match pinned pubkey, fallback to default check" }
-                        throw TcpSocket.IOException.ConnectionClosed(CertificateException("certificate does not match pinned key"))
+                        logger.warning { "server's certificate does not match pinned pubkey" }
+                        throw TcpSocket.IOException.ConnectionClosed(CertificateException("certificate does not match pinned pubkey"))
                     }
                 }
 
@@ -141,11 +141,11 @@ class JvmTcpSocket(val socket: Socket) : TcpSocket {
         fun buildTlsConfigFor(host: String, tls: TcpSocket.TLS.ENABLED, logger: Logger) = when (tls) {
             is TcpSocket.TLS.TRUSTED_CERTIFICATES -> TLSConfigBuilder().build()
             is TcpSocket.TLS.PINNED_PUBLIC_KEY -> {
-                logger.warning { "using unsafe TLS for connection with $host" }
+                logger.info { "using certificate pinning for connections with $host" }
                 tlsConfigForPinnedCert(tls.pubKey, logger)
             }
             is TcpSocket.TLS.UNSAFE_CERTIFICATES -> {
-                logger.info { "using certificate pinning for connections with $host" }
+                logger.warning { "using unsafe TLS for connection with $host" }
                 tlsConfigForUnsafeCertificates()
             }
         }


### PR DESCRIPTION
Commits are independent.

We take the electrum server list and test from phoenix to share with phoenixd. As a further improvements we could automate the testing and updating of this list. For now we keep the simple (and ignored by default) test that phoenix was using.