### PR TITLE
Use bitcoin-kmp 0.32.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,8 @@ kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.9.0"
 ktor = "3.4.1"
-bitcoinkmp = "0.31.0" # when upgrading bitcoin-kmp, keep secpjnijvm in sync!
-secpjnijvm = "0.23.0"
+bitcoinkmp = "0.32.0-SNAPSHOT" # when upgrading bitcoin-kmp, keep secpjnijvm in sync!
+secpjnijvm = "0.24.0"
 kermit = "2.0.8"
 slf4j = "2.0.17"
 

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/transactions/TransactionsTestsCommon.kt
@@ -105,8 +105,9 @@ class TransactionsTestsCommon : LightningTestSuite() {
         when (commitmentFormat) {
             Transactions.CommitmentFormat.AnchorOutputs -> {
                 // ECDSA signatures are der-encoded, which creates some variability in signature size compared to the baseline.
+                // worse case scenario: expected weight as defined in the BOLTs uses 2 73-bytes signatures, but actual signatures are 70 bytes => we'd be 6 bytes below the expected weight
                 assertTrue(actual <= expected + 4, "actual=$actual, expected=$expected")
-                assertTrue(actual >= expected - 4, "actual=$actual, expected=$expected")
+                assertTrue(actual >= expected - 6, "actual=$actual, expected=$expected")
             }
             Transactions.CommitmentFormat.SimpleTaprootChannels -> assertEquals(expected, actual)
         }
@@ -175,7 +176,7 @@ class TransactionsTestsCommon : LightningTestSuite() {
             }
             Transaction.correctlySpends(commitTx, listOf(fundingTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
             // We check the expected weight of the commit input:
-            val commitInputWeight = commitTx.copy(txIn = listOf(commitTx.txIn.first(), commitTx.txIn.first())).weight() - commitTx.weight()
+            val commitInputWeight = commitTx.txIn.first().weight()
             checkExpectedWeight(commitInputWeight, commitmentFormat.fundingInputWeight, commitmentFormat)
             val htlcTxs = Transactions.makeHtlcTxs(commitTx, commitTxOutputs, commitmentFormat)
             val expiries = htlcTxs.associate { it.htlcId to it.htlcExpiry.toLong() }


### PR DESCRIPTION
Uses bitcoin-kmp 0.32.0-SNAPSHOT, will be updated and moved to "ready for review" once 0.32.0 has been published.