### PR TITLE
Use CSPRNG in Noise handshake

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -947,6 +947,7 @@ data class Commitments(
 
     fun receiveRevocation(revocation: RevokeAndAck): Either<ChannelException, Pair<Commitments, List<ChannelAction>>> {
         if (remoteNextCommitInfo.isRight) return Either.Left(UnexpectedRevocation(channelId))
+        if (!revocation.perCommitmentSecret.isValid()) return Either.Left(InvalidRevocation(channelId))
         // Since htlcs are shared across all commitments, we generate the actions only once based on the first commitment.
         val remoteCommit = active.first().remoteCommit
         if (revocation.perCommitmentSecret.publicKey() != remoteCommit.remotePerCommitmentPoint) return Either.Left(InvalidRevocation(channelId))

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/crypto/noise/Noise.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/crypto/noise/Noise.kt
@@ -1,6 +1,6 @@
 package fr.acinq.lightning.crypto.noise
 
-import kotlin.random.Random
+import fr.acinq.lightning.Lightning
 
 interface DHFunctions {
     fun name(): String
@@ -296,9 +296,8 @@ interface ByteStream {
 }
 
 object RandomBytes : ByteStream {
-    override fun nextBytes(length: Int) = Random.nextBytes(length)
+    override fun nextBytes(length: Int) = Lightning.randomBytes(length)
 }
-
 
 sealed class HandshakeState {
     @ExperimentalStdlibApi
@@ -491,7 +490,6 @@ data class HandshakeStateWriter(
             )
     }
 }
-
 
 data class HandshakeStateReader(
     val messages: List<List<MessagePattern>>,

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
@@ -1074,6 +1074,26 @@ class NormalTestsCommon : LightningTestSuite() {
     }
 
     @Test
+    fun `recv RevokeAndAck -- secret is not a valid private key`() {
+        val (alice0, bob0) = reachNormal()
+        val (alice1, bob1) = addHtlc(50_000_000.msat, alice0, bob0).first
+        assertIs<LNChannel<Normal>>(alice1)
+        val tx = alice1.signCommitTx()
+
+        val (alice2, actionsAlice2) = alice1.process(ChannelCommand.Commitment.Sign)
+        val commitSig0 = actionsAlice2.findOutgoingMessage<CommitSig>()
+        val (_, actionsBob2) = bob1.process(ChannelCommand.MessageReceived(commitSig0))
+        val rev = actionsBob2.hasOutgoingMessage<RevokeAndAck>()
+
+        val (alice3, actionsAlice3) = alice2.process(ChannelCommand.MessageReceived(rev.copy(perCommitmentSecret = PrivateKey(ByteVector32.Zeroes))))
+        assertIs<LNChannel<Closing>>(alice3)
+        actionsAlice3.hasOutgoingMessage<Error>()
+        assertEquals(2, actionsAlice3.filterIsInstance<ChannelAction.Blockchain.PublishTx>().count())
+        assertEquals(1, actionsAlice3.findWatches<WatchConfirmed>().count())
+        actionsAlice3.hasPublishTx(tx)
+    }
+
+    @Test
     fun `recv RevokeAndAck -- missing nonce`() {
         val (alice0, bob0) = reachNormal()
         val fundingTxId = alice0.commitments.latest.fundingTxId


### PR DESCRIPTION
We previously used the default, non-cryptographically-secure RNG when deriving Noise ephemeral keys for the Bolt8 transport. This means that a malicious LSP could in theory perform key-recovery attacks. We now use a CSPRNG which fixes this issue.

In the second commit, we also fix a smaller issue: we validate remote commitment secret's validity as elliptic curve points to avoid throwing an unnecessary exception (it will lead to a force-close anyway, but it's cleaner).

Reported by @danielabrozzoni AI scans.