### PR TITLE
Expose payment failure categories

### DIFF
--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -450,6 +450,23 @@ data class LightningOutgoingPayment(
                  * Applications should define their own localized message for each of these failure cases.
                  */
                 sealed class Failure {
+                    val category: OutgoingPaymentFailure.Category
+                        get() = when (this) {
+                            PaymentAmountTooSmall -> OutgoingPaymentFailure.Category.LocalValidation
+                            PaymentAmountTooBig -> OutgoingPaymentFailure.Category.LocalValidation
+                            NotEnoughFunds -> OutgoingPaymentFailure.Category.LocalBalance
+                            NotEnoughFees -> OutgoingPaymentFailure.Category.Fee
+                            PaymentExpiryTooBig -> OutgoingPaymentFailure.Category.Cltv
+                            TooManyPendingPayments -> OutgoingPaymentFailure.Category.Retry
+                            ChannelIsSplicing -> OutgoingPaymentFailure.Category.LocalChannel
+                            ChannelIsClosing -> OutgoingPaymentFailure.Category.LocalChannel
+                            TemporaryRemoteFailure -> OutgoingPaymentFailure.Category.Remote
+                            RecipientLiquidityIssue -> OutgoingPaymentFailure.Category.Liquidity
+                            RecipientIsOffline -> OutgoingPaymentFailure.Category.Recipient
+                            RecipientRejectedPayment -> OutgoingPaymentFailure.Category.Recipient
+                            is Uninterpretable -> OutgoingPaymentFailure.Category.Unknown
+                        }
+
                     // @formatter:off
                     /** The payment is too small: try sending a larger amount. */
                     data object PaymentAmountTooSmall : Failure() { override fun toString(): String = "the payment amount is too small" }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/db/PaymentsDb.kt
@@ -450,21 +450,21 @@ data class LightningOutgoingPayment(
                  * Applications should define their own localized message for each of these failure cases.
                  */
                 sealed class Failure {
-                    val category: OutgoingPaymentFailure.Category
+                    val category: PaymentFailureCategory
                         get() = when (this) {
-                            PaymentAmountTooSmall -> OutgoingPaymentFailure.Category.LocalValidation
-                            PaymentAmountTooBig -> OutgoingPaymentFailure.Category.LocalValidation
-                            NotEnoughFunds -> OutgoingPaymentFailure.Category.LocalBalance
-                            NotEnoughFees -> OutgoingPaymentFailure.Category.Fee
-                            PaymentExpiryTooBig -> OutgoingPaymentFailure.Category.Cltv
-                            TooManyPendingPayments -> OutgoingPaymentFailure.Category.Retry
-                            ChannelIsSplicing -> OutgoingPaymentFailure.Category.LocalChannel
-                            ChannelIsClosing -> OutgoingPaymentFailure.Category.LocalChannel
-                            TemporaryRemoteFailure -> OutgoingPaymentFailure.Category.Remote
-                            RecipientLiquidityIssue -> OutgoingPaymentFailure.Category.Liquidity
-                            RecipientIsOffline -> OutgoingPaymentFailure.Category.Recipient
-                            RecipientRejectedPayment -> OutgoingPaymentFailure.Category.Recipient
-                            is Uninterpretable -> OutgoingPaymentFailure.Category.Unknown
+                            PaymentAmountTooSmall -> PaymentFailureCategory.LocalValidation
+                            PaymentAmountTooBig -> PaymentFailureCategory.LocalValidation
+                            NotEnoughFunds -> PaymentFailureCategory.LocalBalance
+                            NotEnoughFees -> PaymentFailureCategory.Fee
+                            PaymentExpiryTooBig -> PaymentFailureCategory.Cltv
+                            TooManyPendingPayments -> PaymentFailureCategory.Retry
+                            ChannelIsSplicing -> PaymentFailureCategory.LocalChannel
+                            ChannelIsClosing -> PaymentFailureCategory.LocalChannel
+                            TemporaryRemoteFailure -> PaymentFailureCategory.Remote
+                            RecipientLiquidityIssue -> PaymentFailureCategory.Liquidity
+                            RecipientIsOffline -> PaymentFailureCategory.Recipient
+                            RecipientRejectedPayment -> PaymentFailureCategory.Recipient
+                            is Uninterpretable -> PaymentFailureCategory.Unknown
                         }
 
                     // @formatter:off

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OfferManager.kt
@@ -33,6 +33,14 @@ private data class PendingInvoiceRequest(val payOffer: PayOffer, val request: Of
 
 /** Failures occurring when fetching an invoice to pay an offer */
 sealed class Bolt12InvoiceRequestFailure {
+    val category: PaymentFailureCategory
+        get() = when (this) {
+            is NoResponse -> PaymentFailureCategory.Recipient
+            is MalformedResponse -> PaymentFailureCategory.Recipient
+            is ErrorFromRecipient -> PaymentFailureCategory.Recipient
+            is InvoiceMismatch -> PaymentFailureCategory.Recipient
+        }
+
     // @formatter:off
     data class NoResponse(val request: OfferTypes.InvoiceRequest) : Bolt12InvoiceRequestFailure() { override fun toString(): String = "no response to the invoice request" }
     data class MalformedResponse(val request: OfferTypes.InvoiceRequest, val failure: Bolt12Invoice.Companion.Bolt12ParsingResult.Failure.Malformed) : Bolt12InvoiceRequestFailure() { override fun toString(): String = "recipient returned an invalid response to the invoice request" }

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
@@ -17,6 +17,24 @@ sealed class FinalFailure {
     /** Use this function when no payment attempts have been made (e.g. when a precondition failed). */
     fun toPaymentFailure(): OutgoingPaymentFailure = OutgoingPaymentFailure(this, listOf<LightningOutgoingPayment.Part.Status.Failed>())
 
+    val category: OutgoingPaymentFailure.Category
+        get() = when (this) {
+            AlreadyInProgress -> OutgoingPaymentFailure.Category.LocalValidation
+            AlreadyPaid -> OutgoingPaymentFailure.Category.LocalValidation
+            InvalidPaymentAmount -> OutgoingPaymentFailure.Category.LocalValidation
+            FeaturesNotSupported -> OutgoingPaymentFailure.Category.LocalValidation
+            InvalidPaymentId -> OutgoingPaymentFailure.Category.LocalValidation
+            ChannelNotConnected -> OutgoingPaymentFailure.Category.LocalChannel
+            ChannelOpening -> OutgoingPaymentFailure.Category.LocalChannel
+            ChannelClosing -> OutgoingPaymentFailure.Category.LocalChannel
+            NoAvailableChannels -> OutgoingPaymentFailure.Category.LocalChannel
+            InsufficientBalance -> OutgoingPaymentFailure.Category.LocalBalance
+            RecipientUnreachable -> OutgoingPaymentFailure.Category.Recipient
+            RetryExhausted -> OutgoingPaymentFailure.Category.Retry
+            WalletRestarted -> OutgoingPaymentFailure.Category.Retry
+            UnknownError -> OutgoingPaymentFailure.Category.Unknown
+        }
+
     // @formatter:off
     data object AlreadyInProgress : FinalFailure() { override fun toString(): String = "another payment is in progress for that invoice" }
     data object AlreadyPaid : FinalFailure() { override fun toString(): String = "this invoice has already been paid" }
@@ -36,6 +54,19 @@ sealed class FinalFailure {
 }
 
 data class OutgoingPaymentFailure(val reason: FinalFailure, val failures: List<LightningOutgoingPayment.Part.Status.Failed>) {
+    enum class Category {
+        LocalValidation,
+        LocalBalance,
+        LocalChannel,
+        Fee,
+        Cltv,
+        Liquidity,
+        Recipient,
+        Remote,
+        Retry,
+        Unknown
+    }
+
     constructor(reason: FinalFailure, failures: List<Either<ChannelException, FailureMessage>>, completedAt: Long = currentTimestampMillis()) : this(
         reason,
         failures.map { LightningOutgoingPayment.Part.Status.Failed(convertFailure(it), completedAt) }
@@ -49,6 +80,9 @@ data class OutgoingPaymentFailure(val reason: FinalFailure, val failures: List<L
             else -> Either.Right(reason)
         }
     }
+
+    /** Stable classification of the most user-friendly reason for the payment failure. */
+    val category: Category get() = explain().fold({ it.category }, { it.category })
 
     /**
      * A detailed summary of the all internal errors.

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
@@ -9,6 +9,35 @@ import fr.acinq.lightning.utils.currentTimestampMillis
 import fr.acinq.lightning.wire.*
 
 /**
+ * Stable high-level classification for payment failures.
+ *
+ * This is meant for APIs, logs and diagnostics that need machine-readable failure classes without relying on
+ * localized messages or the exact failure hierarchy used internally by lightning-kmp.
+ */
+enum class PaymentFailureCategory {
+    /** The payment request or caller-provided payment parameters are invalid. */
+    LocalValidation,
+    /** The wallet doesn't have enough spendable balance for this payment. */
+    LocalBalance,
+    /** The wallet cannot currently use its local channels to send this payment. */
+    LocalChannel,
+    /** The payment failed because routing fees were insufficient. */
+    Fee,
+    /** The payment failed because CLTV/expiry requirements were not met. */
+    Cltv,
+    /** The payment could not be relayed to the recipient, most likely because of insufficient liquidity. */
+    Liquidity,
+    /** The recipient was unreachable or rejected the payment. */
+    Recipient,
+    /** A remote node in the route failed the payment. */
+    Remote,
+    /** Payment attempts were exhausted or interrupted and the payment may be retried later. */
+    Retry,
+    /** The failure cannot be reliably classified. */
+    Unknown
+}
+
+/**
  * A fatal failure that stops payment attempts.
  * Applications should define their own localized message for each of these failures.
  */
@@ -17,22 +46,22 @@ sealed class FinalFailure {
     /** Use this function when no payment attempts have been made (e.g. when a precondition failed). */
     fun toPaymentFailure(): OutgoingPaymentFailure = OutgoingPaymentFailure(this, listOf<LightningOutgoingPayment.Part.Status.Failed>())
 
-    val category: OutgoingPaymentFailure.Category
+    val category: PaymentFailureCategory
         get() = when (this) {
-            AlreadyInProgress -> OutgoingPaymentFailure.Category.LocalValidation
-            AlreadyPaid -> OutgoingPaymentFailure.Category.LocalValidation
-            InvalidPaymentAmount -> OutgoingPaymentFailure.Category.LocalValidation
-            FeaturesNotSupported -> OutgoingPaymentFailure.Category.LocalValidation
-            InvalidPaymentId -> OutgoingPaymentFailure.Category.LocalValidation
-            ChannelNotConnected -> OutgoingPaymentFailure.Category.LocalChannel
-            ChannelOpening -> OutgoingPaymentFailure.Category.LocalChannel
-            ChannelClosing -> OutgoingPaymentFailure.Category.LocalChannel
-            NoAvailableChannels -> OutgoingPaymentFailure.Category.LocalChannel
-            InsufficientBalance -> OutgoingPaymentFailure.Category.LocalBalance
-            RecipientUnreachable -> OutgoingPaymentFailure.Category.Recipient
-            RetryExhausted -> OutgoingPaymentFailure.Category.Retry
-            WalletRestarted -> OutgoingPaymentFailure.Category.Retry
-            UnknownError -> OutgoingPaymentFailure.Category.Unknown
+            AlreadyInProgress -> PaymentFailureCategory.LocalValidation
+            AlreadyPaid -> PaymentFailureCategory.LocalValidation
+            InvalidPaymentAmount -> PaymentFailureCategory.LocalValidation
+            FeaturesNotSupported -> PaymentFailureCategory.LocalValidation
+            InvalidPaymentId -> PaymentFailureCategory.LocalValidation
+            ChannelNotConnected -> PaymentFailureCategory.LocalChannel
+            ChannelOpening -> PaymentFailureCategory.LocalChannel
+            ChannelClosing -> PaymentFailureCategory.LocalChannel
+            NoAvailableChannels -> PaymentFailureCategory.LocalChannel
+            InsufficientBalance -> PaymentFailureCategory.LocalBalance
+            RecipientUnreachable -> PaymentFailureCategory.Recipient
+            RetryExhausted -> PaymentFailureCategory.Retry
+            WalletRestarted -> PaymentFailureCategory.Retry
+            UnknownError -> PaymentFailureCategory.Unknown
         }
 
     // @formatter:off
@@ -54,35 +83,6 @@ sealed class FinalFailure {
 }
 
 data class OutgoingPaymentFailure(val reason: FinalFailure, val failures: List<LightningOutgoingPayment.Part.Status.Failed>) {
-    /**
-     * Stable high-level classification for outgoing payment failures.
-     *
-     * This is meant for APIs, logs and diagnostics that need machine-readable failure classes without relying on
-     * localized messages or the exact failure hierarchy used internally by lightning-kmp.
-     */
-    enum class Category {
-        /** The payment request or caller-provided payment parameters are invalid. */
-        LocalValidation,
-        /** The wallet doesn't have enough spendable balance for this payment. */
-        LocalBalance,
-        /** The wallet cannot currently use its local channels to send this payment. */
-        LocalChannel,
-        /** The payment failed because routing fees were insufficient. */
-        Fee,
-        /** The payment failed because CLTV/expiry requirements were not met. */
-        Cltv,
-        /** The payment could not be relayed to the recipient, most likely because of insufficient liquidity. */
-        Liquidity,
-        /** The recipient was unreachable or rejected the payment. */
-        Recipient,
-        /** A remote node in the route failed the payment. */
-        Remote,
-        /** Payment attempts were exhausted or interrupted and the payment may be retried later. */
-        Retry,
-        /** The failure cannot be reliably classified. */
-        Unknown
-    }
-
     constructor(reason: FinalFailure, failures: List<Either<ChannelException, FailureMessage>>, completedAt: Long = currentTimestampMillis()) : this(
         reason,
         failures.map { LightningOutgoingPayment.Part.Status.Failed(convertFailure(it), completedAt) }
@@ -98,7 +98,7 @@ data class OutgoingPaymentFailure(val reason: FinalFailure, val failures: List<L
     }
 
     /** Stable classification of the most user-friendly reason for the payment failure. */
-    val category: Category get() = explain().fold({ it.category }, { it.category })
+    val category: PaymentFailureCategory get() = explain().fold({ it.category }, { it.category })
 
     /**
      * A detailed summary of the all internal errors.

--- a/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
+++ b/modules/core/src/commonMain/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailure.kt
@@ -54,16 +54,32 @@ sealed class FinalFailure {
 }
 
 data class OutgoingPaymentFailure(val reason: FinalFailure, val failures: List<LightningOutgoingPayment.Part.Status.Failed>) {
+    /**
+     * Stable high-level classification for outgoing payment failures.
+     *
+     * This is meant for APIs, logs and diagnostics that need machine-readable failure classes without relying on
+     * localized messages or the exact failure hierarchy used internally by lightning-kmp.
+     */
     enum class Category {
+        /** The payment request or caller-provided payment parameters are invalid. */
         LocalValidation,
+        /** The wallet doesn't have enough spendable balance for this payment. */
         LocalBalance,
+        /** The wallet cannot currently use its local channels to send this payment. */
         LocalChannel,
+        /** The payment failed because routing fees were insufficient. */
         Fee,
+        /** The payment failed because CLTV/expiry requirements were not met. */
         Cltv,
+        /** The payment could not be relayed to the recipient, most likely because of insufficient liquidity. */
         Liquidity,
+        /** The recipient was unreachable or rejected the payment. */
         Recipient,
+        /** A remote node in the route failed the payment. */
         Remote,
+        /** Payment attempts were exhausted or interrupted and the payment may be retried later. */
         Retry,
+        /** The failure cannot be reliably classified. */
         Unknown
     }
 

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OfferManagerTestsCommon.kt
@@ -141,7 +141,10 @@ class OfferManagerTestsCommon : LightningTestSuite() {
         val (messageForAlice, _) = trampolineRelay(invoiceRequests.first(), aliceTrampolineKey)
         // The invoice request times out.
         bobOfferManager.checkInvoiceRequestTimeout(invoiceRequestPathId, payOffer)
-        assertEquals(OfferNotPaid(payOffer, Bolt12InvoiceRequestFailure.NoResponse(request)), bobOfferManager.eventsFlow.first())
+        val failure = bobOfferManager.eventsFlow.first()
+        assertIs<OfferNotPaid>(failure)
+        assertEquals(OfferNotPaid(payOffer, Bolt12InvoiceRequestFailure.NoResponse(request)), failure)
+        assertEquals(PaymentFailureCategory.Recipient, failure.reason.category)
         // The timeout can be replayed without any side-effect.
         bobOfferManager.checkInvoiceRequestTimeout(invoiceRequestPathId, payOffer)
         // Alice sends an invoice back to Bob after the timeout.

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailureTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailureTestsCommon.kt
@@ -1,14 +1,22 @@
 package fr.acinq.lightning.payment
 
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.Block
 import fr.acinq.bitcoin.utils.Either
+import fr.acinq.lightning.CltvExpiryDelta
+import fr.acinq.lightning.Lightning
+import fr.acinq.lightning.ShortChannelId
 import fr.acinq.lightning.channel.TooManyAcceptedHtlcs
 import fr.acinq.lightning.db.LightningOutgoingPayment
 import fr.acinq.lightning.tests.utils.LightningTestSuite
 import fr.acinq.lightning.utils.msat
+import fr.acinq.lightning.wire.ChannelUpdate
+import fr.acinq.lightning.wire.FeeInsufficient
 import fr.acinq.lightning.wire.IncorrectOrUnknownPaymentDetails
 import fr.acinq.lightning.wire.PaymentTimeout
+import fr.acinq.lightning.wire.TemporaryChannelFailure
 import fr.acinq.lightning.wire.TemporaryNodeFailure
+import fr.acinq.lightning.wire.TrampolineFeeInsufficient
 import fr.acinq.lightning.wire.UnknownNextPeer
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -16,6 +24,20 @@ import kotlin.test.assertIs
 import kotlin.test.assertIsNot
 
 class OutgoingPaymentFailureTestsCommon : LightningTestSuite() {
+
+    private val channelUpdate = ChannelUpdate(
+        signature = Lightning.randomBytes64(),
+        chainHash = Block.RegtestGenesisBlock.hash,
+        shortChannelId = ShortChannelId(12345),
+        timestampSeconds = 1234567,
+        cltvExpiryDelta = CltvExpiryDelta(100),
+        messageFlags = 0,
+        channelFlags = 1,
+        htlcMinimumMsat = 1000.msat,
+        feeBaseMsat = 12.msat,
+        feeProportionalMillionths = 76,
+        htlcMaximumMsat = null
+    )
 
     @Test
     fun `identify common route failures`() {
@@ -57,6 +79,67 @@ class OutgoingPaymentFailureTestsCommon : LightningTestSuite() {
             )
         )
         assertEquals(Either.Left(LightningOutgoingPayment.Part.Status.Failed.Failure.RecipientLiquidityIssue), failure.explain())
+    }
+
+    @Test
+    fun `categorize final failures`() {
+        val testCases = listOf(
+            FinalFailure.AlreadyInProgress to OutgoingPaymentFailure.Category.LocalValidation,
+            FinalFailure.AlreadyPaid to OutgoingPaymentFailure.Category.LocalValidation,
+            FinalFailure.InvalidPaymentAmount to OutgoingPaymentFailure.Category.LocalValidation,
+            FinalFailure.FeaturesNotSupported to OutgoingPaymentFailure.Category.LocalValidation,
+            FinalFailure.InvalidPaymentId to OutgoingPaymentFailure.Category.LocalValidation,
+            FinalFailure.ChannelNotConnected to OutgoingPaymentFailure.Category.LocalChannel,
+            FinalFailure.ChannelOpening to OutgoingPaymentFailure.Category.LocalChannel,
+            FinalFailure.ChannelClosing to OutgoingPaymentFailure.Category.LocalChannel,
+            FinalFailure.NoAvailableChannels to OutgoingPaymentFailure.Category.LocalChannel,
+            FinalFailure.InsufficientBalance to OutgoingPaymentFailure.Category.LocalBalance,
+            FinalFailure.RecipientUnreachable to OutgoingPaymentFailure.Category.Recipient,
+            FinalFailure.RetryExhausted to OutgoingPaymentFailure.Category.Retry,
+            FinalFailure.WalletRestarted to OutgoingPaymentFailure.Category.Retry,
+            FinalFailure.UnknownError to OutgoingPaymentFailure.Category.Unknown,
+        )
+        testCases.forEach { (failure, category) ->
+            assertEquals(category, failure.category)
+        }
+    }
+
+    @Test
+    fun `categorize payment part failures`() {
+        val testCases = listOf(
+            LightningOutgoingPayment.Part.Status.Failed.Failure.PaymentAmountTooSmall to OutgoingPaymentFailure.Category.LocalValidation,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.PaymentAmountTooBig to OutgoingPaymentFailure.Category.LocalValidation,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.NotEnoughFunds to OutgoingPaymentFailure.Category.LocalBalance,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.NotEnoughFees to OutgoingPaymentFailure.Category.Fee,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.PaymentExpiryTooBig to OutgoingPaymentFailure.Category.Cltv,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.TooManyPendingPayments to OutgoingPaymentFailure.Category.Retry,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.ChannelIsSplicing to OutgoingPaymentFailure.Category.LocalChannel,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.ChannelIsClosing to OutgoingPaymentFailure.Category.LocalChannel,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.TemporaryRemoteFailure to OutgoingPaymentFailure.Category.Remote,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.RecipientLiquidityIssue to OutgoingPaymentFailure.Category.Liquidity,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.RecipientIsOffline to OutgoingPaymentFailure.Category.Recipient,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.RecipientRejectedPayment to OutgoingPaymentFailure.Category.Recipient,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.Uninterpretable("unknown failure") to OutgoingPaymentFailure.Category.Unknown,
+        )
+        testCases.forEach { (failure, category) ->
+            assertEquals(category, failure.category)
+        }
+    }
+
+    @Test
+    fun `categorize outgoing payment failures using explanation`() {
+        val testCases = listOf(
+            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(TrampolineFeeInsufficient))) to OutgoingPaymentFailure.Category.Fee,
+            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(FeeInsufficient(10_000.msat, channelUpdate)))) to OutgoingPaymentFailure.Category.Fee,
+            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(TemporaryChannelFailure(channelUpdate)))) to OutgoingPaymentFailure.Category.Remote,
+            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(UnknownNextPeer))) to OutgoingPaymentFailure.Category.Recipient,
+            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(PaymentTimeout))) to OutgoingPaymentFailure.Category.Liquidity,
+            FinalFailure.RetryExhausted.toPaymentFailure() to OutgoingPaymentFailure.Category.Retry,
+            FinalFailure.InsufficientBalance.toPaymentFailure() to OutgoingPaymentFailure.Category.LocalBalance,
+        )
+        testCases.forEach { (failure, category) ->
+            assertEquals(category, failure.category)
+        }
     }
 
     @Test

--- a/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailureTestsCommon.kt
+++ b/modules/core/src/commonTest/kotlin/fr/acinq/lightning/payment/OutgoingPaymentFailureTestsCommon.kt
@@ -84,20 +84,20 @@ class OutgoingPaymentFailureTestsCommon : LightningTestSuite() {
     @Test
     fun `categorize final failures`() {
         val testCases = listOf(
-            FinalFailure.AlreadyInProgress to OutgoingPaymentFailure.Category.LocalValidation,
-            FinalFailure.AlreadyPaid to OutgoingPaymentFailure.Category.LocalValidation,
-            FinalFailure.InvalidPaymentAmount to OutgoingPaymentFailure.Category.LocalValidation,
-            FinalFailure.FeaturesNotSupported to OutgoingPaymentFailure.Category.LocalValidation,
-            FinalFailure.InvalidPaymentId to OutgoingPaymentFailure.Category.LocalValidation,
-            FinalFailure.ChannelNotConnected to OutgoingPaymentFailure.Category.LocalChannel,
-            FinalFailure.ChannelOpening to OutgoingPaymentFailure.Category.LocalChannel,
-            FinalFailure.ChannelClosing to OutgoingPaymentFailure.Category.LocalChannel,
-            FinalFailure.NoAvailableChannels to OutgoingPaymentFailure.Category.LocalChannel,
-            FinalFailure.InsufficientBalance to OutgoingPaymentFailure.Category.LocalBalance,
-            FinalFailure.RecipientUnreachable to OutgoingPaymentFailure.Category.Recipient,
-            FinalFailure.RetryExhausted to OutgoingPaymentFailure.Category.Retry,
-            FinalFailure.WalletRestarted to OutgoingPaymentFailure.Category.Retry,
-            FinalFailure.UnknownError to OutgoingPaymentFailure.Category.Unknown,
+            FinalFailure.AlreadyInProgress to PaymentFailureCategory.LocalValidation,
+            FinalFailure.AlreadyPaid to PaymentFailureCategory.LocalValidation,
+            FinalFailure.InvalidPaymentAmount to PaymentFailureCategory.LocalValidation,
+            FinalFailure.FeaturesNotSupported to PaymentFailureCategory.LocalValidation,
+            FinalFailure.InvalidPaymentId to PaymentFailureCategory.LocalValidation,
+            FinalFailure.ChannelNotConnected to PaymentFailureCategory.LocalChannel,
+            FinalFailure.ChannelOpening to PaymentFailureCategory.LocalChannel,
+            FinalFailure.ChannelClosing to PaymentFailureCategory.LocalChannel,
+            FinalFailure.NoAvailableChannels to PaymentFailureCategory.LocalChannel,
+            FinalFailure.InsufficientBalance to PaymentFailureCategory.LocalBalance,
+            FinalFailure.RecipientUnreachable to PaymentFailureCategory.Recipient,
+            FinalFailure.RetryExhausted to PaymentFailureCategory.Retry,
+            FinalFailure.WalletRestarted to PaymentFailureCategory.Retry,
+            FinalFailure.UnknownError to PaymentFailureCategory.Unknown,
         )
         testCases.forEach { (failure, category) ->
             assertEquals(category, failure.category)
@@ -107,19 +107,19 @@ class OutgoingPaymentFailureTestsCommon : LightningTestSuite() {
     @Test
     fun `categorize payment part failures`() {
         val testCases = listOf(
-            LightningOutgoingPayment.Part.Status.Failed.Failure.PaymentAmountTooSmall to OutgoingPaymentFailure.Category.LocalValidation,
-            LightningOutgoingPayment.Part.Status.Failed.Failure.PaymentAmountTooBig to OutgoingPaymentFailure.Category.LocalValidation,
-            LightningOutgoingPayment.Part.Status.Failed.Failure.NotEnoughFunds to OutgoingPaymentFailure.Category.LocalBalance,
-            LightningOutgoingPayment.Part.Status.Failed.Failure.NotEnoughFees to OutgoingPaymentFailure.Category.Fee,
-            LightningOutgoingPayment.Part.Status.Failed.Failure.PaymentExpiryTooBig to OutgoingPaymentFailure.Category.Cltv,
-            LightningOutgoingPayment.Part.Status.Failed.Failure.TooManyPendingPayments to OutgoingPaymentFailure.Category.Retry,
-            LightningOutgoingPayment.Part.Status.Failed.Failure.ChannelIsSplicing to OutgoingPaymentFailure.Category.LocalChannel,
-            LightningOutgoingPayment.Part.Status.Failed.Failure.ChannelIsClosing to OutgoingPaymentFailure.Category.LocalChannel,
-            LightningOutgoingPayment.Part.Status.Failed.Failure.TemporaryRemoteFailure to OutgoingPaymentFailure.Category.Remote,
-            LightningOutgoingPayment.Part.Status.Failed.Failure.RecipientLiquidityIssue to OutgoingPaymentFailure.Category.Liquidity,
-            LightningOutgoingPayment.Part.Status.Failed.Failure.RecipientIsOffline to OutgoingPaymentFailure.Category.Recipient,
-            LightningOutgoingPayment.Part.Status.Failed.Failure.RecipientRejectedPayment to OutgoingPaymentFailure.Category.Recipient,
-            LightningOutgoingPayment.Part.Status.Failed.Failure.Uninterpretable("unknown failure") to OutgoingPaymentFailure.Category.Unknown,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.PaymentAmountTooSmall to PaymentFailureCategory.LocalValidation,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.PaymentAmountTooBig to PaymentFailureCategory.LocalValidation,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.NotEnoughFunds to PaymentFailureCategory.LocalBalance,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.NotEnoughFees to PaymentFailureCategory.Fee,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.PaymentExpiryTooBig to PaymentFailureCategory.Cltv,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.TooManyPendingPayments to PaymentFailureCategory.Retry,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.ChannelIsSplicing to PaymentFailureCategory.LocalChannel,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.ChannelIsClosing to PaymentFailureCategory.LocalChannel,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.TemporaryRemoteFailure to PaymentFailureCategory.Remote,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.RecipientLiquidityIssue to PaymentFailureCategory.Liquidity,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.RecipientIsOffline to PaymentFailureCategory.Recipient,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.RecipientRejectedPayment to PaymentFailureCategory.Recipient,
+            LightningOutgoingPayment.Part.Status.Failed.Failure.Uninterpretable("unknown failure") to PaymentFailureCategory.Unknown,
         )
         testCases.forEach { (failure, category) ->
             assertEquals(category, failure.category)
@@ -129,13 +129,13 @@ class OutgoingPaymentFailureTestsCommon : LightningTestSuite() {
     @Test
     fun `categorize outgoing payment failures using explanation`() {
         val testCases = listOf(
-            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(TrampolineFeeInsufficient))) to OutgoingPaymentFailure.Category.Fee,
-            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(FeeInsufficient(10_000.msat, channelUpdate)))) to OutgoingPaymentFailure.Category.Fee,
-            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(TemporaryChannelFailure(channelUpdate)))) to OutgoingPaymentFailure.Category.Remote,
-            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(UnknownNextPeer))) to OutgoingPaymentFailure.Category.Recipient,
-            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(PaymentTimeout))) to OutgoingPaymentFailure.Category.Liquidity,
-            FinalFailure.RetryExhausted.toPaymentFailure() to OutgoingPaymentFailure.Category.Retry,
-            FinalFailure.InsufficientBalance.toPaymentFailure() to OutgoingPaymentFailure.Category.LocalBalance,
+            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(TrampolineFeeInsufficient))) to PaymentFailureCategory.Fee,
+            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(FeeInsufficient(10_000.msat, channelUpdate)))) to PaymentFailureCategory.Fee,
+            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(TemporaryChannelFailure(channelUpdate)))) to PaymentFailureCategory.Remote,
+            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(UnknownNextPeer))) to PaymentFailureCategory.Recipient,
+            OutgoingPaymentFailure(FinalFailure.NoAvailableChannels, listOf(Either.Right(PaymentTimeout))) to PaymentFailureCategory.Liquidity,
+            FinalFailure.RetryExhausted.toPaymentFailure() to PaymentFailureCategory.Retry,
+            FinalFailure.InsufficientBalance.toPaymentFailure() to PaymentFailureCategory.LocalBalance,
         )
         testCases.forEach { (failure, category) ->
             assertEquals(category, failure.category)


### PR DESCRIPTION
  ## Summary

  This PR adds a stable high-level category API for payment failures.

  It exposes categories on:

  - `FinalFailure`
  - `LightningOutgoingPayment.Part.Status.Failed.Failure`
  - `OutgoingPaymentFailure`
  - `Bolt12InvoiceRequestFailure`

  The category enum is shared as `PaymentFailureCategory`, so callers can classify both regular outgoing payment failures and BOLT 12 invoice request failures with the same API.

  ## Context

  This came out of debugging outgoing Lightning payment failures in Ambrosia, which uses phoenixd as a Lightning backend.

  In that investigation, phoenixd accepted outgoing payment attempts, selected a local channel, sent an HTLC, and then received `UpdateFailHtlc`. The existing phoenixd API exposed a human-readable `reason`, but downstream applications could not reliably classify the failure without parsing strings or duplicating lightning-kmp internals.

  A ACINQ/phoenixd#240 PR initially added failure categorization in phoenixd, but review feedback correctly pointed out that phoenixd should remain a thin wrapper and that this classification belongs in lightning-kmp.

  There was also feedback to handle the BOLT 12 case, where paying an offer may fail before a payable invoice is obtained. This PR therefore exposes the same category type for `Bolt12InvoiceRequestFailure`.

  ## Why This Is Useful

  Although the need was discovered while debugging Ambrosia, this is useful for any application built on lightning-kmp, including phoenixd and other wallets/services.

  Callers can now expose structured diagnostics, improve logs, and choose better user-facing messages without depending on localized strings or fragile class-name mappings.

  For example, clients can distinguish:

  - invalid request or payment parameters
  - insufficient local balance
  - unavailable local channels
  - insufficient routing fees
  - CLTV/expiry issues
  - recipient liquidity problems
  - recipient rejection or unreachability
  - remote route failures
  - exhausted/interrupted retries
  - unknown failures

  ## Compatibility

  This is a derived API only.

  - no payment behavior changes
  - no database migration
  - no serialization format change
  - existing failure types and messages remain unchanged

  ## Tests

  Added focused tests covering category mappings for final failures, payment part failures, aggregate `OutgoingPaymentFailure` explanations, and BOLT 12 invoice request failures.

  The tests include the cases that motivated the phoenixd work:

  - `TrampolineFeeInsufficient`
  - `FeeInsufficient`
  - `TemporaryChannelFailure`
  - `UnknownNextPeer`
  - `PaymentTimeout`
  - `RetryExhausted`
  - local insufficient balance
  - BOLT 12 invoice request timeout

  Tested with:

  ```bash
  ./gradlew :lightning-kmp-core:jvmTest \
    --tests fr.acinq.lightning.payment.OutgoingPaymentFailureTestsCommon \
    --tests fr.acinq.lightning.payment.OfferManagerTestsCommon