### PR TITLE
CI: publish linux arm64 binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Publish Linux
         if: matrix.os == 'ubuntu-latest'
         shell: bash
-        run: ./gradlew publishLinuxX64PublicationToMavenLocal
+        run: ./gradlew publishLinuxX64PublicationToMavenLocal publishLinuxArm64PublicationToMavenLocal
       - name: Publish MacOS
         if: matrix.os == 'macOS-latest'
         shell: bash


### PR DESCRIPTION
Update our CI release script to publish linux arm64 binaries.