### PR TITLE
Store the right `commit_sig` signature

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Commitments.kt
@@ -130,14 +130,15 @@ data class LocalCommit(val index: Long, val spec: CommitmentSpec, val txId: TxId
                 val htlcsOut = spec.htlcs.outgoings().map { it.id }.joinToString(",")
                 "built local commit number=$localCommitIndex toLocalMsat=${spec.toLocal.toLong()} toRemoteMsat=${spec.toRemote.toLong()} htlc_in=$htlcsIn htlc_out=$htlcsOut feeratePerKw=${spec.feerate} txid=${localCommitTx.tx.txid} fundingTxId=${commitInput.outPoint.txid}"
             }
-            val remoteSigOk = when (commitmentFormat) {
-                Transactions.CommitmentFormat.AnchorOutputs -> localCommitTx.checkRemoteSig(fundingKey.publicKey(), remoteFundingPubKey, commit.signature)
-                Transactions.CommitmentFormat.SimpleTaprootChannels -> when (val remoteSig = commit.sigOrPartialSig) {
-                    is ChannelSpendSignature.IndividualSignature -> false
-                    is ChannelSpendSignature.PartialSignatureWithNonce -> {
-                        val localNonce = NonceGenerator.verificationNonce(commitInput.outPoint.txid, fundingKey, remoteFundingPubKey, localCommitIndex)
-                        localCommitTx.checkRemotePartialSignature(fundingKey.publicKey(), remoteFundingPubKey, remoteSig, localNonce.publicNonce)
-                    }
+            val remoteSig = when (val sig = commit.signatureFor(commitmentFormat)) {
+                null -> return Either.Left(InvalidCommitmentSignature(channelParams.channelId, localCommitTx.tx.txid))
+                else -> sig
+            }
+            val remoteSigOk = when (remoteSig) {
+                is ChannelSpendSignature.IndividualSignature -> localCommitTx.checkRemoteSig(fundingKey.publicKey(), remoteFundingPubKey, commit.signature)
+                is ChannelSpendSignature.PartialSignatureWithNonce -> {
+                    val localNonce = NonceGenerator.verificationNonce(commitInput.outPoint.txid, fundingKey, remoteFundingPubKey, localCommitIndex)
+                    localCommitTx.checkRemotePartialSignature(fundingKey.publicKey(), remoteFundingPubKey, remoteSig, localNonce.publicNonce)
                 }
             }
             if (!remoteSigOk) {
@@ -152,7 +153,7 @@ data class LocalCommit(val index: Long, val spec: CommitmentSpec, val txId: TxId
                     return Either.Left(InvalidHtlcSignature(channelParams.channelId, htlcTx.tx.txid))
                 }
             }
-            return Either.Right(LocalCommit(localCommitIndex, spec, localCommitTx.tx.txid, commit.sigOrPartialSig, commit.htlcSignatures))
+            return Either.Right(LocalCommit(localCommitIndex, spec, localCommitTx.tx.txid, remoteSig, commit.htlcSignatures))
         }
     }
 }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/channel/Helpers.kt
