### PR TITLE
Force-close on invalid HTLC `cltv_expiry`

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -2,8 +2,10 @@ package fr.acinq.lightning.channel
 
 import fr.acinq.bitcoin.*
 import fr.acinq.bitcoin.Crypto.sha256
+import fr.acinq.bitcoin.Script.LOCKTIME_THRESHOLD
 import fr.acinq.bitcoin.crypto.musig2.IndividualNonce
 import fr.acinq.bitcoin.utils.Either
+import fr.acinq.lightning.CltvExpiry
 import fr.acinq.lightning.CltvExpiryDelta
 import fr.acinq.lightning.Feature
 import fr.acinq.lightning.MilliSatoshi
@@ -777,9 +779,14 @@ data class Commitments(
         return failure?.let { Either.Left(it) } ?: Either.Right(Pair(copy(changes = changes1, payments = payments1), add))
     }
 
-    fun receiveAdd(add: UpdateAddHtlc): Either<ChannelException, Commitments> {
+    fun receiveAdd(add: UpdateAddHtlc, currentBlockHeight: Long): Either<ChannelException, Commitments> {
         if (add.id != changes.remoteNextHtlcId) {
             return Either.Left(UnexpectedHtlcId(channelId, expected = changes.remoteNextHtlcId, actual = add.id))
+        }
+
+        // CLTV expiry values >= 500_000_000 would indicate a time in seconds instead of a block height.
+        if (add.cltvExpiry >= CltvExpiry(LOCKTIME_THRESHOLD)) {
+            return Either.Left(ExpiryTooBig(channelId, CltvExpiry(LOCKTIME_THRESHOLD), add.cltvExpiry, currentBlockHeight))
         }
 
         // we used to not enforce a strictly positive minimum, hence the max(1 msat)

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/states/Normal.kt
@@ -154,7 +154,7 @@ data class Normal(
                     Pair(this@Normal, actions)
                 }
                 else -> when (cmd.message) {
-                    is UpdateAddHtlc -> when (val result = commitments.receiveAdd(cmd.message)) {
+                    is UpdateAddHtlc -> when (val result = commitments.receiveAdd(cmd.message, currentBlockHeight.toLong())) {
                         is Either.Left -> handleLocalError(cmd, result.value)
                         is Either.Right -> {
                             val newState = this@Normal.copy(commitments = result.value)

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/transactions/Scripts.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/transactions/Scripts.kt
@@ -72,7 +72,7 @@ object Scripts {
      */
     fun cltvTimeout(tx: Transaction): Long = when {
         // locktime is a number of blocks
-        tx.lockTime <= Script.LOCKTIME_THRESHOLD -> tx.lockTime
+        tx.lockTime < Script.LOCKTIME_THRESHOLD -> tx.lockTime
         else -> {
             // locktime is a unix epoch timestamp
             require(tx.lockTime <= 0x20FFFFFF) { "locktime should be lesser than 0x20FFFFFF" }

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/CommitmentsTestsCommon.kt
@@ -61,7 +61,7 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
         assertEquals(ac1.availableBalanceForSend(), a - p - htlcOutputFee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
         assertEquals(ac1.availableBalanceForReceive(), b)
 
-        val bc1 = bc0.receiveAdd(add).right!!
+        val bc1 = bc0.receiveAdd(add, currentBlockHeight).right!!
         assertEquals(bc1.availableBalanceForSend(), b)
         assertEquals(bc1.availableBalanceForReceive(), a - p - htlcOutputFee)
 
@@ -147,7 +147,7 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
         assertEquals(ac1.availableBalanceForSend(), a - p - htlcOutputFee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
         assertEquals(ac1.availableBalanceForReceive(), b)
 
-        val bc1 = bc0.receiveAdd(add).right!!
+        val bc1 = bc0.receiveAdd(add, currentBlockHeight).right!!
         assertEquals(bc1.availableBalanceForSend(), b)
         assertEquals(bc1.availableBalanceForReceive(), a - p - htlcOutputFee)
 
@@ -246,15 +246,15 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
         assertEquals(bc1.availableBalanceForSend(), b - p3) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
         assertEquals(bc1.availableBalanceForReceive(), a)
 
-        val bc2 = bc1.receiveAdd(add1).right!!
+        val bc2 = bc1.receiveAdd(add1, currentBlockHeight).right!!
         assertEquals(bc2.availableBalanceForSend(), b - p3)
         assertEquals(bc2.availableBalanceForReceive(), a - p1 - htlcOutputFee)
 
-        val bc3 = bc2.receiveAdd(add2).right!!
+        val bc3 = bc2.receiveAdd(add2, currentBlockHeight).right!!
         assertEquals(bc3.availableBalanceForSend(), b - p3)
         assertEquals(bc3.availableBalanceForReceive(), a - p1 - htlcOutputFee - p2 - htlcOutputFee)
 
-        val ac3 = ac2.receiveAdd(add3).right!!
+        val ac3 = ac2.receiveAdd(add3, currentBlockHeight).right!!
         assertEquals(ac3.availableBalanceForSend(), a - p1 - htlcOutputFee - p2 - htlcOutputFee)
         assertEquals(ac3.availableBalanceForReceive(), b - p3)
 
@@ -396,7 +396,7 @@ class CommitmentsTestsCommon : LightningTestSuite(), LoggingContext {
             val add = UpdateAddHtlc(
                 randomBytes32(), c.changes.remoteNextHtlcId, c.availableBalanceForReceive(), randomBytes32(), CltvExpiry(currentBlockHeight), TestConstants.emptyOnionPacket
             )
-            val result = c.receiveAdd(add)
+            val result = c.receiveAdd(add, currentBlockHeight)
             assertTrue(result.isRight)
         }
     }

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
@@ -456,6 +456,16 @@ class NormalTestsCommon : LightningTestSuite() {
     }
 
     @Test
+    fun `recv UpdateAddHtlc -- invalid cltv_expiry`() {
+        val (_, bob0) = reachNormal()
+        val add = UpdateAddHtlc(bob0.channelId, 0, 15_000.msat, randomBytes32(), CltvExpiry(500_000_000), TestConstants.emptyOnionPacket)
+        val (bob1, actions1) = bob0.process(ChannelCommand.MessageReceived(add))
+        assertIs<LNChannel<Closing>>(bob1)
+        val error = actions1.hasOutgoingMessage<Error>()
+        assertEquals(error.toAscii(), ExpiryTooBig(bob0.channelId, CltvExpiry(500_000_000), CltvExpiry(500_000_000), bob0.currentBlockHeight.toLong()).message)
+    }
+
+    @Test
     fun `recv UpdateAddHtlc -- value too small`() {
         val (_, bob0) = reachNormal()
         val add = UpdateAddHtlc(bob0.channelId, 0, 150.msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(bob0.currentBlockHeight.toLong()), TestConstants.emptyOnionPacket)


### PR DESCRIPTION
Bolt 2 specifies that if the sending node sets `cltv_expiry` to greater or equal to 500,000,000, we should send a warning and close the connection or send an error and fail the channel. We never implemented that, which was fine because we already rejected large `cltv_expiry` before that threshold (without force-closing), but it's better to explicitly force close if our peer is sending such invalid values.