@@ -456,14 +456,22 @@ object Helpers {
             localClosingComplete: ClosingComplete?,
             remoteNonce: IndividualNonce?
         ): Either<ChannelException, Transactions.ClosingTx> {
-            val closingTxsWithSig = listOfNotNull(
-                closingSig.closerAndCloseeOutputsSig?.let { sig -> closingTxs.localAndRemote?.let { tx -> Pair(tx, ChannelSpendSignature.IndividualSignature(sig)) } },
-                closingSig.closerAndCloseeOutputsPartialSig?.let { sig -> remoteNonce?.let { nonce -> closingTxs.localAndRemote?.let { tx -> Pair(tx, ChannelSpendSignature.PartialSignatureWithNonce(sig, nonce)) } } },
-                closingSig.closerOutputOnlySig?.let { sig -> closingTxs.localOnly?.let { tx -> Pair(tx, ChannelSpendSignature.IndividualSignature(sig)) } },
-                closingSig.closerOutputOnlyPartialSig?.let { sig -> remoteNonce?.let { nonce -> closingTxs.localOnly?.let { tx -> Pair(tx, ChannelSpendSignature.PartialSignatureWithNonce(sig, nonce)) } } },
-                closingSig.closeeOutputOnlySig?.let { sig -> closingTxs.remoteOnly?.let { tx -> Pair(tx, ChannelSpendSignature.IndividualSignature(sig)) } },
-                closingSig.closeeOutputOnlyPartialSig?.let { sig -> remoteNonce?.let { nonce -> closingTxs.remoteOnly?.let { tx -> Pair(tx, ChannelSpendSignature.PartialSignatureWithNonce(sig, nonce)) } } },
-            )
+            val closingTxsWithSig = when (commitment.commitmentFormat) {
+                Transactions.CommitmentFormat.AnchorOutputs -> {
+                    listOfNotNull(
+                        closingSig.closerAndCloseeOutputsSig?.let { sig -> closingTxs.localAndRemote?.let { tx -> Pair(tx, ChannelSpendSignature.IndividualSignature(sig)) } },
+                        closingSig.closerOutputOnlySig?.let { sig -> closingTxs.localOnly?.let { tx -> Pair(tx, ChannelSpendSignature.IndividualSignature(sig)) } },
+                        closingSig.closeeOutputOnlySig?.let { sig -> closingTxs.remoteOnly?.let { tx -> Pair(tx, ChannelSpendSignature.IndividualSignature(sig)) } },
+                    )
+                }
+                Transactions.CommitmentFormat.SimpleTaprootChannels -> {
+                    listOfNotNull(
+                        closingSig.closerAndCloseeOutputsPartialSig?.let { sig -> remoteNonce?.let { nonce -> closingTxs.localAndRemote?.let { tx -> Pair(tx, ChannelSpendSignature.PartialSignatureWithNonce(sig, nonce)) } } },
+                        closingSig.closerOutputOnlyPartialSig?.let { sig -> remoteNonce?.let { nonce -> closingTxs.localOnly?.let { tx -> Pair(tx, ChannelSpendSignature.PartialSignatureWithNonce(sig, nonce)) } } },
+                        closingSig.closeeOutputOnlyPartialSig?.let { sig -> remoteNonce?.let { nonce -> closingTxs.remoteOnly?.let { tx -> Pair(tx, ChannelSpendSignature.PartialSignatureWithNonce(sig, nonce)) } } },
+                    )
+                }
+            }
             return when (val preferred = closingTxsWithSig.firstOrNull()) {
                 null -> Either.Left(MissingCloseSignature(commitment.channelId))
                 else -> {

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/wire/LightningMessages.kt
@@ -12,6 +12,7 @@ import fr.acinq.lightning.channel.ChannelFlags
 import fr.acinq.lightning.channel.ChannelSpendSignature
 import fr.acinq.lightning.channel.ChannelType
 import fr.acinq.lightning.router.Announcements
+import fr.acinq.lightning.transactions.Transactions
 import fr.acinq.lightning.utils.*
 import fr.acinq.secp256k1.Hex
 import io.ktor.utils.io.charsets.*
@@ -1314,8 +1315,12 @@ data class CommitSig(
     override val type: Long get() = CommitSig.type
 
     val partialSignature: ChannelSpendSignature.PartialSignatureWithNonce? = tlvStream.get<CommitSigTlv.PartialSignatureWithNonce>()?.psig
-    val sigOrPartialSig: ChannelSpendSignature = partialSignature ?: signature
     val fundingTxId: TxId? = tlvStream.get<CommitSigTlv.FundingTx>()?.txId
+
+    fun signatureFor(commitmentFormat: Transactions.CommitmentFormat): ChannelSpendSignature? = when (commitmentFormat) {
+        Transactions.CommitmentFormat.AnchorOutputs -> signature
+        Transactions.CommitmentFormat.SimpleTaprootChannels -> partialSignature
+    }
 
     override fun write(out: Output) {
         LightningCodecs.writeBytes(channelId, out)

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/channel/states/NormalTestsCommon.kt
@@ -902,6 +902,43 @@ class NormalTestsCommon : LightningTestSuite() {
     }
 
     @Test
+    fun `recv CommitSig -- unnecessary partial signature`() {
+        val (alice0, bob0) = reachNormal(channelType = ChannelType.SupportedChannelType.AnchorOutputs)
+        val (nodes1, _, _) = addHtlc(50_000_000.msat, alice0, bob0)
+        val (_, actions2) = nodes1.first.process(ChannelCommand.Commitment.Sign)
+        val commitSig = actions2.findOutgoingMessage<CommitSig>()
+        assertNull(commitSig.partialSignature)
+        // Alice also includes a taproot partial sig, even though this is a non-taproot channel.
+        // We simply ignore it and use the individual signature for our commitment transaction.
+        val invalidPartialSig = ChannelSpendSignature.PartialSignatureWithNonce(randomBytes32(), IndividualNonce(randomBytes(66)))
+        val commitSig1 = commitSig.copy(tlvStream = TlvStream(CommitSigTlv.FundingTx(commitSig.fundingTxId!!), CommitSigTlv.PartialSignatureWithNonce(invalidPartialSig)))
+        val (bob3, actions3) = nodes1.second.process(ChannelCommand.MessageReceived(commitSig1))
+        actions3.findOutgoingMessage<RevokeAndAck>()
+        val commitTx = bob3.signCommitTx()
+        val commitInput = bob3.commitments.latest.commitInput(bob3.channelKeys)
+        Transaction.correctlySpends(commitTx, mapOf(commitInput.outPoint to commitInput.txOut), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    }
+
+    @Test
+    fun `recv CommitSig -- unnecessary individual signature`() {
+        val (alice0, bob0) = reachNormal(channelType = ChannelType.SupportedChannelType.SimpleTaprootChannels)
+        val (nodes1, _, _) = addHtlc(50_000_000.msat, alice0, bob0)
+        val (_, actions2) = nodes1.first.process(ChannelCommand.Commitment.Sign)
+        val commitSig = actions2.findOutgoingMessage<CommitSig>()
+        assertNotNull(commitSig.partialSignature)
+        assertEquals(ChannelSpendSignature.IndividualSignature(ByteVector64.Zeroes), commitSig.signature)
+        // Alice also includes a non-zero individual signature, even though this is a taproot channel.
+        // We simply ignore it and use the partial signature for our commitment transaction.
+        val invalidIndividualSig = ChannelSpendSignature.IndividualSignature(randomBytes64())
+        val commitSig1 = commitSig.copy(signature = invalidIndividualSig)
+        val (bob3, actions3) = nodes1.second.process(ChannelCommand.MessageReceived(commitSig1))
+        actions3.findOutgoingMessage<RevokeAndAck>()
+        val commitTx = bob3.signCommitTx()
+        val commitInput = bob3.commitments.latest.commitInput(bob3.channelKeys)
+        Transaction.correctlySpends(commitTx, mapOf(commitInput.outPoint to commitInput.txOut), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    }
+
+    @Test
     fun `recv CommitSig -- bad htlc sig count`() {
         val (alice0, bob0) = reachNormal()
         val (alice1, bob1) = addHtlc(50_000_000.msat, alice0, bob0).first


### PR DESCRIPTION
Signatures can either be ECDSA signatures for non-taproot channels, or partial musig2 signatures for taproot channels. We make sure we don't get confused between the two types of signatures and always store and validate the one that matches our commitment format, which guarantees that we're able to broadcast our commitment transaction.